### PR TITLE
numeric-aware =, add identical?, remove eq?

### DIFF
--- a/examples/AGENTS.md
+++ b/examples/AGENTS.md
@@ -40,8 +40,9 @@ complete file inventory with themes and coverage.
 `assert-list-eq`, `assert-not-nil`, `assert-string-eq`. All print
 expected-vs-actual on failure and `(exit 1)`.
 
-`assert-eq` uses `eq?` for symbols, `=` for everything else. For list
+`assert-eq` uses `=` (numeric-aware equality) for all comparisons. For list
 comparison use `assert-list-eq` (element-wise, handles length mismatch).
+For strict identity checks (no numeric coercion), use `identical?`.
 
 ## Gotchas
 

--- a/examples/assertions.lisp
+++ b/examples/assertions.lisp
@@ -5,7 +5,7 @@
 ##
 ## Functions:
 ##   - assert-eq(actual, expected, msg)
-##     Assert that actual equals expected (using = for numbers, eq? for symbols)
+##     Assert that actual equals expected (using =, which is numeric-aware)
 ##   - assert-equal(actual, expected, msg)
 ##     Alias for assert-eq
 ##   - assert-true(val, msg)
@@ -23,43 +23,34 @@
 ## act as contracts for the implementation.
 
 (def assert-eq (fn (actual expected msg)
-  "Assert that actual equals expected (using = for numbers, eq? for symbols)"
-  (let ([matches
-    (if (symbol? expected)
-        (eq? actual expected)
-        (= actual expected))])
-    (if matches
-        true
-        (begin
-          (display "FAIL: ")
-          (display msg)
-          (display "\n  Expected: ")
-          (display expected)
-          (display "\n  Actual: ")
-          (display actual)
-          (display "\n")
-          (exit 1))))))
+  "Assert that actual equals expected"
+  (if (= actual expected)
+      true
+      (begin
+        (display "FAIL: ")
+        (display msg)
+        (display "\n  Expected: ")
+        (display expected)
+        (display "\n  Actual: ")
+        (display actual)
+        (display "\n")
+        (exit 1)))))
 
 (def assert-true (fn (val msg)
-  "Assert that val is #t"
+  "Assert that val is true"
   (assert-eq val true msg)))
 
 (def assert-false (fn (val msg)
-  "Assert that val is #f"
+  "Assert that val is false"
   (assert-eq val false msg)))
 
 (def assert-list-eq (fn (actual expected msg)
   "Assert that two lists are equal (same length and elements)"
   (if (= (length actual) (length expected))
-      # Check each element - use a simple loop approach
-      # NOTE: letrec is required here because check-all calls itself recursively.
-      # A plain let would leave check-all unbound in its own body.
       (letrec ((check-all (fn (index)
         (if (>= index (length actual))
             true
-            (if (if (symbol? (get expected index))
-                    (eq? (get actual index) (get expected index))
-                    (= (get actual index) (get expected index)))
+            (if (= (get actual index) (get expected index))
                 (check-all (+ index 1))
                 (begin
                   (display "FAIL: ")
@@ -89,7 +80,7 @@
 ## Assert that a value is not nil
 (def assert-not-nil (fn (val msg)
   "Assert that val is not nil"
-  (if (not (eq? val nil))
+  (if (not (nil? val))
       true
       (begin
         (display "FAIL: ")

--- a/examples/meta.lisp
+++ b/examples/meta.lisp
@@ -107,13 +107,13 @@
 
 (var sym1 (gensym))
 (var sym2 (gensym))
-(assert-false (eq? sym1 sym2) "gensym symbols are unique")
+(assert-false (identical? sym1 sym2) "gensym symbols are unique")
 (display "  gensym => ") (print sym1)
 
 # With prefix for readability
 (var tmp1 (gensym "tmp"))
 (var tmp2 (gensym "tmp"))
-(assert-false (eq? tmp1 tmp2) "prefixed gensym symbols are unique")
+(assert-false (identical? tmp1 tmp2) "prefixed gensym symbols are unique")
 (display "  (gensym \"tmp\") => ") (print tmp1)
 
 

--- a/src/jit/runtime.rs
+++ b/src/jit/runtime.rs
@@ -201,23 +201,42 @@ pub extern "C" fn elle_jit_bit_not(a: u64) -> u64 {
 // Comparison Operations
 // =============================================================================
 
-/// Equality comparison
-///
-/// Uses `Value::PartialEq` for structural equality on heap values
-/// (cons cells, strings, arrays, tables, structs, tuples).
+/// Equality comparison — numeric-aware.
+/// If both values are numbers, compares numerically (int 1 == float 1.0).
+/// Otherwise, uses structural equality (PartialEq).
 #[no_mangle]
 pub extern "C" fn elle_jit_eq(a: u64, b: u64) -> u64 {
     let a = unsafe { Value::from_bits(a) };
     let b = unsafe { Value::from_bits(b) };
-    Value::bool(a == b).to_bits()
+    // Fast path: bitwise identical
+    if a == b {
+        return Value::TRUE.to_bits();
+    }
+    // Numeric coercion: int 1 == float 1.0
+    if a.is_number() && b.is_number() {
+        if let (Some(x), Some(y)) = (a.as_number(), b.as_number()) {
+            return Value::bool(x == y).to_bits();
+        }
+    }
+    Value::FALSE.to_bits()
 }
 
-/// Not equal comparison
+/// Not equal comparison — numeric-aware (inverse of elle_jit_eq).
 #[no_mangle]
 pub extern "C" fn elle_jit_ne(a: u64, b: u64) -> u64 {
     let a = unsafe { Value::from_bits(a) };
     let b = unsafe { Value::from_bits(b) };
-    Value::bool(a != b).to_bits()
+    // Fast path: bitwise identical → equal → not-equal is false
+    if a == b {
+        return Value::FALSE.to_bits();
+    }
+    // Numeric coercion
+    if a.is_number() && b.is_number() {
+        if let (Some(x), Some(y)) = (a.as_number(), b.as_number()) {
+            return Value::bool(x != y).to_bits();
+        }
+    }
+    Value::TRUE.to_bits()
 }
 
 /// Less than comparison

--- a/src/primitives/AGENTS.md
+++ b/src/primitives/AGENTS.md
@@ -87,7 +87,7 @@ pub fn register_arithmetic(vm: &mut VM, symbols: &mut SymbolTable) {
 | Module | Contains |
 |--------|----------|
 | `arithmetic.rs` | `+`, `-`, `*`, `/`, `mod`, `rem`, `abs`, `min`, `max`, `pow`, `sqrt`, `sin`, `cos`, `tan`, `log`, `exp`, `floor`, `ceil`, `round`, `even?`, `odd?`, `pi`, `e` |
-| `comparison.rs` | `=`, `<`, `>`, `<=`, `>=` |
+| `comparison.rs` | `=` (numeric-aware), `identical?` (strict), `<`, `>`, `<=`, `>=` |
 | `logic.rs` | `not` |
 | `list.rs` | `cons`, `first`, `rest`, `list`, `length`, `empty?`, `append`, `concat`, `reverse`, `last`, `butlast`, `take`, `drop` |
 | `array.rs` | `tuple`, `array`, `array/new`, `push`, `pop`, `popn`, `insert`, `remove` |
@@ -98,7 +98,7 @@ pub fn register_arithmetic(vm: &mut VM, symbols: &mut SymbolTable) {
 | `fileio.rs` | `slurp`, `spit` |
 | `path.rs` | `path/join`, `path/parent`, `path/filename`, `path/stem`, `path/extension`, `path/with-extension`, `path/normalize`, `path/absolute`, `path/canonicalize`, `path/relative`, `path/components`, `path/absolute?`, `path/relative?`, `path/cwd`, `path/exists?`, `path/file?`, `path/dir?` |
 | `display.rs` | `print`, `println`, `display`, `newline` |
-| `types.rs` | `nil?`, `pair?`, `list?`, `number?`, `integer?`, `float?`, `string?`, `boolean?`, `symbol?`, `keyword?`, `array?`, `tuple?`, `table?`, `struct?`, `buffer?`, `box?`, `bytes?`, `blob?`, `type-of`, `eq?`, `equal?` |
+| `types.rs` | `nil?`, `pair?`, `list?`, `number?`, `integer?`, `float?`, `string?`, `boolean?`, `symbol?`, `keyword?`, `array?`, `tuple?`, `table?`, `struct?`, `buffer?`, `box?`, `bytes?`, `blob?`, `type-of` |
 | `concurrency.rs` | `spawn`, `join`, `current-thread-id` |
 | `coroutines.rs` | `coro/new`, `coro/resume`, `coro/done?`, `coro/status`, `coro/value`, `coro/>iterator` |
 | `fibers.rs` | `fiber/new`, `fiber/resume`, `fiber/signal`, `fiber/status`, `fiber/value`, `fiber/bits`, `fiber/mask`, `fiber/parent`, `fiber/child`, `fiber/propagate`, `fiber/cancel`, `fiber?` |

--- a/src/primitives/comparison.rs
+++ b/src/primitives/comparison.rs
@@ -5,7 +5,9 @@ use crate::value::fiber::{SignalBits, SIG_ERROR, SIG_OK};
 use crate::value::types::Arity;
 use crate::value::{error_val, Value};
 
-/// Equality comparison
+/// Equality comparison — numeric-aware.
+/// If both values are numbers, compares numerically (int 1 == float 1.0).
+/// Otherwise, uses structural equality (PartialEq).
 pub fn prim_eq(args: &[Value]) -> (SignalBits, Value) {
     if args.len() != 2 {
         return (
@@ -13,6 +15,31 @@ pub fn prim_eq(args: &[Value]) -> (SignalBits, Value) {
             error_val(
                 "arity-error",
                 format!("=: expected 2 arguments, got {}", args.len()),
+            ),
+        );
+    }
+    // Fast path: bitwise identical (covers same-type immediates)
+    if args[0] == args[1] {
+        return (SIG_OK, Value::TRUE);
+    }
+    // Numeric coercion: if both are numbers, compare as f64
+    if args[0].is_number() && args[1].is_number() {
+        if let (Some(a), Some(b)) = (args[0].as_number(), args[1].as_number()) {
+            return (SIG_OK, if a == b { Value::TRUE } else { Value::FALSE });
+        }
+    }
+    (SIG_OK, Value::FALSE)
+}
+
+/// Strict identity comparison — bitwise/structural equality with no coercion.
+/// This is what `=` used to be: (identical? 1 1.0) is false.
+pub fn prim_identical(args: &[Value]) -> (SignalBits, Value) {
+    if args.len() != 2 {
+        return (
+            SIG_ERROR,
+            error_val(
+                "arity-error",
+                format!("identical?: expected 2 arguments, got {}", args.len()),
             ),
         );
     }
@@ -153,11 +180,22 @@ pub const PRIMITIVES: &[PrimitiveDef] = &[
         func: prim_eq,
         effect: Effect::none(),
         arity: Arity::Exact(2),
-        doc: "Test equality of two values",
+        doc: "Test equality. Numeric-aware: (= 1 1.0) is true. For strict identity, use identical?",
         params: &["a", "b"],
         category: "comparison",
-        example: "(= 1 1)",
-        aliases: &["eq?"],
+        example: "(= 1 1) #=> true\n(= 1 1.0) #=> true\n(= \"a\" \"a\") #=> true",
+        aliases: &[],
+    },
+    PrimitiveDef {
+        name: "identical?",
+        func: prim_identical,
+        effect: Effect::none(),
+        arity: Arity::Exact(2),
+        doc: "Test strict identity. No numeric coercion: (identical? 1 1.0) is false.",
+        params: &["a", "b"],
+        category: "comparison",
+        example: "(identical? 1 1) #=> true\n(identical? 1 1.0) #=> false",
+        aliases: &[],
     },
     PrimitiveDef {
         name: "<",

--- a/src/value/AGENTS.md
+++ b/src/value/AGENTS.md
@@ -45,7 +45,7 @@ Runtime value representation using NaN-boxing.
 
 Fibers maintain cached NaN-boxed `Value`s alongside their handle references
 so that `fiber/parent` and `fiber/child` return identity-preserving values
-(i.e., `(eq? (fiber/parent f) (fiber/parent f))` is `true`):
+(i.e., `(identical? (fiber/parent f) (fiber/parent f))` is `true`):
 
 | Field | Type | Purpose |
 |-------|------|---------|

--- a/src/value/types.rs
+++ b/src/value/types.rs
@@ -98,13 +98,13 @@ pub enum TableKey {
     /// Identity-compared key for reference types (fiber, closure, external).
     ///
     /// **Invariant**: Only constructed via `from_value()`. The stored `Value`
-    /// must be a type where `eq?` uses pointer identity (currently: fiber,
+    /// must be a type where `identical?` uses pointer identity (currently: fiber,
     /// closure, external). Storing a value-compared type here would silently
     /// use bit-pattern comparison instead of value comparison.
     ///
     /// Hash/Eq/Ord compare by `Value.0` (the raw NaN-boxed bits), which
     /// encodes the heap pointer. This gives the same identity semantics as
-    /// `eq?` for these types.
+    /// `identical?` for these types.
     Identity(Value),
 }
 

--- a/src/vm/comparison.rs
+++ b/src/vm/comparison.rs
@@ -4,9 +4,21 @@ use crate::value::{error_val, Value, SIG_ERROR};
 pub fn handle_eq(vm: &mut VM) {
     let b = vm.fiber.stack.pop().expect("VM bug: Stack underflow on Eq");
     let a = vm.fiber.stack.pop().expect("VM bug: Stack underflow on Eq");
-    vm.fiber
-        .stack
-        .push(if a == b { Value::TRUE } else { Value::FALSE });
+    // Fast path: bitwise identical
+    if a == b {
+        vm.fiber.stack.push(Value::TRUE);
+        return;
+    }
+    // Numeric coercion: int 1 == float 1.0
+    if a.is_number() && b.is_number() {
+        if let (Some(x), Some(y)) = (a.as_number(), b.as_number()) {
+            vm.fiber
+                .stack
+                .push(if x == y { Value::TRUE } else { Value::FALSE });
+            return;
+        }
+    }
+    vm.fiber.stack.push(Value::FALSE);
 }
 
 pub fn handle_lt(vm: &mut VM) {

--- a/tests/integration/core.rs
+++ b/tests/integration/core.rs
@@ -488,10 +488,7 @@ fn test_type_of_list_consistency() {
     );
 
     // And that keyword should be :list
-    assert_eq!(
-        eval_source("(eq? (type-of ()) :list)").unwrap(),
-        Value::TRUE
-    );
+    assert_eq!(eval_source("(= (type-of ()) :list)").unwrap(), Value::TRUE);
 }
 
 // Math functions

--- a/tests/integration/fibers.rs
+++ b/tests/integration/fibers.rs
@@ -327,7 +327,7 @@ fn test_fiber_propagate_child_identity() {
                            (fiber/propagate inner))
                          2)))
             (fiber/resume outer)
-            (eq? inner (fiber/child outer))))
+            (identical? inner (fiber/child outer))))
         "#,
     );
     assert!(result.is_ok(), "Expected ok, got: {:?}", result);
@@ -466,7 +466,7 @@ fn test_three_level_nested_fiber_error_propagation() {
 
 #[test]
 fn test_fiber_parent_identity() {
-    // fiber/parent called twice on the same fiber should return eq? values
+    // fiber/parent called twice on the same fiber should return identical? values
     let result = eval_source(
         r#"
         (let ((f (fiber/new (fn () 42) 0)))
@@ -476,7 +476,7 @@ fn test_fiber_parent_identity() {
                            42)
                          0)))
             (fiber/resume outer)
-            (eq? (fiber/parent f) (fiber/parent f))))
+            (identical? (fiber/parent f) (fiber/parent f))))
         "#,
     );
     assert!(result.is_ok(), "Expected ok, got: {:?}", result);
@@ -489,7 +489,7 @@ fn test_fiber_parent_identity() {
 
 #[test]
 fn test_fiber_child_identity() {
-    // fiber/child called twice on the same fiber should return eq? values
+    // fiber/child called twice on the same fiber should return identical? values
     let result = eval_source(
         r#"
         (let ((inner (fiber/new (fn () (fiber/signal 1 "err")) 0)))
@@ -499,7 +499,7 @@ fn test_fiber_child_identity() {
                            42)
                          1)))
             (fiber/resume outer)
-            (eq? (fiber/child outer) (fiber/child outer))))
+            (identical? (fiber/child outer) (fiber/child outer))))
         "#,
     );
     // inner errors, not caught by inner's mask=0, propagates to outer.

--- a/tests/integration/pipeline_point.rs
+++ b/tests/integration/pipeline_point.rs
@@ -181,16 +181,16 @@ fn test_struct_type_check() {
 #[test]
 fn test_type_of_table() {
     // (type-of (table)) returns :table keyword
-    // We verify by checking that (eq? (type-of (table)) :table) is true
-    let result = eval_source("(eq? (type-of (table)) :table)");
+    // We verify by checking that (= (type-of (table)) :table) is true
+    let result = eval_source("(= (type-of (table)) :table)");
     assert_eq!(result.unwrap(), Value::bool(true));
 }
 
 #[test]
 fn test_type_of_struct() {
     // (type-of (struct)) returns :struct keyword
-    // We verify by checking that (eq? (type-of (struct)) :struct) is true
-    let result = eval_source("(eq? (type-of (struct)) :struct)");
+    // We verify by checking that (= (type-of (struct)) :struct) is true
+    let result = eval_source("(= (type-of (struct)) :struct)");
     assert_eq!(result.unwrap(), Value::bool(true));
 }
 
@@ -829,7 +829,7 @@ fn test_put_array_mutable_same_reference() {
     let result = eval_source(
         r#"(let ((a @[1 2 3]))
              (let ((a2 (put a 0 99)))
-               (eq? a a2)))"#,
+               (identical? a a2)))"#,
     );
     assert_eq!(result.unwrap(), Value::bool(true));
 }
@@ -996,7 +996,7 @@ fn test_put_table_mutable_same_reference() {
     let result = eval_source(
         r#"(let ((t @{:a 1}))
              (let ((t2 (put t :a 99)))
-               (eq? t t2)))"#,
+               (identical? t t2)))"#,
     );
     assert_eq!(result.unwrap(), Value::bool(true));
 }
@@ -1149,7 +1149,7 @@ fn test_push_returns_same_array() {
     let result = eval_source(
         r#"(let ((a @[1 2]))
              (let ((a2 (push a 3)))
-               (eq? a a2)))"#,
+               (identical? a a2)))"#,
     );
     assert_eq!(result.unwrap(), Value::bool(true));
 }
