### PR TITLE
feat(jit): implement inline variable storage for compiled code

### DIFF
--- a/src/compiler/cranelift/e2e_test.rs
+++ b/src/compiler/cranelift/e2e_test.rs
@@ -11,6 +11,7 @@ mod tests {
     use cranelift::prelude::*;
 
     fn test_compilation_no_panic(expr: &Expr, name: &str) {
+        use crate::compiler::cranelift::compiler::CompileContext;
         use crate::symbol::SymbolTable;
         let mut builder_ctx = FunctionBuilderContext::new();
         let mut func = cranelift::codegen::ir::Function::new();
@@ -24,7 +25,8 @@ mod tests {
         builder.seal_block(block);
 
         let symbols = SymbolTable::new();
-        let result = ExprCompiler::compile_expr_block(&mut builder, expr, &symbols);
+        let mut ctx = CompileContext::new(&mut builder, &symbols);
+        let result = ExprCompiler::compile_expr_block(&mut ctx, expr);
 
         // Should not panic and should successfully compile
         assert!(


### PR DESCRIPTION
Closes #175

## Summary of Changes

- Added `CompileContext` struct to centralize compilation state with `ScopeManager` and `StackAllocator`
- Added `Expr::Var` handler to load variables from stack slots
- Added `Expr::Set` handler to store values to stack slots
- Updated `try_compile_let` to properly allocate and store bindings on the stack
- Fixed `try_compile_for` to properly bind loop variables with stack storage
- Refactored all helper methods to use `CompileContext`
- Added comprehensive tests for variable operations

## Limitations

- Float variables not yet supported
- Runtime-computed iterables not yet supported (requires runtime list operations)

## Testing

All 723 tests pass
