### PR TITLE
Add selkie plugin for Mermaid diagram rendering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -148,6 +157,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "serde",
+ "wasm-bindgen",
+ "windows-link",
+]
+
+[[package]]
 name = "ciborium"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -207,6 +230,12 @@ checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
 dependencies = [
  "error-code",
 ]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -530,6 +559,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "elle-selkie"
+version = "1.0.0"
+dependencies = [
+ "elle",
+ "selkie-rs",
+]
+
+[[package]]
 name = "elle-sqlite"
 version = "1.0.0"
 dependencies = [
@@ -670,7 +707,17 @@ dependencies = [
  "memmap2",
  "slotmap",
  "tinyvec",
- "ttf-parser",
+ "ttf-parser 0.20.0",
+]
+
+[[package]]
+name = "fontdue"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e57e16b3fe8ff4364c0661fdaac543fb38b29ea9bc9c2f45612d90adf931d2b"
+dependencies = [
+ "hashbrown 0.15.5",
+ "ttf-parser 0.21.1",
 ]
 
 [[package]]
@@ -752,6 +799,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -842,6 +891,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60484b2e469ef4f1af6f196af738889ff375151dd11ac223647ed8a97529107d"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1010,8 +1083,8 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "thiserror",
- "ttf-parser",
+ "thiserror 2.0.18",
+ "ttf-parser 0.20.0",
 ]
 
 [[package]]
