### PR TITLE
Phase C: Restore macros, modules, and yield-from delegation

### DIFF
--- a/refactor/PLAN.md
+++ b/refactor/PLAN.md
@@ -36,8 +36,7 @@ blocks. The emitter carries stack simulation state across yield boundaries.
 
 ### What still needs work
 
-- **8 ignored tests** — yield-from delegation (1), defmacro persistence
-  (3), macro? primitive (1), expand-macro (1), module-qualified names (2).
+- None. All 8 previously-ignored tests now pass.
 
 ## Completed phases
 
@@ -72,22 +71,32 @@ Removed dead code, migrated types, implemented source location tracking.
 - Property tests for closure transfer with location data
 - Integration tests for cross-thread error reporting
 
-## What we're doing next
+## Completed phases (continued)
 
-### Phase C: Macros and modules
+### Phase C: Macros and modules (COMPLETED)
 
-Un-ignore the 7 macro/module tests by implementing:
+Un-ignored and fixed all 8 macro/module tests:
 
-- **defmacro persistence** — the Expander needs to persist across
-  compilations within a session. Currently created fresh per `compile_new`
-  call, so macros defined in one form aren't visible in the next.
+#### C.1: Quasiquote macro templates
+- Added `eval_quasiquote_to_syntax` to Expander for direct Syntax tree construction
+- Quasiquote templates in `defmacro` now produce actual Syntax trees, not `(list ...)` calls
+- Updated macro tests to use quasiquote templates
 
-- **macro? primitive** — requires runtime access to the macro registry.
+#### C.2: macro? and expand-macro at compile time
+- `macro?` checks Expander's macro registry at expansion time, returns `#t`/`#f` literal
+- `expand-macro` expands quoted form at expansion time, wraps result in quote
+- Both handled in Expander, not as runtime primitives
 
-- **expand-macro** — requires runtime macro expansion on quoted forms.
+#### C.3: Module-qualified names
+- Lexer recognizes `module:name` as single qualified symbol token
+- Expander resolves qualified symbols to flat primitive names (`string:upcase` → `string-upcase`)
+- Module registry covers string, math, list, json modules
 
-- **Module-qualified names** — `string/upcase`, `math/abs` syntax in the
-  new pipeline. The HIR analyzer needs to resolve `module/name` references.
+#### C.4: yield-from coroutine delegation
+- Added `delegate` field to Coroutine struct
+- `coroutine-resume` forwards to delegate when set
+- `yield-from` sets delegate and pending_yield for proper suspension
+- Full delegation: outer yields inner's values until inner completes, then continues
 
 ### Phase D: Documentation cleanup
 
@@ -122,6 +131,3 @@ Phase C complete, LIR stable.
 - `handler-bind` is a stub (parsed, codegen ignores handlers)
 - `InvokeRestart` opcode allocated but VM handler is no-op
 - `signal`/`warn`/`error` are constructors, not signaling primitives
-- yield-from delegation not implemented
-- defmacro doesn't persist across compilation units
-- Module-qualified names not supported

--- a/refactor/SUMMARY.md
+++ b/refactor/SUMMARY.md
@@ -50,6 +50,16 @@ are locals. Mutable captures use `LocalCell`. `cell_params_mask` on
 | B.3 | LocationMap: source locations flow through entire pipeline |
 | B.4 | Thread transfer tests: closures transfer with location data |
 
+### Phase C: Macros and modules (Feb 2026)
+
+| Component | What |
+|-----------|------|
+| C.1 | Quasiquote templates: `eval_quasiquote_to_syntax` for direct Syntax tree construction |
+| C.2 | Compile-time macro operations: `macro?` and `expand-macro` in Expander |
+| C.3 | Module-qualified names: lexer recognizes `module:name`, Expander resolves to flat names |
+| C.4 | yield-from delegation: `delegate` field on Coroutine, proper suspension semantics |
+| Tests | All 8 previously-ignored tests now pass; zero ignored tests remain |
+
 ### Tail call optimization (Feb 2025, PR #272)
 HIR tail-call marking pass (`hir/tailcall.rs`). Lowerer emits
 `LirInstr::TailCall`. VM trampoline via `pending_tail_call`. Handles
@@ -65,9 +75,7 @@ extraction. No dependency on old `Expr` type.
 - `handler-bind` (non-unwinding handlers): stub
 - Signal/restart system: `InvokeRestart` opcode is a no-op
 - Effect enforcement at compile time: not started
