### PR TITLE
Limit CI test threads to 2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Run all workspace tests
-        run: cargo test --workspace --verbose
+        run: cargo test --workspace --verbose -- --test-threads=2
         env:
           PROPTEST_CASES: 32
 
@@ -310,7 +310,7 @@ jobs:
           toolchain: ${{ matrix.rust }}
       - uses: Swatinem/rust-cache@v2
       - name: Run all workspace tests
-        run: cargo test --workspace --verbose
+        run: cargo test --workspace --verbose -- --test-threads=2
         env:
           PROPTEST_CASES: 32
 


### PR DESCRIPTION
## Summary

- Sets `--test-threads=2` for CI test runs
- Default parallelism OOMs on the 7GB GitHub Actions runners (property tests each spin up a full compilation pipeline)
- Single-threaded (`--test-threads=1`) was too slow — property tests take ~27s each, exceeding the runner time budget
- 2 threads balances memory usage against wall-clock time