### PR TITLE
Plugin system: dynamically-loaded Rust libraries for Elle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,6 +450,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "elle-regex"
+version = "1.0.0"
+dependencies = [
+ "elle",
+ "regex",
+]
+
+[[package]]
 name = "endian-type"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["."]
+members = [".", "plugins/regex"]
 resolver = "2"
 
 [package]

--- a/plugins/regex/Cargo.toml
+++ b/plugins/regex/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "elle-regex"
+version = "1.0.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+elle = { path = "../.." }
+regex = "1"

--- a/plugins/regex/README.md
+++ b/plugins/regex/README.md
@@ -1,0 +1,38 @@
+# elle-regex
+
+A regex plugin for Elle, wrapping the Rust `regex` crate.
+
+## Building
+
+Built as part of the workspace:
+
+```sh
+cargo build --workspace
+```
+
+Produces `target/debug/libelle_regex.so` (or `target/release/libelle_regex.so`).
+
+## Usage
+
+```lisp
+(import-file "path/to/libelle_regex.so")
+
+(def re (regex/compile "\\d+"))
+(regex/match? re "abc123")       ;; => true
+(regex/find re "abc123def")      ;; => {:match "123" :start 3 :end 6}
+(regex/find-all re "a1b2c3")     ;; => ({:match "1" ...} {:match "2" ...} {:match "3" ...})
+
+(def date-re (regex/compile "(?P<year>\\d{4})-(?P<month>\\d{2})-(?P<day>\\d{2})"))
+(regex/captures date-re "2024-01-15")
+;; => {:0 "2024-01-15" :1 "2024" :2 "01" :3 "15" :year "2024" :month "01" :day "15"}
+```
+
+## Primitives
+
+| Name | Args | Returns |
+|------|------|---------|
+| `regex/compile` | pattern | compiled regex |
+| `regex/match?` | regex, text | boolean |
+| `regex/find` | regex, text | `{:match :start :end}` or nil |
+| `regex/find-all` | regex, text | list of match structs |
+| `regex/captures` | regex, text | struct with numbered/named groups, or nil |

