### PR TITLE
Revert --test-threads=1 in CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Run all workspace tests
-        run: cargo test --workspace --verbose -- --test-threads=1
+        run: cargo test --workspace --verbose
         env:
           PROPTEST_CASES: 32
 
@@ -310,7 +310,7 @@ jobs:
           toolchain: ${{ matrix.rust }}
       - uses: Swatinem/rust-cache@v2
       - name: Run all workspace tests
-        run: cargo test --workspace --verbose -- --test-threads=1
+        run: cargo test --workspace --verbose
         env:
           PROPTEST_CASES: 32
 


### PR DESCRIPTION
## Summary

- Reverts the `--test-threads=1` change from #400
- Single-threaded execution makes property tests take ~27s each, causing the suite to exceed the runner's time budget
- The original CI failures on #393 were caused by the concurrency group cancelling in-progress runs during rebases, not by parallel test execution