### PR TITLE
fix: REPL now returns correct exit code on parse/runtime errors

### DIFF
--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -109,3 +109,7 @@ mod concurrency {
 mod error_reporting {
     include!("error_reporting.rs");
 }
+
+mod repl_exit_codes {
+    include!("repl_exit_codes.rs");
+}

--- a/tests/integration/repl_exit_codes.rs
+++ b/tests/integration/repl_exit_codes.rs
@@ -1,0 +1,123 @@
+// Tests for REPL exit codes with piped input
+//
+// Verifies that the REPL returns appropriate exit codes when parsing errors
+// occur during piped input execution.
+
+use std::io::Write;
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+fn get_elle_binary() -> String {
+    // Try to find the built elle binary
+    let debug_path = "target/debug/elle";
+    if Path::new(debug_path).exists() {
+        debug_path.to_string()
+    } else {
+        // Fallback to looking in common paths
+        "target/debug/elle".to_string()
+    }
+}
+
+#[test]
+fn test_repl_piped_input_parse_error_exit_code() {
+    // Test that piping parse errors to the REPL results in exit code 1
+    let elle_bin = get_elle_binary();
+
+    let mut child = Command::new(&elle_bin)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap_or_else(|_| panic!("Failed to spawn elle process at {}", elle_bin));
+
+    // Write invalid input (unterminated list) to stdin
+    {
+        let stdin = child.stdin.as_mut().expect("Failed to open stdin");
+        stdin
+            .write_all(b"(+ 1 1\n")
+            .expect("Failed to write to stdin");
+    } // stdin is closed here
+
+    let output = child.wait_with_output().expect("Failed to wait on child");
+
+    // Should exit with status 1 due to parse error
+    assert_eq!(
+        output.status.code().unwrap_or(-1),
+        1,
+        "Expected exit code 1, stderr was: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // Verify error was reported
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Parse error") || stderr.contains("unterminated"),
+        "Expected parse error message in stderr, got: {}",
+        stderr
+    );
+}
+
+#[test]
+fn test_repl_piped_input_successful_exit_code() {
+    // Test that piping valid input to the REPL results in exit code 0
+    let elle_bin = get_elle_binary();
+
+    let mut child = Command::new(&elle_bin)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap_or_else(|_| panic!("Failed to spawn elle process at {}", elle_bin));
+
+    // Write valid input to stdin
+    {
+        let stdin = child.stdin.as_mut().expect("Failed to open stdin");
+        stdin
+            .write_all(b"(+ 1 1)\n")
+            .expect("Failed to write to stdin");
+    } // stdin is closed here
+
+    let output = child.wait_with_output().expect("Failed to wait on child");
+
+    // Should exit with status 0 for successful execution
+    assert_eq!(
+        output.status.code().unwrap_or(-1),
+        0,
+        "Expected exit code 0, stderr was: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn test_repl_piped_input_multiple_errors_exit_code() {
+    // Test that piping multiple invalid expressions results in exit code 1
+    let elle_bin = get_elle_binary();
+
+    let mut child = Command::new(&elle_bin)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap_or_else(|_| panic!("Failed to spawn elle process at {}", elle_bin));
+
+    // Write multiple invalid inputs
+    {
+        let stdin = child.stdin.as_mut().expect("Failed to open stdin");
+        stdin
+            .write_all(b"(+ 1 1)\n")
+            .expect("Failed to write to stdin");
+        stdin
+            .write_all(b"(* 2 2\n")
+            .expect("Failed to write to stdin"); // This one has an error
+    } // stdin is closed here
+
+    let output = child.wait_with_output().expect("Failed to wait on child");
+
+    // Should exit with status 1 due to parse error in the second expression
+    assert_eq!(
+        output.status.code().unwrap_or(-1),
+        1,
+        "Expected exit code 1, stderr was: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}


### PR DESCRIPTION
## Summary

The REPL now correctly returns exit code 1 when errors occur during piped input execution, matching the behavior of `run_file()`.

## Changes

- Modified `run_repl()` to return `bool` and track parse/runtime/readline errors
- Modified `run_repl_fallback()` to return `bool` and track errors  
- Updated `main()` to check REPL return values and set exit code accordingly
- Added integration tests for REPL exit codes with piped input

## Testing

- All existing tests pass (1408 total)
- Added 3 new integration tests covering:
  - Parse error exit code (exit 1)
  - Successful execution exit code (exit 0)
  - Multiple expressions with errors (exit 1)
- Verified with manual testing: `echo '(+ 1 1' | elle` now returns exit code 1
- Verified with manual testing: `echo '(+ 1 1)' | elle` returns exit code 0
- Ran clippy - no warnings