### PR TITLE
allocator: scope escape analysis for safe patterns

### DIFF
--- a/src/lir/AGENTS.md
+++ b/src/lir/AGENTS.md
@@ -146,10 +146,27 @@ that push/pop scope marks on the current FiberHeap. In the VM, they call
 `region_enter()`/`region_exit()` which are no-ops for the root fiber
 (no FiberHeap installed).
 
-The lowerer only emits these instructions when escape analysis determines
-the scope's allocations are safe to release at scope exit. Currently the
-escape analysis is maximally conservative (nothing qualifies), so no region
-instructions are emitted. Function bodies never get region instructions.
+The lowerer emits these instructions when escape analysis (in `lower/escape.rs`)
+determines the scope's allocations are safe to release at scope exit.
+Function bodies never get region instructions.
+
+**Escape analysis conditions (all must hold):**
+1. No binding is captured by a nested lambda
+2. Body cannot suspend (`may_suspend()`)
+3. Body result is provably a NaN-boxed immediate (`result_is_safe`)
+4. Body contains no `set` to bindings outside the scope
+
+For `let`/`letrec`: all four conditions. `letrec` delegates to `let`.
+For `block`: conditions 1-4 plus no `break` nodes in the body.
+
+`result_is_safe` returns `true` for: literals (int, float, bool, nil,
+keyword, empty-list), `if`/`begin`/`cond`/`and`/`or` where all result
+positions are recursively safe, and calls to intrinsics (`BinOp`,
+`CmpOp`, `UnaryOp`) with correct arity.
+
+**Known limitation (E5/E6):** If the body passes a scope-allocated
+value to a function that stores it externally, the analysis cannot
+detect this. Requires interprocedural analysis. Accepted for Tier 0.
 
 `break` emits compensating `RegionExit` instructions for each region entered
 between the break site and the target block. The lowerer tracks `region_depth`
@@ -190,7 +207,8 @@ No new bytecode instructions — break compiles to existing Move + Jump.
 | `mod.rs` | 20 | Re-exports |
 | `types.rs` | 270 | `LirFunction`, `LirInstr`, `Reg`, `Label`, etc. |
 | `intrinsics.rs` | ~55 | `IntrinsicOp` enum, maps primitive SymbolIds to specialized LIR instructions (BinOp, CmpOp, UnaryOp) |
-| `lower/mod.rs` | ~280 | `Lowerer` struct, context, entry point |
+| `lower/mod.rs` | ~280 | `Lowerer` struct, context, entry point, `can_scope_allocate_*` analysis |
+| `lower/escape.rs` | ~340 | Escape analysis helpers: `result_is_safe`, `body_contains_outward_set`, `body_contains_break` |
 | `lower/expr.rs` | ~457 | Expression lowering: literals, operators, calls |
 | `lower/binding.rs` | ~280 | Binding forms: `let`, `def`, `var`, `fn` |
 | `lower/lambda.rs` | ~250 | fn lowering, closure capture, cell wrapping |

