### PR TITLE
Closure optimization: dead capture elimination and capture-free specialization

### DIFF
--- a/src/compiler/compile.rs
+++ b/src/compiler/compile.rs
@@ -223,27 +223,35 @@ impl Compiler {
 
                 let idx = self.bytecode.add_constant(Value::Closure(Rc::new(closure)));
 
-                // Emit captured values onto the stack (in order)
-                // These will be stored in the closure's environment by the VM
-                for (sym, depth, index) in captures {
-                    if *index == usize::MAX {
-                        // This is a global variable - load it as a global
-                        let sym_idx = self.bytecode.add_constant(Value::Symbol(*sym));
-                        self.bytecode.emit(Instruction::LoadGlobal);
-                        self.bytecode.emit_u16(sym_idx);
-                    } else {
-                        // This is a local variable from an outer scope
-                        // Load it using LoadUpvalue with the resolved depth and index
-                        self.bytecode.emit(Instruction::LoadUpvalue);
-                        self.bytecode.emit_byte((*depth + 1) as u8);
-                        self.bytecode.emit_byte(*index as u8);
+                if captures.is_empty() {
+                    // No captures — just load the closure template directly as a constant
+                    // No need for MakeClosure instruction
+                    self.bytecode.emit(Instruction::LoadConst);
+                    self.bytecode.emit_u16(idx);
+                } else {
+                    // Has captures — emit capture loads + MakeClosure as before
+                    // Emit captured values onto the stack (in order)
+                    // These will be stored in the closure's environment by the VM
+                    for (sym, depth, index) in captures {
+                        if *index == usize::MAX {
+                            // This is a global variable - load it as a global
+                            let sym_idx = self.bytecode.add_constant(Value::Symbol(*sym));
+                            self.bytecode.emit(Instruction::LoadGlobal);
+                            self.bytecode.emit_u16(sym_idx);
+                        } else {
+                            // This is a local variable from an outer scope
+                            // Load it using LoadUpvalue with the resolved depth and index
+                            self.bytecode.emit(Instruction::LoadUpvalue);
+                            self.bytecode.emit_byte((*depth + 1) as u8);
+                            self.bytecode.emit_byte(*index as u8);
+                        }
                     }
-                }
 
-                // Create closure with captured values
-                self.bytecode.emit(Instruction::MakeClosure);
-                self.bytecode.emit_u16(idx);
-                self.bytecode.emit_byte(captures.len() as u8);
+                    // Create closure with captured values
+                    self.bytecode.emit(Instruction::MakeClosure);
+                    self.bytecode.emit_u16(idx);
+                    self.bytecode.emit_byte(captures.len() as u8);
+                }
             }
 
             Expr::Let { bindings, body } => {


### PR DESCRIPTION
## Summary

Phase 4 closure optimizations (Issue #20):

### Dead Capture Elimination
Wires the existing `analyze_capture_usage` function into the lambda/let/let* capture pipeline. Captures that are never referenced in the lambda body are eliminated at compile time, reducing closure environment size.

Fixed `analyze_capture_usage` to recurse into nested lambdas (was previously leaf-only) and added handling for Block, Letrec, Cond, And, Or expressions.

### Capture-Free Closure Specialization  
Lambdas with zero captures (after dead capture elimination) skip the `MakeClosure` instruction entirely. The closure template is loaded directly via `LoadConst`, avoiding the overhead of popping captured values and creating a new closure object at runtime.

## Changes

- **src/compiler/analysis.rs**: Enhanced `analyze_capture_usage` to recurse into nested lambdas and handle additional expression types (Block, Letrec, Cond, And, Or)
- **src/compiler/converters.rs**: Integrated dead capture elimination into lambda, let, and let* handlers
- **src/compiler/compile.rs**: Added capture-free closure specialization to skip MakeClosure when captures list is empty
- **tests/integration/closure_capture_optimization.rs**: Added 5 new tests for nested lambda capture elimination and capture-free closures

## Test Results

All 1133 existing tests pass, plus 5 new tests for the optimizations.

Relates to #20