### PR TITLE
Add (exit) builtin to exit process with optional exit code

### DIFF
--- a/src/primitives/mod.rs
+++ b/src/primitives/mod.rs
@@ -19,6 +19,7 @@ pub mod meta;
 pub mod module_init;
 pub mod module_loading;
 pub mod package;
+pub mod process;
 pub mod registration;
 pub mod signaling;
 pub mod string;

--- a/src/primitives/process.rs
+++ b/src/primitives/process.rs
@@ -1,0 +1,70 @@
+//! Process-related primitives
+
+use crate::value::Value;
+
+/// Exit the process with an optional exit code
+///
+/// (exit)       ; exits with code 0
+/// (exit 0)     ; exits with code 0
+/// (exit 1)     ; exits with code 1
+/// (exit 42)    ; exits with code 42
+pub fn prim_exit(args: &[Value]) -> Result<Value, String> {
+    let code = if args.is_empty() {
+        0
+    } else if args.len() == 1 {
+        match &args[0] {
+            Value::Int(n) => {
+                if *n < 0 || *n > 255 {
+                    return Err(format!("exit code must be between 0 and 255, got {}", n));
+                }
+                *n as i32
+            }
+            _ => {
+                return Err(format!(
+                    "exit requires an integer argument, got {}",
+                    args[0].type_name()
+                ));
+            }
+        }
+    } else {
+        return Err(format!(
+            "exit requires 0 or 1 arguments, got {}",
+            args.len()
+        ));
+    };
+
+    std::process::exit(code);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_exit_too_many_args() {
+        let result = prim_exit(&[Value::Int(0), Value::Int(1)]);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("0 or 1 arguments"));
+    }
+
+    #[test]
+    fn test_exit_wrong_type() {
+        let result = prim_exit(&[Value::Bool(true)]);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("integer argument"));
+    }
+
+    #[test]
+    fn test_exit_negative() {
+        let result = prim_exit(&[Value::Int(-1)]);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("between 0 and 255"));
+    }
+
+    #[test]
+    fn test_exit_too_large() {
+        let result = prim_exit(&[Value::Int(256)]);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("between 0 and 255"));
+    }
+}

--- a/src/primitives/registration.rs
+++ b/src/primitives/registration.rs
@@ -42,6 +42,7 @@ use super::math::{
 use super::meta::prim_gensym;
 use super::module_loading::{prim_add_module_path, prim_import_file};
 use super::package::{prim_package_info, prim_package_version};
+use super::process::prim_exit;
 use super::signaling::{prim_error, prim_signal, prim_warn};
 use super::string::{
     prim_any_to_string, prim_char_at, prim_number_to_string, prim_string_append,
@@ -324,6 +325,9 @@ pub fn register_primitives(vm: &mut VM, symbols: &mut SymbolTable) {
     register_fn(vm, symbols, "join", prim_join);
     register_fn(vm, symbols, "sleep", prim_sleep);
     register_fn(vm, symbols, "current-thread-id", prim_current_thread_id);
+
+    // Process control
+    register_fn(vm, symbols, "exit", prim_exit);
 
     // Debugging and profiling primitives
     register_fn(vm, symbols, "debug-print", prim_debug_print);


### PR DESCRIPTION
## Summary

Adds the `(exit)` builtin function that terminates the process with an optional exit code.

## Usage

```lisp
(exit)      ; exits with code 0
(exit 0)    ; exits with code 0
(exit 1)    ; exits with code 1
(exit 42)   ; exits with code 42
```

## Implementation

- Exit codes must be integers in the range 0-255
- Calls `std::process::exit()` directly, matching behavior of Python's `sys.exit()`, Ruby's `exit`, etc.
- Invalid arguments return errors before exiting

## Files changed

- `src/primitives/process.rs` - NEW: process-related primitives module
- `src/primitives/mod.rs` - Added module declaration
- `src/primitives/registration.rs` - Registered the `exit` primitive

## Testing

- Added unit tests for argument validation (error cases)
- All 872 tests pass

Closes #234
