### PR TITLE
Remove code coverage job from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,29 +134,6 @@ jobs:
              echo "✓ All examples passed"
             fi
 
-  coverage:
-    name: Code Coverage
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
-    continue-on-error: true
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: llvm-tools-preview
-      - uses: Swatinem/rust-cache@v2
-      - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@cargo-llvm-cov
-      - name: Generate coverage
-        run: cargo llvm-cov --workspace --lcov --output-path lcov.info
-        env:
-          PROPTEST_CASES: 1
-      - name: Upload to Codecov
-        uses: codecov/codecov-action@v4
-        with:
-          files: ./lcov.info
-          fail_ci_if_error: false
-
   docs:
     name: Build Documentation
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Removes the `coverage` job from the CI workflow
- The coverage job was timing out on GitHub Actions runners, causing noise on PRs
- It already had `continue-on-error: true` and wasn't in the `all-checks` gate, but the runner cancellation was cascading to other jobs