### PR TITLE
feat: add (halt) primitive for graceful VM termination

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,6 +146,10 @@ Things that look wrong but aren't:
   returns `EMPTY_LIST`. Use `empty?` (not `nil?`) to check for end-of-list.
   `nil?` only matches `Value::NIL`. This distinction matters in recursive
   list functions and affects `elle-doc/` and `examples/`.
+- Signal bits are partitioned: Bits 0-2 are user-facing (error, yield, debug),
+  Bits 3-7 are VM-internal (resume, FFI, propagate, cancel, query, halt),
+  Bits 9-15 are reserved, and Bits 16-31 are for user-defined signal types.
+  See `src/value/fiber.rs` for the full bit layout.
 
 ## Conventions
 

--- a/docs/BUILTINS.md
+++ b/docs/BUILTINS.md
@@ -2233,6 +2233,29 @@ Parse JSON, modify, and serialize back:
 
 ---
 
+## Process Control
+
+### `halt` (Halt VM)
+
+**Semantics**: Signals the VM to stop execution and return a value to the host. Unlike `exit`, does not terminate the process. The signal is maskable by fiber signal masks but non-resumable: the halted fiber is Dead.
+
+**Usage**:
+```lisp
+(halt)         ; halt, return nil
+(halt value)   ; halt, return value
+```
+
+**Examples**:
+```lisp
+(halt 42)
+⟹ 42
+
+(begin (halt 1) 2)
+⟹ 1
+```
+
+---
+
 ## Module & Package Operations
 
 ### `import-file` (Import Module)

--- a/src/effects/AGENTS.md
+++ b/src/effects/AGENTS.md
@@ -18,6 +18,7 @@ debug, ffi) and which parameter indices propagate their callee's effects.
 | `Effect::yields()` | May yield (SIG_YIELD) |
 | `Effect::yields_raises()` | May yield and raise |
 | `Effect::ffi()` | Calls foreign code (SIG_FFI) |
+| `Effect::halts()` | May halt (SIG_HALT) |
 | `Effect::polymorphic(n)` | Effect depends on parameter n |
 | `Effect::polymorphic_raises(n)` | Polymorphic + may raise |
 | `get_primitive_effects` | Returns effect map for already-interned primitives |
@@ -32,6 +33,7 @@ Each predicate asks a specific question. No vague "is_pure".
 | `may_yield()` | Can yield? (SIG_YIELD) |
 | `may_raise()` | Can raise an error? (SIG_ERROR) |
 | `may_ffi()` | Calls foreign code? (SIG_FFI) |
+| `may_halt()` | Can halt? (SIG_HALT) |
 | `is_polymorphic()` | Effect depends on arguments? (propagates != 0) |
 | `propagated_params()` | Iterator over propagated parameter indices |
 

