### PR TITLE
Reuse VM across proptest cases to eliminate per-case bootstrap cost

### DIFF
--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -141,15 +141,35 @@ Inline tests answer: "Does this private implementation detail work correctly?"
 
 ### `common/mod.rs`
 
-Two functions, both initialize a full VM with primitives and stdlib:
+Functions for evaluating Elle source in tests:
 
-**`eval_source(input: &str) -> Result<Value, String>`** — The canonical test
-eval. Evaluates Elle source through the full pipeline. Handles multi-form
-input via `eval_all`. Sets and clears thread-local VM/symbol-table context.
-Use this for any test that needs to run Elle code.
+**`eval_source(input: &str) -> Result<Value, String>`** — Evaluate Elle source
+through the full pipeline. Creates a fresh VM with primitives and stdlib on
+every call. Use this when you need a guaranteed-fresh VM (rare — prefer
+`eval_reuse` for property tests).
+
+**`eval_source_bare(input: &str) -> Result<Value, String>`** — Same as
+`eval_source` but without stdlib. Creates a fresh VM on every call. Prefer
+`eval_reuse_bare` for property tests.
+
+**`eval_reuse(input: &str) -> Result<Value, String>`** — Evaluate Elle source
+with a cached VM (primitives + stdlib). The VM is created once per thread and
+reused across calls. Between calls, the fiber is reset and globals are restored
+to their post-initialization snapshot. **Use this for property tests that need
+stdlib functions** (map, filter, reverse, etc.).
 
 ```rust
-use crate::common::eval_source;
+use crate::common::eval_reuse as eval_source;
+let result = eval_source("(reverse (list 1 2 3))").unwrap();
+```
+
+**`eval_reuse_bare(input: &str) -> Result<Value, String>`** — Evaluate Elle
+source with a cached VM (primitives only, no stdlib). Same caching behavior as
+`eval_reuse`. **Use this for property tests that don't need stdlib** — this is
+the common case. Most property test files alias this as `eval_source`:
+
+```rust
+use crate::common::eval_reuse_bare as eval_source;
 let result = eval_source("(+ 1 2)").unwrap();
 assert_eq!(result, Value::int(3));
 ```
@@ -157,8 +177,7 @@ assert_eq!(result, Value::int(3));
 **`setup() -> (SymbolTable, VM)`** — Returns an initialized (SymbolTable, VM)
 pair with primitives and stdlib registered. Sets the symbol table context but
 does NOT set VM context. Use this when you need direct access to the VM or
-symbol table (e.g., calling `analyze()` or `compile()` directly, or looking up
-primitives by name).
+symbol table (e.g., calling `analyze()` or `compile()` directly).
 
 ```rust
 use crate::common::setup;
@@ -221,21 +240,21 @@ Some property test files define local strategies for their domain (e.g.,
    }
    ```
 3. In the test file:
-   ```rust
-   use crate::common::eval_source;
-   use elle::Value;
-   use proptest::prelude::*;
+    ```rust
+    use crate::common::eval_reuse_bare as eval_source;
+    use elle::Value;
+    use proptest::prelude::*;
 
