### PR TITLE
WIP: Investigate set! in lambda bodies (issue #106)

### DIFF
--- a/src/compiler/bytecode.rs
+++ b/src/compiler/bytecode.rs
@@ -22,6 +22,9 @@ pub enum Instruction {
     /// Load from closure environment
     LoadUpvalue,
 
+    /// Store to closure environment
+    StoreUpvalue,
+
     /// Pop value from stack
     Pop,
 

--- a/src/compiler/compile.rs
+++ b/src/compiler/compile.rs
@@ -323,16 +323,15 @@ impl Compiler {
                     let idx = self.bytecode.add_constant(Value::Symbol(*var));
                     self.bytecode.emit(Instruction::StoreGlobal);
                     self.bytecode.emit_u16(idx);
-                } else if *depth == 0 {
-                    // Local variable set
-                    self.bytecode.emit(Instruction::StoreLocal);
+                } else if self.scope_depth > 0 {
+                    // Inside a scope (lambda, block, loop) - store to scope_stack
+                    self.bytecode.emit(Instruction::StoreScoped);
+                    self.bytecode.emit_byte(*depth as u8);
                     self.bytecode.emit_byte(*index as u8);
                 } else {
-                    // Upvalue variable set (not supported yet - treat as error or global)
-                    // For now, treat as global to avoid corruption
-                    let idx = self.bytecode.add_constant(Value::Symbol(*var));
-                    self.bytecode.emit(Instruction::StoreGlobal);
-                    self.bytecode.emit_u16(idx);
+                    // At top level - use StoreLocal for stack variables
+                    self.bytecode.emit(Instruction::StoreLocal);
+                    self.bytecode.emit_byte(*index as u8);
                 }
             }
 

--- a/src/compiler/converters.rs
+++ b/src/compiler/converters.rs
@@ -440,11 +440,14 @@ fn value_to_expr_with_scope(
                     }
 
                     "begin" => {
-                        let exprs: Result<Vec<_>, _> = list[1..]
-                            .iter()
-                            .map(|v| value_to_expr_with_scope(v, symbols, scope_stack))
-                            .collect();
-                        Ok(Expr::Begin(exprs?))
+                        // Process expressions sequentially to handle variable definitions properly
+                        // This allows define to register variables that are then available to later expressions
+                        let mut exprs = Vec::new();
+                        for v in &list[1..] {
+                            let expr = value_to_expr_with_scope(v, symbols, scope_stack)?;
+                            exprs.push(expr);
+                        }
+                        Ok(Expr::Begin(exprs))
                     }
 
                     "block" => {
@@ -468,15 +471,18 @@ fn value_to_expr_with_scope(
                         // Push a new scope with the lambda parameters (as Vec for ordered indices)
                         scope_stack.push(param_syms.clone());
 
-                        let body_exprs: Result<Vec<_>, _> = list[2..]
-                            .iter()
-                            .map(|v| value_to_expr_with_scope(v, symbols, scope_stack))
-                            .collect();
+                        // Process body expressions sequentially to handle variable definitions properly
+                        let mut body_exprs_vec = Vec::new();
+                        for expr_val in &list[2..] {
+                            let expr = value_to_expr_with_scope(expr_val, symbols, scope_stack)?;
+                            body_exprs_vec.push(expr);
+                        }
 
                         // Pop the lambda's scope
                         scope_stack.pop();
 
-                        let body_exprs = body_exprs?;
+                        let body_exprs = body_exprs_vec;
+
                         let body = if body_exprs.len() == 1 {
                             Box::new(body_exprs[0].clone())
                         } else {
@@ -537,8 +543,18 @@ fn value_to_expr_with_scope(
                             return Err("define requires exactly 2 arguments".to_string());
                         }
                         let name = list[1].as_symbol()?;
+
+                        // Register the variable in the current scope BEFORE processing the value
+                        // This way, if the value references the variable (unusual but possible),
+                        // it can be found. More importantly, it makes the variable available to
+                        // subsequent expressions in the same scope.
+                        if !scope_stack.is_empty() {
+                            scope_stack.last_mut().unwrap().push(name);
+                        }
+
                         let value =
                             Box::new(value_to_expr_with_scope(&list[2], symbols, scope_stack)?);
+
                         Ok(Expr::Define { name, value })
                     }
 

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -92,6 +92,10 @@ impl VM {
                     variables::handle_load_upvalue(self, bytecode, &mut ip, closure_env)?;
                 }
 
+                Instruction::StoreUpvalue => {
+                    variables::handle_store_upvalue(self, bytecode, &mut ip, closure_env)?;
+                }
+
                 // Control flow
                 Instruction::Jump => {
                     control::handle_jump(bytecode, &mut ip, self);

--- a/src/vm/scope/handlers.rs
+++ b/src/vm/scope/handlers.rs
@@ -85,6 +85,7 @@ pub fn handle_define_local(
     };
 
     // Define in current scope
+    // Note: ScopeStack always has at least the global scope, so we don't need to check
     vm.scope_stack.define_local(sym_id, value);
 
     Ok(())

--- a/src/vm/variables.rs
+++ b/src/vm/variables.rs
@@ -95,3 +95,32 @@ pub fn handle_load_upvalue(
     }
     Ok(())
 }
+
+pub fn handle_store_upvalue(
+    vm: &mut VM,
+    bytecode: &[u8],
+    ip: &mut usize,
+    closure_env: Option<&std::rc::Rc<Vec<Value>>>,
+) -> Result<(), String> {
+    let _depth = vm.read_u8(bytecode, ip);
+    let idx = vm.read_u8(bytecode, ip) as usize;
+    let _val = vm.stack.pop().ok_or("Stack underflow")?;
+
+    // Store to closure environment
+    if let Some(env) = closure_env {
+        if idx < env.len() {
+            // We cannot mutate through an immutable reference
+            // This is a fundamental architectural issue - we need RefCell or similar
+            // For now, return an error that indicates this is not yet supported
+            return Err("Cannot mutate closure environment variables yet".to_string());
+        } else {
+            return Err(format!(
+                "Upvalue index {} out of bounds (env size: {})",
+                idx,
+                env.len()
+            ));
+        }
+    } else {
+        return Err("StoreUpvalue used outside of closure".to_string());
+    }
+}

--- a/tests/integration/closures_and_lambdas.rs
+++ b/tests/integration/closures_and_lambdas.rs
@@ -725,6 +725,21 @@ fn test_set_in_nested_closure() {
 }
 
 #[test]
+fn test_set_local_variable_in_lambda() {
+    // set! on a local variable inside a lambda should work
+    // This is the test case from issue #106
+    let code = r#"
+        (define test (lambda ()
+          (begin
+            (define x 0)
+            (set! x 42)
+            x)))
+        (test)
+    "#;
+    assert_eq!(eval(code).unwrap(), Value::Int(42));
+}
+
+#[test]
 fn test_make_adder_pattern() {
     // Classic make-adder: define, then call
     let code = r#"


### PR DESCRIPTION
## Summary
- Adds test case for `set!` inside lambda bodies (currently failing)
- Adds `StoreUpvalue` bytecode instruction for mutable upvalues
- Registers variables in converter scope when using `define`
- Processes lambda/begin bodies sequentially to handle variable definitions

## Problem
The test case fails with "Undefined global variable" when using `set!` on variables defined inside lambda bodies.

## Root Cause
This is an architectural limitation in how the compiler handles variable scoping vs. runtime storage:
- Parameters are stored in `closure_env` (immutable `Rc<Vec<Value>>`)
- Locally-defined variables go to `scope_stack`
- The `Expr::Var` system cannot distinguish between these at runtime
- Result: locally-defined variables are accessed as if they were in the closure environment, but `LoadUpvalue` fails

## What Would Be Needed for Full Fix
1. Extend AST to track parameter vs locally-defined variables separately
2. Make `closure_env` mutable (e.g., with `RefCell`)
3. Or completely redesign how local variables are stored during lambda execution

## Status
This is a work-in-progress branch showing the investigation and a partial fix. It identifies the exact architectural issue preventing a simple fix to issue #106.