### PR TITLE
feat: harden continuations — handler-case state, O(1) append, edge case tests

### DIFF
--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -25,7 +25,7 @@ pub use condition::Condition;
 pub use send::SendValue;
 
 // Export continuation types
-pub use continuation::{ContinuationData, ContinuationFrame};
+pub use continuation::{ContinuationData, ContinuationFrame, ExceptionHandler};
 
 // Re-export supporting types from value_old (closures, coroutines, etc)
 pub use crate::value_old::{


### PR DESCRIPTION
## Summary

Fix a bug where exception handlers were lost across yield/resume, optimize continuation frame building, and add comprehensive edge case tests.

**7 files changed, +507 / -104**

## Bug Fix: Handler-case state lost across yield/resume

When `yield` occurred inside a `handler-case` body, the exception handler state was not saved in the `ContinuationFrame`. On resume, the handler was gone and exceptions went uncaught:

```lisp
(handler-case
  (begin
    (yield 1)       ; handler active here
    (/ 1 0))        ; after resume, handler was MISSING — bug
  (division-by-zero e "caught"))
```

**Fix:** `ContinuationFrame` now saves `exception_handlers` and `handling_exception`. The Yield handler, Call handler (both closure paths), and `resume_continuation` all participate in saving/restoring this state. A new `execute_bytecode_from_ip_with_state` method accepts initial handler state for continuation resume.

Also fixed: tail calls during continuation resume were silently dropped because the resume path didn't have a tail call loop.

## Optimization: O(1) frame append

Changed `ContinuationData` frame ordering from outermost-first to innermost-first. Replaced `prepend_frame` (O(n) `insert(0, ...)`) with `append_frame` (O(1) `push`). Updated `resume_continuation` to iterate forward instead of reverse.

## New Tests (10)

| Test | What it covers |
|------|---------------|
| `test_yield_inside_handler_case_then_exception` | Handler-case catches after yield/resume |
| `test_yield_inside_handler_case_string_result` | String result from handler after resume |
| `test_yield_inside_nested_handler_case` | Nested handler-case blocks survive yield |
| `test_handler_case_outside_coroutine_wrapping_yield` | Outer handler catches coroutine exception |
| `test_exception_before_yield_caught_normally` | Exception before yield is caught normally |
| `test_multiple_yields_inside_handler_case` | Multiple yields with active handler |
| `test_yield_across_call_with_handler_case` | Yield from called function, handler in caller |
| `test_yield_across_three_call_levels` | 3-level call chain yield propagation |
| `test_yield_in_tail_position` | Yield in tail position |
| `test_deep_call_chain_with_multiple_yields` | Multiple yields at different call depths |

## Verification
- ✅ `cargo test --workspace` — 1,710 tests pass, 0 failures
- ✅ `cargo clippy --workspace --all-targets -- -D warnings` — clean
- ✅ `cargo fmt -- --check` — formatted
- ✅ `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` — clean
- ✅ `elle-doc/generate.lisp` — site generates successfully

## CPS Rework Progress
- [x] Phase 0: Tests + effect threading (#275)
- [x] Phase 1: First-class continuations (#276)
- [x] Phase 2: Delete CPS interpreter (#277)
- [x] **Phase 3: Harden continuations (this PR)**
- [ ] Phase 4: LIR continuation instructions (future — requires JIT to consume LIR)
- [ ] Phase 5: JIT support for yielding functions (future)