-    proptest! {
-        #![proptest_config(crate::common::proptest_cases(200))]
+     proptest! {
+         #![proptest_config(crate::common::proptest_cases(200))]
 
-        #[test]
-        fn my_invariant(n in -1000i64..1000) {
-            let result = eval_source(&format!("(my-fn {})", n)).unwrap();
-            prop_assert_eq!(result, Value::int(n));
-        }
-    }
-   ```
+         #[test]
+         fn my_invariant(n in -1000i64..1000) {
+             let result = eval_source(&format!("(my-fn {})", n)).unwrap();
+             prop_assert_eq!(result, Value::int(n));
+         }
+     }
+    ```
 
 ### Adding a unit test
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -76,3 +76,97 @@ pub fn proptest_cases(default: u32) -> proptest::prelude::ProptestConfig {
         .unwrap_or(default);
     proptest::prelude::ProptestConfig::with_cases(cases)
 }
+
+// ---------------------------------------------------------------------------
+// Cached eval helpers for property tests
+// ---------------------------------------------------------------------------
+//
+// These reuse a thread-local (VM, SymbolTable) pair across proptest cases,
+// eliminating per-case bootstrap cost (VM creation, primitive registration,
+// stdlib loading). Between cases the fiber is reset and globals are restored
+// to their post-initialization snapshot.
+//
+// Use `eval_reuse_bare` for tests that don't need stdlib (the common case).
+// Use `eval_reuse` for tests that need stdlib functions (map, filter, etc.).
+//
+// The old `eval_source` / `eval_source_bare` remain available for tests that
+// need a guaranteed-fresh VM (none currently do, but the option exists).
+
+use std::cell::RefCell;
+use std::thread::LocalKey;
+
+struct TestCache {
+    vm: VM,
+    symbols: SymbolTable,
+    globals_snapshot: Vec<Value>,
+}
+
+thread_local! {
+    static BARE_CACHE: RefCell<Option<TestCache>> = const { RefCell::new(None) };
+    static FULL_CACHE: RefCell<Option<TestCache>> = const { RefCell::new(None) };
+}
+
+fn eval_with_cache(
+    input: &str,
+    cache: &'static LocalKey<RefCell<Option<TestCache>>>,
+    init: fn(&mut VM, &mut SymbolTable),
+) -> Result<Value, String> {
+    cache.with(|cell| {
+        let mut borrow = cell.borrow_mut();
+        let c = borrow.get_or_insert_with(|| {
+            let mut vm = VM::new();
+            let mut symbols = SymbolTable::new();
+            let _effects = register_primitives(&mut vm, &mut symbols);
+            // Context pointers needed during init (stdlib loading uses gensym).
+            set_vm_context(&mut vm as *mut VM);
+            set_symbol_table(&mut symbols as *mut SymbolTable);
+            init(&mut vm, &mut symbols);
+            let globals_snapshot = vm.globals.clone();
+            TestCache {
+                vm,
+                symbols,
+                globals_snapshot,
+            }
+        });
+
+        // Reset per-case state
+        c.vm.reset_fiber();
+        c.vm.jit_cache.clear();
+        c.vm.globals.truncate(c.globals_snapshot.len());
+        c.vm.globals.copy_from_slice(&c.globals_snapshot);
+
+        // Set context pointers (may have been cleared after previous eval)
+        set_vm_context(&mut c.vm as *mut VM);
+        set_symbol_table(&mut c.symbols as *mut SymbolTable);
+
+        let result = eval_all(input, &mut c.symbols, &mut c.vm);
+
+        set_vm_context(std::ptr::null_mut());
+
+        result
+    })
+}
+
+/// Evaluate Elle source with a cached VM (primitives only, no stdlib).
+///
+/// Drop-in replacement for `eval_source_bare` in property tests. The VM
+/// is created once per thread and reused across proptest cases. Between
+/// cases, the fiber is reset and globals are restored to their
+/// post-initialization values.
+#[allow(dead_code)]
+pub fn eval_reuse_bare(input: &str) -> Result<Value, String> {
+    eval_with_cache(input, &BARE_CACHE, |_, _| {})
+}
+
+/// Evaluate Elle source with a cached VM (primitives + stdlib).
+///
+/// Drop-in replacement for `eval_source` in property tests. The VM
+/// is created once per thread and reused across proptest cases. Between
+/// cases, the fiber is reset and globals are restored to their
+/// post-initialization values.
+#[allow(dead_code)]
+pub fn eval_reuse(input: &str) -> Result<Value, String> {
+    eval_with_cache(input, &FULL_CACHE, |vm, symbols| {
+        init_stdlib(vm, symbols);
+    })
+}

--- a/tests/property/arithmetic.rs
+++ b/tests/property/arithmetic.rs
@@ -2,7 +2,7 @@
 //
 // Verifies mathematical laws and int/float promotion rules.
 
-use crate::common::eval_source_bare as eval_source;
+use crate::common::eval_reuse_bare as eval_source;
 use elle::Value;
 use proptest::prelude::*;
 

--- a/tests/property/bugfixes.rs
+++ b/tests/property/bugfixes.rs
@@ -6,7 +6,7 @@
 // 2. defn function definition syntax
 // 3. List display (no `. ()` in proper lists)
 
-use crate::common::eval_source_bare as eval_source;
+use crate::common::eval_reuse_bare as eval_source;
 use elle::Value;
 use proptest::prelude::*;
 

--- a/tests/property/convert.rs
+++ b/tests/property/convert.rs
@@ -1,5 +1,5 @@
 // Property-based tests for conversion primitives
-use crate::common::eval_source_bare as eval_source;
+use crate::common::eval_reuse_bare as eval_source;
 use elle::Value;
 use proptest::prelude::*;
 

--- a/tests/property/coroutines.rs
+++ b/tests/property/coroutines.rs
@@ -4,7 +4,7 @@
 // They exercise the yield/resume mechanics, state transitions, and
 // effect threading through the compilation pipeline.
 
-use crate::common::eval_source_bare as eval_source;
+use crate::common::eval_reuse_bare as eval_source;
 use elle::Value;
 use proptest::prelude::*;
 

--- a/tests/property/destructuring.rs
+++ b/tests/property/destructuring.rs
@@ -8,7 +8,7 @@
 // 5. Table destructuring in fn params equivalent to manual extraction
 // 6. Table in match: type guard rejects non-tables, literal keys filter
 
-use crate::common::eval_source_bare as eval_source;
+use crate::common::eval_reuse_bare as eval_source;
 use elle::Value;
 use proptest::prelude::*;
 

--- a/tests/property/determinism.rs
+++ b/tests/property/determinism.rs
@@ -3,7 +3,7 @@
 // Verifies that the same source code always produces the same result.
 // Catches nondeterminism from HashMap iteration order, uninitialized state, etc.
 
-use crate::common::eval_source_bare as eval_source;
+use crate::common::eval_reuse_bare as eval_source;
 use proptest::prelude::*;
 
 proptest! {

--- a/tests/property/eval.rs
+++ b/tests/property/eval.rs
@@ -1,5 +1,5 @@
 // Property-based tests for the `eval` special form
-use crate::common::eval_source_bare as eval_source;
+use crate::common::eval_reuse_bare as eval_source;
 use elle::Value;
 use proptest::prelude::*;
 

--- a/tests/property/fibers.rs
+++ b/tests/property/fibers.rs
@@ -3,7 +3,7 @@
 // Tests the FiberHandle system, child chain wiring, propagate, and cancel
 // using generated inputs to exercise edge cases that example-based tests miss.
 
-use crate::common::eval_source_bare as eval_source;
+use crate::common::eval_reuse_bare as eval_source;
 use elle::Value;
 use proptest::prelude::*;
 

--- a/tests/property/macros.rs
+++ b/tests/property/macros.rs
@@ -9,7 +9,7 @@
 // 5. Named blocks with break
 // 6. Macro hygiene
 
-use crate::common::eval_source_bare as eval_source;
+use crate::common::eval_reuse_bare as eval_source;
 use elle::Value;
 use proptest::prelude::*;
 

--- a/tests/property/sequences.rs
+++ b/tests/property/sequences.rs
@@ -2,7 +2,7 @@
 // Verifies: first/rest/reverse preserve container types,
 // and reverse is an involution (reverse(reverse(x)) == x).
 
-use crate::common::eval_source;
+use crate::common::eval_reuse as eval_source;
 use elle::Value;
 use proptest::prelude::*;
 

--- a/tests/property/strings.rs
+++ b/tests/property/strings.rs
@@ -3,7 +3,7 @@
 // Covers unicode handling, string operation laws, and edge cases.
 // Existing tests only use [a-z] — these push into multi-byte territory.
 
-use crate::common::eval_source_bare as eval_source;
+use crate::common::eval_reuse_bare as eval_source;
 use elle::Value;
 use proptest::prelude::*;
 


### PR DESCRIPTION
## Summary

Reuse a thread-local `(VM, SymbolTable)` pair across proptest cases instead of creating a fresh VM for every single case. This eliminates the per-case bootstrap cost (VM creation, primitive registration, optional stdlib loading) for all 11 property test files that go through the eval pipeline.

No changes to `src/` — the existing `reset_fiber()` already clears per-case state. All new code is test infrastructure only.

## What changed

### New test helpers (`tests/common/mod.rs`)

Added `eval_reuse_bare` and `eval_reuse` as drop-in replacements for `eval_source_bare` and `eval_source`. Both use a shared `eval_with_cache` function parameterized by a thread-local cache and an initialization function.

Between proptest cases, the cache resets:
- `vm.reset_fiber()` — clears fiber/stack state
- `vm.jit_cache.clear()` — prevents ABA hits from reused bytecode addresses
- `vm.globals` — snapshot-restored to post-initialization values (memcpy of ~2KB)

Two separate thread-locals (`BARE_CACHE` for primitives-only, `FULL_CACHE` for primitives+stdlib) avoid conditional initialization and keep snapshots clean.

### Import migrations (11 property test files)

One-line import change each. The `as eval_source` alias is preserved so no call sites needed modification.

| File | Change |
|------|--------|
| `tests/property/arithmetic.rs` | `eval_source_bare` → `eval_reuse_bare` |
| `tests/property/bugfixes.rs` | `eval_source_bare` → `eval_reuse_bare` |
| `tests/property/convert.rs` | `eval_source_bare` → `eval_reuse_bare` |
| `tests/property/coroutines.rs` | `eval_source_bare` → `eval_reuse_bare` |
| `tests/property/destructuring.rs` | `eval_source_bare` → `eval_reuse_bare` |
| `tests/property/determinism.rs` | `eval_source_bare` → `eval_reuse_bare` |
| `tests/property/eval.rs` | `eval_source_bare` → `eval_reuse_bare` |
| `tests/property/fibers.rs` | `eval_source_bare` → `eval_reuse_bare` |
| `tests/property/macros.rs` | `eval_source_bare` → `eval_reuse_bare` |
| `tests/property/strings.rs` | `eval_source_bare` → `eval_reuse_bare` |
| `tests/property/sequences.rs` | `eval_source` → `eval_reuse` |

### Files NOT modified (no eval pipeline usage)

`nanboxing.rs`, `ffi.rs`, `path.rs`, `effects.rs`, `reader.rs` — these test Rust APIs directly.

### Documentation (`tests/AGENTS.md`)

- Rewrote the test helpers section to document all four eval functions (`eval_source`, `eval_source_bare`, `eval_reuse`, `eval_reuse_bare`) with usage guidance
- Updated the "Adding a property test" example to use `eval_reuse_bare`
- Minor cleanup: removed "or looking up primitives by name" from `setup()` description

## Deviations from plan

1. **Single commit instead of 4 chunks.** The plan called for 4 independently committable chunks (helpers → bare migrations → sequences migration → docs). Implementation was delivered as a single squashed commit. This is fine — the changes are small and coherent — but it means the incremental verification story described in the plan wasn't followed step-by-step.

2. **No deviations in code.** The implementation matches the plan and impl.md exactly: same `TestCache` struct, same `eval_with_cache` signature, same reset sequence, same thread-local design, same import changes. The code in `tests/common/mod.rs` is character-for-character what impl.md specified.

3. **AGENTS.md diff is slightly different from impl.md's spec.** The impl.md described replacing lines 144–167 and updating line 225. The actual diff also removed a phrase from the `setup()` description ("or looking up primitives by name") and adjusted indentation in the code example block. These are minor editorial improvements, not deviations.

## Risks and things to watch

1. **Test isolation depends on snapshot-restore correctness.** If a test case mutates a value *inside* a global (e.g., mutating an array stored in a global slot), the snapshot restores the slot's `Value` (a NaN-boxed pointer) but the pointed-to heap object remains mutated. No existing property tests do this — they use `def` (immutable bindings) and don't mutate globals — but future tests could hit this if they use `var` + `set!` on heap-allocated values.

2. **Symbol table grows monotonically.** Symbols interned by one test case persist for all subsequent cases on that thread. This is safe (interning is idempotent, IDs are stable) but means the symbol table is slightly larger than a fresh one. Negligible in practice.

3. **`eval_expander` persists across cases.** The VM's cached expander is not reset. This is intentional and beneficial (avoids re-creation), but means any test that somehow corrupts the expander would poison subsequent cases. No existing tests do this.

4. **JIT cache clearing is defensive.** The `jit_cache.clear()` call prevents an ABA problem where freed bytecode addresses get reused. Property tests rarely trigger JIT compilation, so this is almost always a no-op, but it's the right thing to do.

## Verification

All 11 migrated property test files pass. The full property test suite passes. No `src/` changes means no risk to non-test code.
