### PR TITLE
Enable tail call optimization for block bodies and break values

### DIFF
--- a/src/hir/tailcall.rs
+++ b/src/hir/tailcall.rs
@@ -25,7 +25,9 @@
 //! - `throw` value, `yield` value
 //! - Match scrutinee and guards
 
-use super::expr::{Hir, HirKind};
+use std::collections::HashSet;
+
+use super::expr::{BlockId, Hir, HirKind};
 
 /// Mark tail calls in a HIR tree.
 ///
@@ -33,17 +35,21 @@ use super::expr::{Hir, HirKind};
 /// and sets `is_tail: true` on `Call` nodes that are in tail position.
 pub fn mark_tail_calls(hir: &mut Hir) {
     // Top-level expressions are not inside a lambda, so not in tail position
-    mark(hir, false);
+    mark(hir, false, &HashSet::new());
 }
 
 /// Recursively mark tail calls in a HIR node.
 ///
 /// `in_tail` indicates whether this node is in tail position.
-fn mark(hir: &mut Hir, in_tail: bool) {
+/// `tail_blocks` tracks which `BlockId`s are in tail position, so that
+/// `break` targeting one of these blocks can mark its value as tail.
+fn mark(hir: &mut Hir, in_tail: bool, tail_blocks: &HashSet<BlockId>) {
     match &mut hir.kind {
-        // Lambda body is always in tail position
+        // Lambda body is always in tail position.
+        // Reset tail_blocks — a new function boundary means no enclosing
+        // blocks are reachable via tail call.
         HirKind::Lambda { body, .. } => {
-            mark(body, true);
+            mark(body, true, &HashSet::new());
         }
 
         // Call: mark as tail if in tail position, recurse into func/args
@@ -54,9 +60,9 @@ fn mark(hir: &mut Hir, in_tail: bool) {
         } => {
             *is_tail = in_tail;
             // Function and arguments are NOT in tail position
-            mark(func, false);
+            mark(func, false, tail_blocks);
             for arg in args {
-                mark(&mut arg.expr, false);
+                mark(&mut arg.expr, false, tail_blocks);
             }
         }
 
@@ -66,27 +72,27 @@ fn mark(hir: &mut Hir, in_tail: bool) {
             then_branch,
             else_branch,
         } => {
-            mark(cond, false);
-            mark(then_branch, in_tail);
-            mark(else_branch, in_tail);
+            mark(cond, false, tail_blocks);
+            mark(then_branch, in_tail, tail_blocks);
+            mark(else_branch, in_tail, tail_blocks);
         }
 
         // Begin: only the last expression inherits tail position
         HirKind::Begin(exprs) => {
             if let Some((last, rest)) = exprs.split_last_mut() {
                 for expr in rest {
-                    mark(expr, false);
+                    mark(expr, false, tail_blocks);
                 }
-                mark(last, in_tail);
+                mark(last, in_tail, tail_blocks);
             }
         }
 
         // Let/Letrec: binding values are not tail, body inherits tail position
         HirKind::Let { bindings, body } | HirKind::Letrec { bindings, body } => {
             for (_, value) in bindings {
-                mark(value, false);
+                mark(value, false, tail_blocks);
             }
-            mark(body, in_tail);
+            mark(body, in_tail, tail_blocks);
         }
 
         // Cond: conditions are not tail, clause bodies and else inherit tail position
@@ -95,22 +101,22 @@ fn mark(hir: &mut Hir, in_tail: bool) {
             else_branch,
         } => {
             for (cond, body) in clauses {
-                mark(cond, false);
-                mark(body, in_tail);
+                mark(cond, false, tail_blocks);
+                mark(body, in_tail, tail_blocks);
             }
             if let Some(else_br) = else_branch {
-                mark(else_br, in_tail);
+                mark(else_br, in_tail, tail_blocks);
             }
         }
 
         // Match: scrutinee and guards are not tail, arm bodies inherit tail position
         HirKind::Match { value, arms } => {
-            mark(value, false);
+            mark(value, false, tail_blocks);
             for (_, guard, body) in arms {
                 if let Some(g) = guard {
-                    mark(g, false);
+                    mark(g, false, tail_blocks);
                 }
-                mark(body, in_tail);
+                mark(body, in_tail, tail_blocks);
             }
         }
 
@@ -118,55 +124,69 @@ fn mark(hir: &mut Hir, in_tail: bool) {
         HirKind::And(exprs) | HirKind::Or(exprs) => {
             if let Some((last, rest)) = exprs.split_last_mut() {
                 for expr in rest {
-                    mark(expr, false);
+                    mark(expr, false, tail_blocks);
                 }
-                mark(last, in_tail);
+                mark(last, in_tail, tail_blocks);
             }
         }
 
-        // Block: body is never in tail position because a `break` could
-        // override the result. Conservative but correct.
-        HirKind::Block { body, .. } => {
-            for expr in body {
-                mark(expr, false);
+        // Block: when in tail position, the last expression inherits tail
+        // and the block's ID is added to tail_blocks so that `break`
+        // targeting this block can also mark its value as tail.
+        HirKind::Block { block_id, body, .. } => {
+            if in_tail {
+                let mut child_tail_blocks = tail_blocks.clone();
+                child_tail_blocks.insert(*block_id);
+                if let Some((last, rest)) = body.split_last_mut() {
+                    for expr in rest {
+                        mark(expr, false, &child_tail_blocks);
+                    }
+                    mark(last, in_tail, &child_tail_blocks);
+                }
+            } else {
+                for expr in body {
+                    mark(expr, false, tail_blocks);
+                }
             }
         }
 
-        // Break: value is not in tail position (stored to result register, then jump)
-        HirKind::Break { value, .. } => {
-            mark(value, false);
+        // Break: value is in tail position if the target block is in
+        // tail_blocks (i.e., the block itself is in tail position).
+        HirKind::Break { block_id, value } => {
+            let break_in_tail = tail_blocks.contains(block_id);
+            mark(value, break_in_tail, tail_blocks);
         }
 
         // While: loop bodies are never in tail position
         HirKind::While { cond, body } => {
-            mark(cond, false);
-            mark(body, false);
+            mark(cond, false, tail_blocks);
+            mark(body, false, tail_blocks);
         }
 
         // Set: value is not in tail position
         HirKind::Set { value, .. } => {
-            mark(value, false);
+            mark(value, false, tail_blocks);
         }
 
         // Define: value is not in tail position
         HirKind::Define { value, .. } => {
-            mark(value, false);
+            mark(value, false, tail_blocks);
         }
 
         // Destructure: value is not in tail position
         HirKind::Destructure { value, .. } => {
-            mark(value, false);
+            mark(value, false, tail_blocks);
         }
 
         // Yield: value is not in tail position
         HirKind::Yield(expr) => {
-            mark(expr, false);
+            mark(expr, false, tail_blocks);
         }
 
         // Eval: neither expr nor env is in tail position (runs in its own context)
         HirKind::Eval { expr, env } => {
-            mark(expr, false);
-            mark(env, false);
+            mark(expr, false, tail_blocks);
+            mark(env, false, tail_blocks);
         }
 
         // Leaves: nothing to recurse into

--- a/tests/elle/tailcalls.lisp
+++ b/tests/elle/tailcalls.lisp
@@ -1,0 +1,248 @@
+# Tests for tail call optimization
+#
+# Comprehensive tests for tail call optimization including:
+# - Basic tail recursion patterns
+# - Block body tail calls (new for #333)
+# - Break value tail calls (new for #333)
+# - Deep recursion tests (prove TCO works)
+# - Fiber tail position tests
+# - Coroutine tail position tests
+
+(import-file "./examples/assertions.lisp")
+
+# ============================================================================
+# Basic tail recursion (existing patterns)
+# ============================================================================
+
+# Accumulator-based tail recursion: sum-to
+# This should be tail-optimized and handle large n without overflow
+(defn sum-to [n acc]
+  "Sum 1..n using tail recursion with accumulator"
+  (if (= n 0)
+      acc
+      (sum-to (- n 1) (+ acc n))))
+
+(assert-eq (sum-to 10 0) 55 "sum-to 10")
+(assert-eq (sum-to 100 0) 5050 "sum-to 100")
+
+# Simple countdown to 0
+# This is a basic tail-recursive pattern
+(defn countdown [n]
+  "Count down from n to 0, returning n"
+  (if (<= n 0)
+      0
+      (countdown (- n 1))))
+
+(assert-eq (countdown 5) 0 "countdown 5")
+(assert-eq (countdown 10) 0 "countdown 10")
+
+# ============================================================================
+# Block body tail calls (new for #333)
+# ============================================================================
+
+# Block in tail position with a call as the last expression
+# The call to sum-to should be marked as tail
+(defn sum-via-block [n]
+  "Sum using block with tail call in body"
+  (block :sum
+    (sum-to n 0)))
+
+(assert-eq (sum-via-block 10) 55 "block with tail call in body")
+
+# Nested blocks with tail calls
+# Both blocks are in tail position, inner call should be tail
+(defn nested-blocks [n]
+  "Nested blocks with tail call"
+  (block :outer
+    (block :inner
+      (sum-to n 0))))
+
+(assert-eq (nested-blocks 10) 55 "nested blocks with tail call")
+
+# Block with break and tail call in body
+# The last expression (call) should be tail
+(defn block-with-break [n]
+  "Block with break and tail call"
+  (block :b
+    (if (< n 0)
+        (break :b -1)
+        (sum-to n 0))))
+
+(assert-eq (block-with-break 10) 55 "block with break, positive n")
+(assert-eq (block-with-break -5) -1 "block with break, negative n")
+
+# ============================================================================
+# Break value tail calls (new for #333)
+# ============================================================================
+
+# Break value that is a call (should be tail)
+# When breaking with a call, that call should be tail
+(defn break-with-call [n]
+  "Break with a call as the value"
+  (block :b
+    (if (< n 0)
+        (break :b (sum-to (- n) 0))
+        (sum-to n 0))))
+
+(assert-eq (break-with-call 10) 55 "break with call, positive n")
+(assert-eq (break-with-call -10) 55 "break with call, negative n")
+
+# Nested breaks with tail calls
+# Both the break value and the final expression should be tail
+(defn nested-breaks [n]
+  "Nested breaks with tail calls"
+  (block :outer
+    (block :inner
+      (if (< n 0)
+          (break :outer (sum-to (- n) 0))
+          (sum-to n 0)))))
+
+(assert-eq (nested-breaks 10) 55 "nested breaks, positive n")
+(assert-eq (nested-breaks -10) 55 "nested breaks, negative n")
+
+# ============================================================================
+# Deep recursion tests (prove TCO works)
+# ============================================================================
+
+# Countdown to 100,000 (would overflow without TCO)
+# This test proves tail call optimization is working
+(defn countdown-large [n]
+  "Count down from n to 0 (tail-optimized)"
+  (if (<= n 0)
+      :done
+      (countdown-large (- n 1))))
+
+# This would overflow without TCO
+(assert-eq (countdown-large 100000) :done "countdown 100,000 (TCO required)")
+
+# Sum to 10,000 (would overflow without TCO)
+# Accumulator-based recursion at large scale
+(defn sum-large [n acc]
+  "Sum 1..n with large n (tail-optimized)"
+  (if (= n 0)
+      acc
+      (sum-large (- n 1) (+ acc n))))
+
+# This would overflow without TCO
+(assert-eq (sum-large 10000 0) 50005000 "sum to 10,000 (TCO required)")
+
+# Fibonacci iterative with tail recursion
+# Compute fib(n) using tail recursion with accumulators
+(defn fib-iter [n a b]
+  "Compute fibonacci(n) iteratively with tail recursion"
+  (if (<= n 0)
+      a
+      (fib-iter (- n 1) b (+ a b))))
+
+(defn fib [n]
+  "Fibonacci using tail-recursive helper"
+  (fib-iter n 0 1))
+
+(assert-eq (fib 0) 0 "fib(0)")
+(assert-eq (fib 1) 1 "fib(1)")
+(assert-eq (fib 5) 5 "fib(5)")
+(assert-eq (fib 10) 55 "fib(10)")
+(assert-eq (fib 20) 6765 "fib(20)")
+
+# Large fibonacci (would overflow without TCO)
+# fib(50) = 12586269025 (within i64 range)
+(assert-eq (fib 50) 12586269025 "fib(50) (TCO required)")
+
+# ============================================================================
+# Fiber tail position tests
+# ============================================================================
+
+# fiber/resume in tail position
+# When a fiber/resume is the last expression, it should be tail
+(defn fiber-tail-test [n]
+  "Test fiber/resume in tail position"
+  (block :b
+    (let ([f (fiber/new (fn () (sum-to n 0)) 1)])
+      (fiber/resume f nil))))
+
+(assert-eq (fiber-tail-test 10) 55 "fiber/resume in tail position")
+
+# fiber/cancel in tail position
+# When a fiber/cancel is the last expression, it should be tail
+(defn fiber-cancel-tail-test [n]
+  "Test fiber/cancel in tail position"
+  (block :b
+    (let ([f (fiber/new (fn () (sum-to n 0)) 1)])
+      (fiber/cancel f))))
+
+(assert-eq (fiber-cancel-tail-test 10) nil "fiber/cancel in tail position")
+
+# ============================================================================
+# Coroutine tail position tests
+# ============================================================================
+
+# yield in tail position
+# When yield is the last expression, it should be tail
+(defn coro-yield-tail-test [n]
+  "Test yield in tail position"
+  (block :b
+    (let ([co (coro/new (fn () (yield (sum-to n 0))))])
+      (coro/resume co))))
+
+(assert-eq (coro-yield-tail-test 10) 55 "yield in tail position")
+
+# Multiple yields with tail calls
+# Each yield should be tail when in tail position
+(defn coro-multi-yield [n]
+  "Test multiple yields with tail calls"
+  (coro/new (fn ()
+    (yield (sum-to n 0))
+    (yield (sum-to (+ n 1) 0))
+    (sum-to (+ n 2) 0))))
+
+(begin
+  (let ([co (coro-multi-yield 5)])
+    (assert-eq (coro/resume co) 15 "first yield in coro")
+    (assert-eq (coro/resume co) 21 "second yield in coro")
+    (assert-eq (coro/resume co) 28 "final value in coro")))
+
+# ============================================================================
+# Complex tail call patterns
+# ============================================================================
+
+# Mutual recursion with tail calls
+(defn is-even [n]
+  "Check if n is even using mutual recursion"
+  (if (= n 0)
+      true
+      (is-odd (- n 1))))
+
+(defn is-odd [n]
+  "Check if n is odd using mutual recursion"
+  (if (= n 0)
+      false
+      (is-even (- n 1))))
+
+(assert-eq (is-even 0) true "is-even 0")
+(assert-eq (is-even 4) true "is-even 4")
+(assert-eq (is-odd 0) false "is-odd 0")
+(assert-eq (is-odd 5) true "is-odd 5")
+
+# Mutual recursion with large n (proves TCO)
+(assert-eq (is-even 10000) true "is-even 10,000 (TCO required)")
+(assert-eq (is-odd 10001) true "is-odd 10,001 (TCO required)")
+
+# Tail call in conditional branches
+(defn conditional-tail [n]
+  "Tail calls in both branches of conditional"
+  (if (< n 0)
+      (countdown-large (- n))
+      (countdown-large n)))
+
+(assert-eq (conditional-tail 100) :done "conditional tail call positive")
+(assert-eq (conditional-tail -100) :done "conditional tail call negative")
+
+# Tail call in loop body (via while)
+(begin
+  (var result 0)
+  (var i 0)
+  (while (< i 10)
+    (begin
+      (set result (+ result i))
+      (set i (+ i 1))))
+  (assert-eq result 45 "accumulation in while loop"))


### PR DESCRIPTION
## Summary

- Enable tail call optimization for block bodies when the block is in tail position
- Mark `break` values as tail when targeting a block in tail position
- Add comprehensive test suite covering block tail calls, break tail calls, and deep recursion patterns

## Why This Matters

Blocks are a common pattern for early exit and structured control flow. Previously, tail calls within block bodies were not optimized, leading to unnecessary stack growth for recursive patterns using blocks. This fix enables TCO for these patterns, improving stack efficiency for code like:

```lisp
(defn sum-via-block [n]
  (block :sum
    (sum-to n 0)))  # This call is now tail-optimized
```

## What Was Tested

- ✅ Existing tail call tests pass (basic recursion, mutual recursion, conditional branches)
- ✅ New Elle test suite added (`tests/elle/tailcalls.lisp`) covering:
  - Block bodies with tail calls
  - Nested blocks with tail calls
  - Break values that are calls (tail-optimized)
  - Deep recursion tests (100k+ iterations proving TCO works)
  - Fiber and coroutine tail position tests
  - Complex patterns (mutual recursion, conditional branches)

## Fixes

Closes #333
