### PR TITLE
feat: implement JIT support for runtime-computed iterables in for loops (fixes #215)

### DIFF
--- a/src/compiler/cranelift/e2e_test.rs
+++ b/src/compiler/cranelift/e2e_test.rs
@@ -12,7 +12,10 @@ mod tests {
 
     fn test_compilation_no_panic(expr: &Expr, name: &str) {
         use crate::compiler::cranelift::compiler::CompileContext;
+        use crate::compiler::cranelift::context::JITContext;
         use crate::symbol::SymbolTable;
+
+        let mut jit_ctx = JITContext::new().expect("Failed to create JIT context");
         let mut builder_ctx = FunctionBuilderContext::new();
         let mut func = cranelift::codegen::ir::Function::new();
         func.signature.params.push(AbiParam::new(types::I64));
@@ -25,7 +28,7 @@ mod tests {
         builder.seal_block(block);
 
         let symbols = SymbolTable::new();
-        let mut ctx = CompileContext::new(&mut builder, &symbols);
+        let mut ctx = CompileContext::new(&mut builder, &symbols, &mut jit_ctx.module);
         let result = ExprCompiler::compile_expr_block(&mut ctx, expr);
 
         // Should not panic and should successfully compile

--- a/src/compiler/cranelift/mod.rs
+++ b/src/compiler/cranelift/mod.rs
@@ -41,6 +41,7 @@ pub mod phase14_milestone;
 pub mod phase15_milestone;
 pub mod primitives;
 pub mod profiler;
+pub mod runtime_helpers;
 pub mod scoping;
 pub mod stack_allocator;
 pub mod tests;

--- a/src/compiler/cranelift/runtime_helpers.rs
+++ b/src/compiler/cranelift/runtime_helpers.rs
@@ -1,0 +1,175 @@
+//! Runtime helper functions for JIT-compiled code
+//!
+//! These functions are called from generated native code to perform
+//! operations that require access to Elle's runtime (heap values, etc.)
+
+use crate::value::Value;
+use std::cell::RefCell;
+
+thread_local! {
+    /// Pinned values that must not be collected during JIT execution
+    static PINNED_VALUES: RefCell<Vec<Value>> = const { RefCell::new(Vec::new()) };
+}
+
+/// Pin a value to prevent collection during JIT execution
+/// Returns an i64 pointer to the pinned value
+pub fn pin_value(value: Value) -> i64 {
+    PINNED_VALUES.with(|pinned| {
+        let mut vec = pinned.borrow_mut();
+        vec.push(value);
+        let ptr = vec.last().unwrap() as *const Value;
+        ptr as i64
+    })
+}
+
+/// Unpin all values after JIT execution completes
+pub fn unpin_all() {
+    PINNED_VALUES.with(|pinned| {
+        pinned.borrow_mut().clear();
+    });
+}
+
+/// Check if a value is nil
+/// Returns 1 for nil, 0 otherwise
+///
+/// # Safety
+/// The value_ptr must be either 0 (encoded nil) or a valid pointer to a Value
+#[no_mangle]
+pub extern "C" fn jit_is_nil(value_ptr: i64) -> i64 {
+    if value_ptr == 0 {
+        return 1; // Encoded nil
+    }
+    let value = unsafe { &*(value_ptr as *const Value) };
+    if value.is_nil() {
+        1
+    } else {
+        0
+    }
+}
+
+/// Extract the car (first element) of a cons cell
+/// Returns an i64-encoded value or pointer
+///
+/// # Safety
+/// The value_ptr must be either 0 or a valid pointer to a Value
+#[no_mangle]
+pub extern "C" fn jit_car(value_ptr: i64) -> i64 {
+    if value_ptr == 0 {
+        return 0; // car of nil is nil
+    }
+    let value = unsafe { &*(value_ptr as *const Value) };
+    match value {
+        Value::Cons(cons) => encode_value_for_jit(&cons.first),
+        _ => 0, // car of non-cons is nil
+    }
+}
+
+/// Extract the cdr (rest) of a cons cell
+/// Returns an i64-encoded value or pointer
+///
+/// # Safety
+/// The value_ptr must be either 0 or a valid pointer to a Value
+#[no_mangle]
+pub extern "C" fn jit_cdr(value_ptr: i64) -> i64 {
+    if value_ptr == 0 {
+        return 0; // cdr of nil is nil
+    }
+    let value = unsafe { &*(value_ptr as *const Value) };
+    match value {
+        Value::Cons(cons) => encode_value_for_jit(&cons.rest),
+        _ => 0, // cdr of non-cons is nil
+    }
+}
+
+/// Encode a Value as an i64 for JIT use
+/// Primitives are encoded directly, heap values return pointers
+fn encode_value_for_jit(value: &Value) -> i64 {
+    match value {
+        Value::Nil => 0,
+        Value::Bool(b) => {
+            if *b {
+                1
+            } else {
+                0
+            }
+        }
+        Value::Int(i) => *i,
+        // For heap values (cons, etc.), return pointer to the value
+        _ => value as *const Value as i64,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::value::cons;
+
+    #[test]
+    fn test_jit_is_nil_with_zero() {
+        assert_eq!(jit_is_nil(0), 1);
+    }
+
+    #[test]
+    fn test_jit_is_nil_with_nil_value() {
+        let nil = Value::Nil;
+        let ptr = &nil as *const Value as i64;
+        assert_eq!(jit_is_nil(ptr), 1);
+    }
+
+    #[test]
+    fn test_jit_is_nil_with_cons() {
+        let list = cons(Value::Int(1), Value::Nil);
+        let ptr = &list as *const Value as i64;
+        assert_eq!(jit_is_nil(ptr), 0);
+    }
+
+    #[test]
+    fn test_jit_car_of_nil() {
+        assert_eq!(jit_car(0), 0);
+    }
+
+    #[test]
+    fn test_jit_car_of_cons() {
+        let list = cons(Value::Int(42), Value::Nil);
+        let ptr = &list as *const Value as i64;
+        // car should return 42 (the integer value directly)
+        assert_eq!(jit_car(ptr), 42);
+    }
+
+    #[test]
+    fn test_jit_cdr_of_nil() {
+        assert_eq!(jit_cdr(0), 0);
+    }
+
+    #[test]
+    fn test_jit_cdr_of_single_element_list() {
+        let list = cons(Value::Int(1), Value::Nil);
+        let ptr = &list as *const Value as i64;
+        // cdr should return 0 (nil)
+        assert_eq!(jit_cdr(ptr), 0);
+    }
+
+    #[test]
+    fn test_jit_cdr_of_multi_element_list() {
+        let list = cons(Value::Int(1), cons(Value::Int(2), Value::Nil));
+        let ptr = &list as *const Value as i64;
+        let cdr_ptr = jit_cdr(ptr);
+        // cdr should be a pointer to the rest of the list
+        assert_ne!(cdr_ptr, 0);
+        // The car of the cdr should be 2
+        assert_eq!(jit_car(cdr_ptr), 2);
+    }
+
+    #[test]
+    fn test_pin_and_unpin() {
+        let value = Value::Int(42);
+        let ptr = pin_value(value);
+        assert_ne!(ptr, 0);
+
+        // Value should be accessible
+        let pinned = unsafe { &*(ptr as *const Value) };
+        assert_eq!(pinned.as_int().unwrap(), 42);
+
+        unpin_all();
+    }
+}


### PR DESCRIPTION
## Summary

This PR implements JIT support for runtime-computed iterables in for loops, addressing issue #215. Previously, the JIT compiler only supported for loops over literal cons lists that could be unrolled at compile time. Now it supports:

- **Literal cons lists** (existing fast path - unrolled at compile time)
- **Runtime-computed iterables** (variables, function calls, expressions)

## Changes

### New Module: `runtime_helpers.rs`
- `jit_is_nil(value_ptr: i64) -> i64` - Check if a value is nil
- `jit_car(value_ptr: i64) -> i64` - Extract car (first element) of cons cell
- `jit_cdr(value_ptr: i64) -> i64` - Extract cdr (rest) of cons cell
- `pin_value(value: Value) -> i64` - Pin values to prevent GC during JIT execution
- `unpin_all()` - Unpin all values after JIT execution

### Modified Files

1. **context.rs**
   - Register runtime helper functions with Cranelift JIT builder
   - Helpers are registered as imported symbols so JIT code can call them

2. **compiler.rs**
   - Modified `CompileContext` to include `module: &'c mut JITModule`
   - Implemented `compile_for_runtime()` for non-literal iterables
   - Implemented `call_helper()` to emit calls to runtime helpers
   - Updated `try_compile_for()` to dispatch to runtime implementation
   - Updated all tests to pass module reference

3. **mod.rs**
   - Added `pub mod runtime_helpers;`

4. **e2e_test.rs**
   - Updated test helper to create JITContext and pass module

## How It Works

For runtime-computed iterables, the compiler generates:

1. **Header block**: Calls `jit_is_nil()` to check if list is empty
2. **Body block**: 
   - Calls `jit_car()` to get current element
   - Stores element in loop variable
   - Executes loop body
   - Calls `jit_cdr()` to advance iterator
   - Jumps back to header
3. **Exit block**: Returns nil

## Testing

- All 734 existing tests pass
- New test `test_compile_for_loop_computed_iterable` verifies runtime for loops compile
- Runtime helpers have comprehensive unit tests
- Code is formatted and clippy-clean

## Example Usage

```lisp
; Now works in JIT:
(define my-list '(1 2 3))
(for x my-list (print x))

(for x (range 10) (print x))

(for x (begin (get-list)) (process x))
```

## Performance Notes

- Literal cons lists still use the fast path (unrolled at compile time)
- Runtime iterables have function call overhead but avoid interpretation
- Values are pinned during JIT execution to prevent GC issues