### PR TITLE
refactor: rename vector to array across codebase

### DIFF
--- a/demos/README.md
+++ b/demos/README.md
@@ -36,7 +36,7 @@ A classic backtracking algorithm that solves the N-Queens chess problem. Tests:
 ### Matrix Operations (`./matrix-ops/`)
 
 Pure Lisp matrix operations testing numeric computation and performance. Tests:
-- **Dense matrix representation** (vector of vectors, 2D arrays)
+- **Dense matrix representation** (array of arrays, 2D arrays)
 - **Numeric computation** (matrix multiply, transpose, LU decomposition)
 - **Performance at different scales** (16x16, 64x64, 256x256 matrices)
 - **Loops vs functional iteration** patterns

--- a/docs/BUILTINS.md
+++ b/docs/BUILTINS.md
@@ -11,7 +11,7 @@ This document provides comprehensive documentation for all built-in primitives i
 5. [String Operations](#string-operations)
 6. [Type Operations](#type-operations)
 7. [Math Functions](#math-functions)
-8. [Vector Operations](#vector-operations)
+8. [Array Operations](#array-operations)
 9. [Table Operations](#table-operations)
 10. [Struct Operations](#struct-operations)
 11. [Higher-Order Functions](#higher-order-functions)
@@ -1126,41 +1126,41 @@ e
 
 ---
 
-## Vector Operations
+## Array Operations
 
-### `vector` (Create Vector)
+### `array` (Create Array)
 
-**Semantics**: Creates a mutable vector from arguments.
+**Semantics**: Creates a mutable array from arguments.
 
 **Usage**:
 ```lisp
-(var v (vector 1 2 3 4 5))
+(var v (array 1 2 3 4 5))
 (length v)
 ⟹ 5
 ```
 
-**Note**: Use `length` (polymorphic) instead of `vector-length` for getting vector length.
+**Note**: Use `length` (polymorphic) instead of `array-length` for getting array length.
 
-### `vector-ref` (Vector Reference)
+### `array-ref` (Array Reference)
 
 **Semantics**: Returns element at given index.
 
 **Usage**:
 ```lisp
-(var v (vector 'a 'b 'c))
-(vector-ref v 1)
+(var v (array 'a 'b 'c))
+(array-ref v 1)
 ⟹ b
 ```
 
-### `vector-set!` (Vector Set)
+### `array-set!` (Array Set)
 
-**Semantics**: Sets element at given index (mutates vector).
+**Semantics**: Sets element at given index (mutates array).
 
 **Usage**:
 ```lisp
-(var v (vector 1 2 3))
-(vector-set! v 1 99)
-(vector-ref v 1)
+(var v (array 1 2 3))
+(array-set! v 1 99)
+(array-ref v 1)
 ⟹ 99
 ```
 
@@ -2123,7 +2123,7 @@ JSON parsing and serialization for working with JSON data. All JSON primitives a
 - Elle `Float` → JSON number (always includes decimal point)
 - Elle `String` → JSON string with proper escaping
 - Elle List → JSON array
-- Elle Vector → JSON array
+- Elle Array → JSON array
 - Elle Table → JSON object (keys must be strings)
 - Elle Struct → JSON object (keys must be strings)
 

--- a/docs/DEBUGGING.md
+++ b/docs/DEBUGGING.md
@@ -94,7 +94,7 @@ unchanged (for `jit`) or signal an error (for `jit!`).
 | `raises?` | `(raises? value)` | `#t` or `#f` | Returns `#t` if the closure may raise an exception, `#f` if it is guaranteed not to. Returns `#f` for non-closures. |
 
 This is a boolean query. When we add specific exception type tracking in the
-future (§4.6), the return type will change to a vector of exception type
+future (§4.6), the return type will change to a list of exception type
 keywords. See §4.5 for details.
 
 ### 1.4 Additional introspection
@@ -329,7 +329,7 @@ in the effect's signal bits). Returns `#t` if the closure may raise, `#f`
 otherwise.
 
 When we add specific exception type tracking (§4.6), the return type will
-change to a vector of exception type keywords (`:error`, `:type-error`,
+change to a list of exception type keywords (`:error`, `:type-error`,
 `:division-by-zero`, etc.) for closures that may raise, and `#f` for those
 that don't.
 
@@ -338,7 +338,7 @@ that don't.
 Once the boolean tracking is proven correct, we can extend to
 `BTreeSet<u32>` tracking specific exception IDs. This would enable:
 - `try`/`catch` catching `error` to subtract error and its children
-- `raises?` returning a vector of specific exception type keywords
+- `raises?` returning a list of specific exception type keywords
 - Primitive annotations (e.g., `/` raises `:division-by-zero`)
 
 This is additive — the boolean version is a proper subset of the set version.

--- a/docs/EFFECTS.md
+++ b/docs/EFFECTS.md
@@ -574,7 +574,7 @@ The compiler's effect information guides JIT decisions:
 (fiber/closure fiber) → closure
 
 ;; The operand stack (for debugging)
-(fiber/stack fiber) → vector
+(fiber/stack fiber) → array
 
 ;; Dynamic bindings (fiber-scoped state)
 (fiber/env fiber) → table | nil

--- a/docs/LANGUAGE_GUIDE.md
+++ b/docs/LANGUAGE_GUIDE.md
@@ -122,16 +122,16 @@ Linked lists are the fundamental collection type in Lisp:
 (nth 1 (list 'a 'b 'c')) ⟹ b
 ```
 
-### Vectors
+### Arrays
 
-Vectors are ordered collections optimized for random access:
+Arrays are ordered collections optimized for random access:
 
 ```lisp
-[1 2 3]             ; Vector literal
-(vector 1 2 3)      ; Create vector
+[1 2 3]             ; Array literal
+(array 1 2 3)       ; Create array
 (length [1 2 3]) ⟹ 3
-(vector-ref [1 2 3] 1) ⟹ 2
-(vector-set! [1 2 3] 0 99) ⟹ [99 2 3]
+(array-ref [1 2 3] 1) ⟹ 2
+(array-set! [1 2 3] 0 99) ⟹ [99 2 3]
 ```
 
 ### Tables

--- a/docs/SEMANTICS.md
+++ b/docs/SEMANTICS.md
@@ -20,7 +20,7 @@ Elle has exactly two falsy values:
 | `0` | **Yes** | Zero is truthy (unlike C) |
 | `0.0` | **Yes** | Float zero is truthy |
 | `""` | **Yes** | Empty string is truthy |
-| `[]` | **Yes** | Empty vector is truthy |
+| `[]` | **Yes** | Empty array is truthy |
 | `#t` | **Yes** | Boolean true |
 
 ### Why nil ≠ empty list

--- a/docs/WHAT_S_NEW.md
+++ b/docs/WHAT_S_NEW.md
@@ -31,7 +31,7 @@ Elle distinguishes between `nil` (absence of value) and `()` (empty list). They 
 | `()` | ✓ Yes | Empty list (distinct from nil) |
 | `0` | ✓ Yes | Zero is truthy |
 | `""` | ✓ Yes | Empty string is truthy |
-| `[]` | ✓ Yes | Empty vector is truthy |
+| `[]` | ✓ Yes | Empty array is truthy |
 | All other values | ✓ Yes | Default |
 
 **Only `#f` and `nil` are falsy.** Everything else, including the empty list, is truthy.
@@ -449,13 +449,13 @@ Call a function with arguments from a list:
 (length s)           ⟹ 2
 ```
 
-### Vectors
+### Arrays
 
 ```lisp
 (var v [1 2 3])
 (length v)           ⟹ 3
-(vector-ref v 1)     ⟹ 2
-(vector-set! v 0 99) ⟹ [99 2 3]
+(array-ref v 1)      ⟹ 2
+(array-set! v 0 99)  ⟹ [99 2 3]
 ```
 
 ### Lists

--- a/elle-doc/docs/pages/concurrency.json
+++ b/elle-doc/docs/pages/concurrency.json
@@ -163,14 +163,14 @@
           "code": "; Capture multiple values for a computation\n(let ((a 2) (b 3) (c 4) (d 5))\n  (let ((handle (spawn (lambda ()\n                         (+ (* a b) (* c d))))))\n    (display (join handle))))  ; prints: 26"
         },
         {
-          "type": "text",
-          "text": "Using vectors and collections in spawned threads:"
-        },
-        {
-          "type": "code",
-          "language": "lisp",
-          "code": "; Spawn with vector capture\n(let ((numbers [1 2 3 4 5]))\n  (let ((handle (spawn (lambda ()\n                         (+ 1 (+ 2 (+ 3 (+ 4 5))))))))\n    (display (join handle))))  ; prints: 15"
-        }
+           "type": "text",
+           "text": "Using arrays and collections in spawned threads:"
+         },
+         {
+           "type": "code",
+           "language": "lisp",
+           "code": "; Spawn with array capture\n(let ((numbers [1 2 3 4 5]))\n  (let ((handle (spawn (lambda ()\n                         (+ 1 (+ 2 (+ 3 (+ 4 5))))))))\n    (display (join handle))))  ; prints: 15"
+         }
       ]
     },
     {

--- a/elle-doc/docs/pages/language-guide.json
+++ b/elle-doc/docs/pages/language-guide.json
@@ -85,21 +85,21 @@
             }
           ]
         },
-        {
-          "type": "heading",
-          "level": 3,
-          "content": [
-            {
-              "type": "paragraph",
-              "text": "**Vectors**"
-            },
-            {
-              "type": "code",
-              "language": "lisp",
-              "text": "[1 2 3]             ; Vector literal\n(vector 1 2 3)      ; Create vector\n(nth vec 0)         ; Access by index\n(length vec)        ; Get length"
-            }
-          ]
-        },
+         {
+           "type": "heading",
+           "level": 3,
+           "content": [
+             {
+               "type": "paragraph",
+               "text": "**Arrays**"
+             },
+             {
+               "type": "code",
+               "language": "lisp",
+               "text": "[1 2 3]             ; Array literal\n(array 1 2 3)       ; Create array\n(nth arr 0)         ; Access by index\n(length arr)        ; Get length"
+             }
+           ]
+         },
         {
           "type": "heading",
           "level": 3,

--- a/elle-doc/docs/pages/stdlib-reference.json
+++ b/elle-doc/docs/pages/stdlib-reference.json
@@ -120,7 +120,7 @@
             ["(symbol? x)", "Check if symbol"],
             ["(keyword? x)", "Check if keyword"],
             ["(list? x)", "Check if list"],
-            ["(vector? x)", "Check if vector"],
+             ["(array? x)", "Check if array"],
             ["(table? x)", "Check if table"],
             ["(function? x)", "Check if function"],
             ["(type-of x)", "Get type name as string"]
@@ -150,23 +150,23 @@
         }
       ]
     },
-    {
-      "heading": "Vector Operations",
-      "level": 2,
-      "content": [
-        {
-          "type": "table",
-          "headers": ["Function", "Description"],
-          "rows": [
-            ["(vector a b ...)", "Create a vector"],
-            ["(nth vec i)", "Get element at index"],
-            ["(length vec)", "Get vector length"],
-            ["(vector-append v1 v2)", "Concatenate vectors"],
-            ["(vector-reverse v)", "Reverse a vector"]
-          ]
-        }
-      ]
-    },
+     {
+       "heading": "Array Operations",
+       "level": 2,
+       "content": [
+         {
+           "type": "table",
+           "headers": ["Function", "Description"],
+           "rows": [
+             ["(array a b ...)", "Create an array"],
+             ["(nth arr i)", "Get element at index"],
+             ["(length arr)", "Get array length"],
+             ["(array-append a1 a2)", "Concatenate arrays"],
+             ["(array-reverse a)", "Reverse an array"]
+           ]
+         }
+       ]
+     },
     {
       "heading": "Table Operations",
       "level": 2,

--- a/elle-lint/README.md
+++ b/elle-lint/README.md
@@ -28,6 +28,9 @@ Enforces kebab-case naming for all identifiers.
 
 ✗ (def setValue! (fn [x v] v))  ; Error: should be set-value!
 ✓ (def set-value! (fn [x v] v)) ; Correct
+
+✗ (def arraySet! (fn [a i v] v))  ; Error: should be array-set!
+✓ (def array-set! (fn [a i v] v)) ; Correct
 ```
 
 ### Planned Rules

--- a/examples/README.md
+++ b/examples/README.md
@@ -53,7 +53,7 @@ See `assertions.lisp` for the standard assertion library documentation.
 ### Basics (Tier 1)
 - **hello.lisp** - Simple greeting, basic output, and shebang script examples
 - **math-and-logic.lisp** - Arithmetic, math functions, predicates (even?/odd?), and logical operations (and, or, not, xor)
-- **lists-and-vectors.lisp** - List operations (first, rest, cons), vector operations (vector-ref, vector-set!), and comparisons
+- **lists-and-arrays.lisp** - List operations (first, rest, cons), array operations (array-ref, array-set!), and comparisons
 - **types.lisp** - All atomic types (keywords, symbols, numbers, strings, booleans, nil), type predicates, type conversions, and mutable storage with boxes
 
 ### Computation (Tier 2)
@@ -184,11 +184,11 @@ echo $?
   - Directory operations and path manipulation
   - File information and properties
 
-- `list-operations.lisp` + `vector-operations.lisp` → **lists-and-vectors.lisp**
-  - List operations (first, rest, cons) and List Module
-  - Vector creation, access (vector-ref), and mutation (vector-set!)
-  - Vectors vs lists comparison
-  - Polymorphic length function
+- `list-operations.lisp` + `array-operations.lisp` → **lists-and-arrays.lisp**
+   - List operations (first, rest, cons) and List Module
+   - Array creation, access (array-ref), and mutation (array-set!)
+   - Arrays vs lists comparison
+   - Polymorphic length function
 
 - `math-operations.lisp` + `logic-operations.lisp` → **math-and-logic.lisp**
   - Basic arithmetic (+, -, *, /, mod)
@@ -286,8 +286,8 @@ echo $?
 - `type-checking.lisp` (merged into types.lisp)
 - `keywords.lisp` (renamed to atoms.lisp, then merged into types.lisp)
 - `file-io.lisp` (renamed to io.lisp)
-- `list-operations.lisp` (merged into lists-and-vectors.lisp)
-- `vector-operations.lisp` (merged into lists-and-vectors.lisp)
+- `list-operations.lisp` (merged into lists-and-arrays.lisp)
+- `array-operations.lisp` (merged into lists-and-arrays.lisp)
 - `math-operations.lisp` (merged into math-and-logic.lisp)
 - `logic-operations.lisp` (merged into math-and-logic.lisp)
 - `file-modules.lisp` (merged into modules.lisp)
@@ -308,9 +308,9 @@ echo $?
 
 ### Polymorphic `length` Function Notes
 The `length` function is polymorphic and works on all sequence types:
-- **Lists**: See `lists-and-vectors.lisp`
+- **Lists**: See `lists-and-arrays.lisp`
 - **Strings**: See `string-operations.lisp`
-- **Vectors**: See `lists-and-vectors.lisp`
+- **Arrays**: See `lists-and-arrays.lisp`
 - **Tables/Structs**: See `tables-and-structs.lisp`
 
 Each file now includes a note about the polymorphic nature of `length`.

--- a/examples/debugging.lisp
+++ b/examples/debugging.lisp
@@ -45,17 +45,17 @@
 
 ;; disbit - bytecode disassembly
 (var disasm-result (disbit add))
-(assert-true (> (length disasm-result) 0) "disbit returns non-empty vector")
-(assert-true (string? (vector-ref disasm-result 0)) "disbit elements are strings")
+(assert-true (> (length disasm-result) 0) "disbit returns non-empty array")
+(assert-true (string? (array-ref disasm-result 0)) "disbit elements are strings")
 (display "  ✓ disbit\n")
 
 ;; disjit - Cranelift IR (may be nil if no LIR stored)
 (var jit-result (disjit add))
-;; disjit returns nil or a vector of strings
+;; disjit returns nil or an array of strings
 (assert-true (or (nil? jit-result)
                  (and (> (length jit-result) 0)
-                      (string? (vector-ref jit-result 0))))
-             "disjit returns nil or vector of strings")
+                      (string? (array-ref jit-result 0))))
+             "disjit returns nil or array of strings")
 (display "  ✓ disjit\n")
 
 (display "\n=== All debugging toolkit tests passed ===\n")

--- a/examples/lists-and-arrays.lisp
+++ b/examples/lists-and-arrays.lisp
@@ -1,8 +1,8 @@
-; Lists and Vectors - Sequence operations and comparisons
+; Lists and Arrays - Sequence operations and comparisons
 
 (import-file "./examples/assertions.lisp")
 
-(display "=== Lists and Vectors ===")
+(display "=== Lists and Arrays ===")
 (newline)
 (newline)
 
@@ -406,111 +406,111 @@
 (newline)
 
 ; ============================================================================
-; PART 2: Vector Operations
+; PART 2: Array Operations
 ; ============================================================================
 
-(display "PART 2: Vector Operations")
+(display "PART 2: Array Operations")
 (newline)
 (newline)
 
-; === Vector Creation ===
-(display "Part 2a: Vector Creation")
+; === Array Creation ===
+(display "Part 2a: Array Creation")
 (newline)
 
-; Create a vector with 5 elements
-(var my-vector (vector 10 20 30 40 50))
-(display "Created vector: ")
-(display my-vector)
+; Create an array with 5 elements
+(var my-array (array 10 20 30 40 50))
+(display "Created array: ")
+(display my-array)
 (newline)
 (newline)
 
-; === Vector Length ===
-(display "Part 2b: Vector Length")
+; === Array Length ===
+(display "Part 2b: Array Length")
 (newline)
 
-; Get the length of the vector
-(display "Vector length: ")
-(display (length my-vector))
+; Get the length of the array
+(display "Array length: ")
+(display (length my-array))
 (newline)
-(assert-eq (length my-vector) 5 "length returns correct length for vector")
+(assert-eq (length my-array) 5 "length returns correct length for array")
 
-; Empty vector has length 0
-(var empty-vec (vector))
-(assert-eq (length empty-vec) 0 "empty vector has length 0")
+; Empty array has length 0
+(var empty-arr (array))
+(assert-eq (length empty-arr) 0 "empty array has length 0")
 (newline)
 
-; === Vector Access (vector-ref) ===
-(display "Part 2c: Vector Access (vector-ref)")
+; === Array Access (array-ref) ===
+(display "Part 2c: Array Access (array-ref)")
 (newline)
 
 ; Access first element (index 0)
 (display "Element at index 0: ")
-(display (vector-ref my-vector 0))
+(display (array-ref my-array 0))
 (newline)
-(assert-eq (vector-ref my-vector 0) 10 "vector-ref index 0 returns first element")
+(assert-eq (array-ref my-array 0) 10 "array-ref index 0 returns first element")
 
 ; Access middle element
 (display "Element at index 2: ")
-(display (vector-ref my-vector 2))
+(display (array-ref my-array 2))
 (newline)
-(assert-eq (vector-ref my-vector 2) 30 "vector-ref index 2 returns middle element")
+(assert-eq (array-ref my-array 2) 30 "array-ref index 2 returns middle element")
 
 ; Access last element
 (display "Element at index 4: ")
-(display (vector-ref my-vector 4))
+(display (array-ref my-array 4))
 (newline)
-(assert-eq (vector-ref my-vector 4) 50 "vector-ref index 4 returns last element")
-(newline)
-
-; === Vector Mutation (vector-set!) ===
-(display "Part 2d: Vector Mutation (vector-set!)")
+(assert-eq (array-ref my-array 4) 50 "array-ref index 4 returns last element")
 (newline)
 
-; Create a mutable vector
-(var mutable-vec (vector 1 2 3 4 5))
-(display "Original vector: ")
-(display mutable-vec)
+; === Array Mutation (array-set!) ===
+(display "Part 2d: Array Mutation (array-set!)")
 (newline)
 
-; Modify first element - vector-set! returns a new vector
-(var mutable-vec (vector-set! mutable-vec 0 100))
+; Create a mutable array
+(var mutable-arr (array 1 2 3 4 5))
+(display "Original array: ")
+(display mutable-arr)
+(newline)
+
+; Modify first element - array-set! returns a new array
+(var mutable-arr (array-set! mutable-arr 0 100))
 (display "After setting index 0 to 100: ")
-(display mutable-vec)
+(display mutable-arr)
 (newline)
-(assert-eq (vector-ref mutable-vec 0) 100 "vector-set! returns new vector with modified element")
+(assert-eq (array-ref mutable-arr 0) 100 "array-set! returns new array with modified element")
 
 ; Modify middle element
-(var mutable-vec (vector-set! mutable-vec 2 300))
+(var mutable-arr (array-set! mutable-arr 2 300))
 (display "After setting index 2 to 300: ")
-(display mutable-vec)
+(display mutable-arr)
 (newline)
-(assert-eq (vector-ref mutable-vec 2) 300 "vector-set! modifies element at index 2")
+(assert-eq (array-ref mutable-arr 2) 300 "array-set! modifies element at index 2")
 
 ; Modify last element
-(var mutable-vec (vector-set! mutable-vec 4 500))
+(var mutable-arr (array-set! mutable-arr 4 500))
 (display "After setting index 4 to 500: ")
-(display mutable-vec)
+(display mutable-arr)
 (newline)
-(assert-eq (vector-ref mutable-vec 4) 500 "vector-set! modifies element at index 4")
-(newline)
-
-; === Vectors vs Lists ===
-(display "Part 2e: Vectors vs Lists")
+(assert-eq (array-ref mutable-arr 4) 500 "array-set! modifies element at index 4")
 (newline)
 
-; Create equivalent list and vector
+; === Arrays vs Lists ===
+(display "Part 2e: Arrays vs Lists")
+(newline)
+
+; Create equivalent list and array
 (var my-list-2 (list 1 2 3 4 5))
-(var my-vec-2 (vector 1 2 3 4 5))
+(var my-arr-2 (array 1 2 3 4 5))
 
 (display "List: ")
 (display my-list-2)
 (newline)
-(display "Vector: ")
-(display my-vec-2)
+(display "Array: ")
+(display my-arr-2)
 (newline)
 
-; Note: vectors and lists are different types
-; Vectors are mutable, lists are immutable
+; Note: arrays and lists are different types
+; Arrays are mutable, lists are immutable
 
 ; Both have length
 (display "List length: ")
@@ -518,29 +518,29 @@
 (newline)
 (assert-eq (length my-list-2) 5 "list length works")
 
-(display "Vector length: ")
-(display (length my-vec-2))
+(display "Array length: ")
+(display (length my-arr-2))
 (newline)
-(assert-eq (length my-vec-2) 5 "vector length works")
+(assert-eq (length my-arr-2) 5 "array length works")
 
-; Lists use first/rest, vectors use vector-ref
+; Lists use first/rest, arrays use array-ref
 (display "List first element: ")
 (display (first my-list-2))
 (newline)
 (assert-eq (first my-list-2) 1 "list first element")
 
-(display "Vector first element: ")
-(display (vector-ref my-vec-2 0))
+(display "Array first element: ")
+(display (array-ref my-arr-2 0))
 (newline)
-(assert-eq (vector-ref my-vec-2 0) 1 "vector first element")
+(assert-eq (array-ref my-arr-2 0) 1 "array first element")
 
-; Vectors are mutable, lists are immutable
+; Arrays are mutable, lists are immutable
 (var test-list (list 10 20 30))
-(var test-vec (vector 10 20 30))
+(var test-arr (array 10 20 30))
 
-; Modify vector - vector-set! returns a new vector
-(var test-vec (vector-set! test-vec 1 200))
-(assert-eq (vector-ref test-vec 1) 200 "vector mutation works")
+; Modify array - array-set! returns a new array
+(var test-arr (array-set! test-arr 1 200))
+(assert-eq (array-ref test-arr 1) 200 "array mutation works")
 
 ; Lists are immutable - cons creates new list
 (var modified-list (cons 5 test-list))
@@ -548,19 +548,19 @@
 (assert-eq (first modified-list) 5 "cons creates new list")
 (newline)
 
-; === Vector with Different Types ===
-(display "Part 2f: Vector with Different Types")
+; === Array with Different Types ===
+(display "Part 2f: Array with Different Types")
 (newline)
 
-; Create vector with mixed types
-(var mixed-vec (vector 42 "hello" 'symbol))
-(display "Mixed type vector: ")
-(display mixed-vec)
+; Create array with mixed types
+(var mixed-arr (array 42 "hello" 'symbol))
+(display "Mixed type array: ")
+(display mixed-arr)
 (newline)
 
-(assert-eq (vector-ref mixed-vec 0) 42 "vector stores numbers")
-(assert-eq (vector-ref mixed-vec 1) "hello" "vector stores strings")
-(assert-eq (vector-ref mixed-vec 2) 'symbol "vector stores symbols")
+(assert-eq (array-ref mixed-arr 0) 42 "array stores numbers")
+(assert-eq (array-ref mixed-arr 1) "hello" "array stores strings")
+(assert-eq (array-ref mixed-arr 2) 'symbol "array stores symbols")
 (newline)
 
 ; ============================================================================
@@ -570,19 +570,19 @@
 (display "PART 3: Polymorphic Operations")
 (newline)
 
-; The `length` function works on both lists and vectors
+; The `length` function works on both lists and arrays
 (var list-len (length (list 1 2 3)))
-(var vec-len (length (vector 1 2 3)))
+(var arr-len (length (array 1 2 3)))
 
 (display "List length: ")
 (display list-len)
 (newline)
 (assert-eq list-len 3 "length works on lists")
 
-(display "Vector length: ")
-(display vec-len)
+(display "Array length: ")
+(display arr-len)
 (newline)
-(assert-eq vec-len 3 "length works on vectors")
+(assert-eq arr-len 3 "length works on arrays")
 
 (display "✓ Polymorphic length verified")
 (newline)
@@ -594,7 +594,7 @@
 
 (display "=== Summary ===")
 (newline)
-(display "Lists and Vectors in Elle:")
+(display "Lists and Arrays in Elle:")
 (newline)
 (display "1. List operations - cons, first/rest, length, reverse, take/drop, nth/last, append")
 (newline)
@@ -602,17 +602,17 @@
 (newline)
 (display "3. Nested lists - Working with lists of lists")
 (newline)
-(display "4. Vector creation - Creating vectors with vector function")
+(display "4. Array creation - Creating arrays with array function")
 (newline)
-(display "5. Vector access - Using vector-ref to access elements")
+(display "5. Array access - Using array-ref to access elements")
 (newline)
-(display "6. Vector mutation - Using vector-set! to modify elements")
+(display "6. Array mutation - Using array-set! to modify elements")
 (newline)
-(display "7. Polymorphic operations - length works on both lists and vectors")
+(display "7. Polymorphic operations - length works on both lists and arrays")
 (newline)
 (newline)
 
-(display "=== Lists and Vectors Complete - All Assertions Passed ===")
+(display "=== Lists and Arrays Complete - All Assertions Passed ===")
 (newline)
 
 (exit 0)

--- a/examples/string-operations.lisp
+++ b/examples/string-operations.lisp
@@ -249,5 +249,5 @@
 (newline)
 
 ;; NOTE: The `length` function is polymorphic and works on all sequence types
-;; (lists, strings, vectors, tables, structs, keywords). See list-operations.lisp,
-;; vector-operations.lisp, and tables-and-structs.lisp for examples with other types.
+;; (lists, strings, arrays, tables, structs, keywords). See list-operations.lisp,
+;; array-operations.lisp, and tables-and-structs.lisp for examples with other types.

--- a/examples/tables-and-structs.lisp
+++ b/examples/tables-and-structs.lisp
@@ -368,5 +368,5 @@
 (newline)
 
 ;; NOTE: The `length` function is polymorphic and works on all sequence types
-;; (lists, strings, vectors, tables, structs, keywords). See list-operations.lisp,
-;; string-operations.lisp, and vector-operations.lisp for examples with other types.
+;; (lists, strings, arrays, tables, structs, keywords). See list-operations.lisp,
+;; string-operations.lisp, and array-operations.lisp for examples with other types.

--- a/examples/types.lisp
+++ b/examples/types.lisp
@@ -2,7 +2,7 @@
 ;
 ; This example demonstrates Elle's type system:
 ; - type-of: Get the type of any value
-; - Type predicates: number?, symbol?, string?, list?, vector?, table?, closure?, coro?
+; - Type predicates: number?, symbol?, string?, list?, array?, table?, closure?, coro?
 ; - Type conversions: string, number, symbol
 ; - Type checking patterns
 ; - Assertions verifying type operations
@@ -34,9 +34,9 @@
 (var person '(:name :John :age :30 :city :NYC))
 (assert-eq (first person) :name "first element of person list is :name")
 
-; Keywords in vectors
+; Keywords in arrays
 (var options [1 :option-a 2 :option-b 3])
-(assert-eq (vector-ref options 1) :option-a "second element of options vector is :option-a")
+(assert-eq (array-ref options 1) :option-a "second element of options array is :option-a")
 
 ; Building configuration with keywords
 (var settings (list :debug #t :host "localhost" :port 8080))
@@ -80,9 +80,9 @@
 (var vars '(x y z))
 (assert-eq (first vars) 'x "first element of vars list is 'x")
 
-; Symbols in vectors
-(var ops (vector 'add 'subtract 'multiply))
-(assert-eq (vector-ref ops 0) 'add "first element of ops vector is 'add")
+; Symbols in arrays
+(var ops (array 'add 'subtract 'multiply))
+(assert-eq (array-ref ops 0) 'add "first element of ops array is 'add")
 
 ; Symbols are distinct from keywords
 (assert-false (eq? 'name :name) "symbol 'name is not eq? to keyword :name")
@@ -131,9 +131,9 @@
 (var nums (list 1 2 3 4 5))
 (assert-eq (first nums) 1 "first element of nums list is 1")
 
-; Numbers in vectors
+; Numbers in arrays
 (var values [10 20 30 40 50])
-(assert-eq (vector-ref values 0) 10 "first element of values vector is 10")
+(assert-eq (array-ref values 0) 10 "first element of values array is 10")
 
 ; Arithmetic with numbers
 (assert-eq (+ 10 5) 15 "arithmetic: 10 + 5 = 15")
@@ -178,9 +178,9 @@
 (var words (list "apple" "banana" "cherry"))
 (assert-eq (first words) "apple" "first element of words list is \"apple\"")
 
-; Strings in vectors
+; Strings in arrays
 (var messages ["hello" "world" "!"])
-(assert-eq (vector-ref messages 0) "hello" "first element of messages vector is \"hello\"")
+(assert-eq (array-ref messages 0) "hello" "first element of messages array is \"hello\"")
 
 ; String concatenation
 (var greeting (string-append "Hello, " "World!"))
@@ -219,9 +219,9 @@
 (var flags (list #t #f #t))
 (assert-eq (first flags) #t "first element of flags list is #t")
 
-; Booleans in vectors
+; Booleans in arrays
 (var states [#t #f #t #f])
-(assert-eq (vector-ref states 0) #t "first element of states vector is #t")
+(assert-eq (array-ref states 0) #t "first element of states array is #t")
 
 ; Boolean predicates
 (assert-true (boolean? #t) "boolean? returns true for #t")
@@ -253,9 +253,9 @@
 (var maybe-values (list 1 nil 3))
 (assert-eq (first (rest maybe-values)) nil "second element of maybe-values list is nil")
 
-; Nil in vectors
+; Nil in arrays
 (var optional [10 nil 30])
-(assert-eq (vector-ref optional 1) nil "second element of optional vector is nil")
+(assert-eq (array-ref optional 1) nil "second element of optional array is nil")
 
 ; Nil predicates
 (assert-true (nil? nil) "nil? returns true for nil")
@@ -279,11 +279,11 @@
 (assert-eq (first (rest mixed-list)) 'symbol "second element is symbol")
 (assert-eq (first (rest (rest mixed-list))) 42 "third element is number")
 
-; Mixed vector
-(var mixed-vec (vector :id 'user 123 "Alice" #t))
-(assert-eq (vector-ref mixed-vec 0) :id "first element is keyword")
-(assert-eq (vector-ref mixed-vec 1) 'user "second element is symbol")
-(assert-eq (vector-ref mixed-vec 2) 123 "third element is number")
+; Mixed array
+(var mixed-arr (array :id 'user 123 "Alice" #t))
+(assert-eq (array-ref mixed-arr 0) :id "first element is keyword")
+(assert-eq (array-ref mixed-arr 1) 'user "second element is symbol")
+(assert-eq (array-ref mixed-arr 2) 123 "third element is number")
 
 (display "✓ Mixed atoms verified\n")
 
@@ -385,7 +385,7 @@
 (var test-symbol 'symbol)
 (var test-string "hello")
 (var test-bool #t)
-(var test-vector (vector 1 2 3))
+(var test-array (array 1 2 3))
 
 ; Display type information
 (display "nil: ")
@@ -434,10 +434,10 @@
 (display (boolean? test-bool))
 (newline)
 
-(display "vector: ")
-(display test-vector)
+(display "array: ")
+(display test-array)
 (display " -> list?=")
-(display (list? test-vector))
+(display (list? test-array))
 (newline)
 
 ;; ============================================================================
@@ -467,18 +467,18 @@
 (display "✓ Type predicate combinations verified\n")
 
 ;; ============================================================================
-;; SECTION 13: Vectors
+;; SECTION 13: Arrays
 ;; ============================================================================
 
-(display "\n=== Vectors ===\n")
+(display "\n=== Arrays ===\n")
 
-; Vectors are a distinct type from lists
-(var test-vec (vector 1 2 3))
-(display "Vector: ")
-(display test-vec)
+; Arrays are a distinct type from lists
+(var test-arr (array 1 2 3))
+(display "Array: ")
+(display test-arr)
 (newline)
-(assert-false (list? test-vec) "vector is not a list")
-(display "✓ vectors are distinct from lists\n")
+(assert-false (list? test-arr) "array is not a list")
+(display "✓ arrays are distinct from lists\n")
 
 ; ========================================
 ; TYPE CONVERSION SECTION
@@ -899,7 +899,7 @@
 (assert-false (box? 42) "box? returns false for number")
 (assert-false (box? "hello") "box? returns false for string")
 (assert-false (box? (list 1 2 3)) "box? returns false for list")
-(assert-false (box? (vector 1 2 3)) "box? returns false for vector")
+(assert-false (box? (array 1 2 3)) "box? returns false for array")
 
 (display "✓ box? works correctly\n")
 
@@ -1065,9 +1065,9 @@
 (assert-true (if '() #t #f) "empty list is truthy in if")
 (display "empty list is truthy (not falsy like C)\n")
 
-; Empty vector is truthy (unlike C)
-(assert-true (if [] #t #f) "empty vector is truthy in if")
-(display "empty vector is truthy (not falsy like C)\n")
+; Empty array is truthy (unlike C)
+(assert-true (if [] #t #f) "empty array is truthy in if")
+(display "empty array is truthy (not falsy like C)\n")
 
 ; Non-empty string is truthy
 (assert-true (if "hello" #t #f) "non-empty string is truthy in if")
@@ -1077,9 +1077,9 @@
 (assert-true (if '(a b c) #t #f) "non-empty list is truthy in if")
 (display "non-empty list is truthy\n")
 
-; Non-empty vector is truthy
-(assert-true (if [1 2 3] #t #f) "non-empty vector is truthy in if")
-(display "non-empty vector is truthy\n")
+; Non-empty array is truthy
+(assert-true (if [1 2 3] #t #f) "non-empty array is truthy in if")
+(display "non-empty array is truthy\n")
 
 ; Symbols are truthy
 (assert-true (if 'symbol #t #f) "symbol is truthy in if")
@@ -1122,7 +1122,7 @@
 (display "  - 0 is truthy (not falsy like C)\n")
 (display "  - \"\" (empty string) is truthy\n")
 (display "  - '() (empty list) is truthy\n")
-(display "  - [] (empty vector) is truthy\n")
+(display "  - [] (empty array) is truthy\n")
 (display "  - All other values are truthy\n")
 
 (display "✓ Truthiness semantics verified\n")

--- a/src/compiler/bytecode.rs
+++ b/src/compiler/bytecode.rs
@@ -70,14 +70,14 @@ pub enum Instruction {
     /// Cdr operation
     Cdr,
 
-    /// Vector construction (size)
-    MakeVector,
+    /// Array construction (size)
+    MakeArray,
 
-    /// Vector ref (index)
-    VectorRef,
+    /// Array ref (index)
+    ArrayRef,
 
-    /// Vector set (index)
-    VectorSet,
+    /// Array set (index)
+    ArraySet,
 
     /// Specialized arithmetic operations
     AddInt,

--- a/src/ffi/README.md
+++ b/src/ffi/README.md
@@ -37,7 +37,7 @@ Types are specified as keywords: `:int`, `:double`, `:string`, `:pointer`.
 | `Int` | `int64_t` | Sign-extended for smaller types |
 | `Float` | `double` | Converted to/from `float` as needed |
 | `String` | `char*` | Null-terminated, copied |
-| `Vector` | `T*` | Pointer to contiguous data |
+| `Array` | `T*` | Pointer to contiguous data |
 | `Nil` | `NULL` | Null pointer |
 
 ## Structs

--- a/src/ffi/marshal/array_marshal.rs
+++ b/src/ffi/marshal/array_marshal.rs
@@ -5,7 +5,7 @@ use crate::value::Value;
 
 /// Marshal an array value to C representation.
 pub fn marshal_array(value: &Value, elem_type: &CType, _count: usize) -> Result<CValue, String> {
-    if let Some(vec_ref) = value.as_vector() {
+    if let Some(vec_ref) = value.as_array() {
         let mut elements = Vec::new();
         let vec = vec_ref.borrow();
         for elem in vec.iter() {
@@ -33,7 +33,7 @@ pub fn unmarshal_array(cvalue: &CValue, elem_type: &CType) -> Result<Value, Stri
             for elem in elements {
                 result.push(conversions::c_to_elle(elem, elem_type)?);
             }
-            Ok(Value::vector(result))
+            Ok(Value::array(result))
         }
         _ => Err("Type mismatch in unmarshal: expected array".to_string()),
     }
@@ -44,8 +44,8 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_marshal_vector_as_array() {
-        let val = Value::vector(vec![Value::int(1), Value::int(2), Value::int(3)]);
+    fn test_marshal_array_as_c_array() {
+        let val = Value::array(vec![Value::int(1), Value::int(2), Value::int(3)]);
         let cval = marshal_array(&val, &CType::Int, 3).unwrap();
         match cval {
             CValue::Array(elems) => {
@@ -76,17 +76,17 @@ mod tests {
     }
 
     #[test]
-    fn test_unmarshal_array_to_vector() {
+    fn test_unmarshal_c_array_to_array() {
         let cval = CValue::Array(vec![CValue::Int(5), CValue::Int(10), CValue::Int(15)]);
         let val = unmarshal_array(&cval, &CType::Int).unwrap();
-        if let Some(vec_ref) = val.as_vector() {
+        if let Some(vec_ref) = val.as_array() {
             let vec = vec_ref.borrow();
             assert_eq!(vec.len(), 3);
             assert_eq!(vec[0], Value::int(5));
             assert_eq!(vec[1], Value::int(10));
             assert_eq!(vec[2], Value::int(15));
         } else {
-            panic!("Expected Vector");
+            panic!("Expected Array");
         }
     }
 }

--- a/src/ffi/marshal/union_marshal.rs
+++ b/src/ffi/marshal/union_marshal.rs
@@ -5,10 +5,10 @@ use crate::value::Value;
 
 /// Marshal a union value to C representation with layout information.
 ///
-/// The union value should be a vector with a single element: \[field_index_or_value\].
+/// The union value should be an array with a single element: \[field_index_or_value\].
 /// The field is packed at offset 0 (all union fields overlap at offset 0).
 pub fn marshal_union_with_layout(value: &Value, layout: &UnionLayout) -> Result<CValue, String> {
-    if let Some(fields_ref) = value.as_vector() {
+    if let Some(fields_ref) = value.as_array() {
         let fields = fields_ref.borrow();
         // Union must have exactly one field value
         if fields.is_empty() || fields.len() > layout.fields.len() {
@@ -55,7 +55,7 @@ pub fn marshal_union_with_layout(value: &Value, layout: &UnionLayout) -> Result<
 
 /// Unmarshal a C union to Elle value with layout information.
 ///
-/// Returns a vector with all field values (all fields read at offset 0).
+/// Returns an array with all field values (all fields read at offset 0).
 /// In practice, the caller must know which field is active.
 pub fn unmarshal_union_with_layout(cvalue: &CValue, layout: &UnionLayout) -> Result<Value, String> {
     match cvalue {
@@ -76,7 +76,7 @@ pub fn unmarshal_union_with_layout(cvalue: &CValue, layout: &UnionLayout) -> Res
                 field_values.push(field_value);
             }
 
-            Ok(Value::vector(field_values))
+            Ok(Value::array(field_values))
         }
         _ => Err("Type mismatch in unmarshal: expected union".to_string()),
     }

--- a/src/formatter/core.rs
+++ b/src/formatter/core.rs
@@ -91,7 +91,7 @@ fn format_value(
             HeapObject::String(s) => {
                 return format!("\"{}\"", s.escape_default());
             }
-            HeapObject::Vector(v) => {
+            HeapObject::Array(v) => {
                 if let Ok(elements) = v.try_borrow() {
                     if elements.is_empty() {
                         return "[]".to_string();

--- a/src/hir/analyze/forms.rs
+++ b/src/hir/analyze/forms.rs
@@ -30,8 +30,8 @@ impl<'a> Analyzer<'a> {
                 }
             }
 
-            // Vector literal - call vector primitive
-            SyntaxKind::Vector(items) => {
+            // Array literal - call array primitive
+            SyntaxKind::Array(items) => {
                 let mut args = Vec::new();
                 let mut effect = Effect::none();
                 for item in items {
@@ -39,8 +39,8 @@ impl<'a> Analyzer<'a> {
                     effect = effect.combine(hir.effect);
                     args.push(hir);
                 }
-                // Look up the 'vector' primitive and call it with the elements
-                let sym = self.symbols.intern("vector");
+                // Look up the 'array' primitive and call it with the elements
+                let sym = self.symbols.intern("array");
                 let id = self.ctx.fresh_binding();
                 self.ctx.register_binding(BindingInfo::global(id, sym));
                 let func = Hir::new(HirKind::Var(id), span.clone(), Effect::none());

--- a/src/hir/analyze/special.rs
+++ b/src/hir/analyze/special.rs
@@ -109,10 +109,10 @@ impl<'a> Analyzer<'a> {
                     items.iter().map(|p| self.analyze_pattern(p)).collect();
                 Ok(HirPattern::List(patterns?))
             }
-            SyntaxKind::Vector(items) => {
+            SyntaxKind::Array(items) => {
                 let patterns: Result<Vec<_>, _> =
                     items.iter().map(|p| self.analyze_pattern(p)).collect();
-                Ok(HirPattern::Vector(patterns?))
+                Ok(HirPattern::Array(patterns?))
             }
             _ => Err(format!("{}: invalid pattern", syntax.span)),
         }

--- a/src/hir/pattern.rs
+++ b/src/hir/pattern.rs
@@ -26,8 +26,8 @@ pub enum HirPattern {
     /// Match a list of specific length
     List(Vec<HirPattern>),
 
-    /// Match a vector of specific length
-    Vector(Vec<HirPattern>),
+    /// Match an array of specific length
+    Array(Vec<HirPattern>),
 }
 
 /// Literal values that can appear in patterns
@@ -77,7 +77,7 @@ impl HirPattern {
                 head.collect_bindings(out);
                 tail.collect_bindings(out);
             }
-            HirPattern::List(patterns) | HirPattern::Vector(patterns) => {
+            HirPattern::List(patterns) | HirPattern::Array(patterns) => {
                 for p in patterns {
                     p.collect_bindings(out);
                 }

--- a/src/jit/compiler.rs
+++ b/src/jit/compiler.rs
@@ -58,7 +58,7 @@ pub(crate) struct RuntimeHelpers {
     pub(crate) cons: FuncId,
     pub(crate) car: FuncId,
     pub(crate) cdr: FuncId,
-    pub(crate) make_vector: FuncId,
+    pub(crate) make_array: FuncId,
     pub(crate) is_nil: FuncId,
     pub(crate) is_pair: FuncId,
     #[allow(dead_code)]
@@ -130,8 +130,8 @@ impl JitCompiler {
         builder.symbol("elle_jit_car", dispatch::elle_jit_car as *const u8);
         builder.symbol("elle_jit_cdr", dispatch::elle_jit_cdr as *const u8);
         builder.symbol(
-            "elle_jit_make_vector",
-            dispatch::elle_jit_make_vector as *const u8,
+            "elle_jit_make_array",
+            dispatch::elle_jit_make_array as *const u8,
         );
         builder.symbol("elle_jit_is_pair", dispatch::elle_jit_is_pair as *const u8);
         builder.symbol(
@@ -200,11 +200,11 @@ impl JitCompiler {
         ternary_sig.params.push(AbiParam::new(I64));
         ternary_sig.returns.push(AbiParam::new(I64));
 
-        // Make vector signature: (ptr, count) -> i64
-        let mut make_vector_sig = module.make_signature();
-        make_vector_sig.params.push(AbiParam::new(I64)); // elements ptr
-        make_vector_sig.params.push(AbiParam::new(I64)); // count (as i64)
-        make_vector_sig.returns.push(AbiParam::new(I64));
+        // Make array signature: (ptr, count) -> i64
+        let mut make_array_sig = module.make_signature();
+        make_array_sig.params.push(AbiParam::new(I64)); // elements ptr
+        make_array_sig.params.push(AbiParam::new(I64)); // count (as i64)
+        make_array_sig.returns.push(AbiParam::new(I64));
 
         // Call signature: (func, args_ptr, nargs, vm) -> i64
         let mut call_sig = module.make_signature();
@@ -244,7 +244,7 @@ impl JitCompiler {
             cons: declare(module, "elle_jit_cons", &binary_sig)?,
             car: declare(module, "elle_jit_car", &unary_sig)?,
             cdr: declare(module, "elle_jit_cdr", &unary_sig)?,
-            make_vector: declare(module, "elle_jit_make_vector", &make_vector_sig)?,
+            make_array: declare(module, "elle_jit_make_array", &make_array_sig)?,
             is_nil: declare(module, "elle_jit_is_nil", &unary_sig)?,
             is_pair: declare(module, "elle_jit_is_pair", &unary_sig)?,
             is_truthy: declare(module, "elle_jit_is_truthy", &unary_sig)?,

--- a/src/jit/dispatch.rs
+++ b/src/jit/dispatch.rs
@@ -89,15 +89,15 @@ pub extern "C" fn elle_jit_cdr(pair_bits: u64) -> u64 {
     }
 }
 
-/// Allocate a vector from an array of elements
+/// Allocate an array from a list of elements
 #[no_mangle]
-pub extern "C" fn elle_jit_make_vector(elements: *const u64, count: u32) -> u64 {
+pub extern "C" fn elle_jit_make_array(elements: *const u64, count: u32) -> u64 {
     let mut vec = Vec::with_capacity(count as usize);
     for i in 0..count as usize {
         let bits = unsafe { *elements.add(i) };
         vec.push(unsafe { Value::from_bits(bits) });
     }
-    Value::vector(vec).to_bits()
+    Value::array(vec).to_bits()
 }
 
 /// Check if value is a pair (cons cell)
@@ -458,17 +458,17 @@ mod tests {
     }
 
     #[test]
-    fn test_make_vector() {
+    fn test_make_array() {
         let elements = [
             Value::int(1).to_bits(),
             Value::int(2).to_bits(),
             Value::int(3).to_bits(),
         ];
-        let vec_bits = elle_jit_make_vector(elements.as_ptr(), 3);
+        let vec_bits = elle_jit_make_array(elements.as_ptr(), 3);
         let vec = unsafe { Value::from_bits(vec_bits) };
 
-        assert!(vec.is_vector());
-        let vec_ref = vec.as_vector().unwrap();
+        assert!(vec.is_array());
+        let vec_ref = vec.as_array().unwrap();
         let borrowed = vec_ref.borrow();
         assert_eq!(borrowed.len(), 3);
         assert_eq!(borrowed[0].as_int(), Some(1));

--- a/src/jit/translate.rs
+++ b/src/jit/translate.rs
@@ -244,18 +244,14 @@ impl<'a> FunctionTranslator<'a> {
                 builder.def_var(var(dst.0), result);
             }
 
-            LirInstr::MakeVector { dst, elements } => {
+            LirInstr::MakeArray { dst, elements } => {
                 // Allocate stack space for elements
                 if elements.is_empty() {
-                    // Empty vector - pass null pointer and 0 count
+                    // Empty array - pass null pointer and 0 count
                     let null_ptr = builder.ins().iconst(I64, 0);
                     let count = builder.ins().iconst(I64, 0);
-                    let result = self.call_helper_binary(
-                        builder,
-                        self.helpers.make_vector,
-                        null_ptr,
-                        count,
-                    )?;
+                    let result =
+                        self.call_helper_binary(builder, self.helpers.make_array, null_ptr, count)?;
                     builder.def_var(var(dst.0), result);
                 } else {
                     // Create stack slot for elements
@@ -274,7 +270,7 @@ impl<'a> FunctionTranslator<'a> {
                     let count = builder.ins().iconst(I64, elements.len() as i64);
                     let result = self.call_helper_binary(
                         builder,
-                        self.helpers.make_vector,
+                        self.helpers.make_array,
                         elements_addr,
                         count,
                     )?;

--- a/src/lint/rules.rs
+++ b/src/lint/rules.rs
@@ -143,11 +143,11 @@ pub fn builtin_arity(name: &str) -> Option<usize> {
         "type-of" => Some(1),
         // Logic
         "not" => Some(1),
-        // Vector operations
-        "vector-ref" => Some(2),
-        "vector-set!" => Some(3),
+        // Array operations
+        "array-ref" => Some(2),
+        "array-set!" => Some(3),
         // Variadic or special forms - return None
-        "list" | "vector" | "var" | "def" | "quote" | "begin" | "let" | "let*" | "fn" | "match"
+        "list" | "array" | "var" | "def" | "quote" | "begin" | "let" | "let*" | "fn" | "match"
         | "if" | "while" | "forever" | "each" => None,
         _ => None,
     }

--- a/src/lir/emit.rs
+++ b/src/lir/emit.rs
@@ -350,11 +350,11 @@ impl Emitter {
                 self.push_reg(*dst);
             }
 
-            LirInstr::MakeVector { dst, elements } => {
+            LirInstr::MakeArray { dst, elements } => {
                 for elem in elements {
                     self.ensure_on_top(*elem);
                 }
-                self.bytecode.emit(Instruction::MakeVector);
+                self.bytecode.emit(Instruction::MakeArray);
                 self.bytecode.emit_byte(elements.len() as u8);
                 for _ in elements {
                     self.pop();

--- a/src/lir/lower/pattern.rs
+++ b/src/lir/lower/pattern.rs
@@ -296,9 +296,9 @@ impl Lowerer {
 
                 Ok(())
             }
-            HirPattern::Vector(_patterns) => {
-                // TODO: Implement vector pattern matching
-                Err("Vector pattern matching not yet implemented".to_string())
+            HirPattern::Array(_patterns) => {
+                // TODO: Implement array pattern matching
+                Err("Array pattern matching not yet implemented".to_string())
             }
         }
     }

--- a/src/lir/types.rs
+++ b/src/lir/types.rs
@@ -157,8 +157,8 @@ pub enum LirInstr {
     // === Data Construction ===
     /// Construct a cons cell
     Cons { dst: Reg, head: Reg, tail: Reg },
-    /// Construct a vector
-    MakeVector { dst: Reg, elements: Vec<Reg> },
+    /// Construct an array
+    MakeArray { dst: Reg, elements: Vec<Reg> },
     /// Get car of cons
     Car { dst: Reg, pair: Reg },
     /// Get cdr of cons

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,7 +42,7 @@ fn print_help() {
     println!("  Integer ops: mod, remainder, even?, odd?");
     println!("  Strings:     string-append, string-upcase, string-downcase,");
     println!("               substring, string-index, char-at");
-    println!("  Vectors:     vector, vector-ref, vector-set!");
+    println!("  Arrays:      array, array-ref, array-set!");
     println!("  Types:       type-of, int, float, string");
     println!("  Logic:       not, if");
     println!("  I/O:         display, newline");

--- a/src/primitives/AGENTS.md
+++ b/src/primitives/AGENTS.md
@@ -6,7 +6,7 @@ Built-in functions. Registered into the VM at startup.
 
 Implement Elle's standard library of built-in functions:
 - Arithmetic, comparison, logic
-- List and vector operations
+- List and array operations
 - String manipulation
 - I/O and file operations
 - Concurrency primitives
@@ -90,7 +90,7 @@ pub fn register_arithmetic(vm: &mut VM, symbols: &mut SymbolTable) {
 | `comparison.rs` | `=`, `<`, `>`, `<=`, `>=` |
 | `logic.rs` | `not`, `and`, `or` (functions, not special forms) |
 | `list.rs` | `cons`, `car`, `cdr`, `list`, `length`, `append` |
-| `vector.rs` | `vector`, `vector-ref`, `vector-set!`, `vector-length` |
+| `array.rs` | `array`, `array-ref`, `array-set!`, `array-length` |
 | `string.rs` | `string-length`, `string-append`, `substring` |
 | `table.rs` | `table`, `table-get`, `table-set!` |
 | `structs.rs` | `struct`, `struct-get` |

--- a/src/primitives/array.rs
+++ b/src/primitives/array.rs
@@ -1,25 +1,25 @@
-//! Vector operations primitives
+//! Array operations primitives
 use crate::value::fiber::{SignalBits, SIG_ERROR, SIG_OK};
 use crate::value::{error_val, Value};
 
-/// Create a vector from arguments
-pub fn prim_vector(args: &[Value]) -> (SignalBits, Value) {
-    (SIG_OK, Value::vector(args.to_vec()))
+/// Create an array from arguments
+pub fn prim_array(args: &[Value]) -> (SignalBits, Value) {
+    (SIG_OK, Value::array(args.to_vec()))
 }
 
-/// Get the length of a vector
-pub fn prim_vector_length(args: &[Value]) -> (SignalBits, Value) {
+/// Get the length of an array
+pub fn prim_array_length(args: &[Value]) -> (SignalBits, Value) {
     if args.len() != 1 {
         return (
             SIG_ERROR,
             error_val(
                 "arity-error",
-                format!("vector-length: expected 1 argument, got {}", args.len()),
+                format!("array-length: expected 1 argument, got {}", args.len()),
             ),
         );
     }
 
-    if let Some(v) = args[0].as_vector() {
+    if let Some(v) = args[0].as_array() {
         let borrowed = v.borrow();
         (SIG_OK, Value::int(borrowed.len() as i64))
     } else {
@@ -27,35 +27,32 @@ pub fn prim_vector_length(args: &[Value]) -> (SignalBits, Value) {
             SIG_ERROR,
             error_val(
                 "type-error",
-                format!(
-                    "vector-length: expected vector, got {}",
-                    args[0].type_name()
-                ),
+                format!("array-length: expected array, got {}", args[0].type_name()),
             ),
         )
     }
 }
 
-/// Get a reference from a vector at an index
-pub fn prim_vector_ref(args: &[Value]) -> (SignalBits, Value) {
+/// Get a reference from an array at an index
+pub fn prim_array_ref(args: &[Value]) -> (SignalBits, Value) {
     if args.len() != 2 {
         return (
             SIG_ERROR,
             error_val(
                 "arity-error",
-                format!("vector-ref: expected 2 arguments, got {}", args.len()),
+                format!("array-ref: expected 2 arguments, got {}", args.len()),
             ),
         );
     }
 
-    let vec = match args[0].as_vector() {
+    let vec = match args[0].as_array() {
         Some(v) => v,
         None => {
             return (
                 SIG_ERROR,
                 error_val(
                     "type-error",
-                    format!("vector-ref: expected vector, got {}", args[0].type_name()),
+                    format!("array-ref: expected array, got {}", args[0].type_name()),
                 ),
             )
         }
@@ -67,7 +64,7 @@ pub fn prim_vector_ref(args: &[Value]) -> (SignalBits, Value) {
                 SIG_ERROR,
                 error_val(
                     "type-error",
-                    format!("vector-ref: expected integer, got {}", args[1].type_name()),
+                    format!("array-ref: expected integer, got {}", args[1].type_name()),
                 ),
             )
         }
@@ -81,7 +78,7 @@ pub fn prim_vector_ref(args: &[Value]) -> (SignalBits, Value) {
             error_val(
                 "error",
                 format!(
-                    "vector-ref: index {} out of bounds (length {})",
+                    "array-ref: index {} out of bounds (length {})",
                     index,
                     borrowed.len()
                 ),
@@ -90,26 +87,26 @@ pub fn prim_vector_ref(args: &[Value]) -> (SignalBits, Value) {
     }
 }
 
-/// Set a value in a vector at an index (returns new vector)
-pub fn prim_vector_set(args: &[Value]) -> (SignalBits, Value) {
+/// Set a value in an array at an index (returns new array)
+pub fn prim_array_set(args: &[Value]) -> (SignalBits, Value) {
     if args.len() != 3 {
         return (
             SIG_ERROR,
             error_val(
                 "arity-error",
-                format!("vector-set!: expected 3 arguments, got {}", args.len()),
+                format!("array-set!: expected 3 arguments, got {}", args.len()),
             ),
         );
     }
 
-    let vec_ref = match args[0].as_vector() {
+    let vec_ref = match args[0].as_array() {
         Some(v) => v,
         None => {
             return (
                 SIG_ERROR,
                 error_val(
                     "type-error",
-                    format!("vector-set!: expected vector, got {}", args[0].type_name()),
+                    format!("array-set!: expected array, got {}", args[0].type_name()),
                 ),
             )
         }
@@ -121,7 +118,7 @@ pub fn prim_vector_set(args: &[Value]) -> (SignalBits, Value) {
                 SIG_ERROR,
                 error_val(
                     "type-error",
-                    format!("vector-set!: expected integer, got {}", args[1].type_name()),
+                    format!("array-set!: expected integer, got {}", args[1].type_name()),
                 ),
             )
         }
@@ -135,7 +132,7 @@ pub fn prim_vector_set(args: &[Value]) -> (SignalBits, Value) {
             error_val(
                 "error",
                 format!(
-                    "vector-set!: index {} out of bounds (length {})",
+                    "array-set!: index {} out of bounds (length {})",
                     index,
                     vec.len()
                 ),
@@ -145,5 +142,5 @@ pub fn prim_vector_set(args: &[Value]) -> (SignalBits, Value) {
 
     vec[index] = value;
     drop(vec);
-    (SIG_OK, Value::vector(vec_ref.borrow().clone()))
+    (SIG_OK, Value::array(vec_ref.borrow().clone()))
 }

--- a/src/primitives/concurrency.rs
+++ b/src/primitives/concurrency.rs
@@ -10,7 +10,7 @@ use std::sync::{Arc, Mutex};
 ///
 /// A value is safe to send if it contains only immutable data:
 /// - Primitives (nil, bool, int, float, symbol, keyword, string)
-/// - Immutable collections (vector, struct)
+/// - Immutable collections (array, struct)
 /// - Closures (if their captured environment is safe)
 ///
 /// Unsafe values:
@@ -44,7 +44,7 @@ fn is_value_sendable(value: &Value) -> bool {
         HeapObject::String(_) => true,
 
         // Immutable collections are safe
-        HeapObject::Vector(vec) => {
+        HeapObject::Array(vec) => {
             if let Ok(borrowed) = vec.try_borrow() {
                 borrowed.iter().all(is_value_sendable)
             } else {

--- a/src/primitives/debugging.rs
+++ b/src/primitives/debugging.rs
@@ -234,7 +234,7 @@ pub fn prim_string_to_keyword(args: &[Value]) -> (SignalBits, Value) {
 // Disassembly
 // ============================================================================
 
-/// (disbit closure) — disassemble bytecode as vector of strings
+/// (disbit closure) — disassemble bytecode as array of strings
 pub fn prim_disbit(args: &[Value]) -> (SignalBits, Value) {
     if args.len() != 1 {
         return (
@@ -252,7 +252,7 @@ pub fn prim_disbit(args: &[Value]) -> (SignalBits, Value) {
         }
         (
             SIG_OK,
-            Value::vector(lines.into_iter().map(Value::string).collect()),
+            Value::array(lines.into_iter().map(Value::string).collect()),
         )
     } else {
         (
@@ -265,7 +265,7 @@ pub fn prim_disbit(args: &[Value]) -> (SignalBits, Value) {
     }
 }
 
-/// (disjit closure) — return Cranelift IR as vector of strings, or nil
+/// (disjit closure) — return Cranelift IR as array of strings, or nil
 pub fn prim_disjit(args: &[Value]) -> (SignalBits, Value) {
     if args.len() != 1 {
         return (
@@ -288,7 +288,7 @@ pub fn prim_disjit(args: &[Value]) -> (SignalBits, Value) {
         match compiler.clif_text(&lir) {
             Ok(lines) => (
                 SIG_OK,
-                Value::vector(lines.into_iter().map(Value::string).collect()),
+                Value::array(lines.into_iter().map(Value::string).collect()),
             ),
             Err(_) => (SIG_OK, Value::NIL),
         }

--- a/src/primitives/json/serializer.rs
+++ b/src/primitives/json/serializer.rs
@@ -49,7 +49,7 @@ pub fn serialize_value(value: &Value) -> Result<String, String> {
         let vec = value.list_to_vec()?;
         let elements: Result<Vec<String>, String> = vec.iter().map(serialize_value).collect();
         Ok(format!("[{}]", elements?.join(",")))
-    } else if let Some(v) = value.as_vector() {
+    } else if let Some(v) = value.as_array() {
         let borrowed = v.borrow();
         let elements: Result<Vec<String>, String> = borrowed.iter().map(serialize_value).collect();
         Ok(format!("[{}]", elements?.join(",")))
@@ -94,7 +94,7 @@ pub fn serialize_value(value: &Value) -> Result<String, String> {
         match tag {
             HeapTag::String => Err("String should have been handled above".to_string()),
             HeapTag::Cons => Err("Cons should have been handled above".to_string()),
-            HeapTag::Vector => Err("Vector should have been handled above".to_string()),
+            HeapTag::Array => Err("Array should have been handled above".to_string()),
             HeapTag::Table => Err("Table should have been handled above".to_string()),
             HeapTag::Struct => Err("Struct should have been handled above".to_string()),
             HeapTag::Closure => Err("Cannot serialize closures to JSON".to_string()),
@@ -164,7 +164,7 @@ pub fn serialize_value_pretty(value: &Value, indent_level: usize) -> Result<Stri
             elements?.join(&format!(",\n{}", next_indent)),
             indent
         ))
-    } else if let Some(v) = value.as_vector() {
+    } else if let Some(v) = value.as_array() {
         let borrowed = v.borrow();
         if borrowed.is_empty() {
             return Ok("[]".to_string());
@@ -233,7 +233,7 @@ pub fn serialize_value_pretty(value: &Value, indent_level: usize) -> Result<Stri
         match tag {
             HeapTag::String => Err("String should have been handled above".to_string()),
             HeapTag::Cons => Err("Cons should have been handled above".to_string()),
-            HeapTag::Vector => Err("Vector should have been handled above".to_string()),
+            HeapTag::Array => Err("Array should have been handled above".to_string()),
             HeapTag::Table => Err("Table should have been handled above".to_string()),
             HeapTag::Struct => Err("Struct should have been handled above".to_string()),
             HeapTag::Closure => Err("Cannot serialize closures to JSON".to_string()),

--- a/src/primitives/list.rs
+++ b/src/primitives/list.rs
@@ -133,13 +133,13 @@ pub fn prim_length(args: &[Value]) -> (SignalBits, Value) {
         (SIG_OK, Value::int(vec.len() as i64))
     } else if let Some(s) = args[0].as_string() {
         (SIG_OK, Value::int(s.chars().count() as i64))
-    } else if args[0].is_vector() {
-        let vec = match args[0].as_vector() {
+    } else if args[0].is_array() {
+        let vec = match args[0].as_array() {
             Some(v) => v,
             None => {
                 return (
                     SIG_ERROR,
-                    error_val("error", "length: failed to get vector".to_string()),
+                    error_val("error", "length: failed to get array".to_string()),
                 )
             }
         };
@@ -183,7 +183,7 @@ pub fn prim_length(args: &[Value]) -> (SignalBits, Value) {
         (SIG_OK, Value::int(name.chars().count() as i64))
     } else {
         (SIG_ERROR, error_val("type-error", format!(
-            "length: expected collection type (list, string, vector, table, struct, symbol, or keyword), got {}",
+            "length: expected collection type (list, string, array, table, struct, symbol, or keyword), got {}",
             args[0].type_name()
         )))
     }
@@ -203,10 +203,14 @@ pub fn prim_empty(args: &[Value]) -> (SignalBits, Value) {
 
     // nil is not a container - error if passed
     if args[0].is_nil() {
-        return (SIG_ERROR, error_val("type-error",
-            "empty?: expected collection type (list, string, vector, table, or struct), got nil"
-                .to_string(),
-        ));
+        return (
+            SIG_ERROR,
+            error_val(
+                "type-error",
+                "empty?: expected collection type (list, string, array, table, or struct), got nil"
+                    .to_string(),
+            ),
+        );
     }
 
     let result = if args[0].is_empty_list() {
@@ -215,13 +219,13 @@ pub fn prim_empty(args: &[Value]) -> (SignalBits, Value) {
         false
     } else if let Some(s) = args[0].as_string() {
         s.is_empty()
-    } else if args[0].is_vector() {
-        let vec = match args[0].as_vector() {
+    } else if args[0].is_array() {
+        let vec = match args[0].as_array() {
             Some(v) => v,
             None => {
                 return (
                     SIG_ERROR,
-                    error_val("error", "empty?: failed to get vector".to_string()),
+                    error_val("error", "empty?: failed to get array".to_string()),
                 )
             }
         };
@@ -254,7 +258,7 @@ pub fn prim_empty(args: &[Value]) -> (SignalBits, Value) {
             error_val(
                 "type-error",
                 format!(
-                "empty?: expected collection type (list, string, vector, table, or struct), got {}",
+                "empty?: expected collection type (list, string, array, table, or struct), got {}",
                 args[0].type_name()
             ),
             ),

--- a/src/primitives/mod.rs
+++ b/src/primitives/mod.rs
@@ -1,4 +1,5 @@
 pub mod arithmetic;
+pub mod array;
 pub mod cell;
 pub mod comparison;
 pub mod concurrency;
@@ -26,7 +27,6 @@ pub mod time;
 pub mod time_def;
 pub mod type_check;
 pub mod utility;
-pub mod vector;
 
 pub use list::{clear_length_symbol_table, set_length_symbol_table};
 pub use module_init::init_stdlib;

--- a/src/primitives/registration.rs
+++ b/src/primitives/registration.rs
@@ -52,6 +52,7 @@ use super::module_loading::{prim_add_module_path, prim_import_file};
 use super::package::{prim_package_info, prim_package_version};
 use super::process::{prim_exit, prim_halt};
 
+use super::array::{prim_array, prim_array_ref, prim_array_set};
 use super::string::{
     prim_any_to_string, prim_char_at, prim_keyword_to_string, prim_number_to_string,
     prim_string_append, prim_string_contains, prim_string_downcase, prim_string_ends_with,
@@ -69,7 +70,6 @@ use super::type_check::{
     prim_is_boolean, prim_is_keyword, prim_is_list, prim_is_nil, prim_is_number, prim_is_pair,
     prim_is_string, prim_is_symbol, prim_type_of,
 };
-use super::vector::{prim_vector, prim_vector_ref, prim_vector_set};
 
 /// Register all primitive functions with the VM.
 /// Returns a map of primitive effects for use by the analyzer.
@@ -464,29 +464,29 @@ pub fn register_primitives(vm: &mut VM, symbols: &mut SymbolTable) -> HashMap<Sy
         Effect::raises(),
     );
 
-    // Vector operations - can raise
+    // Array operations - can raise
     register_fn(
         vm,
         symbols,
         &mut effects,
-        "vector",
-        prim_vector,
+        "array",
+        prim_array,
         Effect::none(),
     );
     register_fn(
         vm,
         symbols,
         &mut effects,
-        "vector-ref",
-        prim_vector_ref,
+        "array-ref",
+        prim_array_ref,
         Effect::raises(),
     );
     register_fn(
         vm,
         symbols,
         &mut effects,
-        "vector-set!",
-        prim_vector_set,
+        "array-set!",
+        prim_array_set,
         Effect::raises(),
     );
 

--- a/src/primitives/string.rs
+++ b/src/primitives/string.rs
@@ -434,7 +434,7 @@ pub fn prim_to_string(args: &[Value]) -> (SignalBits, Value) {
         return (SIG_OK, Value::string(format!(":{}", name)));
     }
 
-    // Handle heap types (Cons, Vector, etc.)
+    // Handle heap types (Cons, Array, etc.)
     if let Some(_cons) = val.as_cons() {
         // Format as list "(1 2 3)"
         let mut items = Vec::new();
@@ -477,7 +477,7 @@ pub fn prim_to_string(args: &[Value]) -> (SignalBits, Value) {
         return (SIG_OK, Value::string(list_str));
     }
 
-    if let Some(vec_ref) = val.as_vector() {
+    if let Some(vec_ref) = val.as_array() {
         // Format as "[1, 2, 3]"
         let vec = vec_ref.borrow();
         let mut formatted_items = Vec::new();
@@ -493,7 +493,7 @@ pub fn prim_to_string(args: &[Value]) -> (SignalBits, Value) {
                         SIG_ERROR,
                         error_val(
                             "error",
-                            "to-string: failed to convert vector item".to_string(),
+                            "to-string: failed to convert array item".to_string(),
                         ),
                     )
                 }

--- a/src/reader/parser.rs
+++ b/src/reader/parser.rs
@@ -63,7 +63,7 @@ impl Reader {
     fn read_one(&mut self, symbols: &mut SymbolTable, token: &OwnedToken) -> Result<Value, String> {
         match token {
             OwnedToken::LeftParen => self.read_list(symbols),
-            OwnedToken::LeftBracket => self.read_vector(symbols),
+            OwnedToken::LeftBracket => self.read_array(symbols),
             OwnedToken::LeftBrace => self.read_struct(symbols),
             OwnedToken::ListSugar => {
                 self.advance();
@@ -251,7 +251,7 @@ impl Reader {
         }
     }
 
-    fn read_vector(&mut self, symbols: &mut SymbolTable) -> Result<Value, String> {
+    fn read_array(&mut self, symbols: &mut SymbolTable) -> Result<Value, String> {
         self.advance(); // skip [
         let mut elements = Vec::new();
 
@@ -260,13 +260,13 @@ impl Reader {
                 None => {
                     let loc = self.current_location();
                     return Err(format!(
-                        "{}: unterminated vector (missing closing bracket)",
+                        "{}: unterminated array (missing closing bracket)",
                         loc.position()
                     ));
                 }
                 Some(OwnedToken::RightBracket) => {
                     self.advance();
-                    return Ok(Value::vector(elements));
+                    return Ok(Value::array(elements));
                 }
                 _ => elements.push(self.read(symbols)?),
             }

--- a/src/symbols/mod.rs
+++ b/src/symbols/mod.rs
@@ -203,9 +203,9 @@ pub fn get_primitive_documentation(name: &str) -> Option<&'static str> {
         "not" => "Logical NOT: (not x)",
         "if" => "Conditional: (if condition then else)",
 
-        // Vector operations
-        "vector-ref" => "Get vector element: (vector-ref v index)",
-        "vector-set!" => "Set vector element: (vector-set! v index value)",
+        // Array operations
+        "array-ref" => "Get array element: (array-ref v index)",
+        "array-set!" => "Set array element: (array-set! v index value)",
 
         // I/O
         "print" => "Print to output: (print x)",

--- a/src/syntax/README.md
+++ b/src/syntax/README.md
@@ -25,7 +25,7 @@ pub struct Syntax {
 pub enum SyntaxKind {
     Nil, Bool(bool), Int(i64), Float(f64),
     Symbol(String), Keyword(String), String(String),
-    List(Vec<Syntax>), Vector(Vec<Syntax>),
+    List(Vec<Syntax>), Array(Vec<Syntax>),
     Quote(Box<Syntax>), Quasiquote(Box<Syntax>),
     Unquote(Box<Syntax>), UnquoteSplicing(Box<Syntax>),
 }

--- a/src/syntax/convert.rs
+++ b/src/syntax/convert.rs
@@ -27,9 +27,9 @@ impl Syntax {
                 let values: Vec<Value> = items.iter().map(|item| item.to_value(symbols)).collect();
                 crate::value::list(values)
             }
-            SyntaxKind::Vector(items) => {
+            SyntaxKind::Array(items) => {
                 let values: Vec<Value> = items.iter().map(|item| item.to_value(symbols)).collect();
-                Value::vector(values)
+                Value::array(values)
             }
             SyntaxKind::Quote(inner) => {
                 let quote_sym = symbols.intern("quote");
@@ -89,13 +89,13 @@ impl Syntax {
                 .map(|v| Syntax::from_value(v, symbols, span.clone()))
                 .collect();
             SyntaxKind::List(syntaxes?)
-        } else if let Some(vec_ref) = value.as_vector() {
+        } else if let Some(vec_ref) = value.as_array() {
             let items = vec_ref.borrow().clone();
             let syntaxes: Result<Vec<Syntax>, String> = items
                 .iter()
                 .map(|v| Syntax::from_value(v, symbols, span.clone()))
                 .collect();
-            SyntaxKind::Vector(syntaxes?)
+            SyntaxKind::Array(syntaxes?)
         } else {
             return Err(format!("Cannot convert {:?} to Syntax", value));
         };
@@ -216,20 +216,20 @@ mod tests {
     }
 
     #[test]
-    fn test_roundtrip_vector() {
+    fn test_roundtrip_array() {
         let mut symbols = SymbolTable::new();
         let syntax = Syntax::new(
-            SyntaxKind::Vector(vec![Syntax::new(SyntaxKind::Int(1), test_span())]),
+            SyntaxKind::Array(vec![Syntax::new(SyntaxKind::Int(1), test_span())]),
             test_span(),
         );
         let value = syntax.to_value(&mut symbols);
         let result = Syntax::from_value(&value, &symbols, test_span()).unwrap();
         match result.kind {
-            SyntaxKind::Vector(items) => {
+            SyntaxKind::Array(items) => {
                 assert_eq!(items.len(), 1);
                 assert!(matches!(items[0].kind, SyntaxKind::Int(1)));
             }
-            other => panic!("expected Vector, got {:?}", other),
+            other => panic!("expected Array, got {:?}", other),
         }
     }
 

--- a/src/syntax/display.rs
+++ b/src/syntax/display.rs
@@ -29,7 +29,7 @@ impl fmt::Display for SyntaxKind {
                 }
                 write!(f, ")")
             }
-            SyntaxKind::Vector(items) => {
+            SyntaxKind::Array(items) => {
                 write!(f, "[")?;
                 for (i, item) in items.iter().enumerate() {
                     if i > 0 {

--- a/src/syntax/expand/mod.rs
+++ b/src/syntax/expand/mod.rs
@@ -152,8 +152,8 @@ impl Expander {
                 // Not a macro call - expand children recursively
                 self.expand_list(items, syntax.span, syntax.scopes, symbols, vm)
             }
-            SyntaxKind::Vector(items) => {
-                self.expand_vector(items, syntax.span, syntax.scopes, symbols, vm)
+            SyntaxKind::Array(items) => {
+                self.expand_array(items, syntax.span, syntax.scopes, symbols, vm)
             }
             SyntaxKind::Quote(_) => {
                 // Don't expand inside quote
@@ -231,7 +231,7 @@ impl Expander {
                     .map(|item| self.add_scope_recursive(item, scope))
                     .collect(),
             ),
-            SyntaxKind::Vector(items) => SyntaxKind::Vector(
+            SyntaxKind::Array(items) => SyntaxKind::Array(
                 items
                     .into_iter()
                     .map(|item| self.add_scope_recursive(item, scope))
@@ -278,7 +278,7 @@ impl Expander {
         ))
     }
 
-    fn expand_vector(
+    fn expand_array(
         &mut self,
         items: &[Syntax],
         span: Span,
@@ -291,7 +291,7 @@ impl Expander {
             .map(|item| self.expand(item.clone(), symbols, vm))
             .collect();
         Ok(Syntax::with_scopes(
-            SyntaxKind::Vector(expanded?),
+            SyntaxKind::Array(expanded?),
             span,
             scopes,
         ))

--- a/src/syntax/mod.rs
+++ b/src/syntax/mod.rs
@@ -76,7 +76,7 @@ impl Syntax {
         self.scopes = scopes.to_vec();
         self.scope_exempt = true;
         match &mut self.kind {
-            SyntaxKind::List(items) | SyntaxKind::Vector(items) => {
+            SyntaxKind::List(items) | SyntaxKind::Array(items) => {
                 for item in items {
                     item.set_scopes_recursive(scopes);
                 }
@@ -138,7 +138,7 @@ pub enum SyntaxKind {
 
     // Compounds
     List(Vec<Syntax>),
-    Vector(Vec<Syntax>),
+    Array(Vec<Syntax>),
 
     // Quote forms - preserved as structure for macro handling
     Quote(Box<Syntax>),
@@ -288,13 +288,13 @@ mod tests {
     }
 
     #[test]
-    fn test_display_vector() {
+    fn test_display_array() {
         let span = Span::new(0, 10, 1, 1);
         let items = vec![
             Syntax::new(SyntaxKind::Int(1), span.clone()),
             Syntax::new(SyntaxKind::Int(2), span.clone()),
         ];
-        let syntax = Syntax::new(SyntaxKind::Vector(items), span);
+        let syntax = Syntax::new(SyntaxKind::Array(items), span);
         assert_eq!(syntax.to_string(), "[1 2]");
     }
 
@@ -374,7 +374,7 @@ mod tests {
     }
 
     #[test]
-    fn test_expander_expand_vector() {
+    fn test_expander_expand_array() {
         let mut expander = Expander::new();
         let mut symbols = crate::symbol::SymbolTable::new();
         let mut vm = crate::vm::VM::new();
@@ -384,7 +384,7 @@ mod tests {
             Syntax::new(SyntaxKind::Int(1), span.clone()),
             Syntax::new(SyntaxKind::Int(2), span.clone()),
         ];
-        let syntax = Syntax::new(SyntaxKind::Vector(items), span);
+        let syntax = Syntax::new(SyntaxKind::Array(items), span);
         let result = expander.expand(syntax, &mut symbols, &mut vm);
         assert!(result.is_ok());
         let expanded = result.unwrap();

--- a/src/value/AGENTS.md
+++ b/src/value/AGENTS.md
@@ -86,7 +86,7 @@ These are set during the swap protocol in `vm/fiber.rs::with_child_fiber`.
 NaN-boxing uses the NaN space of IEEE 754 doubles:
 
 - **Immediate**: nil, bool, int (i48), symbol, keyword, float
-- **Heap pointer**: cons, vector, table, closure, fiber, cell, syntax, etc.
+- **Heap pointer**: cons, array, table, closure, fiber, cell, syntax, etc.
 
 ### Syntax objects
 

--- a/src/value/display.rs
+++ b/src/value/display.rs
@@ -66,8 +66,8 @@ impl fmt::Display for Value {
             return self.fmt_cons(f);
         }
 
-        // Vector
-        if let Some(vec_ref) = self.as_vector() {
+        // Array
+        if let Some(vec_ref) = self.as_array() {
             let vec = vec_ref.borrow();
             write!(f, "[")?;
             for (i, v) in vec.iter().enumerate() {
@@ -191,8 +191,8 @@ impl fmt::Debug for Value {
         if self.as_cons().is_some() {
             return self.fmt_cons_debug(f);
         }
-        // Vector
-        if let Some(vec_ref) = self.as_vector() {
+        // Array
+        if let Some(vec_ref) = self.as_array() {
             let vec = vec_ref.borrow();
             write!(f, "[")?;
             for (i, v) in vec.iter().enumerate() {

--- a/src/value/heap.rs
+++ b/src/value/heap.rs
@@ -38,7 +38,7 @@ impl Cons {
 pub enum HeapTag {
     String = 0,
     Cons = 1,
-    Vector = 2,
+    Array = 2,
     Table = 3,
     Struct = 4,
     Closure = 5,
@@ -65,8 +65,8 @@ pub enum HeapObject {
     /// Cons cell (list pair)
     Cons(Cons),
 
-    /// Mutable vector
-    Vector(RefCell<Vec<Value>>),
+    /// Mutable array
+    Array(RefCell<Vec<Value>>),
 
     /// Mutable table (hash map)
     Table(RefCell<BTreeMap<TableKey, Value>>),
@@ -132,7 +132,7 @@ impl HeapObject {
         match self {
             HeapObject::String(_) => HeapTag::String,
             HeapObject::Cons(_) => HeapTag::Cons,
-            HeapObject::Vector(_) => HeapTag::Vector,
+            HeapObject::Array(_) => HeapTag::Array,
             HeapObject::Table(_) => HeapTag::Table,
             HeapObject::Struct(_) => HeapTag::Struct,
             HeapObject::Closure(_) => HeapTag::Closure,
@@ -153,7 +153,7 @@ impl HeapObject {
         match self {
             HeapObject::String(_) => "string",
             HeapObject::Cons(_) => "list",
-            HeapObject::Vector(_) => "vector",
+            HeapObject::Array(_) => "array",
             HeapObject::Table(_) => "table",
             HeapObject::Struct(_) => "struct",
             HeapObject::Closure(_) => "closure",
@@ -175,7 +175,7 @@ impl std::fmt::Debug for HeapObject {
         match self {
             HeapObject::String(s) => write!(f, "\"{}\"", s),
             HeapObject::Cons(c) => write!(f, "({:?} . {:?})", c.first, c.rest),
-            HeapObject::Vector(v) => {
+            HeapObject::Array(v) => {
                 if let Ok(borrowed) = v.try_borrow() {
                     write!(f, "{:?}", &*borrowed)
                 } else {

--- a/src/value/repr/accessors.rs
+++ b/src/value/repr/accessors.rs
@@ -114,11 +114,11 @@ impl Value {
         self.heap_tag() == Some(HeapTag::Cons)
     }
 
-    /// Check if this is a vector.
+    /// Check if this is an array.
     #[inline]
-    pub fn is_vector(&self) -> bool {
+    pub fn is_array(&self) -> bool {
         use crate::value::heap::HeapTag;
-        self.heap_tag() == Some(HeapTag::Vector)
+        self.heap_tag() == Some(HeapTag::Array)
     }
 
     /// Check if this is a table.
@@ -219,15 +219,15 @@ impl Value {
         }
     }
 
-    /// Extract as vector if this is a vector.
+    /// Extract as array if this is an array.
     #[inline]
-    pub fn as_vector(&self) -> Option<&std::cell::RefCell<Vec<Value>>> {
+    pub fn as_array(&self) -> Option<&std::cell::RefCell<Vec<Value>>> {
         use crate::value::heap::{deref, HeapObject};
         if !self.is_heap() {
             return None;
         }
         match unsafe { deref(*self) } {
-            HeapObject::Vector(v) => Some(v),
+            HeapObject::Array(v) => Some(v),
             _ => None,
         }
     }

--- a/src/value/repr/constructors.rs
+++ b/src/value/repr/constructors.rs
@@ -120,12 +120,12 @@ impl Value {
         }))
     }
 
-    /// Create a vector.
+    /// Create an array.
     #[inline]
-    pub fn vector(elements: Vec<Value>) -> Self {
+    pub fn array(elements: Vec<Value>) -> Self {
         use crate::value::heap::{alloc, HeapObject};
         use std::cell::RefCell;
-        alloc(HeapObject::Vector(RefCell::new(elements)))
+        alloc(HeapObject::Array(RefCell::new(elements)))
     }
 
     /// Create an empty mutable table.

--- a/src/value/repr/tests.rs
+++ b/src/value/repr/tests.rs
@@ -115,18 +115,18 @@ fn test_cons_constructor() {
 }
 
 #[test]
-fn test_vector_constructor() {
+fn test_array_constructor() {
     let elements = vec![Value::int(1), Value::int(2), Value::int(3)];
-    let v = Value::vector(elements.clone());
-    assert!(v.is_vector());
-    if let Some(vec_ref) = v.as_vector() {
+    let v = Value::array(elements.clone());
+    assert!(v.is_array());
+    if let Some(vec_ref) = v.as_array() {
         let borrowed = vec_ref.borrow();
         assert_eq!(borrowed.len(), 3);
         assert_eq!(borrowed[0], Value::int(1));
         assert_eq!(borrowed[1], Value::int(2));
         assert_eq!(borrowed[2], Value::int(3));
     } else {
-        panic!("Expected vector");
+        panic!("Expected array");
     }
 }
 
@@ -196,7 +196,7 @@ fn test_type_name() {
         Value::cons(Value::NIL, Value::EMPTY_LIST).type_name(),
         "list"
     );
-    assert_eq!(Value::vector(vec![]).type_name(), "vector");
+    assert_eq!(Value::array(vec![]).type_name(), "array");
     assert_eq!(Value::table().type_name(), "table");
     assert_eq!(Value::cell(Value::NIL).type_name(), "cell");
 }
@@ -220,8 +220,8 @@ fn test_truthiness_semantics() {
     // Empty list is truthy (it's nil, but we test the list form)
     assert!(Value::EMPTY_LIST.is_truthy(), "empty list is truthy");
 
-    // Empty vector is truthy
-    assert!(Value::vector(vec![]).is_truthy(), "empty vector is truthy");
+    // Empty array is truthy
+    assert!(Value::array(vec![]).is_truthy(), "empty array is truthy");
 
     // Regular values are truthy
     assert!(Value::int(1).is_truthy(), "1 is truthy");
@@ -241,9 +241,9 @@ fn test_truthiness_semantics() {
     let non_empty_list = Value::cons(Value::int(1), Value::NIL);
     assert!(non_empty_list.is_truthy(), "non-empty list is truthy");
 
-    // Non-empty vector is truthy
-    let non_empty_vec = Value::vector(vec![Value::int(1)]);
-    assert!(non_empty_vec.is_truthy(), "non-empty vector is truthy");
+    // Non-empty array is truthy
+    let non_empty_vec = Value::array(vec![Value::int(1)]);
+    assert!(non_empty_vec.is_truthy(), "non-empty array is truthy");
 
     // Table is truthy
     assert!(Value::table().is_truthy(), "table is truthy");

--- a/src/value/repr/traits.rs
+++ b/src/value/repr/traits.rs
@@ -28,8 +28,8 @@ impl PartialEq for Value {
                 // Cons cell comparison
                 (HeapObject::Cons(c1), HeapObject::Cons(c2)) => c1 == c2,
 
-                // Vector comparison (compare contents)
-                (HeapObject::Vector(v1), HeapObject::Vector(v2)) => {
+                // Array comparison (compare contents)
+                (HeapObject::Array(v1), HeapObject::Array(v2)) => {
                     v1.borrow().as_slice() == v2.borrow().as_slice()
                 }
 

--- a/src/vm/dispatch.rs
+++ b/src/vm/dispatch.rs
@@ -130,14 +130,14 @@ impl VM {
                 Instruction::Cdr => {
                     data::handle_cdr(self);
                 }
-                Instruction::MakeVector => {
-                    data::handle_make_vector(self, bc, &mut ip);
+                Instruction::MakeArray => {
+                    data::handle_make_array(self, bc, &mut ip);
                 }
-                Instruction::VectorRef => {
-                    data::handle_vector_ref(self);
+                Instruction::ArrayRef => {
+                    data::handle_array_ref(self);
                 }
-                Instruction::VectorSet => {
-                    data::handle_vector_set(self);
+                Instruction::ArraySet => {
+                    data::handle_array_set(self);
                 }
 
                 // Arithmetic (integer)

--- a/tests/integration/advanced.rs
+++ b/tests/integration/advanced.rs
@@ -197,8 +197,8 @@ fn test_debug_print_with_nested_structures() {
     // debug-print with nested lists
     assert!(eval("(debug-print (list (list 1 2) (list 3 4)))").is_ok());
 
-    // debug-print with vectors
-    assert!(eval("(debug-print (vector 1 2 3))").is_ok());
+    // debug-print with arrays
+    assert!(eval("(debug-print (array 1 2 3))").is_ok());
 }
 
 #[test]

--- a/tests/integration/concurrency.rs
+++ b/tests/integration/concurrency.rs
@@ -58,8 +58,8 @@ fn test_spawn_closure_with_string_capture() {
 }
 
 #[test]
-fn test_spawn_closure_with_vector_capture() {
-    // Test spawning a closure that captures a vector
+fn test_spawn_closure_with_array_capture() {
+    // Test spawning a closure that captures an array
     let result = eval(
         r#"
         (let ((v [1 2 3]))
@@ -356,8 +356,8 @@ fn test_spawn_jit_closure_with_string_capture() {
 }
 
 #[test]
-fn test_spawn_jit_closure_with_vector_capture() {
-    // Test spawning a closure that captures a vector
+fn test_spawn_jit_closure_with_array_capture() {
+    // Test spawning a closure that captures an array
     let result = eval(
         r#"
         (let ((v [10 20 30]))

--- a/tests/integration/core.rs
+++ b/tests/integration/core.rs
@@ -654,87 +654,78 @@ fn test_char_at() {
     }
 }
 
-// Vector operations
+// Array operations
 #[test]
-fn test_vector_creation() {
-    if let Some(vec_ref) = eval("(vector 1 2 3)").unwrap().as_vector() {
+fn test_array_creation() {
+    if let Some(vec_ref) = eval("(array 1 2 3)").unwrap().as_array() {
         let v = vec_ref.borrow();
         assert_eq!(v.len(), 3);
         assert_eq!(v[0], Value::int(1));
         assert_eq!(v[1], Value::int(2));
         assert_eq!(v[2], Value::int(3));
     } else {
-        panic!("Expected vector");
+        panic!("Expected array");
     }
 
-    // Empty vector
-    if let Some(vec_ref) = eval("(vector)").unwrap().as_vector() {
+    // Empty array
+    if let Some(vec_ref) = eval("(array)").unwrap().as_array() {
         assert_eq!(vec_ref.borrow().len(), 0)
     } else {
-        panic!("Expected vector");
+        panic!("Expected array");
     }
 }
 
 #[test]
-fn test_vector_length() {
-    assert_eq!(eval("(length (vector 1 2 3))").unwrap(), Value::int(3));
-    assert_eq!(eval("(length (vector))").unwrap(), Value::int(0));
+fn test_array_length() {
+    assert_eq!(eval("(length (array 1 2 3))").unwrap(), Value::int(3));
+    assert_eq!(eval("(length (array))").unwrap(), Value::int(0));
     assert_eq!(
-        eval("(length (vector 10 20 30 40 50))").unwrap(),
+        eval("(length (array 10 20 30 40 50))").unwrap(),
         Value::int(5)
     );
 }
 
 #[test]
-fn test_vector_ref() {
+fn test_array_ref() {
     assert_eq!(
-        eval("(vector-ref (vector 10 20 30) 0)").unwrap(),
+        eval("(array-ref (array 10 20 30) 0)").unwrap(),
         Value::int(10)
     );
     assert_eq!(
-        eval("(vector-ref (vector 10 20 30) 1)").unwrap(),
+        eval("(array-ref (array 10 20 30) 1)").unwrap(),
         Value::int(20)
     );
     assert_eq!(
-        eval("(vector-ref (vector 10 20 30) 2)").unwrap(),
+        eval("(array-ref (array 10 20 30) 2)").unwrap(),
         Value::int(30)
     );
 }
 
 #[test]
-fn test_vector_set() {
-    if let Some(vec_ref) = eval("(vector-set! (vector 1 2 3) 1 99)")
-        .unwrap()
-        .as_vector()
-    {
+fn test_array_set() {
+    if let Some(vec_ref) = eval("(array-set! (array 1 2 3) 1 99)").unwrap().as_array() {
         let v = vec_ref.borrow();
         assert_eq!(v[0], Value::int(1));
         assert_eq!(v[1], Value::int(99));
         assert_eq!(v[2], Value::int(3));
     } else {
-        panic!("Expected vector");
+        panic!("Expected array");
     }
 
     // Set at beginning
-    if let Some(vec_ref) = eval("(vector-set! (vector 1 2 3) 0 100)")
-        .unwrap()
-        .as_vector()
-    {
+    if let Some(vec_ref) = eval("(array-set! (array 1 2 3) 0 100)").unwrap().as_array() {
         let v = vec_ref.borrow();
         assert_eq!(v[0], Value::int(100))
     } else {
-        panic!("Expected vector")
+        panic!("Expected array")
     }
 
     // Set at end
-    if let Some(vec_ref) = eval("(vector-set! (vector 1 2 3) 2 200)")
-        .unwrap()
-        .as_vector()
-    {
+    if let Some(vec_ref) = eval("(array-set! (array 1 2 3) 2 200)").unwrap().as_array() {
         let v = vec_ref.borrow();
         assert_eq!(v[2], Value::int(200))
     } else {
-        panic!("Expected vector")
+        panic!("Expected array")
     }
 }
 #[test]

--- a/tests/integration/error_reporting.rs
+++ b/tests/integration/error_reporting.rs
@@ -75,7 +75,7 @@ fn test_unexpected_closing_paren_location() {
 }
 
 #[test]
-fn test_unterminated_vector_location() {
+fn test_unterminated_array_location() {
     let mut symbols = SymbolTable::new();
     let input = "[1 2 3";
 
@@ -94,7 +94,7 @@ fn test_unterminated_vector_location() {
     assert!(result.is_err());
     let error = result.unwrap_err();
     assert!(error.contains("1:6")); // EOF at position 6
-    assert!(error.contains("unterminated vector"));
+    assert!(error.contains("unterminated array"));
 }
 
 #[test]

--- a/tests/integration/ffi-callbacks.rs
+++ b/tests/integration/ffi-callbacks.rs
@@ -175,17 +175,13 @@ fn test_callback_with_complex_values() {
         Value::int(1),
         cons(Value::int(2), cons(Value::int(3), Value::NIL)),
     );
-    let vector = Value::vector(vec![
-        Value::int(10),
-        Value::int(20),
-        Value::int(30),
-    ]);
+    let arr = Value::array(vec![Value::int(10), Value::int(20), Value::int(30)]);
 
     let (id1, _) = create_callback(vec![], CType::Pointer(Box::new(CType::Int)));
     let (id2, _) = create_callback(vec![], CType::Pointer(Box::new(CType::Int)));
 
     assert!(register_callback(id1, Rc::new(list)));
-    assert!(register_callback(id2, Rc::new(vector)));
+    assert!(register_callback(id2, Rc::new(arr)));
 
     // Verify retrieval
     assert!(get_callback(id1).is_some());

--- a/tests/integration/ffi-marshaling.rs
+++ b/tests/integration/ffi-marshaling.rs
@@ -122,9 +122,9 @@ fn test_marshal_strings_to_pointers() {
 }
 
 #[test]
-fn test_marshal_vectors_to_arrays() {
-    // Test marshaling Elle vectors to C arrays
-    let vector = Value::vector(vec![
+fn test_marshal_arrays_to_c_arrays() {
+    // Test marshaling Elle arrays to C arrays
+    let arr = Value::array(vec![
         Value::int(1),
         Value::int(2),
         Value::int(3),
@@ -132,7 +132,7 @@ fn test_marshal_vectors_to_arrays() {
         Value::int(5),
     ]);
 
-    let result = Marshal::elle_to_c(&vector, &CType::Array(Box::new(CType::Int), 5));
+    let result = Marshal::elle_to_c(&arr, &CType::Array(Box::new(CType::Int), 5));
     assert!(result.is_ok());
 
     match result.unwrap() {
@@ -229,7 +229,7 @@ fn test_unmarshal_floats() {
 
 #[test]
 fn test_unmarshal_arrays() {
-    // Test unmarshaling C arrays back to Elle vectors
+    // Test unmarshaling C arrays back to Elle arrays
     let carray = CValue::Array(vec![
         CValue::Int(5),
         CValue::Int(10),
@@ -240,7 +240,7 @@ fn test_unmarshal_arrays() {
     let result = Marshal::c_to_elle(&carray, &CType::Array(Box::new(CType::Int), 4));
     assert!(result.is_ok());
 
-    if let Some(vec_ref) = result.unwrap().as_vector() {
+    if let Some(vec_ref) = result.unwrap().as_array() {
         let vec = vec_ref.borrow();
         assert_eq!(vec.len(), 4);
         assert_eq!(vec[0], Value::int(5));
@@ -248,7 +248,7 @@ fn test_unmarshal_arrays() {
         assert_eq!(vec[2], Value::int(15));
         assert_eq!(vec[3], Value::int(20));
     } else {
-        panic!("Expected Value::Vector");
+        panic!("Expected Value::Array");
     }
 }
 
@@ -289,21 +289,21 @@ fn test_roundtrip_marshal_unmarshal_floats() {
 #[test]
 fn test_roundtrip_marshal_unmarshal_arrays() {
     // Test roundtrip marshaling of arrays
-    let original = Value::vector(vec![Value::int(1), Value::int(2), Value::int(3)]);
+    let original = Value::array(vec![Value::int(1), Value::int(2), Value::int(3)]);
 
     let marshaled = Marshal::elle_to_c(&original, &CType::Array(Box::new(CType::Int), 3)).unwrap();
 
     let unmarshaled =
         Marshal::c_to_elle(&marshaled, &CType::Array(Box::new(CType::Int), 3)).unwrap();
 
-    if let Some(vec_ref) = unmarshaled.as_vector() {
+    if let Some(vec_ref) = unmarshaled.as_array() {
         let vec = vec_ref.borrow();
         assert_eq!(vec.len(), 3);
         assert_eq!(vec[0], Value::int(1));
         assert_eq!(vec[1], Value::int(2));
         assert_eq!(vec[2], Value::int(3));
     } else {
-        panic!("Expected Value::Vector");
+        panic!("Expected Value::Array");
     }
 }
 

--- a/tests/integration/ffi-struct-marshaling.rs
+++ b/tests/integration/ffi-struct-marshaling.rs
@@ -26,7 +26,7 @@ fn test_struct_marshaling_libc_timeval_like() {
     );
 
     // Create Elle representation
-    let value = Value::vector(vec![
+    let value = Value::array(vec![
         Value::int(1609459200), // 2021-01-01 00:00:00
         Value::int(500000),     // 500 milliseconds
     ]);
@@ -88,7 +88,7 @@ fn test_struct_marshaling_file_stat_like() {
         8,
     );
 
-    let value = Value::vector(vec![
+    let value = Value::array(vec![
         Value::int(2049),     // st_dev
         Value::int(12345678), // st_ino
         Value::int(33188),    // st_mode (regular file, 0644)
@@ -98,16 +98,16 @@ fn test_struct_marshaling_file_stat_like() {
     let cval = Marshal::marshal_struct_with_layout(&value, &layout).unwrap();
     let result = Marshal::unmarshal_struct_with_layout(&cval, &layout).unwrap();
 
-    if let Some(vec_ref) = result.as_vector() {
-            let vec = vec_ref.borrow();
-            assert_eq!(vec.len(), 4);
-            assert_eq!(vec[0], Value::int(2049));
-            assert_eq!(vec[1], Value::int(12345678));
-            assert_eq!(vec[2], Value::int(33188));
-            assert_eq!(vec[3], Value::int(1));
-        } else {
-            panic!("Expected Vector");
-        }
+    if let Some(vec_ref) = result.as_array() {
+        let vec = vec_ref.borrow();
+        assert_eq!(vec.len(), 4);
+        assert_eq!(vec[0], Value::int(2049));
+        assert_eq!(vec[1], Value::int(12345678));
+        assert_eq!(vec[2], Value::int(33188));
+        assert_eq!(vec[3], Value::int(1));
+    } else {
+        panic!("Expected Array");
+    }
 }
 
 #[test]
@@ -139,7 +139,7 @@ fn test_struct_with_padding() {
         4,
     );
 
-    let value = Value::vector(vec![
+    let value = Value::array(vec![
         Value::int(65), // 'A'
         Value::int(1000),
         Value::int(66), // 'B'
@@ -148,14 +148,14 @@ fn test_struct_with_padding() {
     let cval = Marshal::marshal_struct_with_layout(&value, &layout).unwrap();
     let result = Marshal::unmarshal_struct_with_layout(&cval, &layout).unwrap();
 
-    if let Some(vec_ref) = result.as_vector() {
-            let vec = vec_ref.borrow();
-            assert_eq!(vec[0], Value::int(65));
-            assert_eq!(vec[1], Value::int(1000));
-            assert_eq!(vec[2], Value::int(66));
-        } else {
-            panic!("Expected Vector");
-        }
+    if let Some(vec_ref) = result.as_array() {
+        let vec = vec_ref.borrow();
+        assert_eq!(vec[0], Value::int(65));
+        assert_eq!(vec[1], Value::int(1000));
+        assert_eq!(vec[2], Value::int(66));
+    } else {
+        panic!("Expected Array");
+    }
 }
 
 #[test]
@@ -205,7 +205,7 @@ fn test_struct_all_basic_types() {
         8,
     );
 
-    let value = Value::vector(vec![
+    let value = Value::array(vec![
         Value::bool(true),
         Value::int(100),
         Value::int(1000),
@@ -218,32 +218,32 @@ fn test_struct_all_basic_types() {
     let cval = Marshal::marshal_struct_with_layout(&value, &layout).unwrap();
     let result = Marshal::unmarshal_struct_with_layout(&cval, &layout).unwrap();
 
-    if let Some(vec_ref) = result.as_vector() {
-            let vec = vec_ref.borrow();
-            assert_eq!(vec.len(), 7);
-            assert_eq!(vec[0], Value::bool(true));
-            assert_eq!(vec[1], Value::int(100));
-            assert_eq!(vec[2], Value::int(1000));
-            assert_eq!(vec[3], Value::int(100000));
-            assert_eq!(vec[4], Value::int(10000000));
-            if let Some(f) = vec[5].as_float() {
-                assert!((f - 1.5).abs() < 0.01);
-            } else {
-                panic!("Expected float");
-            }
-            if let Some(f) = vec[6].as_float() {
-                assert!((f - std::f64::consts::E).abs() < 0.01);
-            } else {
-                panic!("Expected float");
-            }
+    if let Some(vec_ref) = result.as_array() {
+        let vec = vec_ref.borrow();
+        assert_eq!(vec.len(), 7);
+        assert_eq!(vec[0], Value::bool(true));
+        assert_eq!(vec[1], Value::int(100));
+        assert_eq!(vec[2], Value::int(1000));
+        assert_eq!(vec[3], Value::int(100000));
+        assert_eq!(vec[4], Value::int(10000000));
+        if let Some(f) = vec[5].as_float() {
+            assert!((f - 1.5).abs() < 0.01);
         } else {
-            panic!("Expected Vector");
+            panic!("Expected float");
         }
+        if let Some(f) = vec[6].as_float() {
+            assert!((f - std::f64::consts::E).abs() < 0.01);
+        } else {
+            panic!("Expected float");
+        }
+    } else {
+        panic!("Expected Array");
+    }
 }
 
 #[test]
 fn test_struct_list_to_struct_conversion() {
-    // Test that cons lists are properly converted to vector representation
+    // Test that cons lists are properly converted to array representation
     use elle::value::cons;
 
     let layout = StructLayout::new(

--- a/tests/integration/ffi-union-marshaling.rs
+++ b/tests/integration/ffi-union-marshaling.rs
@@ -36,7 +36,7 @@ fn test_union_basic_int_float() {
     assert_eq!(layout.align, 4);
 
     // Set integer value
-    let value = Value::vector(vec![Value::int(42)]);
+    let value = Value::array(vec![Value::int(42)]);
     let cval = Marshal::marshal_union_with_layout(&value, &layout).unwrap();
 
     match cval {
@@ -74,7 +74,7 @@ fn test_union_long_double() {
     assert_eq!(layout.align, 8);
 
     // Set long value
-    let value = Value::vector(vec![Value::int(123456789)]);
+    let value = Value::array(vec![Value::int(123456789)]);
     let cval = Marshal::marshal_union_with_layout(&value, &layout).unwrap();
 
     match cval {
@@ -115,7 +115,7 @@ fn test_union_char_int_long() {
     assert_eq!(layout.align, 8);
 
     // Set char value
-    let value = Value::vector(vec![Value::int(65)]); // 'A'
+    let value = Value::array(vec![Value::int(65)]); // 'A'
     let cval = Marshal::marshal_union_with_layout(&value, &layout).unwrap();
 
     match cval {
@@ -145,7 +145,7 @@ fn test_union_roundtrip_marshaling() {
         ],
     );
 
-    let value = Value::vector(vec![Value::int(999)]);
+    let value = Value::array(vec![Value::int(999)]);
 
     // Marshal to C
     let cval = Marshal::marshal_union_with_layout(&value, &layout).unwrap();
@@ -153,7 +153,7 @@ fn test_union_roundtrip_marshaling() {
     // Unmarshal back to Elle
     let result = Marshal::unmarshal_union_with_layout(&cval, &layout).unwrap();
 
-    if let Some(vec_ref) = result.as_vector() {
+    if let Some(vec_ref) = result.as_array() {
         let vec = vec_ref.borrow();
             // Both fields should read the same bytes at offset 0
             assert_eq!(vec.len(), 2);
@@ -162,7 +162,7 @@ fn test_union_roundtrip_marshaling() {
             // Second field (long) at offset 0: also contains 999 (though interpreted as larger value)
             assert_eq!(vec[1], Value::int(999));
     } else {
-        panic!("Expected Vector");
+        panic!("Expected Array");
     }
 }
 
@@ -187,7 +187,7 @@ fn test_union_size_matches_largest_field() {
     assert_eq!(layout.size, 4);
 
     // Set char value (first field)
-    let value = Value::vector(vec![Value::int(65)]); // 'A'
+    let value = Value::array(vec![Value::int(65)]); // 'A'
     let cval = Marshal::marshal_union_with_layout(&value, &layout).unwrap();
 
     match cval {
@@ -279,7 +279,7 @@ fn test_union_multiple_types() {
     assert_eq!(layout.align, 8); // max alignment
 
     // Test with different field sizes
-    let value = Value::vector(vec![Value::int(32767)]); // max short
+    let value = Value::array(vec![Value::int(32767)]); // max short
     let cval = Marshal::marshal_union_with_layout(&value, &layout).unwrap();
 
     match cval {
@@ -311,7 +311,7 @@ fn test_union_bool_fields() {
     assert_eq!(layout.size, 4); // max(1, 4)
 
     // Set bool to true
-    let value = Value::vector(vec![Value::bool(true)]);
+    let value = Value::array(vec![Value::bool(true)]);
     let cval = Marshal::marshal_union_with_layout(&value, &layout).unwrap();
 
     match cval {
@@ -342,7 +342,7 @@ fn test_union_zero_initialize() {
     );
 
     // Set int to 42, rest should be zero-initialized
-    let value = Value::vector(vec![Value::int(42)]);
+    let value = Value::array(vec![Value::int(42)]);
     let cval = Marshal::marshal_union_with_layout(&value, &layout).unwrap();
 
     match cval {
@@ -369,8 +369,8 @@ fn test_union_error_on_empty_value() {
         }],
     );
 
-    // Empty vector should fail
-    let value = Value::vector(vec![]);
+    // Empty array should fail
+    let value = Value::array(vec![]);
     let result = Marshal::marshal_union_with_layout(&value, &layout);
     assert!(result.is_err());
 }
@@ -393,7 +393,7 @@ fn test_union_error_on_too_many_values() {
     );
 
     // Too many values should fail
-    let value = Value::vector(vec![
+    let value = Value::array(vec![
         Value::int(1),
         Value::int(2),
         Value::int(3),
@@ -403,7 +403,7 @@ fn test_union_error_on_too_many_values() {
 }
 
 #[test]
-fn test_union_non_vector_error() {
+fn test_union_non_array_error() {
     let layout = create_union(
         13,
         "test",
@@ -413,7 +413,7 @@ fn test_union_non_vector_error() {
         }],
     );
 
-    // Non-vector should fail
+    // Non-array should fail
     let value = Value::int(42);
     let result = Marshal::marshal_union_with_layout(&value, &layout);
     assert!(result.is_err());
@@ -438,13 +438,13 @@ fn test_union_unmarshal_all_fields_readable() {
     );
 
     // Set int value
-    let value = Value::vector(vec![Value::int(42)]);
+    let value = Value::array(vec![Value::int(42)]);
     let cval = Marshal::marshal_union_with_layout(&value, &layout).unwrap();
 
     // Unmarshal returns all fields (they all read from offset 0)
     let result = Marshal::unmarshal_union_with_layout(&cval, &layout).unwrap();
 
-    if let Some(vec_ref) = result.as_vector() {
+    if let Some(vec_ref) = result.as_array() {
         let vec = vec_ref.borrow();
             // Should have 2 values (one for each field)
             assert_eq!(vec.len(), 2);
@@ -458,7 +458,7 @@ fn test_union_unmarshal_all_fields_readable() {
                     panic!("Expected float");
                 }
     } else {
-        panic!("Expected Vector");
+        panic!("Expected Array");
     }
 }
 
@@ -476,7 +476,7 @@ fn test_union_unmarshal_size_check() {
     // Create union with correct size
     let correct_union = CValue::Union(vec![1, 2, 3, 4]);
     let result = Marshal::unmarshal_union_with_layout(&correct_union, &layout).unwrap();
-    assert!((result).is_vector());
+    assert!((result).is_array());
 
     // Create union with wrong size
     let wrong_union = CValue::Union(vec![1, 2]); // size 2 instead of 4
@@ -537,7 +537,7 @@ fn test_union_max_field_types() {
     assert_eq!(layout.size, 8);
 
     // Marshal with int value
-    let value = Value::vector(vec![Value::int(100)]);
+    let value = Value::array(vec![Value::int(100)]);
     let cval = Marshal::marshal_union_with_layout(&value, &layout).unwrap();
 
     match cval {
@@ -570,7 +570,7 @@ fn test_union_pointer_field() {
     assert_eq!(layout.size, 8);
 
     // Test with int value (first field)
-    let value = Value::vector(vec![Value::int(42)]);
+    let value = Value::array(vec![Value::int(42)]);
     let cval = Marshal::marshal_union_with_layout(&value, &layout).unwrap();
 
     match cval {

--- a/tests/integration/jit.rs
+++ b/tests/integration/jit.rs
@@ -1213,8 +1213,8 @@ fn test_jit_is_pair() {
 }
 
 #[test]
-fn test_jit_make_vector() {
-    // fn(a, b, c) -> vector(a, b, c)
+fn test_jit_make_array() {
+    // fn(a, b, c) -> array(a, b, c)
     let mut func = LirFunction::new(3);
     func.num_regs = 4;
     func.num_captures = 0;
@@ -1225,7 +1225,7 @@ fn test_jit_make_vector() {
     entry.instructions.push(load_arg(Reg(1), 1));
     entry.instructions.push(load_arg(Reg(2), 2));
     entry.instructions.push(SpannedInstr::new(
-        LirInstr::MakeVector {
+        LirInstr::MakeArray {
             dst: Reg(3),
             elements: vec![Reg(0), Reg(1), Reg(2)],
         },
@@ -1244,8 +1244,8 @@ fn test_jit_make_vector() {
         ],
     )
     .unwrap();
-    assert!(result.is_vector());
-    let vec = result.as_vector().unwrap();
+    assert!(result.is_array());
+    let vec = result.as_array().unwrap();
     let borrowed = vec.borrow();
     assert_eq!(borrowed.len(), 3);
     assert_eq!(borrowed[0].as_int(), Some(1));

--- a/tests/integration/new_pipeline_property.rs
+++ b/tests/integration/new_pipeline_property.rs
@@ -437,14 +437,14 @@ proptest! {
 }
 
 // ============================================================================
-// Vector Properties
+// Array Properties
 // ============================================================================
 
 proptest! {
     #![proptest_config(ProptestConfig::with_cases(50))]
 
     #[test]
-    fn vector_length_correct(len in 0usize..10) {
+    fn array_length_correct(len in 0usize..10) {
         let elements: Vec<String> = (0..len).map(|i| i.to_string()).collect();
         let expr = if elements.is_empty() {
             "(length [])".to_string()
@@ -458,8 +458,8 @@ proptest! {
     }
 
     #[test]
-    fn vector_ref_first(a in -100i64..100, b in -100i64..100) {
-        let expr = format!("(vector-ref [{} {}] 0)", a, b);
+    fn array_ref_first(a in -100i64..100, b in -100i64..100) {
+        let expr = format!("(array-ref [{} {}] 0)", a, b);
         let result = eval(&expr);
 
         prop_assert!(result.is_ok(), "failed: {:?}", result);

--- a/tests/integration/thread_transfer.rs
+++ b/tests/integration/thread_transfer.rs
@@ -332,16 +332,16 @@ fn test_location_map_has_valid_line_numbers() {
 }
 
 // ============================================================================
-// Test 15: Spawned closure with vector operations
+// Test 15: Spawned closure with array operations
 // ============================================================================
 
 #[test]
-fn test_spawned_closure_vector_operations() {
-    // Closure performs vector operations
+fn test_spawned_closure_array_operations() {
+    // Closure performs array operations
     let result = eval(
         r#"
         (let ((v [1 2 3]))
-          (join (spawn (fn () (vector-ref v 1)))))
+          (join (spawn (fn () (array-ref v 1)))))
         "#,
     );
 

--- a/tests/unittests/primitives.rs
+++ b/tests/unittests/primitives.rs
@@ -1810,11 +1810,11 @@ fn test_json_serialize_roundtrip() {
 }
 
 #[test]
-fn test_json_serialize_vectors() {
+fn test_json_serialize_arrays() {
     let (vm, mut symbols) = setup();
     let json_serialize = get_primitive(&vm, &mut symbols, "json-serialize");
 
-    let vec = Value::vector(vec![Value::int(1), Value::int(2), Value::int(3)]);
+    let vec = Value::array(vec![Value::int(1), Value::int(2), Value::int(3)]);
     let result = call_primitive(&json_serialize, &[vec]);
     assert_eq!(result.unwrap(), Value::string("[1,2,3]"));
 }
@@ -1850,7 +1850,7 @@ fn test_json_serialize_errors() {
 
 // Disassembly tests
 #[test]
-fn test_disbit_returns_vector_of_strings() {
+fn test_disbit_returns_array_of_strings() {
     let (vm, mut symbols) = setup();
     let disbit = get_primitive(&vm, &mut symbols, "disbit");
 
@@ -1860,9 +1860,9 @@ fn test_disbit_returns_vector_of_strings() {
     let result = pipeline_eval("(fn (x) (+ x 1))", &mut symbols2, &mut vm2).unwrap();
 
     let disasm = call_primitive(&disbit, &[result]).unwrap();
-    let vec = disasm.as_vector().expect("disbit should return a vector");
+    let vec = disasm.as_array().expect("disbit should return an array");
     let vec = vec.borrow();
-    assert!(!vec.is_empty(), "disbit should return non-empty vector");
+    assert!(!vec.is_empty(), "disbit should return non-empty array");
     for elem in vec.iter() {
         assert!(
             elem.as_string().is_some(),
@@ -1888,7 +1888,7 @@ fn test_disbit_arity_error() {
 }
 
 #[test]
-fn test_disjit_returns_vector_for_pure_closure() {
+fn test_disjit_returns_array_for_pure_closure() {
     let (vm, mut symbols) = setup();
     let disjit = get_primitive(&vm, &mut symbols, "disjit");
 
@@ -1899,9 +1899,9 @@ fn test_disjit_returns_vector_for_pure_closure() {
 
     let ir = call_primitive(&disjit, &[result]).unwrap();
     if !ir.is_nil() {
-        let vec = ir.as_vector().expect("disjit should return a vector");
+        let vec = ir.as_array().expect("disjit should return an array");
         let vec = vec.borrow();
-        assert!(!vec.is_empty(), "disjit should return non-empty vector");
+        assert!(!vec.is_empty(), "disjit should return non-empty array");
         for elem in vec.iter() {
             assert!(
                 elem.as_string().is_some(),

--- a/tests/unittests/value.rs
+++ b/tests/unittests/value.rs
@@ -128,11 +128,11 @@ fn test_nested_lists() {
 }
 
 #[test]
-fn test_vector() {
+fn test_array() {
     let vec = vec![Value::int(1), Value::int(2), Value::int(3)];
-    let v = Value::vector(vec);
+    let v = Value::array(vec);
 
-    let vec_ref = v.as_vector().unwrap();
+    let vec_ref = v.as_array().unwrap();
     let borrowed = vec_ref.borrow();
     assert_eq!(borrowed.len(), 3);
     assert_eq!(borrowed[0], Value::int(1));


### PR DESCRIPTION
## Summary

Renames the mutable indexed collection from "vector" to "array" to align with Janet's nomenclature. The immutable "tuple" type is unchanged.

## Changes

- **Rust types**: `HeapObject::Vector` → `Array`, `SyntaxKind::Vector` → `Array`, `LirInstr::MakeVector` → `MakeArray`, etc.
- **Value API**: `Value::vector()` → `array()`, `is_vector()` → `is_array()`, `as_vector()` → `as_array()`
- **Elle primitives**: `vector` → `array`, `vector-ref` → `array-ref`, `vector-set!` → `array-set!`
- **JIT**: `elle_jit_make_vector` → `elle_jit_make_array`
- **Files renamed**: `src/primitives/vector.rs` → `array.rs`, `examples/lists-and-vectors.lisp` → `lists-and-arrays.lisp`
- **74 files** total across source, tests, examples, and docs