--- a/src/primitives/AGENTS.md
+++ b/src/primitives/AGENTS.md
@@ -106,6 +106,7 @@ pub fn register_arithmetic(vm: &mut VM, symbols: &mut SymbolTable) {
 | `meta.rs` | `gensym` (runtime unique symbol generation) |
 | `debugging.rs` | `closure?`, `jit?`, `pure?`, `mutates-params?`, `raises?`, `arity`, `captures`, `bytecode-size`, `call-count`, `global?`, `string->keyword`, `disbit`, `disjit` |
 | `debug.rs` | `debug-print`, `trace`, `memory-usage` |
+| `process.rs` | `exit`, `halt` |
 
 ## Files
 

--- a/src/primitives/registration.rs
+++ b/src/primitives/registration.rs
@@ -50,7 +50,7 @@ use super::math::{
 use super::meta::prim_gensym;
 use super::module_loading::{prim_add_module_path, prim_import_file};
 use super::package::{prim_package_info, prim_package_version};
-use super::process::prim_exit;
+use super::process::{prim_exit, prim_halt};
 
 use super::string::{
     prim_any_to_string, prim_char_at, prim_keyword_to_string, prim_number_to_string,
@@ -813,7 +813,7 @@ pub fn register_primitives(vm: &mut VM, symbols: &mut SymbolTable) -> HashMap<Sy
         Effect::none(),
     );
 
-    // Process control - can raise
+    // Process control
     register_fn(
         vm,
         symbols,
@@ -821,6 +821,14 @@ pub fn register_primitives(vm: &mut VM, symbols: &mut SymbolTable) -> HashMap<Sy
         "exit",
         prim_exit,
         Effect::raises(),
+    );
+    register_fn(
+        vm,
+        symbols,
+        &mut effects,
+        "halt",
+        prim_halt,
+        Effect::halts(),
     );
 
     // Debugging and profiling primitives - pure

--- a/src/value/AGENTS.md
+++ b/src/value/AGENTS.md
@@ -54,7 +54,7 @@ These are set during the swap protocol in `vm/fiber.rs::with_child_fiber`.
 | `SuspendedFrame` | `fiber.rs` | Bytecode/constants/env/IP/stack for resuming a suspended fiber |
 | `Frame` | `fiber.rs` | Single call frame (closure + ip + base) |
 | `FiberStatus` | `fiber.rs` | Fiber lifecycle: New, Alive, Suspended, Dead, Error |
-| `SignalBits` | `fiber.rs` | u32 bitmask: SIG_OK(0), SIG_ERROR(1), SIG_YIELD(2), SIG_DEBUG(4), SIG_RESUME(8), SIG_FFI(16), SIG_PROPAGATE(32), SIG_CANCEL(64) |
+| `SignalBits` | `fiber.rs` | u32 bitmask: SIG_OK(0), SIG_ERROR(1), SIG_YIELD(2), SIG_DEBUG(4), SIG_RESUME(8), SIG_FFI(16), SIG_PROPAGATE(32), SIG_CANCEL(64), SIG_HALT(256) |
 | `Arity` | `types.rs` | Function arity (Exact, AtLeast, Range) |
 | `SymbolId` | `types.rs` | Interned symbol identifier |
 | `SendValue` | `send.rs` | Thread-safe value wrapper |

--- a/src/value/fiber.rs
+++ b/src/value/fiber.rs
@@ -147,6 +147,7 @@ pub const SIG_FFI: SignalBits = 1 << 4; // calls foreign code
 pub const SIG_PROPAGATE: SignalBits = 1 << 5; // re-raise caught signal (VM-internal)
 pub const SIG_CANCEL: SignalBits = 1 << 6; // inject error into fiber (VM-internal)
 pub const SIG_QUERY: SignalBits = 1 << 7; // VM state query (VM-internal)
+pub const SIG_HALT: SignalBits = 1 << 8; // graceful VM termination
 
 // Signal bit partitioning:
 //
@@ -156,7 +157,8 @@ pub const SIG_QUERY: SignalBits = 1 << 7; // VM state query (VM-internal)
 //   Bit  5:     Propagate — re-raise caught signal (VM-internal)
 //   Bit  6:     Cancel — inject error into fiber (VM-internal)
 //   Bit  7:     Query — read VM state without fiber swap (VM-internal)
-//   Bits 8-15:  Reserved for future use
+//   Bit  8:     Halt — graceful VM termination with return value
+//   Bits 9-15:  Reserved for future use
 //   Bits 16-31: User-defined signal types
 //
 // The VM dispatch loop checks all bits. User code only sees

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -33,7 +33,8 @@ pub use types::{Arity, NativeFn, SymbolId, TableKey};
 pub use closure::Closure;
 pub use fiber::{
     CallFrame, Fiber, FiberHandle, FiberStatus, Frame, SignalBits, SuspendedFrame, WeakFiberHandle,
-    SIG_CANCEL, SIG_DEBUG, SIG_ERROR, SIG_OK, SIG_PROPAGATE, SIG_QUERY, SIG_RESUME, SIG_YIELD,
+    SIG_CANCEL, SIG_DEBUG, SIG_ERROR, SIG_HALT, SIG_OK, SIG_PROPAGATE, SIG_QUERY, SIG_RESUME,
+    SIG_YIELD,
 };
 
 // Export FFI types

--- a/src/vm/AGENTS.md
+++ b/src/vm/AGENTS.md
@@ -21,7 +21,7 @@ Does NOT:
 | Type | Purpose |
 |------|---------|
 | `VM` | Global state + root Fiber. Per-execution state lives on `vm.fiber` |
-| `SignalBits` | Internal return type: `SIG_OK`, `SIG_ERROR`, `SIG_YIELD`, `SIG_DEBUG`, `SIG_RESUME`, `SIG_FFI`, `SIG_PROPAGATE`, `SIG_CANCEL` |
+| `SignalBits` | Internal return type: `SIG_OK`, `SIG_ERROR`, `SIG_YIELD`, `SIG_DEBUG`, `SIG_RESUME`, `SIG_FFI`, `SIG_PROPAGATE`, `SIG_CANCEL`, `SIG_HALT` |
 | `CallFrame` | Function name, IP, frame base |
 
 ## Data flow
@@ -58,6 +58,7 @@ inner dispatch loop):
 - `SIG_PROPAGATE` (32): VM-internal. `fiber/propagate` re-raises caught signal.
 - `SIG_CANCEL` (64): VM-internal. `fiber/cancel` injects error into fiber.
 - `SIG_QUERY` (128): VM-internal. Primitive reads VM state (e.g., call counts, global bindings).
+- `SIG_HALT` (256): Graceful VM termination. Value in `fiber.signal`. Non-resumable; fiber is Dead.
 
 The public `execute_bytecode` method is the translation boundary — it converts
 `SignalBits` to `Result<Value, String>` for external callers. On `SIG_ERROR`,

--- a/src/vm/core.rs
+++ b/src/vm/core.rs
@@ -2,7 +2,7 @@ use crate::error::{LocationMap, StackFrame};
 use crate::ffi::FFISubsystem;
 use crate::value::fiber::CallFrame;
 use crate::value::{
-    Closure, Fiber, FiberHandle, SignalBits, SuspendedFrame, Value, SIG_OK, SIG_YIELD,
+    Closure, Fiber, FiberHandle, SignalBits, SuspendedFrame, Value, SIG_HALT, SIG_OK, SIG_YIELD,
 };
 use crate::vm::scope::ScopeStack;
 use rustc_hash::FxHashMap;
@@ -358,7 +358,8 @@ impl VM {
                     // Non-OK signal (yield, error, user-defined).
                     // Save context for potential future resume if not already
                     // set (yield instruction sets it; fiber/signal does not).
-                    if self.fiber.suspended.is_none() {
+                    // SIG_HALT is non-resumable — no suspended frame needed.
+                    if bits != SIG_HALT && self.fiber.suspended.is_none() {
                         self.fiber.suspended = Some(vec![SuspendedFrame {
                             bytecode: frame.bytecode.clone(),
                             constants: frame.constants.clone(),

--- a/src/vm/execute.rs
+++ b/src/vm/execute.rs
@@ -1,6 +1,6 @@
 //! Bytecode execution entry points and helpers.
 
-use crate::value::{SignalBits, Value, SIG_ERROR, SIG_OK, SIG_YIELD};
+use crate::value::{SignalBits, Value, SIG_ERROR, SIG_HALT, SIG_OK, SIG_YIELD};
 use std::rc::Rc;
 
 use super::core::VM;
@@ -124,7 +124,7 @@ impl VM {
                 current_env = tail_env;
             } else {
                 return match bits {
-                    SIG_OK => {
+                    SIG_OK | SIG_HALT => {
                         let (_, value) = self.fiber.signal.take().unwrap();
                         Ok(value)
                     }

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -19,7 +19,7 @@ pub use crate::value::fiber::CallFrame;
 pub use core::VM;
 
 use crate::compiler::bytecode::Bytecode;
-use crate::value::{error_val, Value, SIG_ERROR, SIG_OK, SIG_YIELD};
+use crate::value::{error_val, Value, SIG_ERROR, SIG_HALT, SIG_OK, SIG_YIELD};
 use std::rc::Rc;
 
 impl VM {
@@ -82,7 +82,7 @@ impl VM {
                 current_env = tail_env;
             } else {
                 return match bits {
-                    SIG_OK => {
+                    SIG_OK | SIG_HALT => {
                         let (_, value) = self.fiber.signal.take().unwrap();
                         Ok(value)
                     }

--- a/tests/integration/core.rs
+++ b/tests/integration/core.rs
@@ -1495,3 +1495,39 @@ fn test_empty_list_display() {
     let val = result.unwrap();
     assert_eq!(format!("{}", val), "()");
 }
+
+// ============================================================================
+// halt primitive
+// ============================================================================
+
+#[test]
+fn test_halt_returns_value() {
+    let result = eval("(halt 42)");
+    assert_eq!(result.unwrap(), Value::int(42));
+}
+
+#[test]
+fn test_halt_returns_nil() {
+    let result = eval("(halt)");
+    assert_eq!(result.unwrap(), Value::NIL);
+}
+
+#[test]
+fn test_halt_stops_execution() {
+    // Code after halt should not execute
+    let result = eval("(begin (halt 1) 2)");
+    assert_eq!(result.unwrap(), Value::int(1));
+}
+
+#[test]
+fn test_halt_in_function() {
+    let result = eval("(begin (define f (fn () (halt 99))) (f))");
+    assert_eq!(result.unwrap(), Value::int(99));
+}
+
+#[test]
+fn test_halt_with_complex_value() {
+    let result = eval("(halt (list 1 2 3))");
+    let vec = result.unwrap().list_to_vec().unwrap();
+    assert_eq!(vec, vec![Value::int(1), Value::int(2), Value::int(3)]);
+}


### PR DESCRIPTION
## Summary

Closes #245. Adds `(halt)` / `(halt value)` primitive that terminates VM execution gracefully, returning a value to the host without killing the process.

## Design

- **`SIG_HALT`** (bit 8, value 256): new signal bit in the existing signal system
- **Maskable**: fiber signal masks can catch `SIG_HALT` (enables sandboxing)
- **Non-resumable**: once a fiber halts, it is `Dead` — no `SuspendedFrame` created
- **Non-suspending**: `may_suspend()` is false, so closures calling `halt` are JIT-compatible
- **Effect**: `Effect::halts()` = `SIG_HALT | SIG_ERROR`

## Signal flow

1. `prim_halt` returns `(SIG_HALT, value)`
2. `handle_primitive_signal` catch-all stores in `fiber.signal`, returns `Some(SIG_HALT)`
3. Dispatch loop detects `SIG_HALT` in `fiber.signal` and exits
4. Translation boundary (`execute_bytecode`) maps `SIG_HALT` → `Ok(value)`

In fiber context: if the fiber's mask includes `SIG_HALT`, the parent catches it. Otherwise it propagates. Either way the child fiber is `Dead`.

## Changes

- `src/value/fiber.rs`: `SIG_HALT` constant, re-exported
- `src/vm/dispatch.rs`: dispatch loop catches `SIG_HALT` alongside `SIG_ERROR`
- `src/vm/mod.rs`, `src/vm/execute.rs`: translation boundaries map `SIG_HALT` → `Ok(value)`
- `src/vm/fiber.rs`: non-resumable semantics (Dead status, skip suspended frames)
- `src/vm/core.rs`: `resume_suspended` skips frame creation for `SIG_HALT`
- `src/vm/call.rs`: JIT result check includes `SIG_HALT`
- `src/jit/dispatch.rs`: JIT primitive signal handler and exception checks
- `src/effects/mod.rs`: `Effect::halts()`, `may_halt()`, Display update
- `src/primitives/process.rs`: `prim_halt` + unit tests
- `src/primitives/registration.rs`: registered with `Effect::halts()`
- `tests/integration/core.rs`: 5 integration tests
- AGENTS.md and BUILTINS.md updates across affected modules