@@ -1426,7 +1426,7 @@ fn test_insert_returns_same_array() {
     let result = eval_source(
         r#"(let ((a @[1 3]))
              (let ((a2 (insert a 1 2)))
-               (eq? a a2)))"#,
+               (identical? a a2)))"#,
     );
     assert_eq!(result.unwrap(), Value::bool(true));
 }
@@ -1541,7 +1541,7 @@ fn test_remove_returns_same_array() {
     let result = eval_source(
         r#"(let ((a @[1 2 3]))
              (let ((a2 (remove a 1)))
-               (eq? a a2)))"#,
+               (identical? a a2)))"#,
     );
     assert_eq!(result.unwrap(), Value::bool(true));
 }
@@ -1636,7 +1636,7 @@ fn test_append_arrays_returns_same_reference() {
     let result = eval_source(
         r#"(let ((a @[1 2]))
              (let ((a2 (append a @[3 4])))
-               (eq? a a2)))"#,
+               (identical? a a2)))"#,
     );
     assert_eq!(result.unwrap(), Value::bool(true));
 }

--- a/tests/integration/table_keys.rs
+++ b/tests/integration/table_keys.rs
@@ -73,7 +73,7 @@ fn test_keys_roundtrip_identity_fiber() {
         r#"(let ((f (fiber/new (fn () 1) 0)))
              (let ((t @{}))
                (put t f 1)
-               (eq? (first (keys t)) f)))"#,
+                (identical? (first (keys t)) f)))"#,
     )
     .unwrap();
     assert_eq!(result, Value::TRUE);
