### PR TITLE
Add glob plugin for file pattern matching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -537,6 +537,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "elle-glob"
+version = "1.0.0"
+dependencies = [
+ "elle",
+ "glob",
+]
+
+[[package]]
 name = "elle-mermaid"
 version = "1.0.0"
 dependencies = [
@@ -773,6 +781,12 @@ name = "glam"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "518faa5064866338b013ff9b2350dc318e14cc4fcd6cb8206d7e7c9886c98815"
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "half"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = [".", "plugins/regex", "plugins/mermaid", "plugins/crypto", "plugins/sqlite", "plugins/random", "plugins/sugiyama", "plugins/fdg", "plugins/dagre", "plugins/selkie"]
+members = [".", "plugins/regex", "plugins/mermaid", "plugins/crypto", "plugins/sqlite", "plugins/random", "plugins/sugiyama", "plugins/fdg", "plugins/dagre", "plugins/selkie", "plugins/glob"]
 resolver = "2"
 
 [package]

--- a/plugins/glob/Cargo.toml
+++ b/plugins/glob/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "elle-glob"
+version = "1.0.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+elle = { path = "../.." }
+glob = "0.3"

--- a/plugins/glob/src/lib.rs
+++ b/plugins/glob/src/lib.rs
@@ -1,0 +1,193 @@
+//! Elle glob plugin — file globbing and pattern matching via the `glob` crate.
+
+use elle::effects::Effect;
+use elle::plugin::PluginContext;
+use elle::primitives::def::PrimitiveDef;
+use elle::value::fiber::{SignalBits, SIG_ERROR, SIG_OK};
+use elle::value::types::Arity;
+use elle::value::{error_val, TableKey, Value};
+use glob::Pattern;
+use std::collections::BTreeMap;
+use std::path::Path;
+
+/// Plugin entry point. Called by Elle when loading the `.so`.
+#[no_mangle]
+/// # Safety
+///
+/// Called by Elle's plugin loader via `dlsym`. The caller must pass a valid
+/// `PluginContext` reference. Only safe when called from `load_plugin`.
+pub unsafe extern "C" fn elle_plugin_init(ctx: &mut PluginContext) -> Value {
+    let mut fields = BTreeMap::new();
+    for def in PRIMITIVES {
+        ctx.register(def);
+        let short_name = def.name.strip_prefix("glob/").unwrap_or(def.name);
+        fields.insert(
+            TableKey::Keyword(short_name.into()),
+            Value::native_fn(def.func),
+        );
+    }
+    Value::struct_from(fields)
+}
+
+// ---------------------------------------------------------------------------
+// Primitives
+// ---------------------------------------------------------------------------
+
+fn prim_glob_glob(args: &[Value]) -> (SignalBits, Value) {
+    if let Some(result) = args[0].with_string(|pattern_str| {
+        let mut results = Vec::new();
+        match glob::glob(pattern_str) {
+            Ok(paths) => {
+                for entry in paths {
+                    match entry {
+                        Ok(path) => {
+                            if let Some(path_str) = path.to_str() {
+                                results.push(Value::string(path_str));
+                            }
+                        }
+                        Err(_) => {
+                            // Skip errored entries and continue collecting results
+                        }
+                    }
+                }
+                (SIG_OK, Value::array(results))
+            }
+            Err(_) => (
+                SIG_ERROR,
+                error_val(
+                    "pattern-error",
+                    format!("glob/glob: invalid pattern: {}", pattern_str),
+                ),
+            ),
+        }
+    }) {
+        result
+    } else {
+        (
+            SIG_ERROR,
+            error_val(
+                "type-error",
+                format!("glob/glob: expected string, got {}", args[0].type_name()),
+            ),
+        )
+    }
+}
+
+fn prim_glob_match(args: &[Value]) -> (SignalBits, Value) {
+    if let Some(result) = args[0].with_string(|pattern_str| {
+        if let Some(result2) = args[1].with_string(|test_str| match Pattern::new(pattern_str) {
+            Ok(pattern) => (SIG_OK, Value::bool(pattern.matches(test_str))),
+            Err(_) => (
+                SIG_ERROR,
+                error_val(
+                    "pattern-error",
+                    format!("glob/match?: invalid pattern: {}", pattern_str),
+                ),
+            ),
+        }) {
+            result2
+        } else {
+            (
+                SIG_ERROR,
+                error_val(
+                    "type-error",
+                    format!("glob/match?: expected string, got {}", args[1].type_name()),
+                ),
+            )
+        }
+    }) {
+        result
+    } else {
+        (
+            SIG_ERROR,
+            error_val(
+                "type-error",
+                format!("glob/match?: expected string, got {}", args[0].type_name()),
+            ),
+        )
+    }
+}
+
+fn prim_glob_match_path(args: &[Value]) -> (SignalBits, Value) {
+    if let Some(result) = args[0].with_string(|pattern_str| {
+        if let Some(result2) = args[1].with_string(|path_str| match Pattern::new(pattern_str) {
+            Ok(pattern) => (
+                SIG_OK,
+                Value::bool(pattern.matches_path(Path::new(path_str))),
+            ),
+            Err(_) => (
+                SIG_ERROR,
+                error_val(
+                    "pattern-error",
+                    format!("glob/match-path?: invalid pattern: {}", pattern_str),
+                ),
+            ),
+        }) {
+            result2
+        } else {
+            (
+                SIG_ERROR,
+                error_val(
+                    "type-error",
+                    format!(
+                        "glob/match-path?: expected string, got {}",
+                        args[1].type_name()
+                    ),
+                ),
+            )
+        }
+    }) {
+        result
+    } else {
+        (
+            SIG_ERROR,
+            error_val(
+                "type-error",
+                format!(
+                    "glob/match-path?: expected string, got {}",
+                    args[0].type_name()
+                ),
+            ),
+        )
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Registration table
+// ---------------------------------------------------------------------------
+
+static PRIMITIVES: &[PrimitiveDef] = &[
+    PrimitiveDef {
+        name: "glob/glob",
+        func: prim_glob_glob,
+        effect: Effect::pure(),
+        arity: Arity::Exact(1),
+        doc: "Return array of file paths matching a glob pattern",
+        params: &["pattern"],
+        category: "glob",
+        example: "(glob/glob \"src/**/*.rs\")",
+        aliases: &[],
+    },
+    PrimitiveDef {
+        name: "glob/match?",
+        func: prim_glob_match,
+        effect: Effect::pure(),
+        arity: Arity::Exact(2),
+        doc: "Test if a string matches a glob pattern",
+        params: &["pattern", "str"],
+        category: "glob",
+        example: "(glob/match? \"*.rs\" \"main.rs\")",
+        aliases: &[],
+    },
+    PrimitiveDef {
+        name: "glob/match-path?",
+        func: prim_glob_match_path,
+        effect: Effect::pure(),
+        arity: Arity::Exact(2),
+        doc: "Test if a path matches a glob pattern (separator-aware)",
+        params: &["pattern", "path"],
+        category: "glob",
+        example: "(glob/match-path? \"src/*.rs\" \"src/main.rs\")",
+        aliases: &[],
+    },
+];

--- a/tests/integration/glob.rs
+++ b/tests/integration/glob.rs
@@ -1,0 +1,199 @@
+// Integration tests for the glob plugin (.so loaded via import-file).
+
+use crate::common::eval_source;
+use elle::Value;
+
+/// Path to the compiled glob plugin shared object.
+fn plugin_path() -> String {
+    let manifest = env!("CARGO_MANIFEST_DIR");
+    format!("{}/target/debug/libelle_glob.so", manifest)
+}
+
+/// Returns true if the plugin .so exists on disk.
+fn plugin_available() -> bool {
+    std::path::Path::new(&plugin_path()).exists()
+}
+
+// ── Availability gate ──────────────────────────────────────────────
+
+#[test]
+fn test_glob_plugin_loads() {
+    if !plugin_available() {
+        eprintln!("SKIP: glob plugin not built (run `cargo build -p elle-glob`)");
+        return;
+    }
+    let result = eval_source(&format!(r#"(import-file "{}") :ok"#, plugin_path()));
+    assert_eq!(result.unwrap(), Value::keyword("ok"));
+}
+
+// ── glob/glob ──────────────────────────────────────────────────────
+
+#[test]
+fn test_glob_glob_returns_array() {
+    if !plugin_available() {
+        return;
+    }
+    let result = eval_source(&format!(
+        r#"(import-file "{}") (array? (glob/glob "Cargo.toml"))"#,
+        plugin_path()
+    ));
+    assert_eq!(result.unwrap(), Value::TRUE);
+}
+
+#[test]
+fn test_glob_glob_finds_cargo_toml() {
+    if !plugin_available() {
+        return;
+    }
+    let result = eval_source(&format!(
+        r#"(import-file "{}")
+           (def matches (glob/glob "Cargo.toml"))
+           @[(length matches) (get matches 0)]"#,
+        plugin_path()
+    ));
+    let v = result.unwrap();
+    let arr = v.as_array().unwrap();
+    let arr = arr.borrow();
+    assert_eq!(arr[0].as_int(), Some(1));
+    assert_eq!(arr[1], Value::string("Cargo.toml"));
+}
+
+#[test]
+fn test_glob_glob_wildcard() {
+    if !plugin_available() {
+        return;
+    }
+    let result = eval_source(&format!(
+        r#"(import-file "{}")
+           (def matches (glob/glob "plugins/*/Cargo.toml"))
+           (> (length matches) 0)"#,
+        plugin_path()
+    ));
+    assert_eq!(result.unwrap(), Value::TRUE);
+}
+
+#[test]
+fn test_glob_glob_no_matches() {
+    if !plugin_available() {
+        return;
+    }
+    let result = eval_source(&format!(
+        r#"(import-file "{}")
+           (def matches (glob/glob "nonexistent_*.xyz"))
+           (= (length matches) 0)"#,
+        plugin_path()
+    ));
+    assert_eq!(result.unwrap(), Value::TRUE);
+}
+
+#[test]
+fn test_glob_glob_invalid_pattern() {
+    if !plugin_available() {
+        return;
+    }
+    let result = eval_source(&format!(
+        r#"(import-file "{}") (glob/glob "[invalid")"#,
+        plugin_path()
+    ));
+    assert!(result.is_err(), "invalid pattern should error");
+}
+
+#[test]
+fn test_glob_glob_wrong_type() {
+    if !plugin_available() {
+        return;
+    }
+    let result = eval_source(&format!(
+        r#"(import-file "{}") (glob/glob 42)"#,
+        plugin_path()
+    ));
+    assert!(result.is_err(), "non-string should error");
+}
+
+// ── glob/match? ────────────────────────────────────────────────────
+
+#[test]
+fn test_glob_match_true() {
+    if !plugin_available() {
+        return;
+    }
+    let result = eval_source(&format!(
+        r#"(import-file "{}") (glob/match? "*.rs" "main.rs")"#,
+        plugin_path()
+    ));
+    assert_eq!(result.unwrap(), Value::TRUE);
+}
+
+#[test]
+fn test_glob_match_false() {
+    if !plugin_available() {
+        return;
+    }
+    let result = eval_source(&format!(
+        r#"(import-file "{}") (glob/match? "*.rs" "main.py")"#,
+        plugin_path()
+    ));
+    assert_eq!(result.unwrap(), Value::FALSE);
+}
+
+#[test]
+fn test_glob_match_invalid_pattern() {
+    if !plugin_available() {
+        return;
+    }
+    let result = eval_source(&format!(
+        r#"(import-file "{}") (glob/match? "[invalid" "test")"#,
+        plugin_path()
+    ));
+    assert!(result.is_err(), "invalid pattern should error");
+}
+
+#[test]
+fn test_glob_match_wrong_type() {
+    if !plugin_available() {
+        return;
+    }
+    let result = eval_source(&format!(
+        r#"(import-file "{}") (glob/match? 42 "test")"#,
+        plugin_path()
+    ));
+    assert!(result.is_err(), "non-string should error");
+}
+
+// ── glob/match-path? ───────────────────────────────────────────────
+
+#[test]
+fn test_glob_match_path_true() {
+    if !plugin_available() {
+        return;
+    }
+    let result = eval_source(&format!(
+        r#"(import-file "{}") (glob/match-path? "src/*.rs" "src/main.rs")"#,
+        plugin_path()
+    ));
+    assert_eq!(result.unwrap(), Value::TRUE);
+}
+
+#[test]
+fn test_glob_match_path_false() {
+    if !plugin_available() {
+        return;
+    }
+    let result = eval_source(&format!(
+        r#"(import-file "{}") (glob/match-path? "*.py" "src/main.rs")"#,
+        plugin_path()
+    ));
+    assert_eq!(result.unwrap(), Value::FALSE);
+}
+
+#[test]
+fn test_glob_match_path_invalid_pattern() {
+    if !plugin_available() {
+        return;
+    }
+    let result = eval_source(&format!(
+        r#"(import-file "{}") (glob/match-path? "[invalid" "test")"#,
+        plugin_path()
+    ));
+    assert!(result.is_err(), "invalid pattern should error");
+}

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -107,6 +107,9 @@ mod bytes {
 mod regex {
     include!("regex.rs");
 }
+mod glob {
+    include!("glob.rs");
+}
 mod docstrings {
     include!("docstrings.rs");
 }


### PR DESCRIPTION
## Summary

- Adds a new `glob` plugin (`plugins/glob/`) using the `glob` crate (rust-lang's standard globbing library)
- Three primitives: `glob/glob` (filesystem search), `glob/match?` (string matching), `glob/match-path?` (path-aware matching)
- 14 integration tests covering all primitives, error handling, and edge cases

## Usage

```lisp
(import-file "target/debug/libelle_glob.so")

(glob/glob "src/**/*.rs")                    ; => @["src/main.rs" ...]
(glob/match? "*.rs" "main.rs")               ; => true
(glob/match-path? "src/*.rs" "src/main.rs")  ; => true
(glob/match-path? "*.rs" "src/main.rs")      ; => false (separator-aware)
```