--- a/src/lir/lower/escape.rs
+++ b/src/lir/lower/escape.rs
@@ -1,0 +1,354 @@
+//! Escape analysis for scope allocation.
+//!
+//! Determines whether a `let`/`letrec`/`block` scope's allocations can be
+//! safely released at scope exit (via `RegionEnter`/`RegionExit`).
+//!
+//! **Error asymmetry:** A false positive (scope-allocating something that
+//! escapes) is use-after-free. A false negative (not scope-allocating
+//! something safe) is the status quo. Every function here errs toward
+//! returning `false` (conservative).
+//!
+//! ## Safety conditions
+//!
+//! A scope is safe to allocate when ALL conditions hold:
+//!
+//! 1. No binding is captured by a nested lambda (`is_captured()`)
+//! 2. Body cannot suspend (`may_suspend()`)
+//! 3. Body result is provably a NaN-boxed immediate (`result_is_safe`)
+//! 4. Body contains no `set` to bindings outside this scope
+//!    (`body_contains_outward_set`)
+//! 5. Body contains no `break` (`hir_contains_break`) — a break carries
+//!    a value past the compensating `RegionExit`
+//!
+//! ## What `RegionExit` frees
+//!
+//! `RegionExit` runs destructors for ALL heap objects allocated between
+//! `RegionEnter` and `RegionExit` — including objects the body allocated
+//! (not just binding values). This is why condition 3 is required: the
+//! body's result, if heap-allocated inside the scope, gets freed before
+//! the caller uses it.
+
+use super::Lowerer;
+use crate::hir::{Binding, CallArg, Hir, HirKind};
+use crate::lir::intrinsics::IntrinsicOp;
+
+impl Lowerer {
+    /// Check if the result of a HIR expression is provably a NaN-boxed
+    /// immediate (not a heap pointer to something allocated inside the scope).
+    ///
+    /// Returns `true` only for expressions that are guaranteed to produce
+    /// non-heap values: literals, intrinsic arithmetic/comparison/logical
+    /// operations, and control flow where all result positions are safe.
+    ///
+    /// Returns `false` for anything that might produce a heap-allocated
+    /// value: variables (might hold heap pointers), non-intrinsic calls,
+    /// lambdas, strings, quotes, etc.
+    pub(super) fn result_is_safe(&self, hir: &Hir) -> bool {
+        match &hir.kind {
+            // Literals: all NaN-boxed immediates
+            HirKind::Int(_)
+            | HirKind::Float(_)
+            | HirKind::Bool(_)
+            | HirKind::Nil
+            | HirKind::Keyword(_)
+            | HirKind::EmptyList => true,
+
+            // Control flow: recurse into all result positions
+            HirKind::If {
+                then_branch,
+                else_branch,
+                ..
+            } => self.result_is_safe(then_branch) && self.result_is_safe(else_branch),
+
+            HirKind::Begin(exprs) => {
+                // Empty begin produces nil (an immediate)
+                match exprs.last() {
+                    Some(last) => self.result_is_safe(last),
+                    None => true,
+                }
+            }
+
+            HirKind::Cond {
+                clauses,
+                else_branch,
+            } => {
+                // All clause bodies must be safe
+                let clauses_safe = clauses.iter().all(|(_, body)| self.result_is_safe(body));
+                // Missing else produces nil (safe); present else must be safe
+                let else_safe = match else_branch {
+                    Some(branch) => self.result_is_safe(branch),
+                    None => true,
+                };
+                clauses_safe && else_safe
+            }
+
+            HirKind::And(exprs) | HirKind::Or(exprs) => {
+                // Short-circuit: any sub-expression could be the result
+                exprs.iter().all(|e| self.result_is_safe(e))
+            }
+
+            // Intrinsic calls that return immediates
+            HirKind::Call { func, args, .. } => self.call_result_is_safe(func, args),
+
+            // Everything else: conservatively unsafe
+            // String, Var, Lambda, Let, Letrec, Block, While, Match,
+            // Yield, Quote, Eval, Set, Define, Destructure, Break
+            _ => false,
+        }
+    }
+
+    /// Check if a function call is to a known intrinsic with the correct
+    /// arity, meaning its result is guaranteed to be an immediate.
+    fn call_result_is_safe(&self, func: &Hir, args: &[CallArg]) -> bool {
+        // Must be a variable reference to a global
+        let HirKind::Var(binding) = &func.kind else {
+            return false;
+        };
+
+        // Must be a non-mutated global (same check as try_lower_intrinsic)
+        if !binding.is_global() || binding.is_mutated() {
+            return false;
+        }
+
+        // Any spliced argument means generic CallArray, not intrinsic
+        if args.iter().any(|a| a.spliced) {
+            return false;
+        }
+
+        let sym = binding.name();
+
+        // Look up in intrinsics map
+        let Some(op) = self.intrinsics.get(&sym) else {
+            return false;
+        };
+
+        // Verify arity matches what try_lower_intrinsic expects
+        match op {
+            IntrinsicOp::Binary(_) | IntrinsicOp::Compare(_) => args.len() == 2,
+            IntrinsicOp::Unary(_) => args.len() == 1,
+        }
+    }
+
+    /// Check if a HIR body contains any `set!` to a binding that is NOT
+    /// in the given set of scope-local bindings.
+    ///
+    /// An outward `set!` stores a value (possibly heap-allocated inside
+    /// the scope) into a binding that outlives the scope. After
+    /// `RegionExit`, that binding holds a dangling pointer.
+    ///
+    /// Recursion rules:
+    /// - Recurses into all sub-expressions.
+    /// - Does NOT recurse into `Lambda` bodies (separate scope; captures
+    ///   caught by condition 1).
+    /// - DOES recurse into nested `Let`/`Letrec`/`Block` bodies (part of
+    ///   the current execution flow).
+    pub(super) fn body_contains_outward_set(hir: &Hir, scope_bindings: &[Binding]) -> bool {
+        Self::walk_for_outward_set(hir, scope_bindings)
+    }
+
+    fn walk_for_outward_set(hir: &Hir, scope_bindings: &[Binding]) -> bool {
+        match &hir.kind {
+            HirKind::Set { target, value } => {
+                // Check if target is outside our scope
+                if !scope_bindings.contains(target) {
+                    return true;
+                }
+                Self::walk_for_outward_set(value, scope_bindings)
+            }
+
+            // Do NOT recurse into lambda bodies
+            HirKind::Lambda { .. } => false,
+
+            // Recurse into all sub-expressions for other node types
+            HirKind::Int(_)
+            | HirKind::Float(_)
+            | HirKind::Bool(_)
+            | HirKind::Nil
+            | HirKind::Keyword(_)
+            | HirKind::EmptyList
+            | HirKind::String(_) => false,
+
+            HirKind::Var(_) => false,
+
+            HirKind::If {
+                cond,
+                then_branch,
+                else_branch,
+            } => {
+                Self::walk_for_outward_set(cond, scope_bindings)
+                    || Self::walk_for_outward_set(then_branch, scope_bindings)
+                    || Self::walk_for_outward_set(else_branch, scope_bindings)
+            }
+
+            HirKind::Begin(exprs) => exprs
+                .iter()
+                .any(|e| Self::walk_for_outward_set(e, scope_bindings)),
+
+            HirKind::Cond {
+                clauses,
+                else_branch,
+            } => {
+                clauses.iter().any(|(cond, body)| {
+                    Self::walk_for_outward_set(cond, scope_bindings)
+                        || Self::walk_for_outward_set(body, scope_bindings)
+                }) || else_branch
+                    .as_ref()
+                    .is_some_and(|b| Self::walk_for_outward_set(b, scope_bindings))
+            }
+
+            HirKind::And(exprs) | HirKind::Or(exprs) => exprs
+                .iter()
+                .any(|e| Self::walk_for_outward_set(e, scope_bindings)),
+
+            HirKind::Call { func, args, .. } => {
+                Self::walk_for_outward_set(func, scope_bindings)
+                    || args
+                        .iter()
+                        .any(|a| Self::walk_for_outward_set(&a.expr, scope_bindings))
+            }
+
+            HirKind::Let { bindings, body } | HirKind::Letrec { bindings, body } => {
+                bindings
+                    .iter()
+                    .any(|(_, init)| Self::walk_for_outward_set(init, scope_bindings))
+                    || Self::walk_for_outward_set(body, scope_bindings)
+            }
+
+            HirKind::Define { value, .. } => Self::walk_for_outward_set(value, scope_bindings),
+
+            HirKind::While { cond, body } => {
+                Self::walk_for_outward_set(cond, scope_bindings)
+                    || Self::walk_for_outward_set(body, scope_bindings)
+            }
+
+            HirKind::Block { body, .. } => body
+                .iter()
+                .any(|e| Self::walk_for_outward_set(e, scope_bindings)),
+
+            HirKind::Break { value, .. } => Self::walk_for_outward_set(value, scope_bindings),
+
+            HirKind::Match { value, arms } => {
+                Self::walk_for_outward_set(value, scope_bindings)
+                    || arms.iter().any(|(_, guard, body)| {
+                        guard
+                            .as_ref()
+                            .is_some_and(|g| Self::walk_for_outward_set(g, scope_bindings))
+                            || Self::walk_for_outward_set(body, scope_bindings)
+                    })
+            }
+
+            HirKind::Yield(expr) => Self::walk_for_outward_set(expr, scope_bindings),
+
+            HirKind::Quote(_) => false,
+
+            HirKind::Destructure { value, .. } => Self::walk_for_outward_set(value, scope_bindings),
+
+            HirKind::Eval { expr, env } => {
+                Self::walk_for_outward_set(expr, scope_bindings)
+                    || Self::walk_for_outward_set(env, scope_bindings)
+            }
+        }
+    }
+
+    /// Check if a HIR body (slice) contains any `Break` node.
+    ///
+    /// Used by block scope allocation to conservatively reject blocks
+    /// with breaks (break values might be heap-allocated).
+    pub(super) fn body_contains_break(body: &[Hir]) -> bool {
+        body.iter().any(Self::walk_for_break)
+    }
+
+    /// Check if a single HIR expression contains any `Break` node.
+    ///
+    /// Used by let/letrec scope allocation: a break inside the let body
+    /// carries a value past the compensating `RegionExit`, which would
+    /// free scope-allocated objects the break value might reference.
+    pub(super) fn hir_contains_break(hir: &Hir) -> bool {
+        Self::walk_for_break(hir)
+    }
+
+    /// Recursion rules:
+    /// - Does NOT recurse into `Lambda` bodies (break can't cross fn boundaries).
+    /// - DOES recurse into nested `Block` bodies (a break inside a nested
+    ///   block might target an outer block, escaping our scope).
+    fn walk_for_break(hir: &Hir) -> bool {
+        match &hir.kind {
+            HirKind::Break { .. } => true,
+
+            // Do NOT recurse into lambda bodies
+            HirKind::Lambda { .. } => false,
+
+            // DO recurse into nested block bodies: a break inside a nested
+            // block can target an outer block, carrying a value past our
+            // scope's RegionExit.
+            HirKind::Block { body, .. } => body.iter().any(Self::walk_for_break),
+
+            // Terminals
+            HirKind::Int(_)
+            | HirKind::Float(_)
+            | HirKind::Bool(_)
+            | HirKind::Nil
+            | HirKind::Keyword(_)
+            | HirKind::EmptyList
+            | HirKind::String(_)
+            | HirKind::Var(_)
+            | HirKind::Quote(_) => false,
+
+            // Recurse into sub-expressions
+            HirKind::If {
+                cond,
+                then_branch,
+                else_branch,
+            } => {
+                Self::walk_for_break(cond)
+                    || Self::walk_for_break(then_branch)
+                    || Self::walk_for_break(else_branch)
+            }
+
+            HirKind::Begin(exprs) | HirKind::And(exprs) | HirKind::Or(exprs) => {
+                exprs.iter().any(Self::walk_for_break)
+            }
+
+            HirKind::Cond {
+                clauses,
+                else_branch,
+            } => {
+                clauses
+                    .iter()
+                    .any(|(c, b)| Self::walk_for_break(c) || Self::walk_for_break(b))
+                    || else_branch.as_deref().is_some_and(Self::walk_for_break)
+            }
+
+            HirKind::Call { func, args, .. } => {
+                Self::walk_for_break(func) || args.iter().any(|a| Self::walk_for_break(&a.expr))
+            }
+
+            HirKind::Set { value, .. } | HirKind::Define { value, .. } => {
+                Self::walk_for_break(value)
+            }
+
+            HirKind::Let { bindings, body } | HirKind::Letrec { bindings, body } => {
+                bindings.iter().any(|(_, init)| Self::walk_for_break(init))
+                    || Self::walk_for_break(body)
+            }
+
+            HirKind::While { cond, body } => {
+                Self::walk_for_break(cond) || Self::walk_for_break(body)
+            }
+
+            HirKind::Match { value, arms } => {
+                Self::walk_for_break(value)
+                    || arms.iter().any(|(_, guard, body)| {
+                        guard.as_ref().is_some_and(Self::walk_for_break)
+                            || Self::walk_for_break(body)
+                    })
+            }
+
+            HirKind::Yield(expr) => Self::walk_for_break(expr),
+
+            HirKind::Destructure { value, .. } => Self::walk_for_break(value),
+
+            HirKind::Eval { expr, env } => Self::walk_for_break(expr) || Self::walk_for_break(env),
+        }
+    }
+}

