### PR TITLE
feat: add GitHub Pages preview deployment for pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,19 +292,7 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: |
-                📚 **Documentation Preview**
-
-                Generated documentation is available as an artifact:
-
-                [Download PR #${{ github.event.number }} Documentation](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
-
-                Including:
-                - Elle language documentation (getting started, language guide, stdlib reference)
-                - Rust API documentation
-                - Cross-language demos (N-Queens, Matrix Operations)
-
-                To view: Download the artifact and open `index.html` in your browser.
+              body: `📚 **Documentation Preview**\n\nGenerated documentation is available as an artifact:\n\n[Download PR #${{ github.event.number }} Documentation](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})\n\nIncluding:\n- Elle language documentation (getting started, language guide, stdlib reference)\n- Rust API documentation\n- Cross-language demos (N-Queens, Matrix Operations)\n\nTo view: Download the artifact and open \`index.html\` in your browser.`
             })
 
   benchmarks:


### PR DESCRIPTION
## Summary

Automatically generate and deploy documentation previews for every pull request, allowing reviewers to see how documentation changes will look without waiting for main branch deployment.

## Changes

- **New `deploy-pr-preview` CI job**: Runs for pull requests to build documentation
- **Artifact upload**: Documentation stored as PR-specific artifact with 7-day retention
- **Automatic PR comment**: CI automatically comments on PR with link to preview
- **Live Pages unchanged**: Main branch continues to deploy live documentation to GitHub Pages

## Benefits

- Reviewers can preview documentation changes before merging
- No manual steps required - fully automated
- Documentation changes are validated by the CI system
- Uses artifact storage so no permanent deployment

## How It Works

When a PR is created:
1. CI runs the `docs` job (already existed) to build Elle docs + Rust API docs
2. New `deploy-pr-preview` job downloads the artifacts
3. Uploads as PR-specific artifact (retention: 7 days)
4. Posts comment on PR with download link
5. Artifact includes everything: Elle guides, stdlib reference, API docs, demos

Reviewers can download and open `index.html` to preview all changes.