### PR TITLE
add const form for immutable bindings

### DIFF
--- a/src/hir/analyze/forms.rs
+++ b/src/hir/analyze/forms.rs
@@ -92,6 +92,7 @@ impl<'a> Analyzer<'a> {
                         "begin" => return self.analyze_begin(&items[1..], span),
                         "block" => return self.analyze_block(&items[1..], span),
                         "define" => return self.analyze_define(items, span),
+                        "const" => return self.analyze_const(items, span),
                         "set!" => return self.analyze_set(items, span),
                         "while" => return self.analyze_while(items, span),
                         "each" => return self.analyze_for(items, span),

--- a/src/hir/analyze/mod.rs
+++ b/src/hir/analyze/mod.rs
@@ -151,6 +151,10 @@ pub struct Analyzer<'a> {
     current_effect_sources: EffectSources,
     /// Parameters of the current lambda being analyzed (for polymorphic inference)
     current_lambda_params: Vec<BindingId>,
+    /// Immutable global bindings from previous forms (for cross-form const tracking)
+    immutable_globals: std::collections::HashSet<SymbolId>,
+    /// Immutable global bindings defined in this form (for cross-form tracking)
+    defined_immutable_globals: std::collections::HashSet<SymbolId>,
 }
 
 impl<'a> Analyzer<'a> {
@@ -177,6 +181,8 @@ impl<'a> Analyzer<'a> {
             defined_global_effects: HashMap::new(),
             current_effect_sources: EffectSources::default(),
             current_lambda_params: Vec::new(),
+            immutable_globals: std::collections::HashSet::new(),
+            defined_immutable_globals: std::collections::HashSet::new(),
         };
         // Initialize with a global scope so top-level bindings can be registered
         analyzer.push_scope(false);
@@ -191,6 +197,19 @@ impl<'a> Analyzer<'a> {
     /// Take the defined global effects (consumes them, for use after analysis)
     pub fn take_defined_global_effects(&mut self) -> HashMap<SymbolId, Effect> {
         std::mem::take(&mut self.defined_global_effects)
+    }
+
+    /// Set immutable globals from previous forms (for cross-form const tracking)
+    pub fn set_immutable_globals(
+        &mut self,
+        immutable_globals: std::collections::HashSet<SymbolId>,
+    ) {
+        self.immutable_globals = immutable_globals;
+    }
+
+    /// Take the defined immutable globals (consumes them, for use after analysis)
+    pub fn take_defined_immutable_globals(&mut self) -> std::collections::HashSet<SymbolId> {
+        std::mem::take(&mut self.defined_immutable_globals)
     }
 
     /// Analyze a syntax tree into HIR

--- a/src/hir/binding.rs
+++ b/src/hir/binding.rs
@@ -26,6 +26,8 @@ pub struct BindingInfo {
     pub is_mutated: bool,
     /// Whether this binding is captured by a nested closure
     pub is_captured: bool,
+    /// Whether this binding is immutable (const)
+    pub is_immutable: bool,
     /// The kind of binding
     pub kind: BindingKind,
 }
@@ -71,6 +73,7 @@ impl BindingInfo {
             name,
             is_mutated: false,
             is_captured: false,
+            is_immutable: false,
             kind: BindingKind::Parameter { index },
         }
     }
@@ -82,6 +85,7 @@ impl BindingInfo {
             name,
             is_mutated: false,
             is_captured: false,
+            is_immutable: false,
             kind: BindingKind::Local { index },
         }
     }
@@ -93,6 +97,7 @@ impl BindingInfo {
             name,
             is_mutated: false,
             is_captured: false,
+            is_immutable: false,
             kind: BindingKind::Global,
         }
     }

--- a/src/lir/lower/expr.rs
+++ b/src/lir/lower/expr.rs
@@ -104,9 +104,15 @@ impl Lowerer {
                 }
             }
         } else if let Some(info) = self.bindings.get(binding_id) {
-            match info.kind {
+            let kind = info.kind;
+            let sym = info.name;
+            // Drop the borrow on self.bindings
+            match kind {
                 BindingKind::Global => {
-                    let sym = info.name;
+                    // Check if this is an immutable binding with a known literal value
+                    if let Some(&literal_value) = self.immutable_values.get(binding_id) {
+                        return self.emit_value_const(literal_value);
+                    }
                     let dst = self.fresh_reg();
                     self.emit(LirInstr::LoadGlobal { dst, sym });
                     Ok(dst)

--- a/src/lir/lower/mod.rs
+++ b/src/lir/lower/mod.rs
@@ -40,6 +40,8 @@ pub struct Lowerer {
     /// Intrinsic operations for operator specialization.
     /// Maps global SymbolId to specialized LIR instruction.
     intrinsics: FxHashMap<SymbolId, IntrinsicOp>,
+    /// Compile-time constant values for immutable bindings (for LoadConst optimization)
+    immutable_values: HashMap<BindingId, Value>,
 }
 
 impl Lowerer {
@@ -56,6 +58,7 @@ impl Lowerer {
             upvalue_bindings: std::collections::HashSet::new(),
             current_span: Span::synthetic(),
             intrinsics: FxHashMap::default(),
+            immutable_values: HashMap::new(),
         }
     }
 


### PR DESCRIPTION
Closes #301

## Summary

- Add `(const name value)` special form: immutable binding with compile-time `set!` enforcement
- `(const (f x) body)` shorthand desugars like `(define (f x) body)`
- Literal values (int, float, string, bool, nil, keyword) emit `LoadConst` instead of `LoadGlobal`
- Cross-form immutability tracking via `immutable_globals: HashSet<SymbolId>` in `compile_all`/`analyze_all`
- No new `HirKind` variants — `is_immutable: bool` on `BindingInfo`

## Files changed

- `hir/binding.rs` — `is_immutable` field on `BindingInfo`
- `hir/analyze/binding.rs` — `analyze_const`, `is_define_form` recognizes `const`, `analyze_set` enforces immutability
- `hir/analyze/forms.rs` — dispatch `"const"` to `analyze_const`
- `hir/analyze/mod.rs` — `immutable_globals` + `defined_immutable_globals` on `Analyzer`
- `syntax/expand/mod.rs` — `(const (f x) body)` desugaring
- `lir/lower/mod.rs` — `immutable_values` map, `hir_to_literal_value` helper
- `lir/lower/binding.rs` — record literal values in `lower_define`
- `lir/lower/expr.rs` — emit `LoadConst` for immutable literal globals in `lower_var`
- `pipeline.rs` — `scan_const_binding`, cross-form immutable tracking in `compile_all`/`analyze_all`

## Test plan

8 new tests covering: basic const, set! error, function shorthand, cross-form enforcement, function-scope const.