--- a/src/lir/lower/mod.rs
+++ b/src/lir/lower/mod.rs
@@ -2,6 +2,7 @@
 
 mod binding;
 mod control;
+mod escape;
 mod expr;
 mod lambda;
 mod pattern;
@@ -190,28 +191,90 @@ impl Lowerer {
         self.region_depth -= 1;
     }
 
-    // ── Escape analysis stubs ─────────────────────────────────────
+    // ── Escape analysis ────────────────────────────────────────────
+    //
+    // See `escape.rs` for helper functions (`result_is_safe`,
+    // `body_contains_outward_set`, `body_contains_break`).
 
     /// Determine if a `let` scope's allocations can be safely released
-    /// at scope exit. Returns `false` if any binding's value might escape.
+    /// at scope exit via `RegionEnter`/`RegionExit`.
     ///
-    /// Current policy: maximally conservative (always returns `false`).
-    /// No scopes qualify for scope allocation until escape analysis is
-    /// implemented and validated.
-    fn can_scope_allocate_let(&self, _bindings: &[(Binding, Hir)], _body: &Hir) -> bool {
-        false
+    /// Returns `true` when ALL five conditions hold:
+    /// 1. No binding is captured by a nested lambda
+    /// 2. Body cannot suspend (yield/debug/polymorphic)
+    /// 3. Body result is provably a NaN-boxed immediate
+    /// 4. Body contains no `set` to bindings outside this scope
+    /// 5. Body contains no `break` (break carries a value past RegionExit)
+    fn can_scope_allocate_let(&self, bindings: &[(Binding, Hir)], body: &Hir) -> bool {
+        // Condition 1: no captures
+        if bindings.iter().any(|(b, _)| b.is_captured()) {
+            return false;
+        }
+
+        // Condition 2: no suspension
+        if body.effect.may_suspend() {
+            return false;
+        }
+
+        // Condition 3: result is immediate
+        if !self.result_is_safe(body) {
+            return false;
+        }
+
+        // Condition 4: no outward mutation
+        let scope_bindings: Vec<Binding> = bindings.iter().map(|(b, _)| *b).collect();
+        if Self::body_contains_outward_set(body, &scope_bindings) {
+            return false;
+        }
+
+        // Condition 5: no break (break value escapes via compensating RegionExit)
+        if Self::hir_contains_break(body) {
+            return false;
+        }
+
+        true
     }
 
     /// Determine if a `letrec` scope's allocations can be safely released.
-    /// Same conservative policy as `can_scope_allocate_let`.
-    fn can_scope_allocate_letrec(&self, _bindings: &[(Binding, Hir)], _body: &Hir) -> bool {
-        false
+    /// Identical analysis to `let` — letrec's mutual recursion and two-phase
+    /// initialization don't change the escape conditions.
+    fn can_scope_allocate_letrec(&self, bindings: &[(Binding, Hir)], body: &Hir) -> bool {
+        self.can_scope_allocate_let(bindings, body)
     }
 
     /// Determine if a `block` scope's allocations can be safely released.
-    /// Same conservative policy as above.
-    fn can_scope_allocate_block(&self, _body: &[Hir]) -> bool {
-        false
+    ///
+    /// Blocks don't introduce bindings but bracket a scope of allocations.
+    /// Conditions:
+    /// 1. No expression in body can suspend
+    /// 2. Body result is provably immediate
+    /// 3. No `break` in body (conservative — break values hard to check)
+    /// 4. No `set!` to non-local bindings (blocks have no own bindings)
+    fn can_scope_allocate_block(&self, body: &[Hir]) -> bool {
+        // Condition 1: no suspension
+        if body.iter().any(|e| e.effect.may_suspend()) {
+            return false;
+        }
+
+        // Condition 2: result is immediate (empty body → nil → safe)
+        if let Some(last) = body.last() {
+            if !self.result_is_safe(last) {
+                return false;
+            }
+        }
+
+        // Condition 3: no breaks
+        if Self::body_contains_break(body) {
+            return false;
+        }
+
+        // Condition 4: no outward mutation (blocks have no own bindings,
+        // so any set! to a non-local is outward)
+        if body.iter().any(|e| Self::body_contains_outward_set(e, &[])) {
+            return false;
+        }
+
+        true
     }
 }
 

--- a/src/value/fiber_heap.rs
+++ b/src/value/fiber_heap.rs
@@ -17,10 +17,10 @@
 //! `RegionExit` pops the mark and calls `release()` to run destructors for
 //! objects allocated within the scope.
 //!
-//! The lowerer gates `RegionEnter`/`RegionExit` emission on escape analysis:
-//! only scopes where no allocated values can escape get region instructions.
-//! Currently the escape analysis is maximally conservative (nothing qualifies),
-//! so region instructions are not emitted and the scope mark stack stays empty.
+//! The lowerer gates `RegionEnter`/`RegionExit` emission on escape analysis
+//! (`src/lir/lower/escape.rs`): only scopes where no allocated values can
+//! escape get region instructions. The analysis checks: no captures, no
+//! suspension, result is immediate, no outward mutation.
 //!
 //! ## Active allocator pointer
 //!

--- a/tests/integration/arena.rs
+++ b/tests/integration/arena.rs
@@ -297,28 +297,32 @@ fn count_in_bytecode(source: &str, needle: &str) -> usize {
 }
 
 #[test]
-fn test_let_no_region_instructions_conservative() {
-    // Conservative escape analysis: no scopes qualify for scope allocation.
-    // let* should NOT emit RegionEnter/RegionExit.
+fn test_let_no_region_when_result_is_var() {
+    // Body returns a variable → result_is_safe returns false.
+    // No scope allocation, no region instructions.
     assert!(!bytecode_contains("(let* ((x 1)) x)", "RegionEnter"));
     assert!(!bytecode_contains("(let* ((x 1)) x)", "RegionExit"));
 }
 
 #[test]
-fn test_nested_let_no_regions_conservative() {
-    // No region instructions emitted under conservative analysis
+fn test_nested_let_regions_for_safe_body() {
+    // Inner let: body is (+ x y) — intrinsic call, result is immediate.
+    // No captures, pure body → inner let qualifies for scope allocation.
+    // Outer let: body is the inner let — result_is_safe returns false
+    // for Let nodes (wildcard), so outer let does NOT scope-allocate.
     let source = "(let* ((x 1)) (let* ((y 2)) (+ x y)))";
     let enters = count_in_bytecode(source, "RegionEnter");
     let exits = count_in_bytecode(source, "RegionExit");
-    assert_eq!(enters, 0, "conservative: no RegionEnter");
-    assert_eq!(exits, 0, "conservative: no RegionExit");
+    assert_eq!(enters, 1, "inner let should emit RegionEnter");
+    assert_eq!(exits, 1, "inner let should emit RegionExit");
 }
 
 #[test]
-fn test_block_no_region_instructions_conservative() {
-    // Conservative: block should not emit region instructions
-    assert!(!bytecode_contains("(block :done 42)", "RegionEnter"));
-    assert!(!bytecode_contains("(block :done 42)", "RegionExit"));
+fn test_block_region_for_literal_body() {
+    // Block body is a literal → result is immediate, no suspension,
+    // no breaks, no outward set. Block qualifies for scope allocation.
+    assert!(bytecode_contains("(block :done 42)", "RegionEnter"));
+    assert!(bytecode_contains("(block :done 42)", "RegionExit"));
 }
 
 #[test]

--- a/tests/integration/escape.rs
+++ b/tests/integration/escape.rs
@@ -1,0 +1,438 @@
+use crate::common::eval_source;
+use elle::compiler::bytecode::disassemble_lines;
+use elle::pipeline::compile;
+use elle::SymbolTable;
+use elle::Value;
+
+fn bytecode_contains(source: &str, needle: &str) -> bool {
+    let mut symbols = SymbolTable::new();
+    let compiled = compile(source, &mut symbols).expect("compilation failed");
+    let lines = disassemble_lines(&compiled.bytecode.instructions);
+    lines.iter().any(|line| line.contains(needle))
+}
+
+fn has_region(source: &str) -> bool {
+    bytecode_contains(source, "RegionEnter")
+}
+
+// ── Positive: scopes that SHOULD emit RegionEnter/RegionExit ────────
+
+#[test]
+fn region_emitted_for_literal_result() {
+    // Body is a literal (int) → result is immediate → safe
+    assert!(has_region("(let ((a 1) (b 2)) 42)"));
+}
+
+#[test]
+fn region_emitted_for_intrinsic_add() {
+    // Body is (+ a b) → intrinsic BinOp::Add with 2 args → result is immediate
+    assert!(has_region("(let ((a 1) (b 2)) (+ a b))"));
+}
+
+#[test]
+fn region_emitted_for_intrinsic_compare() {
+    // Body is (< a b) → intrinsic CmpOp::Lt → result is bool
+    assert!(has_region("(let ((a 1) (b 2)) (< a b))"));
+}
+
+#[test]
+fn region_emitted_for_intrinsic_not() {
+    // Body is (not true) → intrinsic UnaryOp::Not → result is bool
+    assert!(has_region("(let ((a true)) (not a))"));
+}
+
+#[test]
+fn region_emitted_for_if_with_safe_branches() {
+    // Both branches are literals → safe
+    assert!(has_region("(let ((x 1)) (if true 1 2))"));
+}
+
+#[test]
+fn region_emitted_for_begin_with_safe_last() {
+    // Begin: last expression is literal → safe
+    assert!(has_region("(let ((x 1)) (begin x 42))"));
+}
+
+#[test]
+fn region_emitted_for_nil_result() {
+    assert!(has_region("(let ((x 1)) nil)"));
+}
+
+#[test]
+fn region_emitted_for_bool_result() {
+    assert!(has_region("(let ((x 1)) true)"));
+}
+
+#[test]
+fn region_emitted_for_keyword_result() {
+    assert!(has_region("(let ((x 1)) :done)"));
+}
+
+#[test]
+fn region_emitted_for_empty_list_result() {
+    // () is the empty list literal in expression position
+    assert!(has_region("(let ((x 1)) ())"));
+}
+
+#[test]
+fn region_emitted_for_float_result() {
+    assert!(has_region("(let ((x 1)) 3.14)"));
+}
+
+#[test]
+fn region_emitted_for_letrec_with_safe_body() {
+    // letrec delegates to let analysis — same conditions.
+    // Note: recursive functions capture their own binding (fib captures fib),
+    // so letrec with recursive lambdas does NOT qualify.
+    // A letrec with non-capturing bindings does qualify.
+    assert!(has_region("(letrec ((x 1) (y 2)) (+ x y))"));
+}
+
+#[test]
+fn region_emitted_for_block_literal_body() {
+    assert!(has_region("(block :done 42)"));
+}
+
+#[test]
+fn region_emitted_for_nested_arithmetic() {
+    // (+ (+ a b) (- c d)) → both are intrinsic calls → safe
+    assert!(has_region(
+        "(let ((a 1) (b 2) (c 3) (d 4)) (+ (+ a b) (- c d)))"
+    ));
+}
+
+// ── Negative: scopes that must NOT emit RegionEnter/RegionExit ──────
+
+#[test]
+fn no_region_when_result_is_var() {
+    // Body returns binding value → might be heap-allocated → unsafe
+    assert!(!has_region("(let ((x (list 1 2 3))) x)"));
+}
+
+#[test]
+fn no_region_when_result_is_string() {
+    // String literal is heap-allocated
+    assert!(!has_region(r#"(let ((x 1)) "hello")"#));
+}
+
+#[test]
+fn no_region_when_result_is_call() {
+    // Non-intrinsic call → result unknown → unsafe
+    assert!(!has_region("(let ((x (list 1 2 3))) (length x))"));
+}
+
+#[test]
+fn no_region_when_binding_captured() {
+    // Binding captured by lambda → escapes → unsafe
+    assert!(!has_region("(let ((x 1)) (fn () x))"));
+}
+
+#[test]
+fn no_region_when_body_yields() {
+    // Body contains yield → may suspend → unsafe
+    // Must be inside a function for yield to be valid
+    assert!(!has_region("(fn () (let ((x 1)) (yield x) 42))"));
+}
+
+#[test]
+fn no_region_when_set_to_global() {
+    // Body contains set to outer var → outward mutation → unsafe
+    assert!(!has_region(
+        "(begin (var holder nil) (let ((x (list 1 2 3))) (set holder x) 42))"
+    ));
+}
+
+#[test]
+fn no_region_when_result_is_quote() {
+    // Quote might produce a heap value
+    assert!(!has_region("(let ((x 1)) '(1 2 3))"));
+}
+
+#[test]
+fn no_region_when_result_is_lambda() {
+    // Lambda is a heap-allocated closure
+    assert!(!has_region("(let ((x 1)) (fn () 42))"));
+}
+
+#[test]
+fn no_region_when_if_branch_unsafe() {
+    // One branch returns a string → unsafe
+    assert!(!has_region(r#"(let ((x 1)) (if true 42 "bad"))"#));
+}
+
+#[test]
+fn no_region_for_variadic_intrinsic() {
+    // (+ 1 2 3) → 3 args → BinOp requires 2 → generic call → unsafe
+    assert!(!has_region("(let ((a 1)) (+ 1 2 3))"));
+}
+
+#[test]
+fn no_region_for_block_with_break() {
+    // Block with break → conservative rejection
+    assert!(!has_region("(block :done (if true (break :done 42) 0))"));
+}
+
+#[test]
+fn no_region_for_block_with_set() {
+    // Block body with set to outer binding → outward mutation
+    assert!(!has_region(
+        "(begin (var holder nil) (block :done (set holder 42) 0))"
+    ));
+}
+
+#[test]
+fn no_region_fn_body() {
+    // Function bodies never get region instructions
+    assert!(!has_region("(fn (x) (+ x 1))"));
+}
+
+// ── Negative: bug regression tests ──────────────────────────────────────
+
+#[test]
+fn no_region_when_break_carries_heap_value() {
+    // Bug 1: break inside let body carries a heap-allocated value past RegionExit.
+    // The let passes conditions 1-4 but condition 5 catches the break.
+    assert!(!has_region(
+        "(block :outer (let ((x (list 1 2 3))) (if true (break :outer x) nil) 42))"
+    ));
+}
+
+#[test]
+fn no_region_when_break_in_nested_block_targets_outer() {
+    // Bug 2: break inside a nested block targets the outer block.
+    // walk_for_break must recurse into nested Block bodies.
+    assert!(!has_region(
+        "(block :outer (block :inner (break :outer 42) 0) 0)"
+    ));
+}
+
+#[test]
+fn no_region_when_and_has_unsafe_element() {
+    // (and ...) short-circuits: any sub-expression could be the result.
+    // If any element is unsafe, the whole result is unsafe.
+    assert!(!has_region(r#"(let ((x 1)) (and true "heap"))"#));
+}
+
+#[test]
+fn no_region_when_or_has_unsafe_element() {
+    assert!(!has_region(r#"(let ((x 1)) (or false "heap"))"#));
+}
+
+#[test]
+fn no_region_when_cond_clause_body_unsafe() {
+    // A cond clause body returns a string → heap-allocated → unsafe
+    assert!(!has_region(
+        r#"(let ((x 1)) (cond (true "bad") (else 42)))"#
+    ));
+}
+
+#[test]
+fn region_emitted_for_cond_without_else() {
+    // cond with no else clause: missing else produces nil (safe).
+    // All clause bodies are safe ints → scope allocation should work.
+    assert!(has_region("(let ((x 1)) (cond ((< x 0) 1) ((> x 0) 2)))"));
+}
+
+#[test]
+fn no_region_when_set_to_outer_local() {
+    // set to a local binding from an enclosing let (not a global).
+    // The inner let's scope-allocated objects would dangle in the outer binding.
+    assert!(!has_region(
+        "(let ((holder nil)) (let ((x (list 1 2 3))) (set holder x) 42))"
+    ));
+}
+
+#[test]
+fn no_region_when_intrinsic_has_spliced_args() {
+    // Spliced args to an intrinsic cause a CallArray (not intrinsic lowering),
+    // so the result type is unknown → unsafe.
+    assert!(!has_region("(let ((a @[1 2])) (+ ;a))"));
+}
+
+// ── Correctness: programs with scope allocation produce correct results ─
+
+#[test]
+fn correct_arithmetic_in_scope() {
+    assert_eq!(
+        eval_source("(let ((a 1) (b 2) (c 3)) (+ a (+ b c)))").unwrap(),
+        Value::int(6)
+    );
+}
+
+#[test]
+fn correct_nested_scope() {
+    assert_eq!(
+        eval_source("(let ((x 4)) (let ((y 6)) (+ x y)))").unwrap(),
+        Value::int(10)
+    );
+}
+
+#[test]
+fn correct_comparison_in_scope() {
+    assert_eq!(
+        eval_source("(let ((a 10) (b 20)) (< a b))").unwrap(),
+        Value::TRUE
+    );
+}
+
+#[test]
+fn correct_if_with_scope() {
+    assert_eq!(
+        eval_source("(let ((x 5)) (if (> x 3) 1 0))").unwrap(),
+        Value::int(1)
+    );
+}
+
+#[test]
+fn correct_letrec_fibonacci() {
+    assert_eq!(
+        eval_source(
+            "(letrec ((fib (fn (n)
+                           (if (<= n 1) n
+                               (+ (fib (- n 1)) (fib (- n 2)))))))
+               (fib 10))"
+        )
+        .unwrap(),
+        Value::int(55)
+    );
+}
+
+#[test]
+fn correct_block_scope() {
+    assert_eq!(
+        eval_source("(block :done (+ 10 20))").unwrap(),
+        Value::int(30)
+    );
+}
+
+#[test]
+fn correct_deeply_nested_scopes() {
+    assert_eq!(
+        eval_source(
+            "(let ((a 1))
+               (let ((b 2))
+                 (let ((c 3))
+                   (+ a (+ b c)))))"
+        )
+        .unwrap(),
+        Value::int(6)
+    );
+}
+
+// ── Regression: unsafe patterns must produce correct results ────────
+//
+// These verify that the analysis correctly REJECTS patterns that would
+// be use-after-free if scope-allocated. The programs must work correctly
+// (values are NOT freed because scope allocation was not applied).
+
+#[test]
+fn regression_returned_binding_not_freed() {
+    let result = eval_source("(def result (let ((x (list 1 2 3))) x)) (length result)").unwrap();
+    assert_eq!(result, Value::int(3));
+}
+
+#[test]
+fn regression_global_set_not_freed() {
+    let result = eval_source(
+        "(var holder nil)
+         (let ((x (list 1 2 3)))
+           (set holder x)
+           42)
+         (length holder)",
+    )
+    .unwrap();
+    assert_eq!(result, Value::int(3));
+}
+
+#[test]
+fn regression_captured_binding_not_freed() {
+    let result = eval_source(
+        "(def make-getter
+           (fn ()
+             (let ((data (list 1 2 3)))
+               (fn () data))))
+         (def getter (make-getter))
+         (length (getter))",
+    )
+    .unwrap();
+    assert_eq!(result, Value::int(3));
+}
+
+#[test]
+fn regression_yielded_value_not_freed() {
+    let result = eval_source(
+        "(def gen (fn () (let ((x (list 1 2 3))) (yield x) nil)))
+         (def f (fiber/new gen 2))
+         (def yielded (fiber/resume f))
+         (length yielded)",
+    )
+    .unwrap();
+    assert_eq!(result, Value::int(3));
+}
+
+// ── Stress: allocation-heavy programs with scope allocation ─────────
+
+#[test]
+fn stress_loop_with_scope_allocation() {
+    // Tight loop where each iteration scope-allocates and releases.
+    // Note: the let body does `(set i ...)` which is an outward set,
+    // so this let does NOT scope-allocate. But it exercises the path.
+    let result = eval_source(
+        "(var i 0)
+         (while (< i 1000)
+           (let ((a i) (b (+ i 1)))
+             (set i (+ a b))))",
+    )
+    .unwrap();
+    assert!(result.is_nil());
+}
+
+#[test]
+fn stress_nested_scope_allocation() {
+    let result = eval_source(
+        "(var sum 0)
+         (var i 0)
+         (while (< i 100)
+           (let ((a i))
+             (let ((b (+ a 1)))
+               (set sum (+ sum (+ a b)))))
+           (set i (+ i 1)))
+         sum",
+    )
+    .unwrap();
+    // sum = Σ(i=0 to 99) of (i + i+1) = Σ(2i+1) = 2*4950 + 100 = 10000
+    assert_eq!(result, Value::int(10000));
+}
+
+// ── Correctness of break with scoped blocks ─────────────────────────
+
+#[test]
+fn break_from_nested_scoped_let_correct() {
+    // Inner let qualifies for scope allocation.
+    // Break exits the block, compensating exits fire for the inner let's scope.
+    let result = eval_source(
+        "(block :done
+           (let ((x 10))
+             (let ((y 20))
+               (break :done (+ x y)))))",
+    )
+    .unwrap();
+    assert_eq!(result, Value::int(30));
+}
+
+#[test]
+fn break_from_scoped_let_in_fiber() {
+    // Same test but in a child fiber — exercises real scope marks
+    let result = eval_source(
+        "(let ((f (fiber/new
+                     (fn ()
+                        (block :done
+                          (let ((x 10))
+                            (let ((y 20))
+                              (break :done (+ x y))))))
+                      1)))
+           (fiber/resume f))",
+    )
+    .unwrap();
+    assert_eq!(result, Value::int(30));
+}

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -122,6 +122,9 @@ mod table_keys {
 mod arena {
     include!("arena.rs");
 }
+mod escape {
+    include!("escape.rs");
+}
 // Temporarily disabled while sorting out compilation caching.
 // mod fn_flow {
 //     include!("fn_flow.rs");


### PR DESCRIPTION
## Summary

- Replace the always-false escape analysis stubs (`can_scope_allocate_let/letrec/block`) with real analysis that enables scope-based allocation for provably safe patterns
- New `escape.rs` module with `result_is_safe` (structural HIR walk proving result is NaN-boxed immediate), `body_contains_outward_set` (detects mutations escaping scope), and `walk_for_break` (detects break nodes that could carry heap values past RegionExit)
- 5 safety conditions for let/letrec, 4 for block — all must hold for scope allocation
- 50 new tests: 14 positive (patterns that should scope-allocate), 13 negative (patterns that must not), 7 correctness (runtime verification), 8 regression (specific bug patterns), 4 stress, 4 break-related
- Canonical winning pattern: `(let ((a ...) (b ...)) (+ a b))` — temporary bindings reduced to arithmetic

## Design process

Three design iterations with architect/engineer review cycle. Architect caught critical soundness issue: RegionExit frees ALL allocations in scope (not just bindings), so body result must be provably immediate. Engineer review caught outward-set escape path. Final architect review caught break-inside-let use-after-free and walk_for_break not recursing into nested blocks. Both fixed before merge.

## Deviations

1. **Merged implementation chunks** — dead code warnings under `-D warnings` prevent committing unused helpers separately
2. **No feature gate** — the analysis itself is the safety gate (per engineer review recommendation)
3. **No metrics counters** — deferred, not safety-critical
