### PR TITLE
fix: upgrade GitHub Pages actions to avoid deprecated v3 artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -255,14 +255,14 @@ jobs:
           name: documentation
           path: ./doc-build
       - name: Setup Pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v4
       - name: Upload pages artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ./doc-build
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4
 
   deploy-pr-preview:
     name: Deploy PR Preview


### PR DESCRIPTION
## Summary

Upgrade GitHub Pages CI actions to newer versions that don't use deprecated `actions/upload-artifact@v3`, which GitHub has blocked in workflows.

## Changes

- **actions/configure-pages**: v3 → v4
- **actions/upload-pages-artifact**: v2 → v3  
- **actions/deploy-pages**: v2 → v4

## Why

GitHub deprecated `actions/upload-artifact@v3` and now rejects any workflows that use it, even transitively. The older GitHub Pages actions used v3 internally, causing deployment to fail with:

```
This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`
```

The upgraded actions use the newer artifact API and don't have this issue.

## Testing

This allows Pages deployment to proceed on main branch pushes and enables the `gh-pages` branch to be created/updated as intended.