### PR TITLE
docs: update AGENTS.md files for post-migration state

### DIFF
--- a/elle-lint/AGENTS.md
+++ b/elle-lint/AGENTS.md
@@ -1,0 +1,47 @@
+# elle-lint
+
+Static analysis tool for Elle source files.
+
+## Responsibility
+
+Lint Elle code for naming conventions, arity mismatches, and style issues.
+Outputs diagnostics in human-readable or JSON format.
+
+## Architecture
+
+elle-lint is a normal application consuming the `elle` library. It uses the
+new pipeline exclusively:
+
+```
+Source → Reader → Syntax → Expander → Analyzer → HIR
+                                                   ↓
+                                            HirLinter → Diagnostics
+```
+
+Entry point: `elle::analyze_all_new()` → `elle::hir::HirLinter`
+
+## Files
+
+| File | Lines | Content |
+|------|-------|---------|
+| `src/main.rs` | ~120 | CLI: arg parsing, file/directory traversal |
+| `src/lib.rs` | ~160 | `Linter` wrapper, config, output formatting |
+
+## Key types
+
+| Type | Purpose |
+|------|---------|
+| `Linter` | Main linter instance with config |
+| `LintConfig` | Severity filter, output format |
+| `OutputFormat` | `Human` or `Json` |
+
+## Dependencies
+
+- `elle` — core library (analyze_all_new, HirLinter, Diagnostic, Severity)
+- `serde_json` — JSON output formatting
+
+## Invariants
+
+1. **Uses new pipeline only.** No `Expr`, no `value_to_expr`, no old pipeline.
+2. **Lint rules live in `elle::lint::rules`.** elle-lint does not define its own rules.
+3. **Exit codes:** 0 = clean, 1 = errors, 2 = warnings only.

