### PR TITLE
fix: include jsonrpc and id fields in LSP notification responses

### DIFF
--- a/elle-lsp/src/main.rs
+++ b/elle-lsp/src/main.rs
@@ -193,7 +193,11 @@ fn handle_request(request: &Value, compiler_state: &mut CompilerState) -> (Value
                     }
                 }
             }
-            json!({})
+            json!({
+                "jsonrpc": "2.0",
+                "id": id,
+                "result": null
+            })
         }
         "textDocument/didChange" => {
             if let Some(params) = params {
@@ -251,7 +255,11 @@ fn handle_request(request: &Value, compiler_state: &mut CompilerState) -> (Value
                     }
                 }
             }
-            json!({})
+            json!({
+                "jsonrpc": "2.0",
+                "id": id,
+                "result": null
+            })
         }
         "textDocument/didClose" => {
             if let Some(params) = params {
@@ -263,7 +271,11 @@ fn handle_request(request: &Value, compiler_state: &mut CompilerState) -> (Value
                     compiler_state.on_document_close(uri);
                 }
             }
-            json!({})
+            json!({
+                "jsonrpc": "2.0",
+                "id": id,
+                "result": null
+            })
         }
         "textDocument/hover" => {
             let mut result = None;


### PR DESCRIPTION
## Summary
Fixed elle-lsp server responses for textDocument lifecycle events (didOpen, didChange, didClose) to conform to LSP specification.

## Problem
Elle-lsp was sending invalid LSP messages that caused Neovim LSP client to reject them with `INVALID_SERVER_MESSAGE` errors. The three message handlers were returning empty JSON objects instead of proper LSP responses.

## Solution
Updated three handlers to return proper LSP responses with required fields:
- `jsonrpc`: "2.0"
- `id`: the request ID from the client
- `result`: null (for these notification-style messages)

This ensures compatibility with all LSP clients that strictly follow the LSP specification.

## Testing
- Direct protocol testing confirms server now responds correctly
- Neovim LSP client successfully connects and receives diagnostics
- Both .lisp and .elle files are recognized and handled properly