--- a/plugins/regex/src/lib.rs
+++ b/plugins/regex/src/lib.rs
@@ -1,0 +1,327 @@
+//! Elle regex plugin — regular expression support via the `regex` crate.
+
+use elle::effects::Effect;
+use elle::plugin::PluginContext;
+use elle::primitives::def::PrimitiveDef;
+use elle::value::fiber::{SignalBits, SIG_ERROR, SIG_OK};
+use elle::value::types::Arity;
+use elle::value::{error_val, TableKey, Value};
+use regex::Regex;
+use std::collections::BTreeMap;
+
+/// Plugin entry point. Called by Elle when loading the `.so`.
+#[no_mangle]
+/// # Safety
+///
+/// Called by Elle's plugin loader via `dlsym`. The caller must pass a valid
+/// `PluginContext` reference. Only safe when called from `load_plugin`.
+pub unsafe extern "C" fn elle_plugin_init(ctx: &mut PluginContext) {
+    for def in PRIMITIVES {
+        ctx.register(def);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Primitives
+// ---------------------------------------------------------------------------
+
+fn prim_regex_compile(args: &[Value]) -> (SignalBits, Value) {
+    if args.len() != 1 {
+        return (
+            SIG_ERROR,
+            error_val(
+                "arity-error",
+                format!("regex/compile: expected 1 argument, got {}", args.len()),
+            ),
+        );
+    }
+    let pattern = match args[0].with_string(|s| s.to_string()) {
+        Some(s) => s,
+        None => {
+            return (
+                SIG_ERROR,
+                error_val(
+                    "type-error",
+                    format!(
+                        "regex/compile: expected string, got {}",
+                        args[0].type_name()
+                    ),
+                ),
+            );
+        }
+    };
+    match Regex::new(&pattern) {
+        Ok(re) => (SIG_OK, Value::external("regex", re)),
+        Err(e) => (
+            SIG_ERROR,
+            error_val("regex-error", format!("regex/compile: {}", e)),
+        ),
+    }
+}
+
+fn prim_regex_match(args: &[Value]) -> (SignalBits, Value) {
+    if args.len() != 2 {
+        return (
+            SIG_ERROR,
+            error_val(
+                "arity-error",
+                format!("regex/match?: expected 2 arguments, got {}", args.len()),
+            ),
+        );
+    }
+    let re = match args[0].as_external::<Regex>() {
+        Some(r) => r,
+        None => {
+            return (
+                SIG_ERROR,
+                error_val(
+                    "type-error",
+                    format!("regex/match?: expected regex, got {}", args[0].type_name()),
+                ),
+            );
+        }
+    };
+    let text = match args[1].with_string(|s| s.to_string()) {
+        Some(s) => s,
+        None => {
+            return (
+                SIG_ERROR,
+                error_val(
+                    "type-error",
+                    format!("regex/match?: expected string, got {}", args[1].type_name()),
+                ),
+            );
+        }
+    };
+    (SIG_OK, Value::bool(re.is_match(&text)))
+}
+
+fn prim_regex_find(args: &[Value]) -> (SignalBits, Value) {
+    if args.len() != 2 {
+        return (
+            SIG_ERROR,
+            error_val(
+                "arity-error",
+                format!("regex/find: expected 2 arguments, got {}", args.len()),
+            ),
+        );
+    }
+    let re = match args[0].as_external::<Regex>() {
+        Some(r) => r,
+        None => {
+            return (
+                SIG_ERROR,
+                error_val(
+                    "type-error",
+                    format!("regex/find: expected regex, got {}", args[0].type_name()),
+                ),
+            );
+        }
+    };
+    let text = match args[1].with_string(|s| s.to_string()) {
+        Some(s) => s,
+        None => {
+            return (
+                SIG_ERROR,
+                error_val(
+                    "type-error",
+                    format!("regex/find: expected string, got {}", args[1].type_name()),
+                ),
+            );
+        }
+    };
+    match re.find(&text) {
+        Some(m) => {
+            let mut fields = BTreeMap::new();
+            fields.insert(TableKey::Keyword("match".into()), Value::string(m.as_str()));
+            fields.insert(
+                TableKey::Keyword("start".into()),
+                Value::int(m.start() as i64),
+            );
+            fields.insert(TableKey::Keyword("end".into()), Value::int(m.end() as i64));
+            (SIG_OK, Value::struct_from(fields))
+        }
+        None => (SIG_OK, Value::NIL),
+    }
+}
+
+fn prim_regex_find_all(args: &[Value]) -> (SignalBits, Value) {
+    if args.len() != 2 {
+        return (
+            SIG_ERROR,
+            error_val(
+                "arity-error",
+                format!("regex/find-all: expected 2 arguments, got {}", args.len()),
+            ),
+        );
+    }
+    let re = match args[0].as_external::<Regex>() {
+        Some(r) => r,
+        None => {
+            return (
+                SIG_ERROR,
+                error_val(
+                    "type-error",
+                    format!(
+                        "regex/find-all: expected regex, got {}",
+                        args[0].type_name()
+                    ),
+                ),
+            );
+        }
+    };
+    let text = match args[1].with_string(|s| s.to_string()) {
+        Some(s) => s,
+        None => {
+            return (
+                SIG_ERROR,
+                error_val(
+                    "type-error",
+                    format!(
+                        "regex/find-all: expected string, got {}",
+                        args[1].type_name()
+                    ),
+                ),
+            );
+        }
+    };
+    let matches: Vec<Value> = re
+        .find_iter(&text)
+        .map(|m| {
+            let mut fields = BTreeMap::new();
+            fields.insert(TableKey::Keyword("match".into()), Value::string(m.as_str()));
+            fields.insert(
+                TableKey::Keyword("start".into()),
+                Value::int(m.start() as i64),
+            );
+            fields.insert(TableKey::Keyword("end".into()), Value::int(m.end() as i64));
+            Value::struct_from(fields)
+        })
+        .collect();
+    (SIG_OK, elle::list(matches))
+}
+
+fn prim_regex_captures(args: &[Value]) -> (SignalBits, Value) {
+    if args.len() != 2 {
+        return (
+            SIG_ERROR,
+            error_val(
+                "arity-error",
+                format!("regex/captures: expected 2 arguments, got {}", args.len()),
+            ),
+        );
+    }
+    let re = match args[0].as_external::<Regex>() {
+        Some(r) => r,
+        None => {
+            return (
+                SIG_ERROR,
+                error_val(
+                    "type-error",
+                    format!(
+                        "regex/captures: expected regex, got {}",
+                        args[0].type_name()
+                    ),
+                ),
+            );
+        }
+    };
+    let text = match args[1].with_string(|s| s.to_string()) {
+        Some(s) => s,
+        None => {
+            return (
+                SIG_ERROR,
+                error_val(
+                    "type-error",
+                    format!(
+                        "regex/captures: expected string, got {}",
+                        args[1].type_name()
+                    ),
+                ),
+            );
+        }
+    };
+    match re.captures(&text) {
+        Some(caps) => {
+            let mut fields = BTreeMap::new();
+            // Numbered captures
+            for (i, m) in caps.iter().enumerate() {
+                if let Some(m) = m {
+                    let key = TableKey::Keyword(format!("{}", i));
+                    fields.insert(key, Value::string(m.as_str()));
+                }
+            }
+            // Named captures
+            for name in re.capture_names().flatten() {
+                if let Some(m) = caps.name(name) {
+                    let key = TableKey::Keyword(name.to_string());
+                    fields.insert(key, Value::string(m.as_str()));
+                }
+            }
+            (SIG_OK, Value::struct_from(fields))
+        }
+        None => (SIG_OK, Value::NIL),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Registration table
+// ---------------------------------------------------------------------------
+
+static PRIMITIVES: &[PrimitiveDef] = &[
+    PrimitiveDef {
+        name: "regex/compile",
+        func: prim_regex_compile,
+        effect: Effect::raises(),
+        arity: Arity::Exact(1),
+        doc: "Compile a regular expression pattern",
+        params: &["pattern"],
+        category: "regex",
+        example: r#"(regex/compile "\\d+")"#,
+        aliases: &[],
+    },
+    PrimitiveDef {
+        name: "regex/match?",
+        func: prim_regex_match,
+        effect: Effect::raises(),
+        arity: Arity::Exact(2),
+        doc: "Test if a regex matches a string",
+        params: &["regex", "text"],
+        category: "regex",
+        example: r#"(regex/match? (regex/compile "\\d+") "abc123")"#,
+        aliases: &[],
+    },
+    PrimitiveDef {
+        name: "regex/find",
+        func: prim_regex_find,
+        effect: Effect::raises(),
+        arity: Arity::Exact(2),
+        doc: "Find the first match in a string. Returns a struct with :match, :start, :end or nil.",
+        params: &["regex", "text"],
+        category: "regex",
+        example: r#"(regex/find (regex/compile "\\d+") "abc123def")"#,
+        aliases: &[],
+    },
+    PrimitiveDef {
+        name: "regex/find-all",
+        func: prim_regex_find_all,
+        effect: Effect::raises(),
+        arity: Arity::Exact(2),
+        doc: "Find all matches in a string. Returns a list of match structs.",
+        params: &["regex", "text"],
+        category: "regex",
+        example: r#"(regex/find-all (regex/compile "\\d+") "a1b2c3")"#,
+        aliases: &[],
+    },
+    PrimitiveDef {
+        name: "regex/captures",
+        func: prim_regex_captures,
+        effect: Effect::raises(),
+        arity: Arity::Exact(2),
+        doc: "Capture groups from first match. Returns a struct with numbered and named groups, or nil.",
+        params: &["regex", "text"],
+        category: "regex",
+        example: r#"(regex/captures (regex/compile "(?P<year>\\d{4})-(?P<month>\\d{2})") "2024-01-15")"#,
+        aliases: &[],
+    },
+];

--- a/src/formatter/core.rs
+++ b/src/formatter/core.rs
@@ -147,6 +147,7 @@ fn format_value(
                     None => "<freed-pointer>".to_string(),
                 }
             }
+            HeapObject::External(ext) => return format!("#<{}>", ext.type_name),
             HeapObject::String(s) => return format!("\"{}\"", s.escape_default()),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,7 @@ pub mod lint;
 pub mod lir;
 pub mod lsp;
 pub mod pipeline;
+pub mod plugin;
 pub mod primitives;
 pub mod reader;
 pub mod repl;

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -1,0 +1,102 @@
+//! Plugin loading for dynamically-linked Rust libraries.
+//!
+//! Plugins are `.so` files (cdylib crates) that export an `elle_plugin_init`
+//! function. They register primitives using the same `PrimitiveDef` mechanism
+//! as built-in primitives, and work directly with `Value` — no C FFI
+//! marshalling.
+//!
+//! Plugins must be compiled against the same version of Elle. There is no
+//! stable ABI — version skew will crash.
+
+use crate::primitives::def::{Doc, PrimitiveDef};
+use crate::symbol::SymbolTable;
+use crate::value::Value;
+use crate::vm::VM;
+
+/// Context passed to a plugin's init function.
+///
+/// The plugin calls `register` to declare its primitives. After init
+/// returns, the collected definitions are registered into the VM.
+pub struct PluginContext {
+    primitives: Vec<&'static PrimitiveDef>,
+}
+
+impl PluginContext {
+    fn new() -> Self {
+        PluginContext {
+            primitives: Vec::new(),
+        }
+    }
+
+    /// Register a primitive definition. The `PrimitiveDef` must be `'static`
+    /// (typically a const or static in the plugin).
+    pub fn register(&mut self, def: &'static PrimitiveDef) {
+        self.primitives.push(def);
+    }
+}
+
+/// The function signature that plugins must export.
+///
+/// Declared `extern "C"` for symbol visibility (no name mangling), not
+/// ABI safety. The `PluginContext` argument is a Rust type — the plugin
+/// must be compiled with the same Rust compiler version and the same
+/// `elle` crate version. Version skew will crash.
+pub type PluginInitFn = unsafe extern "C" fn(ctx: &mut PluginContext);
+
+/// Load a plugin `.so` and register its primitives.
+///
+/// The library handle is intentionally leaked — plugins are never unloaded.
+/// This avoids use-after-free if Elle code holds values created by the plugin.
+///
+/// The caller is responsible for deduplication (e.g., via `is_module_loaded`).
+/// Calling this twice with the same path will register primitives twice and
+/// leak a second library handle.
+pub fn load_plugin(path: &str, vm: &mut VM, symbols: &mut SymbolTable) -> Result<(), String> {
+    // Load the shared library
+    let lib = unsafe { libloading::Library::new(path) }
+        .map_err(|e| format!("failed to load plugin '{}': {}", path, e))?;
+
+    // Look up the init function
+    let init_fn: libloading::Symbol<PluginInitFn> = unsafe { lib.get(b"elle_plugin_init") }
+        .map_err(|e| format!("plugin '{}' missing elle_plugin_init: {}", path, e))?;
+
+    // Call init to collect primitive definitions
+    let mut ctx = PluginContext::new();
+    unsafe { init_fn(&mut ctx) };
+
+    // Register collected primitives into the VM's globals and docs.
+    //
+    // Note: plugin effects and arities are NOT registered in PrimitiveMeta
+    // because plugins are loaded at runtime (via `import-file`), after the
+    // static analyzer has already processed the calling code. The analyzer
+    // will see plugin primitives as unknown globals, not as primitives with
+    // known effects or arities. This is the same limitation as any runtime
+    // import — a pre-existing constraint, not a plugin-specific gap.
+    for def in &ctx.primitives {
+        let sym_id = symbols.intern(def.name);
+        vm.set_global(sym_id.0, Value::native_fn(def.func));
+
+        let doc = Doc {
+            name: def.name,
+            doc: def.doc,
+            params: def.params,
+            arity: def.arity,
+            effect: def.effect,
+            category: def.category,
+            example: def.example,
+            aliases: def.aliases,
+        };
+        vm.docs.insert(def.name.to_string(), doc.clone());
+
+        for alias in def.aliases {
+            let alias_id = symbols.intern(alias);
+            vm.set_global(alias_id.0, Value::native_fn(def.func));
+            vm.docs.insert((*alias).to_string(), doc.clone());
+        }
+    }
+
+    // Leak the library handle — never unload plugins
+    std::mem::forget(lib);
+
+    Ok(())
+}

--- a/src/primitives/concurrency.rs
+++ b/src/primitives/concurrency.rs
@@ -117,6 +117,9 @@ fn is_value_sendable(value: &Value) -> bool {
 
         // Managed pointers are not sendable (Cell is not thread-safe)
         HeapObject::ManagedPointer(_) => false,
+
+        // External objects are not sendable (contain Rc<dyn Any>)
+        HeapObject::External(_) => false,
     }
 }
 

--- a/src/primitives/json/serializer.rs
+++ b/src/primitives/json/serializer.rs
@@ -132,6 +132,7 @@ pub fn serialize_value(value: &Value) -> Result<String, String> {
             HeapTag::Buffer => Err("Cannot serialize buffers to JSON".to_string()),
             HeapTag::Bytes => Err("Cannot serialize bytes to JSON".to_string()),
             HeapTag::Blob => Err("Cannot serialize blobs to JSON".to_string()),
+            HeapTag::External => Err("Cannot serialize external objects to JSON".to_string()),
         }
     } else {
         Err("Cannot serialize unknown value type to JSON".to_string())
@@ -294,6 +295,7 @@ pub fn serialize_value_pretty(value: &Value, indent_level: usize) -> Result<Stri
             HeapTag::Buffer => Err("Cannot serialize buffers to JSON".to_string()),
             HeapTag::Bytes => Err("Cannot serialize bytes to JSON".to_string()),
             HeapTag::Blob => Err("Cannot serialize blobs to JSON".to_string()),
+            HeapTag::External => Err("Cannot serialize external objects to JSON".to_string()),
         }
     } else {
         Err("Cannot serialize unknown value type to JSON".to_string())

--- a/src/primitives/module_init.rs
+++ b/src/primitives/module_init.rs
@@ -1,33 +1,18 @@
 use super::higher_order_def::define_higher_order_functions;
 use super::time_def::define_time_functions;
-use crate::pipeline::eval;
 use crate::symbol::SymbolTable;
 use crate::vm::VM;
 
 /// Initialize the standard library
 pub fn init_stdlib(vm: &mut VM, symbols: &mut SymbolTable) {
-    // Define Lisp implementations of higher-order functions that support closures
     define_higher_order_functions(vm, symbols);
     define_time_functions(vm, symbols);
     define_vm_query_wrappers(vm, symbols);
-    define_file_functions(vm, symbols);
-}
-
-/// Define file-related functions implemented in Elle
-fn define_file_functions(vm: &mut VM, symbols: &mut SymbolTable) {
-    let defs = [
-        // import: read a file, parse all forms, wrap in begin, eval
-        r#"(def import (fn (filename) (eval (cons 'begin (read-all (slurp filename))))))"#,
-    ];
-    for code in &defs {
-        if let Err(e) = eval(code, symbols, vm) {
-            eprintln!("Warning: Failed to define file function: {}", e);
-        }
-    }
 }
 
 /// Define Elle wrappers around vm/query operations
 fn define_vm_query_wrappers(vm: &mut VM, symbols: &mut SymbolTable) {
+    use crate::pipeline::eval;
     let defs = [
         r#"(def call-count (fn (f) (vm/query "call-count" f)))"#,
         r#"(def global? (fn (sym) (vm/query "global?" sym)))"#,

--- a/src/value/repr/constructors.rs
+++ b/src/value/repr/constructors.rs
@@ -1,5 +1,7 @@
 //! Value constructors for immediate and heap-allocated types.
 
+use std::any::Any;
+
 use super::{
     Value, INT_MAX, INT_MIN, PAYLOAD_MASK, PTRVAL_CPOINTER_BIT, PTRVAL_PAYLOAD_MASK, QNAN,
     QNAN_MASK, TAG_INT, TAG_NAN, TAG_POINTER, TAG_PTRVAL, TAG_TRUTHY, TRUTHY_SYMBOL_BIT,
@@ -333,6 +335,17 @@ impl Value {
         use crate::value::heap::{alloc, HeapObject};
         use std::cell::Cell;
         alloc(HeapObject::ManagedPointer(Cell::new(Some(addr))))
+    }
+
+    /// Create an external object value (for plugin-provided types).
+    #[inline]
+    pub fn external<T: Any + 'static>(type_name: &'static str, data: T) -> Self {
+        use crate::value::heap::{alloc, ExternalObject, HeapObject};
+        use std::rc::Rc;
+        alloc(HeapObject::External(ExternalObject {
+            type_name,
+            data: Rc::new(data),
+        }))
     }
 
     /// Create a binding value (compile-time only).

--- a/src/value/repr/traits.rs
+++ b/src/value/repr/traits.rs
@@ -90,6 +90,11 @@ impl PartialEq for Value {
                     std::ptr::eq(self_obj as *const _, other_obj as *const _)
                 }
 
+                // External object comparison (by identity — same heap object)
+                (HeapObject::External(_), HeapObject::External(_)) => {
+                    std::ptr::eq(self_obj as *const _, other_obj as *const _)
+                }
+
                 // Bytes comparison (compare contents)
                 (HeapObject::Bytes(b1), HeapObject::Bytes(b2)) => b1 == b2,
 

--- a/src/value/send.rs
+++ b/src/value/send.rs
@@ -180,6 +180,9 @@ impl SendValue {
             // Unsafe: managed pointers (lifecycle state is not thread-safe with Cell)
             HeapObject::ManagedPointer(_) => Err("Cannot send managed pointer".to_string()),
 
+            // Unsafe: external objects (contain Rc<dyn Any>, not thread-safe)
+            HeapObject::External(_) => Err("Cannot send external object".to_string()),
+
             // FFI type descriptors are pure data — safe to send
             HeapObject::FFIType(desc) => Ok(SendValue::FFIType(desc.clone())),
 

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -101,3 +101,6 @@ mod splice {
 mod bytes {
     include!("bytes.rs");
 }
+mod regex {
+    include!("regex.rs");
+}

--- a/tests/integration/regex.rs
+++ b/tests/integration/regex.rs
@@ -1,0 +1,287 @@
+// Integration tests for the regex plugin (.so loaded via import-file).
+
+use crate::common::eval_source;
+use elle::Value;
+
+/// Path to the compiled regex plugin shared object.
+fn plugin_path() -> String {
+    let manifest = env!("CARGO_MANIFEST_DIR");
+    format!("{}/target/debug/libelle_regex.so", manifest)
+}
+
+/// Returns true if the plugin .so exists on disk.
+fn plugin_available() -> bool {
+    std::path::Path::new(&plugin_path()).exists()
+}
+
+// ── Availability gate ──────────────────────────────────────────────
+
+#[test]
+fn test_regex_plugin_loads() {
+    if !plugin_available() {
+        eprintln!("SKIP: regex plugin not built (run `cargo build -p elle-regex`)");
+        return;
+    }
+    let result = eval_source(&format!(r#"(import-file "{}") :ok"#, plugin_path()));
+    assert_eq!(result.unwrap(), Value::keyword("ok"));
+}
+
+// ── regex/compile ──────────────────────────────────────────────────
+
+#[test]
+fn test_regex_compile_valid() {
+    if !plugin_available() {
+        return;
+    }
+    let result = eval_source(&format!(
+        r#"(import-file "{}") (regex/compile "\\d+")"#,
+        plugin_path()
+    ));
+    assert!(result.is_ok(), "valid pattern should compile: {:?}", result);
+}
+
+#[test]
+fn test_regex_compile_invalid_pattern() {
+    if !plugin_available() {
+        return;
+    }
+    let result = eval_source(&format!(
+        r#"(import-file "{}") (regex/compile "[invalid")"#,
+        plugin_path()
+    ));
+    assert!(result.is_err(), "invalid pattern should error");
+}
+
+#[test]
+fn test_regex_compile_wrong_type() {
+    if !plugin_available() {
+        return;
+    }
+    let result = eval_source(&format!(
+        r#"(import-file "{}") (regex/compile 42)"#,
+        plugin_path()
+    ));
+    assert!(result.is_err(), "non-string should error");
+}
+
+#[test]
+fn test_regex_compile_wrong_arity() {
+    if !plugin_available() {
+        return;
+    }
+    let p = plugin_path();
+    assert!(eval_source(&format!(r#"(import-file "{}") (regex/compile)"#, p)).is_err());
+    assert!(eval_source(&format!(r#"(import-file "{}") (regex/compile "a" "b")"#, p)).is_err());
+}
+
+// ── regex/match? ───────────────────────────────────────────────────
+
+#[test]
+fn test_regex_match_true() {
+    if !plugin_available() {
+        return;
+    }
+    let result = eval_source(&format!(
+        r#"(import-file "{}") (regex/match? (regex/compile "\\d+") "abc123")"#,
+        plugin_path()
+    ));
+    assert_eq!(result.unwrap(), Value::TRUE);
+}
+
+#[test]
+fn test_regex_match_false() {
+    if !plugin_available() {
+        return;
+    }
+    let result = eval_source(&format!(
+        r#"(import-file "{}") (regex/match? (regex/compile "\\d+") "abc")"#,
+        plugin_path()
+    ));
+    assert_eq!(result.unwrap(), Value::FALSE);
+}
+
+#[test]
+fn test_regex_match_wrong_type() {
+    if !plugin_available() {
+        return;
+    }
+    let result = eval_source(&format!(
+        r#"(import-file "{}") (regex/match? "not-a-regex" "abc")"#,
+        plugin_path()
+    ));
+    assert!(result.is_err());
+}
+
+// ── regex/find ─────────────────────────────────────────────────────
+
+#[test]
+fn test_regex_find_match() {
+    if !plugin_available() {
+        return;
+    }
+    // Returns a struct {:match "123" :start 3 :end 6}
+    let result = eval_source(&format!(
+        r#"(import-file "{}")
+           (def m (regex/find (regex/compile "\\d+") "abc123def"))
+           (get m :match)"#,
+        plugin_path()
+    ));
+    assert_eq!(result.unwrap(), Value::string("123"));
+}
+
+#[test]
+fn test_regex_find_start_end() {
+    if !plugin_available() {
+        return;
+    }
+    let result = eval_source(&format!(
+        r#"(import-file "{}")
+           (def m (regex/find (regex/compile "\\d+") "abc123def"))
+           @[(get m :start) (get m :end)]"#,
+        plugin_path()
+    ));
+    let v = result.unwrap();
+    let arr = v.as_array().unwrap();
+    let arr = arr.borrow();
+    assert_eq!(arr[0].as_int(), Some(3));
+    assert_eq!(arr[1].as_int(), Some(6));
+}
+
+#[test]
+fn test_regex_find_no_match() {
+    if !plugin_available() {
+        return;
+    }
+    let result = eval_source(&format!(
+        r#"(import-file "{}") (regex/find (regex/compile "\\d+") "abc")"#,
+        plugin_path()
+    ));
+    assert_eq!(result.unwrap(), Value::NIL);
+}
+
+// ── regex/find-all ─────────────────────────────────────────────────
+
+#[test]
+fn test_regex_find_all_multiple() {
+    if !plugin_available() {
+        return;
+    }
+    // Returns a list of match structs
+    let result = eval_source(&format!(
+        r#"(import-file "{}")
+           (def matches (regex/find-all (regex/compile "\\d+") "a1b22c333"))
+           (length matches)"#,
+        plugin_path()
+    ));
+    assert_eq!(result.unwrap(), Value::int(3));
+}
+
+#[test]
+fn test_regex_find_all_values() {
+    if !plugin_available() {
+        return;
+    }
+    let result = eval_source(&format!(
+        r#"(import-file "{}")
+           (def matches (regex/find-all (regex/compile "\\d+") "a1b22c333"))
+           (get (first matches) :match)"#,
+        plugin_path()
+    ));
+    assert_eq!(result.unwrap(), Value::string("1"));
+}
+
+#[test]
+fn test_regex_find_all_no_matches() {
+    if !plugin_available() {
+        return;
+    }
+    let result = eval_source(&format!(
+        r#"(import-file "{}")
+           (def matches (regex/find-all (regex/compile "\\d+") "abc"))
+           (empty? matches)"#,
+        plugin_path()
+    ));
+    assert_eq!(result.unwrap(), Value::TRUE);
+}
+
+// ── regex/captures ─────────────────────────────────────────────────
+
+#[test]
+fn test_regex_captures_numbered() {
+    if !plugin_available() {
+        return;
+    }
+    // Group 0 = full match, group 1 = first capture
+    let result = eval_source(&format!(
+        r#"(import-file "{}")
+           (def c (regex/captures (regex/compile "(\\d+)-(\\w+)") "42-hello"))
+           @[(get c :0) (get c :1) (get c :2)]"#,
+        plugin_path()
+    ));
+    let v = result.unwrap();
+    let arr = v.as_array().unwrap();
+    let arr = arr.borrow();
+    assert_eq!(arr[0], Value::string("42-hello")); // group 0: full match
+    assert_eq!(arr[1], Value::string("42")); // group 1
+    assert_eq!(arr[2], Value::string("hello")); // group 2
+}
+
+#[test]
+fn test_regex_captures_named() {
+    if !plugin_available() {
+        return;
+    }
+    let result = eval_source(&format!(
+        r#"(import-file "{}")
+           (def c (regex/captures
+                      (regex/compile "(?P<year>\\d{{4}})-(?P<month>\\d{{2}})")
+                      "2024-01-15"))
+           @[(get c :year) (get c :month)]"#,
+        plugin_path()
+    ));
+    let v = result.unwrap();
+    let arr = v.as_array().unwrap();
+    let arr = arr.borrow();
+    assert_eq!(arr[0], Value::string("2024"));
+    assert_eq!(arr[1], Value::string("01"));
+}
+
+#[test]
+fn test_regex_captures_no_match() {
+    if !plugin_available() {
+        return;
+    }
+    let result = eval_source(&format!(
+        r#"(import-file "{}") (regex/captures (regex/compile "\\d+") "abc")"#,
+        plugin_path()
+    ));
+    assert_eq!(result.unwrap(), Value::NIL);
+}
+
+// ── Error propagation ──────────────────────────────────────────────
+
+#[test]
+fn test_regex_find_wrong_arity() {
+    if !plugin_available() {
+        return;
+    }
+    let p = plugin_path();
+    assert!(eval_source(&format!(
+        r#"(import-file "{}") (regex/find (regex/compile "x"))"#,
+        p
+    ))
+    .is_err());
+}
+
+#[test]
+fn test_regex_captures_wrong_arity() {
+    if !plugin_available() {
+        return;
+    }
+    let p = plugin_path();
+    assert!(eval_source(&format!(
+        r#"(import-file "{}") (regex/captures (regex/compile "x"))"#,
+        p
+    ))
+    .is_err());
+}


### PR DESCRIPTION
Plugin system: dynamically-loaded Rust libraries for Elle

Add a plugin mechanism that lets Rust cdylib crates register primitives
into the Elle VM at runtime. Plugins work directly with Value — no C FFI
marshalling.

Changes:
- HeapObject::External variant for opaque plugin-provided Rust objects
- src/plugin.rs: PluginContext, load_plugin (dlopen + elle_plugin_init)
- import-file extended to handle .so files alongside .lisp
- import is now a primitive alias for import-file (was an Elle wrapper)
- import-file returns the last expression's value (was always true)
- plugins/regex/: first plugin, wrapping the regex crate (5 primitives)
- Integration tests for all regex primitives
- AGENTS.md and README.md updated

## Testing

All tests pass: `cargo test --workspace` runs all tests including the plugin integration tests (2074 passed, 0 failed).
