### PR TITLE
fix: show symbol name in undefined variable errors (#300)

### DIFF
--- a/src/ffi/primitives/context.rs
+++ b/src/ffi/primitives/context.rs
@@ -43,6 +43,16 @@ pub fn clear_symbol_table() {
     SYMBOL_TABLE.with(|ctx| *ctx.borrow_mut() = None);
 }
 
+/// Resolve a symbol ID to its name using the thread-local symbol table.
+/// Returns None if the symbol table is unavailable or the ID is unknown.
+pub fn resolve_symbol_name(sym_id: u32) -> Option<String> {
+    unsafe {
+        get_symbol_table()
+            .and_then(|ptr| (*ptr).name(crate::value::SymbolId(sym_id)))
+            .map(|s| s.to_string())
+    }
+}
+
 /// Register FFI primitives in the VM.
 pub fn register_ffi_primitives(_vm: &mut VM) {
     // Phase 2: FFI primitives for function calling

--- a/src/vm/variables.rs
+++ b/src/vm/variables.rs
@@ -23,7 +23,9 @@ pub fn handle_load_global(vm: &mut VM, bytecode: &[u8], ip: &mut usize, constant
             vm.fiber.stack.push(*val);
         } else {
             // Signal undefined-variable exception
-            let msg = format!("undefined variable: symbol #{}", sym_id);
+            let name = crate::ffi::primitives::context::resolve_symbol_name(sym_id)
+                .unwrap_or_else(|| format!("symbol #{}", sym_id));
+            let msg = format!("undefined variable: {}", name);
             vm.fiber.signal = Some((SIG_ERROR, error_val("undefined-variable", msg)));
             vm.fiber.stack.push(Value::NIL); // Push placeholder
         }

--- a/tests/integration/core.rs
+++ b/tests/integration/core.rs
@@ -225,6 +225,24 @@ fn test_undefined_variable() {
 }
 
 #[test]
+fn test_undefined_variable_error_shows_name() {
+    // Issue #300: error message should show the variable name, not a SymbolId
+    let result = eval("nonexistent-foo");
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(
+        err.contains("nonexistent-foo"),
+        "Error should contain variable name, got: {}",
+        err
+    );
+    assert!(
+        !err.contains("symbol #"),
+        "Error should not contain raw SymbolId, got: {}",
+        err
+    );
+}
+
+#[test]
 fn test_arity_error() {
     assert!(eval("(+)").is_ok()); // + accepts 0 args
     assert!(eval("(first)").is_err()); // first requires 1 arg


### PR DESCRIPTION
Closes #300

## Summary
- Added `resolve_symbol_name(sym_id)` helper to `ffi/primitives/context.rs` — encapsulates the unsafe thread-local symbol table access in one place
- `handle_load_global` in `vm/variables.rs` now shows `undefined variable: foo` instead of `undefined variable: symbol #208`
- Falls back to `symbol #N` if the symbol table is unavailable (defensive, shouldn't happen in practice)

## Test results
1121 tests pass, clippy clean.
