### PR TITLE
feat: first-class continuations for yield across call boundaries

### DIFF
--- a/src/compiler/cps/trampoline.rs
+++ b/src/compiler/cps/trampoline.rs
@@ -316,8 +316,12 @@ impl Trampoline {
                         Ok(crate::vm::VmResult::Done(result)) => {
                             current_action = Action::return_value(result, continuation);
                         }
-                        Ok(crate::vm::VmResult::Yielded(value)) => {
+                        Ok(crate::vm::VmResult::Yielded {
+                            value,
+                            continuation: _,
+                        }) => {
                             // Yield happened - propagate it up
+                            // Note: We ignore the VM continuation here because CPS has its own
                             return TrampolineResult::Suspended {
                                 value,
                                 continuation,

--- a/src/formatter/core.rs
+++ b/src/formatter/core.rs
@@ -131,6 +131,9 @@ fn format_value(
             HeapObject::Cell(_, _) => return "#<cell>".to_string(),
             HeapObject::Float(_) => return "#<float>".to_string(),
             HeapObject::Coroutine(_) => return "#<coroutine>".to_string(),
+            HeapObject::Continuation(c) => {
+                return format!("#<continuation:{} frames>", c.frames.len())
+            }
         }
     }
 

--- a/src/primitives/concurrency.rs
+++ b/src/primitives/concurrency.rs
@@ -162,6 +162,9 @@ fn is_value_sendable(value: &Value) -> bool {
 
         // Float values that couldn't be stored inline
         HeapObject::Float(_) => true,
+
+        // Continuations are not sendable (contain frame data with closures)
+        HeapObject::Continuation(_) => false,
     }
 }
 

--- a/src/primitives/json/serializer.rs
+++ b/src/primitives/json/serializer.rs
@@ -110,6 +110,7 @@ pub fn serialize_value(value: &Value) -> Result<String, String> {
             HeapTag::LibHandle => Err("Cannot serialize library handles to JSON".to_string()),
             HeapTag::CHandle => Err("Cannot serialize C handles to JSON".to_string()),
             HeapTag::ThreadHandle => Err("Cannot serialize thread handles to JSON".to_string()),
+            HeapTag::Continuation => Err("Cannot serialize continuations to JSON".to_string()),
         }
     } else {
         Err("Cannot serialize unknown value type to JSON".to_string())
@@ -240,6 +241,7 @@ pub fn serialize_value_pretty(value: &Value, indent_level: usize) -> Result<Stri
             HeapTag::LibHandle => Err("Cannot serialize library handles to JSON".to_string()),
             HeapTag::CHandle => Err("Cannot serialize C handles to JSON".to_string()),
             HeapTag::ThreadHandle => Err("Cannot serialize thread handles to JSON".to_string()),
+            HeapTag::Continuation => Err("Cannot serialize continuations to JSON".to_string()),
         }
     } else {
         Err("Cannot serialize unknown value type to JSON".to_string())

--- a/src/value/continuation.rs
+++ b/src/value/continuation.rs
@@ -1,0 +1,121 @@
+//! Continuation data structures for first-class continuations.
+//!
+//! A continuation captures the full chain of frames from a yield point
+//! up to the coroutine boundary. On resume, the VM replays the chain
+//! from outermost to innermost.
+
+use crate::value::Value;
+use std::rc::Rc;
+
+/// A single saved execution frame.
+///
+/// When a coroutine yields, each frame in the call chain is captured
+/// with its bytecode, constants, environment, instruction pointer,
+/// and operand stack state.
+#[derive(Debug, Clone)]
+pub struct ContinuationFrame {
+    /// The bytecode for this frame
+    pub bytecode: Rc<Vec<u8>>,
+    /// The constants pool for this frame
+    pub constants: Rc<Vec<Value>>,
+    /// The closure environment for this frame
+    pub env: Rc<Vec<Value>>,
+    /// The instruction pointer to resume at (after the Yield/Call instruction)
+    pub ip: usize,
+    /// The operand stack state for this frame
+    pub stack: Vec<Value>,
+}
+
+/// A captured continuation - the full chain of pending computation.
+///
+/// When function A calls function B and B yields:
+/// - `frames[0]` = A's frame (outermost, the caller)
+/// - `frames[1]` = B's frame (innermost, the yielder)
+///
+/// On resume with value V:
+/// 1. Start with innermost frame (B): restore stack, push V, execute from B's saved IP
+/// 2. B returns a value -> pop B's frame
+/// 3. Continue with next frame (A): push B's return value on A's stack, execute from A's saved IP
+/// 4. A returns -> coroutine body is done
+#[derive(Debug, Clone)]
+pub struct ContinuationData {
+    /// The frames in the continuation chain.
+    /// Outermost (caller) first, innermost (yielder) last.
+    pub frames: Vec<ContinuationFrame>,
+}
+
+impl ContinuationData {
+    /// Create a new continuation with a single frame (the innermost/yielding frame).
+    pub fn new(frame: ContinuationFrame) -> Self {
+        ContinuationData {
+            frames: vec![frame],
+        }
+    }
+
+    /// Prepend a caller's frame to the continuation chain.
+    ///
+    /// This is called when a yield propagates through a Call instruction.
+    /// The caller's frame is added at the front (outermost position).
+    pub fn prepend_frame(&mut self, frame: ContinuationFrame) {
+        self.frames.insert(0, frame);
+    }
+
+    /// Check if the continuation has no frames.
+    pub fn is_empty(&self) -> bool {
+        self.frames.is_empty()
+    }
+
+    /// Get the number of frames in the continuation.
+    pub fn len(&self) -> usize {
+        self.frames.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_continuation_frame_creation() {
+        let frame = ContinuationFrame {
+            bytecode: Rc::new(vec![1, 2, 3]),
+            constants: Rc::new(vec![Value::int(42)]),
+            env: Rc::new(vec![]),
+            ip: 10,
+            stack: vec![Value::int(1), Value::int(2)],
+        };
+
+        assert_eq!(frame.ip, 10);
+        assert_eq!(frame.stack.len(), 2);
+    }
+
+    #[test]
+    fn test_continuation_data_prepend() {
+        let inner_frame = ContinuationFrame {
+            bytecode: Rc::new(vec![1]),
+            constants: Rc::new(vec![]),
+            env: Rc::new(vec![]),
+            ip: 5,
+            stack: vec![],
+        };
+
+        let mut cont = ContinuationData::new(inner_frame);
+        assert_eq!(cont.len(), 1);
+
+        let outer_frame = ContinuationFrame {
+            bytecode: Rc::new(vec![2]),
+            constants: Rc::new(vec![]),
+            env: Rc::new(vec![]),
+            ip: 10,
+            stack: vec![],
+        };
+
+        cont.prepend_frame(outer_frame);
+        assert_eq!(cont.len(), 2);
+
+        // Outer frame should be first
+        assert_eq!(cont.frames[0].ip, 10);
+        // Inner frame should be last
+        assert_eq!(cont.frames[1].ip, 5);
+    }
+}

--- a/src/value/heap.rs
+++ b/src/value/heap.rs
@@ -9,6 +9,7 @@ use std::ffi::c_void;
 use std::rc::Rc;
 use std::sync::{Arc, Mutex};
 
+use crate::value::continuation::ContinuationData;
 use crate::value::Value;
 
 // Re-use types from the old value system during migration
@@ -50,6 +51,7 @@ pub enum HeapTag {
     LibHandle = 12,
     CHandle = 13,
     ThreadHandle = 14,
+    Continuation = 15,
 }
 
 /// All heap-allocated value types.
@@ -108,6 +110,9 @@ pub enum HeapObject {
 
     /// Thread handle for concurrent execution
     ThreadHandle(ThreadHandleData),
+
+    /// First-class continuation for yield across call boundaries
+    Continuation(Rc<ContinuationData>),
 }
 
 /// Data for thread handles.
@@ -138,6 +143,7 @@ impl HeapObject {
             HeapObject::LibHandle(_) => HeapTag::LibHandle,
             HeapObject::CHandle(_, _) => HeapTag::CHandle,
             HeapObject::ThreadHandle(_) => HeapTag::ThreadHandle,
+            HeapObject::Continuation(_) => HeapTag::Continuation,
         }
     }
 
@@ -159,6 +165,7 @@ impl HeapObject {
             HeapObject::LibHandle(_) => "library-handle",
             HeapObject::CHandle(_, _) => "c-handle",
             HeapObject::ThreadHandle(_) => "thread-handle",
+            HeapObject::Continuation(_) => "continuation",
         }
     }
 }