@@ -137,7 +137,7 @@ fn test_keys_roundtrip_identity_closure() {
         r#"(let ((c (fn () 1)))
              (let ((t @{}))
                (put t c 1)
-               (eq? (first (keys t)) c)))"#,
+                (identical? (first (keys t)) c)))"#,
     )
     .unwrap();
     assert_eq!(result, Value::TRUE);

--- a/tests/unittests/primitives.rs
+++ b/tests/unittests/primitives.rs
@@ -1903,13 +1903,13 @@ fn test_fiber_self_identity() {
     let result = eval_full(
         "(let ((f (fiber/new (fn () (fiber/self)) 0)))
            (fiber/resume f nil)
-           (eq? f (fiber/value f)))",
+            (identical? f (fiber/value f)))",
     )
     .unwrap();
     assert_eq!(
         result,
         Value::TRUE,
-        "fiber/self should be eq? to the fiber handle"
+        "fiber/self should be identical? to the fiber handle"
     );
 }
 


### PR DESCRIPTION
## What

`=` is now numeric-aware: `(= 1 1.0)` returns `true`. Previously it was strict bitwise identity, so int and float representations of the same number were "not equal."

This makes `=` consistent with `<`, `>`, `<=`, `>=` which already coerce across numeric types.

## Changes

### Semantics
- `=` compares numbers numerically (coerces int↔float via `as_number()`)
- `identical?` added — strict bitwise/structural identity (what `=` used to be)
- `eq?` alias removed — the name suggested equality, but the semantics were identity

### Execution paths (all three updated)
- **`prim_eq`** (`src/primitives/comparison.rs`) — primitive fallback
- **`handle_eq`** (`src/vm/comparison.rs`) — VM bytecode handler for intrinsic `=`
- **`elle_jit_eq` / `elle_jit_ne`** (`src/jit/runtime.rs`) — JIT runtime helpers

### Test/example updates
- `examples/assertions.lisp` — simplified: `assert-eq` uses `=` uniformly (no more symbol special case with `eq?`), `assert-not-nil` uses `nil?`
- `examples/meta.lisp` — `eq?` → `identical?` for gensym identity checks
- Integration tests — `eq?` → `identical?` (fiber identity) or `=` (type/keyword comparison)
