### PR TITLE
Remove Goodbye message when REPL exits

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -351,7 +351,6 @@ fn main() {
 
     if args.len() == 1 {
         println!();
-        println!("Goodbye!");
     }
 
     // Exit with appropriate status code


### PR DESCRIPTION
## Summary

Removes the printed "Goodbye!" message that was displayed when the REPL exited, providing a cleaner exit experience.

## Changes

- Removed the `println!("Goodbye!");` statement from the REPL exit handler in `src/main.rs:354`

## Testing

- All 201 unit tests pass
- All 1169 integration tests pass
- Clippy checks pass with no warnings
- Code formatted with cargo fmt