### PR TITLE
Run CI tests with --test-threads=1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Run all workspace tests
-        run: cargo test --workspace --verbose
+        run: cargo test --workspace --verbose -- --test-threads=1
         env:
           PROPTEST_CASES: 32
 
@@ -310,7 +310,7 @@ jobs:
           toolchain: ${{ matrix.rust }}
       - uses: Swatinem/rust-cache@v2
       - name: Run all workspace tests
-        run: cargo test --workspace --verbose
+        run: cargo test --workspace --verbose -- --test-threads=1
         env:
           PROPTEST_CASES: 32
 


### PR DESCRIPTION
## Summary

- Serializes test execution in CI to prevent OOM kills on GitHub Actions runners
- The property tests each spin up a full compilation pipeline; running them in parallel exhausts the runner's memory