--- a/elle-lsp/AGENTS.md
+++ b/elle-lsp/AGENTS.md
@@ -1,0 +1,58 @@
+# elle-lsp
+
+Language Server Protocol implementation for Elle.
+
+## Responsibility
+
+Provide IDE features for Elle via the LSP protocol:
+- Hover information (symbol name, kind, arity, docs)
+- Go-to-definition
+- Find references
+- Rename symbol
+- Code completion
+- Document formatting
+- Diagnostics (via linting)
+
+## Architecture
+
+elle-lsp is a synchronous LSP server reading JSON-RPC from stdin and writing
+to stdout. It uses the new pipeline exclusively:
+
+```
+Source → analyze_all_new → HIR + bindings
+                              ↓
+                    extract_symbols_from_hir → SymbolIndex
+                    HirLinter → Diagnostics
+```
+
+`CompilerState` holds per-document state. On every open/change, it re-analyzes
+the document and rebuilds the `SymbolIndex` and diagnostics. IDE features
+(hover, completion, definition, references, rename) query the `SymbolIndex`.
+
+## Files
+
+| File | Lines | Content |
+|------|-------|---------|
+| `src/main.rs` | ~550 | LSP message loop, JSON-RPC dispatch |
+| `src/lib.rs` | ~20 | Module declarations |
+| `src/compiler_state.rs` | ~200 | Document state, compilation, symbol extraction |
+| `src/hover.rs` | ~110 | Hover provider |
+| `src/completion.rs` | ~180 | Completion provider |
+| `src/definition.rs` | ~110 | Go-to-definition |
+| `src/references.rs` | ~160 | Find references |
+| `src/rename.rs` | ~350 | Rename with validation |
+| `src/formatting.rs` | ~110 | Document formatting via `elle::formatter` |
+
+## Dependencies
+
+- `elle` — core library (analyze_all_new, HirLinter, extract_symbols_from_hir, SymbolIndex)
+- `elle-lint` — not used directly (linting is done via elle's HirLinter)
+- `lsp-types` — LSP type definitions
+- `serde` / `serde_json` — JSON-RPC serialization
+
+## Invariants
+
+1. **Uses new pipeline only.** No `Expr`, no `value_to_expr`, no old pipeline.
+2. **Synchronous I/O.** No async runtime. Reads stdin, writes stdout.
+3. **Per-document state.** Each open document has its own `SymbolIndex` and diagnostics.
+4. **Formatting is pipeline-independent.** Uses `elle::formatter::format_code` on source text directly.

--- a/src/compiler/AGENTS.md
+++ b/src/compiler/AGENTS.md
@@ -11,7 +11,6 @@ new development.
 - CPS transformation (alternative execution path)
 - Cranelift JIT compilation
 - Macro expansion support
-- Linting
 
 Note: Effect types and inference have been moved to `src/effects/`.
 
@@ -25,8 +24,8 @@ Note: Effect types and inference have been moved to `src/effects/`.
 | `converters/` | `Value` ↔ `Expr` conversion |
 | `cps/` | Continuation-passing style transform and interpreter |
 | `cranelift/` | Native code generation via Cranelift |
-| `linter/` | Static analysis |
-| `scope.rs` | Legacy scope tracking |
+| `linter/` | Legacy Expr-based linter (re-exports from `src/lint/`) |
+| `symbol_index.rs` | Legacy Expr-based symbol extraction (types moved to `src/symbols/`) |
 | `capture_resolution.rs` | Legacy capture analysis |
 | `jit_coordinator.rs` | Hot path detection, JIT triggering |
 | `jit_executor.rs` | Native code execution |
@@ -87,6 +86,20 @@ Located here. Uses `VarRef`. Being phased out.
 | `compile/mod.rs` | ~800 | Legacy compilation |
 | `cps/` | ~1500 | CPS transform and interpreter |
 | `cranelift/` | ~500 | Cranelift code generation |
+
+## Relocated modules
+
+The following were moved out of `compiler/` because they are pipeline-agnostic:
+
+| Was | Now | Why |
+|-----|-----|-----|
+| `effects/` | `src/effects/` | Used by both pipelines (HIR, LIR, VM, closures) |
+| `scope.rs` | `src/vm/scope/` | Only used by VM scope system |
+| `linter/diagnostics.rs` | `src/lint/diagnostics.rs` | Used by HIR linter and external crates |
+| `linter/rules.rs` | `src/lint/rules.rs` | Used by HIR linter |
+| `symbol_index.rs` types | `src/symbols/` | Used by HIR symbol extraction and LSP |
+
+The old locations re-export from the new locations for backward compatibility.
 
 ## Anti-patterns
 

--- a/src/effects/AGENTS.md
+++ b/src/effects/AGENTS.md
@@ -1,0 +1,40 @@
+# effects
+
+Effect system for tracking which expressions may yield.
+
+## Responsibility
+
+Define the `Effect` type and provide effect inference for colorless coroutines.
+Effects track whether an expression may suspend execution (yield).
+
+## Interface
+
+| Type | Purpose |
+|------|---------|
+| `Effect` | `Pure`, `Yields`, `Polymorphic(usize)` |
+| `EffectContext` | Tracks known function effects for inference |
+
+## Dependents
+
+Used across both pipelines and the runtime:
+- `hir/analyze.rs` — infers effects during analysis
+- `hir/expr.rs` — `Hir` carries an `Effect`
+- `lir/emit.rs` — emits effect metadata on closures
+- `value/closure.rs` — `Closure` stores its `Effect`
+- `compiler/cps/` — CPS transform uses effects
+- `primitives/coroutines.rs` — coroutine primitives use `EffectContext`
+
+## Files
+
+| File | Lines | Content |
+|------|-------|---------|
+| `mod.rs` | ~140 | `Effect` enum, combine logic, tests |
+| `inference.rs` | ~300 | `EffectContext`, effect inference on Expr |
+| `primitives.rs` | ~50 | Registers known primitive effects |
+
+## Invariants
+
+1. **Effect::Pure is the default.** Unknown effects start as Pure.
+2. **Yields propagates.** If any sub-expression yields, the parent yields.
+3. **Polymorphic tracks parameter index.** `Polymorphic(i)` means the effect
+   depends on the i-th parameter's effect (for higher-order functions).

--- a/src/hir/AGENTS.md
+++ b/src/hir/AGENTS.md
@@ -29,6 +29,8 @@ Does NOT:
 | `CaptureKind` | `Local`, `Capture` (transitive), or `Global` |
 | `Analyzer` | Transforms Syntax → HIR |
 | `AnalysisResult` | HIR + binding metadata |
+| `HirLinter` | HIR-based linter producing Diagnostics |
+| `extract_symbols_from_hir` | Builds SymbolIndex from HIR |
 
 ## Data flow
 
@@ -50,6 +52,8 @@ HIR + bindings HashMap
 
 - `lir/lower.rs` - consumes HIR, uses binding info for cell decisions
 - `pipeline.rs` - orchestrates Syntax → HIR → LIR → Bytecode
+- `elle-lint` - uses `HirLinter` for static analysis
+- `elle-lsp` - uses `extract_symbols_from_hir` and `HirLinter` for IDE features
 
 ## Invariants
 
@@ -76,8 +80,11 @@ HIR + bindings HashMap
 
 | File | Lines | Content |
 |------|-------|---------|
-| `mod.rs` | 21 | Re-exports |
-| `analyze.rs` | 1400 | `Analyzer`, scope tracking, HIR construction |
+| `mod.rs` | 25 | Re-exports |
+| `analyze.rs` | ~1400 | `Analyzer`, scope tracking, HIR construction |
 | `expr.rs` | 180 | `Hir`, `HirKind` |
 | `binding.rs` | 120 | `BindingId`, `BindingInfo`, `CaptureInfo` |
 | `pattern.rs` | ~100 | Pattern matching types |
+| `tailcall.rs` | ~80 | Post-analysis pass marking tail calls |
+| `lint.rs` | ~150 | HIR-based linter (walks HirKind, produces Diagnostics) |
+| `symbols.rs` | ~200 | HIR-based symbol extraction (builds SymbolIndex) |

--- a/src/lint/AGENTS.md
+++ b/src/lint/AGENTS.md
@@ -1,0 +1,37 @@
+# lint
+
+Pipeline-agnostic lint types and rules.
+
+## Responsibility
+
+Define diagnostic types and lint rules that can be used by any pipeline.
+The actual linting logic (tree walking) lives in `hir/lint.rs`; this module
+provides the shared types and rule implementations.
+
+## Interface
+
+| Type | Purpose |
+|------|---------|
+| `Diagnostic` | Lint finding with severity, code, message, location |
+| `Severity` | `Info`, `Warning`, `Error` |
+| `DiagnosticContext` | Optional source text for context display |
+
+| Function | Purpose |
+|----------|---------|
+| `check_naming_convention` | Warns on non-kebab-case identifiers |
+| `check_call_arity` | Warns on wrong argument count for known functions |
+
+## Dependents
+
+- `hir/lint.rs` — HIR linter calls rules and produces Diagnostics
+- `elle-lint` — re-exports Diagnostic/Severity for CLI output
+- `elle-lsp` — uses Diagnostic/Severity for LSP diagnostics
+- `compiler/linter/` — backward-compat re-export
+
+## Files
+
+| File | Lines | Content |
+|------|-------|---------|
+| `mod.rs` | ~5 | Module declarations, re-exports |
+| `diagnostics.rs` | ~180 | `Diagnostic`, `Severity`, formatting |
+| `rules.rs` | ~190 | Naming convention checks, arity checks |

--- a/src/symbols/AGENTS.md
+++ b/src/symbols/AGENTS.md
@@ -1,0 +1,34 @@
+# symbols
+
+Pipeline-agnostic symbol index types for IDE features.
+
+## Responsibility
+
+Define the data types used by IDE features (hover, completion, go-to-definition,
+find-references, rename). The actual extraction logic lives in `hir/symbols.rs`
+(new pipeline) and `compiler/symbol_index.rs` (legacy); this module provides
+the shared types.
+
+## Interface
+
+| Type | Purpose |
+|------|---------|
+| `SymbolIndex` | Collection of definitions, usages, and locations |
+| `SymbolDef` | Definition info: name, kind, location, arity, docs |
+| `SymbolKind` | `Function`, `Variable`, `Builtin`, `Macro`, `Module` |
+
+| Function | Purpose |
+|----------|---------|
+| `get_primitive_documentation` | Returns doc strings for built-in functions |
+
+## Dependents
+
+- `hir/symbols.rs` — HIR-based symbol extraction builds SymbolIndex
+- `elle-lsp` — all IDE features query SymbolIndex
+- `compiler/symbol_index.rs` — backward-compat re-export
+
+## Files
+
+| File | Lines | Content |
+|------|-------|---------|
+| `mod.rs` | ~200 | All types and the primitive documentation function |


### PR DESCRIPTION
## Summary

- Updated root, `src/compiler/`, and `src/hir/` AGENTS.md files to reflect the post-migration pipeline state
- Added new AGENTS.md files for `elle-lint/`, `elle-lsp/`, `src/effects/`, `src/lint/`, and `src/symbols/` modules

Documentation-only changes. No code modifications.