@@ -188,6 +195,7 @@ impl std::fmt::Debug for HeapObject {
             HeapObject::LibHandle(id) => write!(f, "<lib-handle:{}>", id),
             HeapObject::CHandle(_, id) => write!(f, "<c-handle:{}>", id),
             HeapObject::ThreadHandle(_) => write!(f, "<thread-handle>"),
+            HeapObject::Continuation(c) => write!(f, "<continuation:{} frames>", c.frames.len()),
         }
     }
 }

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -5,6 +5,7 @@
 
 pub mod closure;
 pub mod condition;
+pub mod continuation;
 pub mod display;
 pub mod heap;
 pub mod intern;
@@ -22,6 +23,9 @@ pub use condition::Condition;
 
 // Export SendValue for thread-safe value transmission
 pub use send::SendValue;
+
+// Export continuation types
+pub use continuation::{ContinuationData, ContinuationFrame};
 
 // Re-export supporting types from value_old (closures, coroutines, etc)
 pub use crate::value_old::{

--- a/src/value/send.rs
+++ b/src/value/send.rs
@@ -139,6 +139,9 @@ impl SendValue {
 
             // Unsafe: coroutines (contain closures with mutable state)
             HeapObject::Coroutine(_) => Err("Cannot send coroutine".to_string()),
+
+            // Unsafe: continuations (contain frame data with closures)
+            HeapObject::Continuation(_) => Err("Cannot send continuation".to_string()),
         }
     }
 

