### PR TITLE
feat: make Yield a proper LIR terminator with multi-block support

### DIFF
--- a/src/lir/types.rs
+++ b/src/lir/types.rs
@@ -184,8 +184,11 @@ pub enum LirInstr {
     LabelMarker { label_id: u32 },
 
     // === Coroutines ===
-    /// Yield a value
-    Yield { dst: Reg, value: Reg },
+    /// Load the resume value after a yield.
+    /// This is the first instruction in a yield's resume block.
+    /// At runtime, the resume value is on top of the operand stack
+    /// (pushed by the VM's resume_continuation).
+    LoadResumeValue { dst: Reg },
 
     // === Exception Handling ===
     /// Push exception handler
@@ -255,6 +258,9 @@ pub enum Terminator {
         then_label: Label,
         else_label: Label,
     },
+    /// Yield control with a value. Execution resumes at resume_label
+    /// with the resume value on the stack.
+    Yield { value: Reg, resume_label: Label },
     /// Unreachable (for incomplete blocks)
     Unreachable,
 }


### PR DESCRIPTION
## Summary

Make Yield a proper block terminator in LIR, correctly representing that it suspends execution and resumes in a new basic block. This is a correctness-of-representation change that prepares LIR for future JIT compilation.

**No VM or bytecode changes.** Same `Instruction::Yield` opcode, same continuation mechanism. The bytecode output is functionally identical.

## Changes

### LIR types
- `Terminator::Yield { value: Reg, resume_label: Label }` — new terminator that splits the block at yield points
- `LirInstr::LoadResumeValue { dst: Reg }` — pseudo-instruction at start of resume block (emits no bytecode, just registers the resume value in stack simulation)
- Removed `LirInstr::Yield { dst, value }` — replaced by the terminator

### Lowerer
- `fresh_label()` and `start_new_block()` helpers for multi-block functions
- `HirKind::Yield` lowering now terminates the current block, creates a resume block, and emits `LoadResumeValue` as its first instruction
- Yielding functions produce multiple basic blocks; non-yielding functions unchanged (single block)

### Emitter
- `yield_stack_state` field carries stack simulation state across yield boundaries
- Resume blocks inherit the pre-yield stack state (not empty), ensuring intermediate values on the operand stack survive across yield/resume
- `Terminator::Yield` handler emits `Instruction::Yield` and saves stack state
- `LoadResumeValue` handler registers the resume value — no bytecode emitted

## Why this matters

1. **Correct representation**: LIR analysis (liveness, optimization) needs to know values don't survive across yield without the VM's save/restore. Yield-as-terminator makes this explicit.
2. **JIT preparation**: Cranelift codegen needs basic blocks with explicit terminators to emit save/restore code at yield points.
3. **No regression**: All tests pass, bytecode is functionally identical.

## New Tests (4)

Tests that exercise intermediate operand stack values surviving across yield/resume:

| Test | Expression | Verifies |
|------|-----------|----------|
| `test_yield_with_intermediate_values_on_stack` | `(+ 1 (yield 2) 3)` | Single intermediate value |
| `test_yield_with_multiple_intermediate_values` | `(+ 1 2 (yield 3) 4 5)` | Multiple intermediates |
| `test_yield_in_nested_call_with_intermediate_values` | `(* 2 (+ 1 (yield 5) 3))` | Nested calls with intermediates |
| `test_multiple_yields_with_intermediate_values` | `(+ (+ 1 (yield 2) 3) (+ 4 (yield 5) 6))` | Multiple yields, each with intermediates |

## Verification
- ✅ `cargo test --workspace` — all tests pass
- ✅ `cargo clippy --workspace --all-targets -- -D warnings` — clean
- ✅ `cargo fmt -- --check` — formatted
- ✅ `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` — clean
- ✅ `elle-doc/generate.lisp` — site generates

## CPS Rework Progress
- [x] Phase 0: Tests + effect threading (#275)
- [x] Phase 1: First-class continuations (#276)
- [x] Phase 2: Delete CPS interpreter (#277)
- [x] Phase 3: Harden continuations (#278)
- [x] **Phase 4: LIR Yield terminator (this PR)**
- [ ] Phase 5: JIT support for yielding functions