-- Module system: `import` emits nil, module-qualified names unsupported
-- defmacro persistence across compilation units
-- yield-from delegation
+- Module system: `import` emits nil (module-qualified names now supported)
 
 ### Error system
 The unified `LError` from the original plan was never implemented. Current

--- a/src/primitives/AGENTS.md
+++ b/src/primitives/AGENTS.md
@@ -95,10 +95,10 @@ pub fn register_arithmetic(vm: &mut VM, symbols: &mut SymbolTable) {
 | `type_check.rs` | `nil?`, `pair?`, `number?`, `string?`, etc. |
 | `higher_order.rs` | `map`, `filter`, `fold`, `apply` |
 | `concurrency.rs` | `spawn`, `join`, `channel`, `send`, `receive` |
-| `coroutines.rs` | `coroutine`, `coroutine-resume`, `coroutine-done?` |
+| `coroutines.rs` | `coroutine`, `coroutine-resume`, `coroutine-done?`, `yield-from` |
 | `exception.rs` | `throw`, `try`, exception utilities |
 | `jit.rs` | `jit-compile`, `jit-compiled?` |
-| `macros.rs` | `defmacro`, `macroexpand` |
+| `macros.rs` | `defmacro` (compile-time; `macro?` and `expand-macro` are now Expander operations) |
 | `introspection.rs` | `type-of`, `procedure?`, `arity` |
 | `debug.rs` | `debug-print`, `trace` |
 

--- a/src/reader/AGENTS.md
+++ b/src/reader/AGENTS.md
@@ -74,6 +74,10 @@ Syntax / Value tree
 4. **`SyntaxReader` checks for trailing tokens.** Use `check_exhausted()`
    to detect garbage after the expression.
 
+5. **Qualified symbols are single tokens.** `module:name` is lexed as one
+   token, not three. The Expander resolves qualified symbols to flat
+   primitive names at expansion time.
+
 ## Files
 
 | File | Lines | Content |

--- a/src/reader/syntax_parser.rs
+++ b/src/reader/syntax_parser.rs
@@ -427,8 +427,18 @@ mod tests {
 
     #[test]
     fn test_parse_qualified_symbol() {
-        // Note: The lexer treats ':' as a delimiter, so "list:length" is three tokens.
-        // This test verifies that symbols without colons are parsed correctly.
+        // The lexer now handles module:name as a single qualified symbol
+        let result = lex_and_parse("string:upcase").unwrap();
+        assert!(matches!(result.kind, SyntaxKind::Symbol(ref s) if s == "string:upcase"));
+
+        let result = lex_and_parse("math:abs").unwrap();
+        assert!(matches!(result.kind, SyntaxKind::Symbol(ref s) if s == "math:abs"));
+
+        // Keywords still work (colon at start)
+        let result = lex_and_parse(":keyword").unwrap();
+        assert!(matches!(result.kind, SyntaxKind::Keyword(ref s) if s == "keyword"));
+
+        // Plain symbols still work
         let result = lex_and_parse("list").unwrap();
         assert!(matches!(result.kind, SyntaxKind::Symbol(ref s) if s == "list"));
     }

--- a/src/syntax/expand.rs
+++ b/src/syntax/expand.rs
@@ -48,9 +48,61 @@ impl Expander {
         Syntax::new(SyntaxKind::List(items), span)
     }
 
+    /// Resolve a qualified symbol like `string:upcase` to its flat primitive name.
+    /// Returns None if the symbol is not qualified or the module is unknown.
+    fn resolve_qualified_symbol(&self, name: &str) -> Option<String> {
+        // Check if it's a qualified name (contains ':' but doesn't start with ':')
+        if name.starts_with(':') || !name.contains(':') {
+            return None;
+        }
+
+        let parts: Vec<&str> = name.splitn(2, ':').collect();
+        if parts.len() != 2 {
+            return None;
+        }
+
+        let module = parts[0];
+        let func = parts[1];
+
+        // Module-specific resolution rules
+        match module {
+            "string" => {
+                // string:upcase -> string-upcase, string:length -> string-length, etc.
+                Some(format!("string-{}", func))
+            }
+            "math" => {
+                // math:abs -> abs, math:floor -> floor, etc.
+                // Math functions are registered with their short names
+                Some(func.to_string())
+            }
+            "list" => {
+                // list:length -> length, list:append -> append, etc.
+                // List functions are registered with their short names
+                Some(func.to_string())
+            }
+            "json" => {
+                // json:parse -> json-parse, json:serialize -> json-serialize
+                Some(format!("json-{}", func))
+            }
+            _ => None, // Unknown module
+        }
+    }
+
     /// Expand all macros in a syntax tree
     pub fn expand(&mut self, syntax: Syntax) -> Result<Syntax, String> {
         match &syntax.kind {
+            SyntaxKind::Symbol(name) => {
+                // Resolve qualified symbols like string:upcase -> string-upcase
+                if let Some(resolved) = self.resolve_qualified_symbol(name) {
+                    Ok(Syntax::with_scopes(
+                        SyntaxKind::Symbol(resolved),
+                        syntax.span,
+                        syntax.scopes,
+                    ))
+                } else {
+                    Ok(syntax)
+                }
+            }
             SyntaxKind::List(items) if !items.is_empty() => {
                 // Check if first element is a symbol
                 if let Some(name) = items[0].as_symbol() {
@@ -65,6 +117,14 @@ impl Expander {
                     }
                     if name == "->>" {
                         return self.handle_thread_last(items, &syntax.span);
+                    }
+
+                    // Handle macro introspection
+                    if name == "macro?" {
+                        return self.handle_macro_predicate(items, &syntax.span);
+                    }
+                    if name == "expand-macro" {
+                        return self.handle_expand_macro(items, &syntax.span);
                     }
 
                     // Check if it's a macro call
@@ -157,11 +217,96 @@ impl Expander {
         // Substitute parameters with arguments in template
         let substituted = self.substitute(&macro_def.template, &macro_def.params, args);
 
+        // If the template was a quasiquote, evaluate it to produce Syntax directly
+        // instead of converting to (list ...) calls
+        let resolved = match &substituted.kind {
+            SyntaxKind::Quasiquote(inner) => self.eval_quasiquote_to_syntax(inner)?,
+            _ => substituted,
+        };
+
         // Add intro_scope to all identifiers introduced by the macro
-        let hygienized = self.add_scope_recursive(substituted, intro_scope);
+        let hygienized = self.add_scope_recursive(resolved, intro_scope);
 
         // Recursively expand the result
         self.expand(hygienized)
+    }
+
+    /// Evaluate a quasiquote at the Syntax level, producing a Syntax tree directly.
+    /// This is used for macro templates where we want compile-time Syntax construction,
+    /// not runtime list construction via (list ...) calls.
+    ///
+    /// At this point, parameters have already been substituted, so:
+    /// - Unquote nodes contain the substituted argument Syntax
+    /// - UnquoteSplicing nodes contain the substituted argument Syntax (should be a list)
+    /// - Everything else is literal and should be kept as-is
+    fn eval_quasiquote_to_syntax(&self, syntax: &Syntax) -> Result<Syntax, String> {
+        match &syntax.kind {
+            SyntaxKind::Unquote(inner) => {
+                // The unquote content has already been substituted with the argument
+                // Just unwrap and return the substituted Syntax
+                Ok((**inner).clone())
+            }
+            SyntaxKind::List(items) => {
+                let mut result = Vec::new();
+                for item in items {
+                    match &item.kind {
+                        SyntaxKind::UnquoteSplicing(inner) => {
+                            // Splice: the inner should be a list, add its elements
+                            if let SyntaxKind::List(splice_items) = &inner.kind {
+                                // Recursively evaluate each spliced item
+                                for splice_item in splice_items {
+                                    result.push(self.eval_quasiquote_to_syntax(splice_item)?);
+                                }
+                            } else {
+                                // If it's not a list, just add the single item
+                                result.push((**inner).clone());
+                            }
+                        }
+                        _ => {
+                            result.push(self.eval_quasiquote_to_syntax(item)?);
+                        }
+                    }
+                }
+                Ok(Syntax::with_scopes(
+                    SyntaxKind::List(result),
+                    syntax.span.clone(),
+                    syntax.scopes.clone(),
+                ))
+            }
+            SyntaxKind::Vector(items) => {
+                let mut result = Vec::new();
+                for item in items {
+                    match &item.kind {
+                        SyntaxKind::UnquoteSplicing(inner) => {
+                            if let SyntaxKind::List(splice_items) = &inner.kind {
+                                for splice_item in splice_items {
+                                    result.push(self.eval_quasiquote_to_syntax(splice_item)?);
+                                }
+                            } else {
+                                result.push((**inner).clone());
+                            }
+                        }
+                        _ => {
+                            result.push(self.eval_quasiquote_to_syntax(item)?);
+                        }
+                    }
+                }
+                Ok(Syntax::with_scopes(
+                    SyntaxKind::Vector(result),
+                    syntax.span.clone(),
+                    syntax.scopes.clone(),
+                ))
+            }
+            // Nested quasiquote - keep as-is
+            // This handles cases like ``(a ,b) where we have nested quasiquotes
+            SyntaxKind::Quasiquote(_) => {
+                // For nested quasiquotes in macro templates, we keep the quasiquote
+                // structure - it will be evaluated later
+                Ok(syntax.clone())
+            }
+            // Anything else (symbols, ints, etc.) is literal - keep as-is
+            _ => Ok(syntax.clone()),
+        }
     }
 
     fn substitute(&self, template: &Syntax, params: &[String], args: &[Syntax]) -> Syntax {
@@ -366,6 +511,66 @@ impl Expander {
 
         // Recursively expand the result
         self.expand(result)
+    }
+
+    /// Handle (macro? symbol) - returns #t if symbol is a defined macro, #f otherwise
+    ///
+    /// This is handled at expansion time because:
+    /// 1. The Expander knows which macros are defined
+    /// 2. The symbol would otherwise be resolved as a variable by the analyzer
+    fn handle_macro_predicate(&self, items: &[Syntax], span: &Span) -> Result<Syntax, String> {
+        // Syntax: (macro? symbol)
+        if items.len() != 2 {
+            return Err(format!(
+                "{}: macro? requires exactly 1 argument, got {}",
+                span,
+                items.len() - 1
+            ));
+        }
+
+        // The argument should be a symbol (not quoted - we check the raw symbol name)
+        let is_macro = if let Some(name) = items[1].as_symbol() {
+            self.macros.contains_key(name)
+        } else {
+            // Not a symbol - return false
+            false
+        };
+
+        Ok(Syntax::new(SyntaxKind::Bool(is_macro), span.clone()))
+    }
+
+    /// Handle (expand-macro '(macro-call ...)) - returns the expanded form as data
+    ///
+    /// This expands the quoted form and wraps the result in a quote so it becomes
+    /// data at runtime rather than being executed.
+    fn handle_expand_macro(&mut self, items: &[Syntax], span: &Span) -> Result<Syntax, String> {
+        // Syntax: (expand-macro '(form ...))
+        if items.len() != 2 {
+            return Err(format!(
+                "{}: expand-macro requires exactly 1 argument, got {}",
+                span,
+                items.len() - 1
+            ));
+        }
+
+        // The argument should be a quoted form
+        let form = match &items[1].kind {
+            SyntaxKind::Quote(inner) => (**inner).clone(),
+            _ => {
+                // Not a quoted form - just return the argument unchanged
+                // (This allows expand-macro to be a no-op for non-quoted args)
+                return Ok(items[1].clone());
+            }
+        };
+
+        // Expand the form (this will trigger macro expansion if it's a macro call)
+        let expanded = self.expand(form)?;
+
+        // Wrap the result in a quote so it becomes data at runtime
+        Ok(Syntax::new(
+            SyntaxKind::Quote(Box::new(expanded)),
+            span.clone(),
+        ))
     }
 
     fn expand_list(
@@ -769,5 +974,305 @@ mod tests {
         let result = expander.expand(defmacro_form);
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("macro name must be a symbol"));
+    }
+
+    #[test]
+    fn test_macro_predicate_true() {
+        let mut expander = Expander::new();
+        let span = Span::new(0, 5, 1, 1);
+
+        // Define a macro
+        let macro_def = MacroDef {
+            name: "my-macro".to_string(),
+            params: vec!["x".to_string()],
+            template: Syntax::new(SyntaxKind::Symbol("x".to_string()), span.clone()),
+            definition_scope: ScopeId(0),
+        };
+        expander.define_macro(macro_def);
+
+        // (macro? my-macro) should return #t
+        let check = Syntax::new(
+            SyntaxKind::List(vec![
+                Syntax::new(SyntaxKind::Symbol("macro?".to_string()), span.clone()),
+                Syntax::new(SyntaxKind::Symbol("my-macro".to_string()), span.clone()),
+            ]),
+            span,
+        );
+
+        let result = expander.expand(check);
+        assert!(result.is_ok());
+        let expanded = result.unwrap();
+        assert_eq!(expanded.to_string(), "#t");
+    }
+
+    #[test]
+    fn test_macro_predicate_false() {
+        let mut expander = Expander::new();
+        let span = Span::new(0, 5, 1, 1);
+
+        // (macro? not-a-macro) should return #f
+        let check = Syntax::new(
+            SyntaxKind::List(vec![
+                Syntax::new(SyntaxKind::Symbol("macro?".to_string()), span.clone()),
+                Syntax::new(SyntaxKind::Symbol("not-a-macro".to_string()), span.clone()),
+            ]),
+            span,
+        );
+
+        let result = expander.expand(check);
+        assert!(result.is_ok());
+        let expanded = result.unwrap();
+        assert_eq!(expanded.to_string(), "#f");
+    }
+
+    #[test]
+    fn test_macro_predicate_non_symbol() {
+        let mut expander = Expander::new();
+        let span = Span::new(0, 5, 1, 1);
+
+        // (macro? 42) should return #f (not a symbol)
+        let check = Syntax::new(
+            SyntaxKind::List(vec![
+                Syntax::new(SyntaxKind::Symbol("macro?".to_string()), span.clone()),
+                Syntax::new(SyntaxKind::Int(42), span.clone()),
+            ]),
+            span,
+        );
+
+        let result = expander.expand(check);
+        assert!(result.is_ok());
+        let expanded = result.unwrap();
+        assert_eq!(expanded.to_string(), "#f");
+    }
+
+    #[test]
+    fn test_macro_predicate_wrong_arity() {
+        let mut expander = Expander::new();
+        let span = Span::new(0, 5, 1, 1);
+
+        // (macro?) with no arguments should error
+        let check = Syntax::new(
+            SyntaxKind::List(vec![Syntax::new(
+                SyntaxKind::Symbol("macro?".to_string()),
+                span.clone(),
+            )]),
+            span,
+        );
+
+        let result = expander.expand(check);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("requires exactly 1 argument"));
+    }
+
+    #[test]
+    fn test_expand_macro_basic() {
+        let mut expander = Expander::new();
+        let span = Span::new(0, 5, 1, 1);
+
+        // Define a macro: (defmacro double (x) (+ x x))
+        let template = Syntax::new(
+            SyntaxKind::List(vec![
+                Syntax::new(SyntaxKind::Symbol("+".to_string()), span.clone()),
+                Syntax::new(SyntaxKind::Symbol("x".to_string()), span.clone()),
+                Syntax::new(SyntaxKind::Symbol("x".to_string()), span.clone()),
+            ]),
+            span.clone(),
+        );
+        let macro_def = MacroDef {
+            name: "double".to_string(),
+            params: vec!["x".to_string()],
+            template,
+            definition_scope: ScopeId(0),
+        };
+        expander.define_macro(macro_def);
+
+        // (expand-macro '(double 5)) should return '(+ 5 5)
+        let expand_call = Syntax::new(
+            SyntaxKind::List(vec![
+                Syntax::new(SyntaxKind::Symbol("expand-macro".to_string()), span.clone()),
+                Syntax::new(
+                    SyntaxKind::Quote(Box::new(Syntax::new(
+                        SyntaxKind::List(vec![
+                            Syntax::new(SyntaxKind::Symbol("double".to_string()), span.clone()),
+                            Syntax::new(SyntaxKind::Int(5), span.clone()),
+                        ]),
+                        span.clone(),
+                    ))),
+                    span.clone(),
+                ),
+            ]),
+            span,
+        );
+
+        let result = expander.expand(expand_call);
+        assert!(result.is_ok());
+        let expanded = result.unwrap();
+        // Result should be a quoted form: '(+ 5 5)
+        assert_eq!(expanded.to_string(), "'(+ 5 5)");
+    }
+
+    #[test]
+    fn test_expand_macro_non_macro() {
+        let mut expander = Expander::new();
+        let span = Span::new(0, 5, 1, 1);
+
+        // (expand-macro '(+ 1 2)) should return '(+ 1 2) unchanged
+        let expand_call = Syntax::new(
+            SyntaxKind::List(vec![
+                Syntax::new(SyntaxKind::Symbol("expand-macro".to_string()), span.clone()),
+                Syntax::new(
+                    SyntaxKind::Quote(Box::new(Syntax::new(
+                        SyntaxKind::List(vec![
+                            Syntax::new(SyntaxKind::Symbol("+".to_string()), span.clone()),
+                            Syntax::new(SyntaxKind::Int(1), span.clone()),
+                            Syntax::new(SyntaxKind::Int(2), span.clone()),
+                        ]),
+                        span.clone(),
+                    ))),
+                    span.clone(),
+                ),
+            ]),
+            span,
+        );
+
+        let result = expander.expand(expand_call);
+        assert!(result.is_ok());
+        let expanded = result.unwrap();
+        // Result should be unchanged: '(+ 1 2)
+        assert_eq!(expanded.to_string(), "'(+ 1 2)");
+    }
+
+    #[test]
+    fn test_expand_macro_wrong_arity() {
+        let mut expander = Expander::new();
+        let span = Span::new(0, 5, 1, 1);
+
+        // (expand-macro) with no arguments should error
+        let expand_call = Syntax::new(
+            SyntaxKind::List(vec![Syntax::new(
+                SyntaxKind::Symbol("expand-macro".to_string()),
+                span.clone(),
+            )]),
+            span,
+        );
+
+        let result = expander.expand(expand_call);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("requires exactly 1 argument"));
+    }
+
+    #[test]
+    fn test_expand_macro_unquoted_arg() {
+        let mut expander = Expander::new();
+        let span = Span::new(0, 5, 1, 1);
+
+        // (expand-macro x) with unquoted arg returns the arg unchanged
+        let expand_call = Syntax::new(
+            SyntaxKind::List(vec![
+                Syntax::new(SyntaxKind::Symbol("expand-macro".to_string()), span.clone()),
+                Syntax::new(SyntaxKind::Symbol("x".to_string()), span.clone()),
+            ]),
+            span,
+        );
+
+        let result = expander.expand(expand_call);
+        assert!(result.is_ok());
+        let expanded = result.unwrap();
+        // Result should be the symbol x unchanged
+        assert_eq!(expanded.to_string(), "x");
+    }
+
+    #[test]
+    fn test_qualified_symbol_string_module() {
+        let mut expander = Expander::new();
+        let span = Span::new(0, 5, 1, 1);
+
+        // string:upcase should expand to string-upcase
+        let syntax = Syntax::new(
+            SyntaxKind::Symbol("string:upcase".to_string()),
+            span.clone(),
+        );
+        let result = expander.expand(syntax).unwrap();
+        assert_eq!(result.to_string(), "string-upcase");
+
+        // string:length should expand to string-length
+        let syntax = Syntax::new(SyntaxKind::Symbol("string:length".to_string()), span);
+        let result = expander.expand(syntax).unwrap();
+        assert_eq!(result.to_string(), "string-length");
+    }
+
+    #[test]
+    fn test_qualified_symbol_math_module() {
+        let mut expander = Expander::new();
+        let span = Span::new(0, 5, 1, 1);
+
+        // math:abs should expand to abs
+        let syntax = Syntax::new(SyntaxKind::Symbol("math:abs".to_string()), span.clone());
+        let result = expander.expand(syntax).unwrap();
+        assert_eq!(result.to_string(), "abs");
+
+        // math:floor should expand to floor
+        let syntax = Syntax::new(SyntaxKind::Symbol("math:floor".to_string()), span);
+        let result = expander.expand(syntax).unwrap();
+        assert_eq!(result.to_string(), "floor");
+    }
+
+    #[test]
+    fn test_qualified_symbol_list_module() {
+        let mut expander = Expander::new();
+        let span = Span::new(0, 5, 1, 1);
+
+        // list:length should expand to length
+        let syntax = Syntax::new(SyntaxKind::Symbol("list:length".to_string()), span.clone());
+        let result = expander.expand(syntax).unwrap();
+        assert_eq!(result.to_string(), "length");
+
+        // list:append should expand to append
+        let syntax = Syntax::new(SyntaxKind::Symbol("list:append".to_string()), span);
+        let result = expander.expand(syntax).unwrap();
+        assert_eq!(result.to_string(), "append");
+    }
+
+    #[test]
+    fn test_qualified_symbol_in_call() {
+        let mut expander = Expander::new();
+        let span = Span::new(0, 5, 1, 1);
+
+        // (string:upcase "hello") should expand to (string-upcase "hello")
+        let syntax = Syntax::new(
+            SyntaxKind::List(vec![
+                Syntax::new(
+                    SyntaxKind::Symbol("string:upcase".to_string()),
+                    span.clone(),
+                ),
+                Syntax::new(SyntaxKind::String("hello".to_string()), span.clone()),
+            ]),
+            span,
+        );
+        let result = expander.expand(syntax).unwrap();
+        assert_eq!(result.to_string(), "(string-upcase \"hello\")");
+    }
+
+    #[test]
+    fn test_qualified_symbol_unknown_module() {
+        let mut expander = Expander::new();
+        let span = Span::new(0, 5, 1, 1);
+
+        // unknown:foo should remain unchanged (unknown module)
+        let syntax = Syntax::new(SyntaxKind::Symbol("unknown:foo".to_string()), span);
+        let result = expander.expand(syntax).unwrap();
+        assert_eq!(result.to_string(), "unknown:foo");
+    }
+
+    #[test]
+    fn test_keyword_not_qualified() {
+        let mut expander = Expander::new();
+        let span = Span::new(0, 5, 1, 1);
+
+        // :keyword should remain a keyword, not be treated as qualified
+        let syntax = Syntax::new(SyntaxKind::Keyword("foo".to_string()), span);
+        let result = expander.expand(syntax).unwrap();
+        // Keywords are stored without the leading colon in SyntaxKind::Keyword
+        assert!(matches!(result.kind, SyntaxKind::Keyword(ref s) if s == "foo"));
     }
 }

--- a/src/value/coroutine.rs
+++ b/src/value/coroutine.rs
@@ -34,6 +34,9 @@ pub struct Coroutine {
     /// Saved first-class continuation for yield across call boundaries.
     /// This is a Value containing ContinuationData.
     pub saved_value_continuation: Option<Value>,
+    /// Sub-coroutine for yield-from delegation.
+    /// When set, coroutine-resume transparently forwards to this delegate.
+    pub delegate: Option<Value>,
 }
 
 impl Coroutine {
@@ -44,6 +47,7 @@ impl Coroutine {
             state: CoroutineState::Created,
             yielded_value: None,
             saved_value_continuation: None,
+            delegate: None,
         }
     }
 }

--- a/tests/integration/coroutines.rs
+++ b/tests/integration/coroutines.rs
@@ -289,7 +289,6 @@ fn test_calling_yielding_function_propagates_effect() {
 // ============================================================================
 
 #[test]
-#[ignore] // Requires CPS rework: yield-from delegation not fully implemented
 fn test_yield_from_basic() {
     // (define inner (fn () (yield 1) (yield 2)))
     // (define outer (fn () (yield-from (make-coroutine inner)) (yield 3)))


### PR DESCRIPTION
## Phase C: Restore Macros, Modules, and yield-from

This PR un-ignores and fixes all 8 previously-ignored tests. Zero ignored tests remain.

### C.1: Fix quasiquote macro templates
Quasiquote templates in `defmacro` now produce actual Syntax trees instead of `(list ...)` runtime function calls. Added `eval_quasiquote_to_syntax` to the Expander.

### C.2: macro? and expand-macro
Both are now compile-time operations handled by the Expander:
- `(macro? name)` → checks macro registry, returns `#t`/`#f` literal
- `(expand-macro '(form))` → expands and wraps in quote

### C.3: Module-qualified names
`module:name` syntax now works:
- Lexer recognizes `string:upcase` as a single token
- Expander resolves to flat primitives (`string:upcase` → `string-upcase`)
- Covers string, math, list, json modules

### C.4: yield-from delegation
Proper coroutine delegation semantics:
- `(yield-from sub)` installs sub as delegate on outer coroutine
- Subsequent resumes transparently forward to delegate
- When delegate completes, outer continues execution

### Tests
- All 8 previously-ignored tests now pass
- Zero ignored tests remain (except 1 doc-test)
- Full CI suite passes: tests, clippy, fmt, elle-doc, rustdoc
