### PR TITLE
fix: wire up jit-compile primitive to actually compile closures

### DIFF
--- a/src/compiler/cranelift/codegen.rs
+++ b/src/compiler/cranelift/codegen.rs
@@ -108,33 +108,42 @@ impl IrEmitter {
     }
 
     /// Emit CLIF IR for integer less-than comparison
+    /// Returns i64 (0 for false, 1 for true)
     pub fn emit_lt_int(
         builder: &mut FunctionBuilder,
         left: cranelift::prelude::Value,
         right: cranelift::prelude::Value,
     ) -> cranelift::prelude::Value {
         let cond = IntCC::SignedLessThan;
-        builder.ins().icmp(cond, left, right)
+        let result = builder.ins().icmp(cond, left, right);
+        // Extend i8 boolean result to i64
+        builder.ins().uextend(types::I64, result)
     }
 
     /// Emit CLIF IR for integer greater-than comparison
+    /// Returns i64 (0 for false, 1 for true)
     pub fn emit_gt_int(
         builder: &mut FunctionBuilder,
         left: cranelift::prelude::Value,
         right: cranelift::prelude::Value,
     ) -> cranelift::prelude::Value {
         let cond = IntCC::SignedGreaterThan;
-        builder.ins().icmp(cond, left, right)
+        let result = builder.ins().icmp(cond, left, right);
+        // Extend i8 boolean result to i64
+        builder.ins().uextend(types::I64, result)
     }
 
     /// Emit CLIF IR for integer equality comparison
+    /// Returns i64 (0 for false, 1 for true)
     pub fn emit_eq_int(
         builder: &mut FunctionBuilder,
         left: cranelift::prelude::Value,
         right: cranelift::prelude::Value,
     ) -> cranelift::prelude::Value {
         let cond = IntCC::Equal;
-        builder.ins().icmp(cond, left, right)
+        let result = builder.ins().icmp(cond, left, right);
+        // Extend i8 boolean result to i64
+        builder.ins().uextend(types::I64, result)
     }
 
     /// Emit CLIF IR for float less-than comparison

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,10 @@
 use elle::compiler::converters::value_to_expr;
 use elle::ffi::primitives::context::set_symbol_table;
 use elle::ffi_primitives;
-use elle::primitives::{clear_macro_symbol_table, set_length_symbol_table, set_macro_symbol_table};
+use elle::primitives::{
+    clear_jit_context, clear_macro_symbol_table, init_jit_context, set_jit_symbol_table,
+    set_length_symbol_table, set_macro_symbol_table,
+};
 use elle::repl::Repl;
 use elle::{compile, init_stdlib, read_str, register_primitives, SymbolTable, VM};
 use rustyline::error::ReadlineError;
@@ -437,6 +440,10 @@ fn main() {
     // Set symbol table context for length primitive
     set_length_symbol_table(&mut symbols as *mut SymbolTable);
 
+    // Initialize JIT context for jit-compile primitive
+    init_jit_context();
+    set_jit_symbol_table(&mut symbols as *mut SymbolTable);
+
     // Check for command-line arguments
     let args: Vec<String> = env::args().collect();
     let mut had_errors = false;
@@ -476,6 +483,9 @@ fn main() {
 
     // Clear macro symbol table context
     clear_macro_symbol_table();
+
+    // Clear JIT context
+    clear_jit_context();
 
     if args.len() == 1 {
         println!();

--- a/src/primitives/mod.rs
+++ b/src/primitives/mod.rs
@@ -27,6 +27,7 @@ pub mod type_check;
 pub mod utility;
 pub mod vector;
 
+pub use jit::{clear_jit_context, init_jit_context, set_jit_symbol_table};
 pub use list::{clear_length_symbol_table, set_length_symbol_table};
 pub use macros::{clear_macro_symbol_table, set_macro_symbol_table};
 pub use module_init::init_stdlib;


### PR DESCRIPTION
## Summary

Previously, the `jit-compile` primitive was a stub that just returned the original closure without compiling. This PR wires it up to actually invoke Cranelift compilation.

## Changes

### JIT Primitives (`src/primitives/jit.rs`)
- Implemented thread-local JIT context and symbol table storage
- `prim_jit_compile` now actually compiles closures to native code
- `prim_jit_stats` returns real compilation statistics
- Added `init_jit_context()`, `set_jit_symbol_table()`, `clear_jit_context()`

### Compiler Fixes (`src/compiler/cranelift/`)
- Fixed comparison operators to properly extend i8 boolean results to i64
- Fixed if-expression compilation to set up block parameters before jumps
- Fixed scope depth handling (parameters are at depth=0)
- Added support for `GlobalVar` in addition to `Literal(Symbol)` for operators

### Initialization (`src/main.rs`)
- Added JIT context initialization and cleanup

## Testing

```lisp
(define add1 (fn (x) (+ x 1)))
(define add1-jit (jit-compile add1))
(jit-compiled? add1-jit)  ; => true
(add1-jit 41)             ; => 42
```

## Limitations

The JIT currently supports:
- Simple arithmetic: `+`, `-`, `*`, `/`
- Comparisons: `=`, `<`, `>`, `<=`, `>=`, `!=`
- Unary ops: `empty?`, `abs`, `nil?`, `not`
- Functions with 1-2 arguments

Not yet supported (future work):
- List operations: `first`, `rest`, `cons`, `list`, `append`, `reverse`
- Functions with >2 arguments
- Recursive calls to non-JIT functions

Relates to #169 (performance analysis)
