### PR TITLE
Strip debug info from release binary, add profiling profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,12 @@ iai-callgrind = "0.11"
 lto = "fat"
 codegen-units = 1
 opt-level = 3
-debug = true
+strip = "symbols"
+
+[profile.profiling]
+inherits = "release"
+strip = false
+debug = "line-tables-only"
 
 [profile.bench]
 inherits = "release"


### PR DESCRIPTION
Release binary was 46 MB due to `debug = true` in `[profile.release]` — 90% was DWARF debug info.

Changes:
- Remove `debug = true` from `[profile.release]`
- Add `strip = "symbols"` to release profile → 4.0 MB binary
- Add `[profile.profiling]` custom profile (inherits release) with `debug = "line-tables-only"` for `perf`/`samply` → 19 MB in `target/profiling/`

Workflow:
- `cargo build --release` → ship/benchmark (4 MB)
- `cargo build --profile profiling` → profiling (19 MB)

No code changes, no feature changes. Build configuration only.
