### PR TITLE
fix: make type-of return :list for all list-like values

### DIFF
--- a/docs/BUILTINS.md
+++ b/docs/BUILTINS.md
@@ -836,7 +836,7 @@ This document provides comprehensive documentation for all built-in primitives i
 ⟹ :string
 
 (type-of (list 1 2))
-⟹ :pair
+⟹ :list
 
 (type-of nil)
 ⟹ :nil

--- a/docs/WHAT_S_NEW.md
+++ b/docs/WHAT_S_NEW.md
@@ -539,7 +539,7 @@ Get the type name as a keyword:
 (type-of "hello")⟹ :string
 (type-of #t)     ⟹ :boolean
 (type-of 'x)     ⟹ :symbol
-(type-of (list)) ⟹ :pair
+(type-of (list)) ⟹ :list
 ```
 
 ---

--- a/src/value/heap.rs
+++ b/src/value/heap.rs
@@ -143,7 +143,7 @@ impl HeapObject {
     pub fn type_name(&self) -> &'static str {
         match self {
             HeapObject::String(_) => "string",
-            HeapObject::Cons(_) => "cons",
+            HeapObject::Cons(_) => "list",
             HeapObject::Vector(_) => "vector",
             HeapObject::Table(_) => "table",
             HeapObject::Struct(_) => "struct",

--- a/src/value/repr/tests.rs
+++ b/src/value/repr/tests.rs
@@ -194,7 +194,7 @@ fn test_type_name() {
     assert_eq!(Value::string("test").type_name(), "string");
     assert_eq!(
         Value::cons(Value::NIL, Value::EMPTY_LIST).type_name(),
-        "cons"
+        "list"
     );
     assert_eq!(Value::vector(vec![]).type_name(), "vector");
     assert_eq!(Value::table().type_name(), "table");

--- a/tests/integration/core.rs
+++ b/tests/integration/core.rs
@@ -459,6 +459,31 @@ fn test_type() {
     }
 }
 
+#[test]
+fn test_type_of_list_consistency() {
+    // Issue #308: type-of should return :list for all list-like values
+    let empty = eval("(type-of ())").unwrap();
+    let proper = eval("(type-of (list 1 2))").unwrap();
+    let cons = eval("(type-of (cons 1 2))").unwrap();
+
+    assert!(empty.is_keyword(), "expected keyword for empty list");
+    assert!(proper.is_keyword(), "expected keyword for proper list");
+    assert!(cons.is_keyword(), "expected keyword for cons cell");
+
+    // All three must return the same keyword
+    assert_eq!(
+        empty, proper,
+        "empty list and proper list should have same type"
+    );
+    assert_eq!(
+        proper, cons,
+        "proper list and cons cell should have same type"
+    );
+
+    // And that keyword should be :list
+    assert_eq!(eval("(eq? (type-of ()) :list)").unwrap(), Value::TRUE);
+}
+
 // Math functions
 #[test]
 fn test_sqrt() {


### PR DESCRIPTION
## Summary

Fixes #308. `type-of` returned inconsistent type names for list values: `:list` for empty lists, `:cons` for cons cells, while docs said `:pair`.

## Changes

- `HeapObject::Cons::type_name()` now returns `"list"` instead of `"cons"`, matching the empty list case
- Updated `BUILTINS.md` and `WHAT_S_NEW.md` to document `:list` instead of `:pair`
- Added integration test `test_type_of_list_consistency` verifying all three forms return the same keyword
- Updated unit test assertion to expect `"list"`

## Design rationale

- `:list` aligns with `list?` predicate (which is "empty list OR cons cell")
- Walking the spine to distinguish proper/improper lists would be O(n) — rejected
- `pair?` predicate remains unchanged — it tests structural "is this a cons cell?"
