### PR TITLE
fix: caught SIG_ERROR leaves fiber Suspended, not Error (#299)

### DIFF
--- a/src/value/fiber.rs
+++ b/src/value/fiber.rs
@@ -162,7 +162,8 @@ pub const SIG_QUERY: SignalBits = 1 << 7; // VM state query (VM-internal)
 // The VM dispatch loop checks all bits. User code only sees
 // bits 0-2 and 16-31. Bits 3-15 are internal.
 
-/// Fiber status. Matches Janet's model.
+/// Fiber lifecycle status. Diverges from Janet: caught SIG_ERROR leaves
+/// fiber Suspended (resumable), not Error. See vm/fiber.rs for details.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FiberStatus {
     /// Not yet started (has closure but hasn't been resumed)


### PR DESCRIPTION
Closes #299

## Summary

- `with_child_fiber` now sets provisional status (Dead or Suspended) instead of unconditionally marking SIG_ERROR as terminal
- Callers finalize status based on signal mask: caught SIG_ERROR → Suspended (resumable), uncaught → Error (terminal)
- Cancel operations always result in Error status regardless of mask

## Note

This intentionally diverges from Janet, where all non-yield signals are terminal. Elle's model treats terminality as a handler decision, enabling condition/restart-style recovery patterns.

## Test Results

- ✅ 1711 tests pass
- ✅ clippy clean (no warnings)
- ✅ code formatted
