### PR TITLE
Fix misleading 'must be a list' errors with bracket hints (#349)

### DIFF
--- a/src/hir/analyze/forms.rs
+++ b/src/hir/analyze/forms.rs
@@ -504,9 +504,22 @@ impl<'a> Analyzer<'a> {
         let mut effect = Effect::none();
 
         for clause in &items[1..] {
-            let parts = clause
-                .as_list()
-                .ok_or_else(|| format!("{}: cond clause must be a list", span))?;
+            let parts = clause.as_list().ok_or_else(|| {
+                if matches!(clause.kind, SyntaxKind::Array(_)) {
+                    format!(
+                        "{}: cond clause must use parentheses (test body...), \
+                         not brackets [...]",
+                        clause.span
+                    )
+                } else {
+                    format!(
+                        "{}: cond clause must be a parenthesized list (test body...), \
+                         got {}",
+                        clause.span,
+                        clause.kind_label()
+                    )
+                }
+            })?;
             if parts.is_empty() {
                 continue;
             }

--- a/src/hir/analyze/lambda.rs
+++ b/src/hir/analyze/lambda.rs
@@ -9,9 +9,22 @@ impl<'a> Analyzer<'a> {
             return Err(format!("{}: lambda requires parameters and body", span));
         }
 
-        let params_syntax = items[1]
-            .as_list()
-            .ok_or_else(|| format!("{}: lambda parameters must be a list", span))?;
+        let params_syntax = items[1].as_list().ok_or_else(|| {
+            if matches!(items[1].kind, SyntaxKind::Array(_)) {
+                format!(
+                    "{}: lambda parameters must use parentheses (params...), \
+                     not brackets [...]",
+                    items[1].span
+                )
+            } else {
+                format!(
+                    "{}: lambda parameters must be a parenthesized list (params...), \
+                     got {}",
+                    items[1].span,
+                    items[1].kind_label()
+                )
+            }
+        })?;
 
         // Save current captures and parent captures, start fresh for this lambda
         let saved_captures = std::mem::take(&mut self.current_captures);

--- a/src/hir/analyze/special.rs
+++ b/src/hir/analyze/special.rs
@@ -35,9 +35,22 @@ impl<'a> Analyzer<'a> {
         let mut arms = Vec::new();
 
         for arm in &items[2..] {
-            let parts = arm
-                .as_list()
-                .ok_or_else(|| format!("{}: match arm must be a list", span))?;
+            let parts = arm.as_list().ok_or_else(|| {
+                if matches!(arm.kind, SyntaxKind::Array(_)) {
+                    format!(
+                        "{}: match arm must use parentheses (pattern body), \
+                         not brackets [...]",
+                        arm.span
+                    )
+                } else {
+                    format!(
+                        "{}: match arm must be a parenthesized list (pattern body), \
+                         got {}",
+                        arm.span,
+                        arm.kind_label()
+                    )
+                }
+            })?;
             if parts.len() < 2 {
                 return Err(format!("{}: match arm requires pattern and body", span));
             }

--- a/src/syntax/expand/mod.rs
+++ b/src/syntax/expand/mod.rs
@@ -167,9 +167,22 @@ impl Expander {
             .to_string();
 
         // Get parameter list
-        let params_syntax = items[2]
-            .as_list()
-            .ok_or_else(|| format!("{}: macro parameters must be a list", span))?;
+        let params_syntax = items[2].as_list().ok_or_else(|| {
+            if matches!(items[2].kind, SyntaxKind::Array(_)) {
+                format!(
+                    "{}: macro parameters must use parentheses (params...), \
+                     not brackets [...]",
+                    items[2].span
+                )
+            } else {
+                format!(
+                    "{}: macro parameters must be a parenthesized list (params...), \
+                     got {}",
+                    items[2].span,
+                    items[2].kind_label()
+                )
+            }
+        })?;
 
         // Parse params, recognizing & as rest separator
         let mut fixed_params = Vec::new();

--- a/src/syntax/mod.rs
+++ b/src/syntax/mod.rs
@@ -123,6 +123,27 @@ impl Syntax {
             _ => None,
         }
     }
+
+    /// Human-readable label for the syntax kind, used in error messages.
+    pub fn kind_label(&self) -> &'static str {
+        match &self.kind {
+            SyntaxKind::Nil => "nil",
+            SyntaxKind::Bool(_) => "boolean",
+            SyntaxKind::Int(_) => "integer",
+            SyntaxKind::Float(_) => "float",
+            SyntaxKind::Symbol(_) => "symbol",
+            SyntaxKind::Keyword(_) => "keyword",
+            SyntaxKind::String(_) => "string",
+            SyntaxKind::List(_) => "list",
+            SyntaxKind::Array(_) => "array",
+            SyntaxKind::Table(_) => "table",
+            SyntaxKind::Quote(_) => "quote",
+            SyntaxKind::Quasiquote(_) => "quasiquote",
+            SyntaxKind::Unquote(_) => "unquote",
+            SyntaxKind::UnquoteSplicing(_) => "unquote-splicing",
+            SyntaxKind::SyntaxLiteral(_) => "syntax-literal",
+        }
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/tests/integration/bracket_errors.rs
+++ b/tests/integration/bracket_errors.rs
@@ -1,0 +1,70 @@
+// Tests for bracket-vs-parenthesis error messages (issue #349).
+//
+// Verifies that using [...] where (...) is expected produces a helpful
+// error mentioning "not brackets" rather than the old generic "must be
+// a list" message.
+
+use crate::common::eval_source;
+
+#[test]
+fn match_arm_bracket_error() {
+    let err = eval_source("(match 42 [42 \"yes\"])").unwrap_err();
+    assert!(
+        err.contains("not brackets"),
+        "Expected hint about brackets, got: {err}"
+    );
+}
+
+#[test]
+fn match_arm_non_list_error() {
+    let err = eval_source("(match 42 99)").unwrap_err();
+    assert!(
+        err.contains("got integer"),
+        "Expected kind label in error, got: {err}"
+    );
+}
+
+#[test]
+fn cond_clause_bracket_error() {
+    let err = eval_source("(cond [#t 1])").unwrap_err();
+    assert!(
+        err.contains("not brackets"),
+        "Expected hint about brackets, got: {err}"
+    );
+}
+
+#[test]
+fn let_bindings_bracket_error() {
+    let err = eval_source("(let [(x 1)] x)").unwrap_err();
+    assert!(
+        err.contains("not brackets"),
+        "Expected hint about brackets, got: {err}"
+    );
+}
+
+#[test]
+fn fn_params_bracket_error() {
+    let err = eval_source("(fn [x] x)").unwrap_err();
+    assert!(
+        err.contains("not brackets"),
+        "Expected hint about brackets, got: {err}"
+    );
+}
+
+#[test]
+fn defmacro_params_bracket_error() {
+    let err = eval_source("(defmacro foo [x] x)").unwrap_err();
+    assert!(
+        err.contains("not brackets"),
+        "Expected hint about brackets, got: {err}"
+    );
+}
+
+#[test]
+fn letrec_bindings_bracket_error() {
+    let err = eval_source("(letrec [(f (fn (x) x))] (f 1))").unwrap_err();
+    assert!(
+        err.contains("not brackets"),
+        "Expected hint about brackets, got: {err}"
+    );
+}

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -74,3 +74,6 @@ mod primitives {
 mod ffi {
     include!("ffi.rs");
 }
+mod bracket_errors {
+    include!("bracket_errors.rs");
+}


### PR DESCRIPTION
Closes #349

# Review: Issue #349 — Misleading "must be a list" errors

## Summary

Six error sites across the analyzer and expander were updated to produce
context-specific error messages when users write `[...]` where `(...)` is
expected. A `kind_label()` method was added to `Syntax` to provide
human-readable type names for the fallback (non-bracket) case. Seven
integration tests cover the new error paths. One new test file and one
module registration line were added.

## Correctness

### Does each change match impl.md exactly?

Yes. All 8 changes in impl.md are faithfully implemented:

1. **`kind_label()` on `Syntax`** — matches impl.md verbatim. Covers all
   15 `SyntaxKind` variants. Placed after `as_list()` as specified.

2. **`match` arm error** (`special.rs:38-53`) — matches. Uses `arm.span`
   instead of `span` as specified. Array branch says "not brackets",
   fallback branch uses `kind_label()`.

3. **`cond` clause error** (`forms.rs:507-522`) — matches. Uses
   `clause.span` instead of `span`.

4. **`let` bindings error** (`binding.rs:12-27`) — matches. `SyntaxKind`
   added to import (line 4). Uses `items[1].span`.

5. **`letrec` bindings error** (`binding.rs:150-165`) — matches. Uses
   `items[1].span`.

6. **`fn` parameters error** (`lambda.rs:12-27`) — matches. Uses
   `items[1].span`.

7. **`defmacro` parameters error** (`expand/mod.rs:170-185`) — matches.
   Uses `items[2].span`.

8. **Tests** — 7 tests in new file `bracket_errors.rs`, registered in
   `mod.rs`. Matches impl.md. The deviation from the plan (new file
   instead of appending to `advanced.rs`) is documented and justified
   by the 500-line convention.

### Are there any deviations?

No deviations from impl.md. The impl.md itself documents one deviation
from the original plan (new test file vs. appending to `advanced.rs`),
which is justified.

### Do the error messages actually help users?

Yes. The bracket-specific messages are clear and actionable:
- `"match arm must use parentheses (pattern body), not brackets [...]"`
- `"let bindings must use parentheses ((name value) ...), not brackets [...]"`
- `"lambda parameters must use parentheses (params...), not brackets [...]"`

Each message shows the correct syntax. The fallback messages are also
improved: `"got integer"` is more useful than the old `"must be a list"`.

## Test Coverage

### Do the 7 tests cover all the changed error paths?

Yes. Each of the 6 error sites has at least one bracket test:
1. `match_arm_bracket_error` — `special.rs` array branch
2. `match_arm_non_list_error` — `special.rs` fallback branch
3. `cond_clause_bracket_error` — `forms.rs` array branch
4. `let_bindings_bracket_error` — `binding.rs` let array branch
5. `letrec_bindings_bracket_error` — `binding.rs` letrec array branch
6. `fn_params_bracket_error` — `lambda.rs` array branch
7. `defmacro_params_bracket_error` — `expand/mod.rs` array branch

### Are there any gaps?

Minor gaps, none blocking:

- **Fallback (non-bracket, non-list) paths for `cond`, `let`, `letrec`,
  `fn`, `defmacro`** are not tested. Only `match` has a non-list test
  (`match_arm_non_list_error`). The pattern is identical across all 6
  sites so one representative test is defensible, but a purist would want
  at least one more (e.g., `(fn 42 x)` → "got integer").

- **Individual binding pair errors** inside `let` and `letrec` (lines
  39-41 and 172-174 in `binding.rs`) still use the old pattern:
  `"let binding must be a pair"` / `"letrec binding must be a pair"`.
  These are *different* error sites from the ones changed (they fire when
  an individual binding like `(x 1)` is not a list, not when the bindings
  *list* is wrong). They're outside the scope of this issue but worth
  noting — a user writing `(let ([x 1]) x)` would hit the inner error,
  not the outer one.

### Could any test pass vacuously?

No. Each test calls `eval_source(...)` with syntactically valid Elle that
the reader can parse (brackets are valid syntax — they produce
`SyntaxKind::Array`). The error is produced during analysis/expansion,
not parsing. The `unwrap_err()` ensures an error occurred, and the
`assert!(err.contains(...))` checks the specific substring. The assertion
messages include the actual error for debugging.

The assertions are substring-based (`contains("not brackets")` /
`contains("got integer")`), which is appropriate — they're specific
enough to distinguish the new messages from the old ones, but not so
brittle that reformatting breaks them.

## Code Quality

### Is the pattern consistent across all 6 error sites?

Yes. Every site follows the same structure:
```rust
.ok_or_else(|| {
    if matches!(item.kind, SyntaxKind::Array(_)) {
        format!("{}: <form> must use parentheses <syntax>, not brackets [...]", item.span)
    } else {
        format!("{}: <form> must be a parenthesized list <syntax>, got {}", item.span, item.kind_label())
    }
})?;
```

The only variation is the form-specific wording ("match arm", "cond
clause", "let bindings", etc.) and the syntax hint ("(pattern body)",
"(test body...)", etc.), which is correct — each message is tailored to
its context.

### Any code duplication concerns?

The pattern is repeated 6 times. This is acceptable because:
1. Each message is context-specific (different form names, different
   syntax hints).
2. Extracting a helper would require passing the form name, syntax hint,
   span, and item — the helper signature would be as complex as the
   inline code.
3. The sites are spread across 4 files in 2 different modules (analyzer
   and expander), so a shared helper would create a cross-module
   dependency for a formatting concern.

### Does `kind_label()` cover all `SyntaxKind` variants?

Yes. All 15 variants are covered:
- Atoms: `Nil`, `Bool`, `Int`, `Float`, `Symbol`, `Keyword`, `String`
- Compounds: `List`, `Array`, `Table`
- Quote forms: `Quote`, `Quasiquote`, `Unquote`, `UnquoteSplicing`
- Internal: `SyntaxLiteral`

The match is exhaustive (Rust enforces this). If a new variant is added
to `SyntaxKind`, the compiler will force an update to `kind_label()`.

## Conventions

### Does the code follow Elle project conventions from AGENTS.md?

- **File sizes**: `syntax/mod.rs` is 553 lines (over the 500-line soft
  limit, but it was already 520+ before this change — the 20-line
  `kind_label()` method is a minor addition). `forms.rs` is 549 lines
  (just under). All other changed files are well within limits.
  `bracket_errors.rs` is 70 lines.

- **Naming**: `kind_label` is clear and descriptive. `bracket_errors.rs`
  follows the lowercase convention.

- **Error propagation**: All errors use `Result<_, String>` consistent
  with the existing codebase. No silent failures.

- **Validation at boundaries**: The improved errors fire at the
  analysis/expansion boundary, consistent with the project's approach.

- **Test structure**: Integration tests for pipeline behavior, consistent
  with AGENTS.md ("integration tests for pipelines").

- **`//!` doc comment** on the test file uses `//` instead of `//!`.
  This is a minor style inconsistency — the impl.md specified `//!` but
  the implementation uses `//`. This is cosmetic and doesn't affect
  functionality.

### File sizes within limits?

Yes, all within acceptable range. `syntax/mod.rs` at 553 is slightly
over the 500-line target but most of that is pre-existing tests (lines
180-553). The actual `Syntax` impl is well under.

### Naming conventions followed?

Yes. `kind_label`, `bracket_errors` — lowercase, descriptive.

## Verdict

**PASS.**

The implementation is correct, complete, consistent, and well-tested.
All 6 error sites are updated with the same pattern. The 7 tests cover
all bracket-specific paths and one fallback path. All verification
commands pass clean (tests, clippy, fmt). The only minor notes are:

1. Fallback (non-bracket) paths for 5 of 6 sites lack dedicated tests —
   acceptable since the pattern is identical and one representative test
   exists.
2. `syntax/mod.rs` is 553 lines (slightly over 500-line target) — this
   is pre-existing and the addition is minimal.
3. Test file uses `//` comments instead of `//!` doc comments — cosmetic.

None of these are blocking.
