### PR TITLE
feat: make type() return keywords instead of strings

### DIFF
--- a/src/ffi/primitives/context.rs
+++ b/src/ffi/primitives/context.rs
@@ -2,11 +2,13 @@
 //!
 //! Provides thread-local storage and management of the current VM context.
 
+use crate::symbol::SymbolTable;
 use crate::vm::VM;
 use std::cell::RefCell;
 
 thread_local! {
     static VM_CONTEXT: RefCell<Option<*mut VM>> = const { RefCell::new(None) };
+    static SYMBOL_TABLE: RefCell<Option<*mut SymbolTable>> = const { RefCell::new(None) };
 }
 
 /// Set the current VM context (called before executing code)
@@ -22,6 +24,23 @@ pub fn get_vm_context() -> Option<*mut VM> {
 /// Clear the VM context
 pub fn clear_vm_context() {
     VM_CONTEXT.with(|ctx| *ctx.borrow_mut() = None);
+}
+
+/// Set the current symbol table context
+pub fn set_symbol_table(symbols: *mut SymbolTable) {
+    SYMBOL_TABLE.with(|ctx| *ctx.borrow_mut() = Some(symbols));
+}
+
+/// Get the current symbol table context
+/// # Safety
+/// The returned pointer must not be used after the symbol table is dropped.
+pub unsafe fn get_symbol_table() -> Option<*mut SymbolTable> {
+    SYMBOL_TABLE.with(|ctx| ctx.borrow().as_ref().copied())
+}
+
+/// Clear the symbol table context
+pub fn clear_symbol_table() {
+    SYMBOL_TABLE.with(|ctx| *ctx.borrow_mut() = None);
 }
 
 /// Register FFI primitives in the VM.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use elle::compiler::converters::value_to_expr;
+use elle::ffi::primitives::context::set_symbol_table;
 use elle::ffi_primitives;
 use elle::repl::Repl;
 use elle::{compile, init_stdlib, read_str, register_primitives, SymbolTable, VM};
@@ -324,6 +325,9 @@ fn main() {
 
     // Set VM context for FFI primitives
     ffi_primitives::set_vm_context(&mut vm as *mut VM);
+
+    // Set symbol table context for primitives
+    set_symbol_table(&mut symbols as *mut SymbolTable);
 
     // Check for command-line arguments
     let args: Vec<String> = env::args().collect();


### PR DESCRIPTION
## Summary

Changed the `type` function to return **keywords** (e.g., `:int`, `:string`, `:list`) instead of **strings** (e.g., `"int"`, `"string"`, `"list"`).

## Motivation

- Keywords are semantically more correct for type tags than strings
- Matches Lisp tradition where keywords represent immutable, singleton values
- Provides consistency with our recently added keyword support (PR #88)
- Keywords are designed for use as identifiers/tags, making them more appropriate for type information

## Implementation Details

- Added thread-local SymbolTable context storage in `src/ffi/primitives/context.rs`
- Modified `prim_type()` in `src/primitives/type_check.rs` to access the symbol table and return keyword values
- Set up the symbol table context in `main.rs` after registering primitives

## Behavioral Changes

Before:
\`\`\`lisp
(type 5)         ⟹ "int"
(type 3.14)      ⟹ "float"
(type "hello")   ⟹ "string"
(type '(1 2))    ⟹ "list"
(type nil)       ⟹ "nil"
\`\`\`

After:
\`\`\`lisp
(type 5)         ⟹ :int
(type 3.14)      ⟹ :float
(type "hello")   ⟹ :string
(type '(1 2))    ⟹ :list
(type nil)       ⟹ :nil
\`\`\`

## Testing

- All 1086 existing tests pass ✅
- Manually verified type returns keywords for all basic types ✅
- Code formatted with `cargo fmt` ✅
- Verified with `cargo clippy` ✅