@@ -1404,7 +1477,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8a1f2315036ef6b1fbacd1972e8ee7688030b0a2121edfc2a6550febd41574d"
 dependencies = [
  "hashbrown 0.16.1",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1498,6 +1571,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "selkie-rs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e4dbea3faa448acb0485c6b63cca7dbfa102b177eacdcb870b31296eb82716d"
+dependencies = [
+ "chrono",
+ "fontdue",
+ "log",
+ "pest",
+ "pest_derive",
+ "regex",
+ "roxmltree",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "uuid",
 ]
 
 [[package]]
@@ -1653,11 +1745,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -1701,6 +1813,12 @@ name = "ttf-parser"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17f77d76d837a7830fe1d4f12b7b4ba4192c1888001c7164257e4bc6d21d96b4"
+
+[[package]]
+name = "ttf-parser"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c591d83f69777866b9126b24c6dd9a18351f177e49d625920d19f989fd31cf8"
 
 [[package]]
 name = "typenum"
@@ -1749,6 +1867,17 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb"
+dependencies = [
+ "getrandom 0.4.1",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "vcpkg"
@@ -1910,10 +2039,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.116",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.116",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = [".", "plugins/regex", "plugins/mermaid", "plugins/crypto", "plugins/sqlite", "plugins/random", "plugins/sugiyama", "plugins/fdg", "plugins/dagre"]
+members = [".", "plugins/regex", "plugins/mermaid", "plugins/crypto", "plugins/sqlite", "plugins/random", "plugins/sugiyama", "plugins/fdg", "plugins/dagre", "plugins/selkie"]
 resolver = "2"
 
 [package]

--- a/plugins/selkie/Cargo.toml
+++ b/plugins/selkie/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "elle-selkie"
+version = "1.0.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+elle = { path = "../.." }
+selkie-rs = { version = "0.3", default-features = false }

--- a/plugins/selkie/README.md
+++ b/plugins/selkie/README.md
@@ -1,0 +1,35 @@
+# elle-selkie
+
+A Mermaid diagram rendering plugin for Elle, wrapping the Rust `selkie-rs` crate.
+
+## Building
+
+Built as part of the workspace:
+
+```sh
+cargo build --workspace
+```
+
+Produces `target/debug/libelle_selkie.so` (or `target/release/libelle_selkie.so`).
+
+## Usage
+
+```lisp
+(import-file "path/to/libelle_selkie.so")
+
+(def svg (selkie/render "flowchart LR; A-->B-->C"))
+(print svg)  ;; => SVG string
+
+(selkie/render-to-file "flowchart TD; X-->Y-->Z" "diagram.svg")
+
+(def ascii (selkie/render-ascii "flowchart LR; A-->B"))
+(print ascii)  ;; => ASCII art string
+```
+
+## Primitives
+
+| Name | Args | Returns |
+|------|------|---------|
+| `selkie/render` | diagram | SVG string |
+| `selkie/render-to-file` | diagram, path | path string |
+| `selkie/render-ascii` | diagram | ASCII art string |

--- a/plugins/selkie/src/lib.rs
+++ b/plugins/selkie/src/lib.rs
@@ -1,0 +1,241 @@
+//! Elle selkie plugin — Mermaid diagram rendering via the `selkie-rs` crate.
+
+use elle::effects::Effect;
+use elle::plugin::PluginContext;
+use elle::primitives::def::PrimitiveDef;
+use elle::value::fiber::{SignalBits, SIG_ERROR, SIG_OK};
+use elle::value::types::Arity;
+use elle::value::{error_val, TableKey, Value};
+use std::collections::BTreeMap;
+use std::fs;
+
+/// Plugin entry point. Called by Elle when loading the `.so`.
+#[no_mangle]
+/// # Safety
+///
+/// Called by Elle's plugin loader via `dlsym`. The caller must pass a valid
+/// `PluginContext` reference. Only safe when called from `load_plugin`.
+pub unsafe extern "C" fn elle_plugin_init(ctx: &mut PluginContext) -> Value {
+    let mut fields = BTreeMap::new();
+    for def in PRIMITIVES {
+        ctx.register(def);
+        let short_name = def.name.strip_prefix("selkie/").unwrap_or(def.name);
+        fields.insert(
+            TableKey::Keyword(short_name.into()),
+            Value::native_fn(def.func),
+        );
+    }
+    Value::struct_from(fields)
+}
+
+// ---------------------------------------------------------------------------
+// Primitives
+// ---------------------------------------------------------------------------
+
+fn prim_selkie_render(args: &[Value]) -> (SignalBits, Value) {
+    if args.len() != 1 {
+        return (
+            SIG_ERROR,
+            error_val(
+                "arity-error",
+                format!("selkie/render: expected 1 argument, got {}", args.len()),
+            ),
+        );
+    }
+    let diagram = match args[0].with_string(|s| s.to_string()) {
+        Some(s) => s,
+        None => {
+            return (
+                SIG_ERROR,
+                error_val(
+                    "type-error",
+                    format!(
+                        "selkie/render: expected string, got {}",
+                        args[0].type_name()
+                    ),
+                ),
+            );
+        }
+    };
+    let parsed = match selkie::parse(&diagram) {
+        Ok(d) => d,
+        Err(e) => {
+            return (
+                SIG_ERROR,
+                error_val("selkie-error", format!("selkie/render: parse: {}", e)),
+            );
+        }
+    };
+    match selkie::render(&parsed) {
+        Ok(svg) => (SIG_OK, Value::string(&*svg)),
+        Err(e) => (
+            SIG_ERROR,
+            error_val("selkie-error", format!("selkie/render: render: {}", e)),
+        ),
+    }
+}
+
+fn prim_selkie_render_to_file(args: &[Value]) -> (SignalBits, Value) {
+    if args.len() != 2 {
+        return (
+            SIG_ERROR,
+            error_val(
+                "arity-error",
+                format!(
+                    "selkie/render-to-file: expected 2 arguments, got {}",
+                    args.len()
+                ),
+            ),
+        );
+    }
+    let diagram = match args[0].with_string(|s| s.to_string()) {
+        Some(s) => s,
+        None => {
+            return (
+                SIG_ERROR,
+                error_val(
+                    "type-error",
+                    format!(
+                        "selkie/render-to-file: expected string, got {}",
+                        args[0].type_name()
+                    ),
+                ),
+            );
+        }
+    };
+    let path = match args[1].with_string(|s| s.to_string()) {
+        Some(s) => s,
+        None => {
+            return (
+                SIG_ERROR,
+                error_val(
+                    "type-error",
+                    format!(
+                        "selkie/render-to-file: expected string, got {}",
+                        args[1].type_name()
+                    ),
+                ),
+            );
+        }
+    };
+    let parsed = match selkie::parse(&diagram) {
+        Ok(d) => d,
+        Err(e) => {
+            return (
+                SIG_ERROR,
+                error_val(
+                    "selkie-error",
+                    format!("selkie/render-to-file: parse: {}", e),
+                ),
+            );
+        }
+    };
+    let svg = match selkie::render(&parsed) {
+        Ok(svg) => svg,
+        Err(e) => {
+            return (
+                SIG_ERROR,
+                error_val(
+                    "selkie-error",
+                    format!("selkie/render-to-file: render: {}", e),
+                ),
+            );
+        }
+    };
+    match fs::write(&path, &svg) {
+        Ok(()) => (SIG_OK, Value::string(&*path)),
+        Err(e) => (
+            SIG_ERROR,
+            error_val("io-error", format!("selkie/render-to-file: {}", e)),
+        ),
+    }
+}
+
+fn prim_selkie_render_ascii(args: &[Value]) -> (SignalBits, Value) {
+    if args.len() != 1 {
+        return (
+            SIG_ERROR,
+            error_val(
+                "arity-error",
+                format!(
+                    "selkie/render-ascii: expected 1 argument, got {}",
+                    args.len()
+                ),
+            ),
+        );
+    }
+    let diagram = match args[0].with_string(|s| s.to_string()) {
+        Some(s) => s,
+        None => {
+            return (
+                SIG_ERROR,
+                error_val(
+                    "type-error",
+                    format!(
+                        "selkie/render-ascii: expected string, got {}",
+                        args[0].type_name()
+                    ),
+                ),
+            );
+        }
+    };
+    let parsed = match selkie::parse(&diagram) {
+        Ok(d) => d,
+        Err(e) => {
+            return (
+                SIG_ERROR,
+                error_val("selkie-error", format!("selkie/render-ascii: parse: {}", e)),
+            );
+        }
+    };
+    match selkie::render_ascii(&parsed) {
+        Ok(ascii) => (SIG_OK, Value::string(&*ascii)),
+        Err(e) => (
+            SIG_ERROR,
+            error_val(
+                "selkie-error",
+                format!("selkie/render-ascii: render: {}", e),
+            ),
+        ),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Registration table
+// ---------------------------------------------------------------------------
+
+static PRIMITIVES: &[PrimitiveDef] = &[
+    PrimitiveDef {
+        name: "selkie/render",
+        func: prim_selkie_render,
+        effect: Effect::raises(),
+        arity: Arity::Exact(1),
+        doc: "Render a Mermaid diagram to SVG",
+        params: &["diagram"],
+        category: "selkie",
+        example: r#"(selkie/render "flowchart LR; A-->B-->C")"#,
+        aliases: &[],
+    },
+    PrimitiveDef {
+        name: "selkie/render-to-file",
+        func: prim_selkie_render_to_file,
+        effect: Effect::raises(),
+        arity: Arity::Exact(2),
+        doc: "Render a Mermaid diagram to an SVG file",
+        params: &["diagram", "path"],
+        category: "selkie",
+        example: r#"(selkie/render-to-file "flowchart LR; A-->B" "out.svg")"#,
+        aliases: &[],
+    },
+    PrimitiveDef {
+        name: "selkie/render-ascii",
+        func: prim_selkie_render_ascii,
+        effect: Effect::raises(),
+        arity: Arity::Exact(1),
+        doc: "Render a Mermaid diagram to ASCII art",
+        params: &["diagram"],
+        category: "selkie",
+        example: r#"(selkie/render-ascii "flowchart LR; A-->B-->C")"#,
+        aliases: &[],
+    },
+];


### PR DESCRIPTION
## Summary

- Adds `plugins/selkie/` — an Elle plugin wrapping the `selkie-rs` crate, a native Rust Mermaid diagram parser and renderer
- Exposes three primitives: `selkie/render` (→ SVG string), `selkie/render-to-file` (→ SVG file), `selkie/render-ascii` (→ ASCII art)
- Follows the existing mermaid plugin pattern exactly (same init, registration, error handling)

This is an alternative to the existing `mermaid-rs-renderer`-based plugin, offering ASCII art output and a different rendering engine.