### PR TITLE
fix: self-recursive and mutual-recursive define inside lambda bodies

### DIFF
--- a/examples/recursive-define.lisp
+++ b/examples/recursive-define.lisp
@@ -1,0 +1,22 @@
+#!/usr/bin/env elle
+
+;; Self-recursive define inside lambda (Issue #179)
+(define run-factorial (lambda (n)
+  (begin
+    (define fact (lambda (x) (if (= x 0) 1 (* x (fact (- x 1))))))
+    (fact n))))
+
+(display "Factorial of 6: ")
+(display (run-factorial 6))
+(newline)
+
+;; Mutual recursion with define inside lambda (Issue #180)
+(define run-even-odd (lambda ()
+  (begin
+    (define is-even (lambda (n) (if (= n 0) #t (is-odd (- n 1)))))
+    (define is-odd (lambda (n) (if (= n 0) #f (is-even (- n 1)))))
+    (is-even 8))))
+
+(display "Is 8 even? ")
+(display (run-even-odd))
+(newline)

--- a/src/compiler/compile.rs
+++ b/src/compiler/compile.rs
@@ -262,11 +262,17 @@ impl Compiler {
 
                 let idx = self.bytecode.add_constant(Value::Closure(Rc::new(closure)));
 
-                if captures.is_empty() {
-                    // No captures — just load the closure template directly as a constant
+                if captures.is_empty() && locals.is_empty() {
+                    // No captures AND no locals — just load the closure template directly as a constant
                     // No need for MakeClosure instruction
                     self.bytecode.emit(Instruction::LoadConst);
                     self.bytecode.emit_u16(idx);
+                } else if captures.is_empty() {
+                    // Has locals but no external captures — still need MakeClosure for closure env
+                    // so that nested lambdas can access locally-defined variables via LoadUpvalueRaw
+                    self.bytecode.emit(Instruction::MakeClosure);
+                    self.bytecode.emit_u16(idx);
+                    self.bytecode.emit_byte(0); // 0 captures
                 } else {
                     // Has captures — emit capture loads + MakeClosure as before
                     // First, analyze which variables are mutated in the lambda body

--- a/src/primitives/concurrency.rs
+++ b/src/primitives/concurrency.rs
@@ -58,6 +58,16 @@ fn is_value_sendable(value: &Value) -> bool {
 
         // Unsafe: thread handles
         Value::ThreadHandle(_) => false,
+
+        // Cells are safe if their contents are sendable
+        Value::Cell(cell) => {
+            if let Ok(val) = cell.try_borrow() {
+                is_value_sendable(&val)
+            } else {
+                // If we can't borrow, assume it's not sendable (to be safe)
+                false
+            }
+        }
     }
 }
 

--- a/tests/integration/closures_and_lambdas.rs
+++ b/tests/integration/closures_and_lambdas.rs
@@ -729,12 +729,13 @@ fn test_set_local_variable_in_lambda() {
     // set! on a local variable inside a lambda should work
     // This is the test case from issue #106
     let code = r#"
-        (define test (lambda ()
-          (begin
-            (define x 0)
-            (set! x 42)
-            x)))
-        (test)
+        (begin
+          (define test (lambda ()
+            (begin
+              (define x 0)
+              (set! x 42)
+              x)))
+          (test))
     "#;
     assert_eq!(eval(code).unwrap(), Value::Int(42));
 }


### PR DESCRIPTION
Fixes #179 and #180.

Two root causes fixed:
1. Lambdas with locals but no captures used LoadConst instead of MakeClosure, so no closure env existed at runtime for LoadUpvalueRaw.
2. Converter processed define names sequentially, preventing mutual visibility between sibling defines in lambda bodies.

Changes:
- compile.rs: Add locals.is_empty() check to LoadConst condition; add MakeClosure-with-0-captures path
- converters.rs: Pre-scan lambda body for define names before processing expressions; prevent duplicate scope entries; include locally-defined variables in local_bindings to prevent treating them as free variables
- concurrency.rs: Add Cell case to is_value_sendable match (pre-existing compilation error)
- closures_and_lambdas.rs: Fix test_set_local_variable_in_lambda by wrapping in begin (pre-existing test issue)