### PR TITLE
refactor: Use fold for list processing in elle-doc

### DIFF
--- a/elle-doc/lib/template.lisp
+++ b/elle-doc/lib/template.lisp
@@ -1,21 +1,18 @@
 ;; Page template generation
 
-;; Generate navigation HTML
+;; Generate navigation HTML using fold
 (define generate-nav
   (lambda (nav-items current-slug)
-    (define render-nav-items
-      (lambda (items result)
-        (if (empty? items)
-          result
-          (let ((item (first items)))
-            (let ((slug (get item "slug"))
-                  (title (get item "title"))
-                  (active-class (if (string-contains? slug current-slug) " active" "")))
-              (render-nav-items (rest items)
-                (string-append result 
-                  "<li><a href=\"" slug ".html\" class=\"nav-link" active-class "\">" 
-                  title "</a></li>")))))))
-    (render-nav-items items "")))
+    (fold
+      (lambda (acc item)
+        (let ((slug (get item "slug"))
+              (title (get item "title"))
+              (active-class (if (string-contains? slug current-slug) " active" "")))
+          (string-append acc
+            "<li><a href=\"" slug ".html\" class=\"nav-link" active-class "\">" 
+            title "</a></li>")))
+      ""
+      nav-items)))
 
 ;; Generate the full HTML page
 (define generate-page


### PR DESCRIPTION
## Summary

Updated elle-doc to use elle's new `map`, `filter`, and `fold` functions for functional list processing, replacing recursive patterns with more idiomatic functional code.

## Changes

- **render-list**: Replaced recursive list item rendering with `fold`
- **render-table**: Replaced three nested recursive functions with `fold` calls for headers, row cells, and rows
- **render-sections**: Replaced recursive section rendering with `fold`
- **lib/content.lisp**: Applied same refactorings to library module
- **lib/template.lisp**: Applied fold to navigation generation

## Benefits

- More functional and idiomatic Elle code
- Reduced code duplication
- Improved readability
- Better alignment with elle's functional paradigm
- All tests pass, documentation generates correctly

## Testing

Verified that:
- Documentation generates without errors
- All HTML files are created correctly
- Content is properly formatted and rendered
- Navigation items display correctly