--- a/src/value_old/mod.rs
+++ b/src/value_old/mod.rs
@@ -273,6 +273,9 @@ pub struct Coroutine {
     /// Saved execution environment for CPS resumption (shared mutable)
     /// This preserves local variables across yields
     pub saved_env: Option<Rc<RefCell<Vec<Value>>>>,
+    /// Saved first-class continuation for yield across call boundaries (new path)
+    /// This is a Value containing ContinuationData
+    pub saved_value_continuation: Option<crate::value::Value>,
 }
 
 impl Coroutine {
@@ -285,6 +288,7 @@ impl Coroutine {
             saved_context: None,
             saved_continuation: None,
             saved_env: None,
+            saved_value_continuation: None,
         }
     }
 }

--- a/tests/integration/coroutines.rs
+++ b/tests/integration/coroutines.rs
@@ -261,13 +261,8 @@ fn test_yielding_function_detected() {
 }
 
 #[test]
-#[ignore] // Requires CPS rework: yield across call boundaries
 fn test_calling_yielding_function_propagates_effect() {
     // If f yields and g calls f, g should also yield
-    // NOTE: This test documents expected behavior for effect propagation.
-    // Currently, calling a yielding function from within a coroutine
-    // does not propagate the yield - the inner function's yield is not
-    // visible to the outer coroutine. This requires the CPS rework to fix.
     let result = eval(
         r#"
          (define f (fn ()


### PR DESCRIPTION
## CPS Rework Phase 1: First-Class Continuations

This PR introduces `Value::Continuation` — a first-class continuation type
that captures the full frame chain when a coroutine yields. This makes yield
work correctly across call boundaries, which was previously broken.

### The Problem

When function A calls function B and B yields, the VM needs to save both
A's and B's frames. Previously, only B's frame was saved (as `CoroutineContext`),
and A's frame was lost during yield propagation. On resume, B would execute
but had nowhere to return to.

### The Solution

A continuation captures the entire chain of pending frames from the yield
point up to the coroutine boundary. Each frame records its bytecode,
constants, environment, instruction pointer, and operand stack segment.

**New types** (`src/value/continuation.rs`):
- `ContinuationFrame` — a single saved execution frame
- `ContinuationData` — the full chain (outermost caller first, innermost yielder last)

**New heap variant** (`src/value/heap.rs`):
- `HeapObject::Continuation(Rc<ContinuationData>)` with `HeapTag::Continuation = 15`
- `Value::continuation()`, `.as_continuation()`, `.is_continuation()`

**Changed VM flow**:
- `VmResult::Yielded` now carries `{ value, continuation }` instead of just the value
- The Yield instruction creates the initial 1-frame continuation
- The Call handler (coroutine path) captures the caller's frame and prepends it
  to the continuation chain before propagating upward
- Each caller in the chain captures its own frame as the yield bubbles up
- `VM::resume_continuation()` replays the chain from innermost to outermost

**Changed coroutine resume**:
- `Coroutine` gains a `saved_value_continuation: Option<Value>` field
- `prim_coroutine_resume` uses `resume_continuation` when a saved
  continuation exists, falling back to old paths for backward compat

### Tests

Un-ignored `test_calling_yielding_function_propagates_effect` — now passes.

New tests:
- `yield_across_call_boundaries` — helper yields, caller receives it
- `yield_across_two_call_levels` — A→B→C, C yields
- `yield_across_call_then_resume_then_yield` — multiple yields across calls
- `yield_across_call_with_return_value` — helper yields then returns, caller uses return value

### What's Next

Phase 2 will expose continuations to user code via new bytecode instructions
(`CaptureCont`, `ApplyCont`) and begin removing the CPS interpreter.
