### PR TITLE
fix: build binary before coverage so integration tests find it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,6 +148,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
+      - name: Build binary for integration tests
+        run: cargo build
       - name: Generate coverage
         run: cargo llvm-cov --workspace --lcov --output-path lcov.info
       - name: Upload to Codecov


### PR DESCRIPTION
## Summary

- The coverage job runs `cargo llvm-cov` which builds test artifacts but not the main binary
- Integration tests (`dispatch.rs`, `repl_exit_codes.rs`) spawn `target/debug/elle` and fail with "No such file or directory"
- Add a `cargo build` step before `cargo llvm-cov` so the binary exists when tests run

Fixes CI regression from #366.
