### PR TITLE
Fix letrec binding lost after fiber yield/resume (#415)

### DIFF
--- a/src/ffi/callback.rs
+++ b/src/ffi/callback.rs
@@ -136,13 +136,12 @@ unsafe extern "C" fn trampoline_callback(
     let new_env_rc = Rc::new(new_env);
 
     vm.fiber.call_depth += 1;
-    let (bits, _ip) =
-        vm.execute_bytecode_saving_stack(&closure.bytecode, &closure.constants, &new_env_rc);
+    let exec = vm.execute_bytecode_saving_stack(&closure.bytecode, &closure.constants, &new_env_rc);
     vm.fiber.call_depth -= 1;
 
     // 4. Handle result
     use crate::value::fiber::{SIG_ERROR, SIG_OK};
-    match bits {
+    match exec.bits {
         SIG_OK => {
             let (_, value) = vm.fiber.signal.take().unwrap_or((SIG_OK, Value::NIL));
             write_return_value(result, &value, &sig.ret);
@@ -156,7 +155,7 @@ unsafe extern "C" fn trampoline_callback(
             // Yield or other signal inside a callback is not supported.
             set_callback_error(crate::value::error_val(
                 "ffi-error",
-                format!("callback: unexpected signal {} from closure", bits),
+                format!("callback: unexpected signal {} from closure", exec.bits),
             ));
             zero_result(result, &sig.ret);
         }

--- a/src/vm/call.rs
+++ b/src/vm/call.rs
@@ -164,7 +164,7 @@ impl VM {
 
             // Execute the closure, saving/restoring the caller's stack.
             // Essential for fiber/signal propagation and yield-through-nested-calls.
-            let (bits, _ip) = self.execute_bytecode_saving_stack(
+            let result = self.execute_bytecode_saving_stack(
                 &closure.bytecode,
                 &closure.constants,
                 &new_env_rc,
@@ -172,6 +172,7 @@ impl VM {
 
             self.fiber.call_depth -= 1;
 
+            let bits = result.bits;
             match bits {
                 SIG_OK => {
                     let (_, value) = self.fiber.signal.take().unwrap();

--- a/src/vm/core.rs
+++ b/src/vm/core.rs
@@ -340,14 +340,14 @@ impl VM {
             // Push the value from the inner frame (or resume value for innermost)
             self.fiber.stack.push(current_value);
 
-            let (bits, ip) = self.execute_bytecode_from_ip(
+            let exec = self.execute_bytecode_from_ip(
                 &frame.bytecode,
                 &frame.constants,
                 &frame.env,
                 frame.ip,
             );
 
-            match bits {
+            match exec.bits {
                 SIG_OK => {
                     let (_, v) = self.fiber.signal.take().unwrap();
                     current_value = v;
@@ -357,19 +357,23 @@ impl VM {
                     // Save context for potential future resume if not already
                     // set (yield instruction sets it; fiber/signal does not).
                     // SIG_HALT is non-resumable — no suspended frame needed.
-                    if bits != SIG_HALT && self.fiber.suspended.is_none() {
+                    //
+                    // Use the active bytecode/constants/env from ExecResult,
+                    // not the original frame — a tail call may have switched
+                    // to a different function's bytecode before the signal.
+                    if exec.bits != SIG_HALT && self.fiber.suspended.is_none() {
                         self.fiber.suspended = Some(vec![SuspendedFrame {
-                            bytecode: frame.bytecode.clone(),
-                            constants: frame.constants.clone(),
-                            env: frame.env.clone(),
-                            ip,
+                            bytecode: exec.bytecode,
+                            constants: exec.constants,
+                            env: exec.env,
+                            ip: exec.ip,
                             stack: vec![],
                             active_allocator: crate::value::fiber_heap::save_active_allocator(),
                         }]);
                     }
 
                     // For yield signals, merge remaining outer frames
-                    if bits == SIG_YIELD && i + 1 < frames.len() {
+                    if exec.bits == SIG_YIELD && i + 1 < frames.len() {
                         if let Some(ref mut new_frames) = self.fiber.suspended {
                             for f in frames[i + 1..].iter() {
                                 new_frames.push(f.clone());
@@ -378,7 +382,7 @@ impl VM {
                     }
 
                     self.fiber.stack = saved_stack;
-                    return bits;
+                    return exec.bits;
                 }
             }
         }

--- a/src/vm/eval.rs
+++ b/src/vm/eval.rs
@@ -120,9 +120,9 @@ fn eval_inner(
     let consts_rc = Rc::new(bytecode.constants);
     let empty_env = Rc::new(vec![]);
 
-    let (bits, _ip) = vm.execute_bytecode_saving_stack(&bc_rc, &consts_rc, &empty_env);
+    let result = vm.execute_bytecode_saving_stack(&bc_rc, &consts_rc, &empty_env);
 
-    match bits {
+    match result.bits {
         SIG_OK => {
             let (_, value) = vm.fiber.signal.take().unwrap_or((SIG_OK, Value::NIL));
             Ok(value)
@@ -131,7 +131,7 @@ fn eval_inner(
             let (_, err_value) = vm.fiber.signal.take().unwrap_or((SIG_ERROR, Value::NIL));
             Err(crate::value::format_error(err_value))
         }
-        _ => Err(format!("eval: unexpected signal: {}", bits)),
+        _ => Err(format!("eval: unexpected signal: {}", result.bits)),
     }
 }
 

--- a/src/vm/execute.rs
+++ b/src/vm/execute.rs
@@ -5,18 +5,34 @@ use std::rc::Rc;
 
 use super::core::VM;
 
+/// Result of `execute_bytecode_saving_stack`.
+///
+/// Contains the signal, IP, and the active bytecode/constants/env at exit.
+/// When a tail call occurs before a signal, the active context differs from
+/// the original closure — callers that create `SuspendedFrame`s must use
+/// these fields, not the original closure's bytecode/constants.
+pub struct ExecResult {
+    pub bits: SignalBits,
+    pub ip: usize,
+    pub bytecode: Rc<Vec<u8>>,
+    pub constants: Rc<Vec<Value>>,
+    pub env: Rc<Vec<Value>>,
+}
+
 impl VM {
     /// Execute bytecode starting from a specific instruction pointer.
     /// Used for resuming fibers from where they suspended.
     ///
-    /// Returns `(SignalBits, ip)` — the signal and the IP at exit.
+    /// Returns `ExecResult` containing the signal, IP, and the active
+    /// bytecode/constants/env at exit. The active context may differ from
+    /// the input if a tail call occurred before the signal.
     pub fn execute_bytecode_from_ip(
         &mut self,
         bytecode: &Rc<Vec<u8>>,
         constants: &Rc<Vec<Value>>,
         closure_env: &Rc<Vec<Value>>,
         start_ip: usize,
-    ) -> (SignalBits, usize) {
+    ) -> ExecResult {
         let mut current_bytecode = bytecode.clone();
         let mut current_constants = constants.clone();
         let mut current_env = closure_env.clone();
@@ -31,7 +47,13 @@ impl VM {
             );
 
             if bits != SIG_OK {
-                break (bits, ip);
+                break ExecResult {
+                    bits,
+                    ip,
+                    bytecode: current_bytecode,
+                    constants: current_constants,
+                    env: current_env,
+                };
             }
 
             if let Some((tail_bytecode, tail_constants, tail_env)) = self.pending_tail_call.take() {
@@ -40,7 +62,13 @@ impl VM {
                 current_env = tail_env;
                 current_ip = 0;
             } else {
-                break (bits, ip);
+                break ExecResult {
+                    bits,
+                    ip,
+                    bytecode: current_bytecode,
+                    constants: current_constants,
+                    env: current_env,
+                };
             }
         }
     }
@@ -51,13 +79,17 @@ impl VM {
     /// Saves/restores the caller's stack and the active allocator pointer
     /// around execution. Handles pending tail calls in a loop.
     ///
-    /// Returns `(SignalBits, ip)` — the signal and the IP at exit.
+    /// Returns `ExecResult` containing the signal, IP, and the active
+    /// bytecode/constants/env at exit. The active context may differ from
+    /// the input if a tail call occurred before the signal — callers that
+    /// create `SuspendedFrame`s must use the returned context, not the
+    /// original closure fields.
     pub fn execute_bytecode_saving_stack(
         &mut self,
         bytecode: &Rc<Vec<u8>>,
         constants: &Rc<Vec<Value>>,
         closure_env: &Rc<Vec<Value>>,
-    ) -> (SignalBits, usize) {
+    ) -> ExecResult {
         // Save the caller's stack and active allocator (Package 4 plumbing;
         // the allocator pointer is write-only until Package 5 activates it).
         let saved_stack = std::mem::take(&mut self.fiber.stack);
@@ -76,7 +108,13 @@ impl VM {
             );
 
             if bits != SIG_OK {
-                break (bits, ip);
+                break ExecResult {
+                    bits,
+                    ip,
+                    bytecode: current_bytecode,
+                    constants: current_constants,
+                    env: current_env,
+                };
             }
 
             if let Some((tail_bytecode, tail_constants, tail_env)) = self.pending_tail_call.take() {
@@ -84,7 +122,13 @@ impl VM {
                 current_constants = tail_constants;
                 current_env = tail_env;
             } else {
-                break (bits, ip);
+                break ExecResult {
+                    bits,
+                    ip,
+                    bytecode: current_bytecode,
+                    constants: current_constants,
+                    env: current_env,
+                };
             }
         };
 

--- a/src/vm/fiber.rs
+++ b/src/vm/fiber.rs
@@ -312,24 +312,28 @@ impl VM {
             }
         };
 
-        let (bits, ip) =
+        let result =
             self.execute_bytecode_saving_stack(&closure.bytecode, &closure.constants, &env_rc);
 
         // If the fiber signaled (not normal completion), save context for resumption.
         // Only save if the yield instruction didn't already set up suspended frames.
         // SIG_HALT is non-resumable — no suspended frame needed.
-        if bits != SIG_OK && bits != SIG_HALT && self.fiber.suspended.is_none() {
+        //
+        // Use the active bytecode/constants/env from ExecResult, not the
+        // original closure fields — a tail call may have switched to a
+        // different function's bytecode before the signal occurred.
+        if result.bits != SIG_OK && result.bits != SIG_HALT && self.fiber.suspended.is_none() {
             self.fiber.suspended = Some(vec![SuspendedFrame {
-                bytecode: closure.bytecode.clone(),
-                constants: closure.constants.clone(),
-                env: env_rc,
-                ip,
+                bytecode: result.bytecode,
+                constants: result.constants,
+                env: result.env,
+                ip: result.ip,
                 stack: vec![],
                 active_allocator: crate::value::fiber_heap::save_active_allocator(),
             }]);
         }
 
-        bits
+        result.bits
     }
 
     /// Resume a Suspended fiber — continue from suspended frames.

--- a/tests/integration/fibers.rs
+++ b/tests/integration/fibers.rs
@@ -665,3 +665,80 @@ fn test_fiber_zero_param_closure_still_works() {
     assert!(result.is_ok(), "Expected ok, got: {:?}", result);
     assert_eq!(result.unwrap(), Value::int(42));
 }
+
+// ── Issue #415: letrec binding reads as nil after fiber yield/resume ──
+
+#[test]
+fn test_letrec_binding_survives_fiber_yield_resume() {
+    // letrec-bound recursive function should remain accessible across
+    // multiple fiber yield/resume cycles.
+    let result = eval_source(
+        r#"
+        (let* ((f (fiber/new (fn ()
+                        (letrec ((go (fn (n)
+                                    (fiber/signal 2 n)
+                                    (go (+ n 1)))))
+                          (go 0)))
+                    2)))
+            (list (fiber/resume f) (fiber/resume f) (fiber/resume f)))
+        "#,
+    );
+    assert!(result.is_ok(), "Expected ok, got: {:?}", result);
+    // Should yield 0, 1, 2 across three resumes
+    let list = result.unwrap();
+    let first = list.as_cons().expect("expected cons for first element");
+    assert_eq!(first.first, Value::int(0));
+    let second = first
+        .rest
+        .as_cons()
+        .expect("expected cons for second element");
+    assert_eq!(second.first, Value::int(1));
+    let third = second
+        .rest
+        .as_cons()
+        .expect("expected cons for third element");
+    assert_eq!(third.first, Value::int(2));
+}
+
+#[test]
+fn test_tail_call_then_signal_preserves_state() {
+    // A non-letrec variant: tail call into a helper that signals.
+    // Verifies that the tail-called function's env is saved, not the caller's.
+    let result = eval_source(
+        r#"
+        (defn helper (n)
+          (fiber/signal 2 n)
+          (helper (+ n 10)))
+        (let* ((f (fiber/new (fn () (helper 1)) 2)))
+          (list (fiber/resume f) (fiber/resume f) (fiber/resume f)))
+        "#,
+    );
+    assert!(result.is_ok(), "Expected ok, got: {:?}", result);
+    let list = result.unwrap();
+    let first = list.as_cons().expect("first");
+    assert_eq!(first.first, Value::int(1));
+    let second = first.rest.as_cons().expect("second");
+    assert_eq!(second.first, Value::int(11));
+    let third = second.rest.as_cons().expect("third");
+    assert_eq!(third.first, Value::int(21));
+}
+
+#[test]
+fn test_multiple_tail_calls_before_signal() {
+    // Chain of tail calls before signaling: a -> b -> signal.
+    // Ensures the deepest tail-called function's context is saved.
+    let result = eval_source(
+        r#"
+        (defn signaler (n) (fiber/signal 2 n) (signaler (+ n 1)))
+        (defn bouncer (n) (signaler n))
+        (let* ((f (fiber/new (fn () (bouncer 100)) 2)))
+          (list (fiber/resume f) (fiber/resume f)))
+        "#,
+    );
+    assert!(result.is_ok(), "Expected ok, got: {:?}", result);
+    let list = result.unwrap();
+    let first = list.as_cons().expect("first");
+    assert_eq!(first.first, Value::int(100));
+    let second = first.rest.as_cons().expect("second");
+    assert_eq!(second.first, Value::int(101));
+}


### PR DESCRIPTION
## Summary

Fixes #415: letrec binding reads as nil after fiber yield/resume

When a fiber body tail-calls into another function and that function yields via `fiber/signal`, the VM was saving the wrong execution context in the `SuspendedFrame`. The suspended frame had the outer closure's bytecode but the tail-called function's IP, causing corruption on resume.

## Root Cause

The issue occurred because:
1. Fiber starts executing outer closure's bytecode
2. Outer closure tail-calls into another function
3. The tail-called function's bytecode becomes the active context
4. If the tail-called function yields, the VM saved the original closure's bytecode/constants/env but the tail-called function's IP
5. On resume, the VM tried to execute the wrong bytecode at the wrong IP, corrupting the execution state

## Solution

Introduced `ExecResult` struct that returns the active bytecode/constants/env at exit from `execute_bytecode_saving_stack` and `execute_bytecode_from_ip`. When a tail call occurs, these fields reflect the tail-called function's context, not the original closure's.

Callers that create `SuspendedFrame`s now use the returned context instead of the original closure fields, ensuring the correct bytecode/constants/env are restored on resume.

## Changes

- `src/vm/execute.rs`: Added `ExecResult` struct, updated both execute functions to return it
- `src/vm/fiber.rs`: Use `result.bytecode/constants/env` from `ExecResult`
- `src/vm/core.rs`: Use `exec.bytecode/constants/env` from `ExecResult`
- `src/vm/call.rs`: Destructure `ExecResult`
- `src/vm/eval.rs`: Destructure `ExecResult`
- `src/ffi/callback.rs`: Destructure `ExecResult`
- `tests/integration/fibers.rs`: Added 3 regression tests

## Test Results

Full test suite: 2522 passed, 3 failed (pre-existing timing flakes in sleep tests, unrelated to this fix).

New tests:
- `test_letrec_binding_survives_fiber_yield_resume` (exact repro from #415)
- `test_tail_call_then_signal_preserves_state` (non-letrec variant)
- `test_multiple_tail_calls_before_signal` (chain of tail calls)
