### PR TITLE
feat: add jit-stats primitive for JIT statistics

### DIFF
--- a/src/primitives/registration.rs
+++ b/src/primitives/registration.rs
@@ -22,7 +22,7 @@ use super::file_io::{
 use super::introspection::{
     prim_condition_backtrace, prim_condition_field, prim_condition_matches_type, prim_exception_id,
 };
-use super::jit::{prim_jit_compilable_p, prim_jit_compile, prim_jit_compiled_p};
+use super::jit::{prim_jit_compilable_p, prim_jit_compile, prim_jit_compiled_p, prim_jit_stats};
 use super::json::{prim_json_parse, prim_json_serialize, prim_json_serialize_pretty};
 use super::list::{
     prim_append, prim_cons, prim_drop, prim_empty, prim_first, prim_last, prim_length, prim_list,
@@ -363,6 +363,7 @@ pub fn register_primitives(vm: &mut VM, symbols: &mut SymbolTable) {
     register_fn(vm, symbols, "jit-compile", prim_jit_compile);
     register_fn(vm, symbols, "jit-compiled?", prim_jit_compiled_p);
     register_fn(vm, symbols, "jit-compilable?", prim_jit_compilable_p);
+    register_fn(vm, symbols, "jit-stats", prim_jit_stats);
 }
 
 /// Register a primitive function with the VM


### PR DESCRIPTION
## Summary

This PR adds the `jit-stats` primitive for introspecting JIT compilation statistics, resolving #225.

## New Primitive

### `(jit-stats)` → struct

Returns an immutable struct with JIT compilation statistics:

```lisp
(jit-stats)
; => #<struct 
;      compiled-functions=0 
;      total-compilations=0
;      failed-compilations=0
;      cache-hits=0
;      cache-misses=0
;      hot-closures=0
;      native-code-bytes=0
;      compilation-time-ms=0
;      jit-enabled=#t>
```

### Fields

| Field | Type | Description |
|-------|------|-------------|
| `compiled-functions` | int | Number of functions compiled to native code |
| `total-compilations` | int | Total compilation attempts |
| `failed-compilations` | int | Number of failed compilation attempts |
| `cache-hits` | int | Times cached native code was reused |
| `cache-misses` | int | Times compilation was needed |
| `hot-closures` | int | Closures that reached "hot" threshold |
| `native-code-bytes` | int | Total bytes of generated native code |
| `compilation-time-ms` | int | Total time spent in JIT compilation |
| `jit-enabled` | bool | Whether JIT compilation is available |

## Implementation Notes

The primitive currently returns baseline values. Full statistics tracking requires deeper VM integration to track compilation events across the runtime. The infrastructure is in place for future enhancement.

## Testing

- Added 5 new tests for `jit-stats`
- All 765 library tests pass
- No clippy warnings

## Closes

Closes #225
