### PR TITLE
Remove stack-machine artifacts from LIR (Pop, Move, Dup)

### DIFF
--- a/src/jit/translate.rs
+++ b/src/jit/translate.rs
@@ -134,16 +134,6 @@ impl<'a> FunctionTranslator<'a> {
                 builder.def_var(var(dst.0), val);
             }
 
-            LirInstr::Move { dst, src } => {
-                let val = builder.use_var(var(src.0));
-                builder.def_var(var(dst.0), val);
-            }
-
-            LirInstr::Dup { dst, src } => {
-                let val = builder.use_var(var(src.0));
-                builder.def_var(var(dst.0), val);
-            }
-
             LirInstr::LoadLocal { dst, slot } => {
                 // In LIR, locals are just registers
                 let val = builder.use_var(var(*slot as u32));
@@ -253,10 +243,6 @@ impl<'a> FunctionTranslator<'a> {
                 let src_val = builder.use_var(var(src.0));
                 let result = self.call_helper_unary(builder, self.helpers.is_pair, src_val)?;
                 builder.def_var(var(dst.0), result);
-            }
-
-            LirInstr::Pop { src: _ } => {
-                // No-op in JIT (stack operations are implicit)
             }
 
             // === Phase 3: Data structures ===

--- a/src/lir/display.rs
+++ b/src/lir/display.rs
@@ -167,11 +167,6 @@ impl fmt::Display for LirInstr {
             LirInstr::LoadCell { dst, cell } => write!(f, "{} ← deref({})", dst, cell),
             LirInstr::StoreCell { cell, value } => write!(f, "deref({}) ← {}", cell, value),
 
-            // === Control Flow Helpers ===
-            LirInstr::Move { dst, src } => write!(f, "{} ← {}", dst, src),
-            LirInstr::Dup { dst, src } => write!(f, "{} ← dup({})", dst, src),
-            LirInstr::Pop { src } => write!(f, "pop {}", src),
-
             // === Destructuring (silent nil) ===
             LirInstr::CarOrNil { dst, src } => write!(f, "{} ← car?({})", dst, src),
             LirInstr::CdrOrNil { dst, src } => write!(f, "{} ← cdr?({})", dst, src),
@@ -365,15 +360,6 @@ mod tests {
             src: Reg(0),
         };
         assert_eq!(format!("{}", instr), "r1 ← tuple?(r0)");
-    }
-
-    #[test]
-    fn test_instr_move() {
-        let instr = LirInstr::Move {
-            dst: Reg(1),
-            src: Reg(0),
-        };
-        assert_eq!(format!("{}", instr), "r1 ← r0");
     }
 
     #[test]

--- a/src/lir/emit.rs
+++ b/src/lir/emit.rs
@@ -224,8 +224,11 @@ impl Emitter {
                 self.bytecode.emit(Instruction::StoreLocal);
                 self.bytecode.emit_byte(0); // depth 0
                 self.bytecode.emit_byte(*slot as u8);
-                // StoreLocal pops the value, stores it, and pushes it back
-                // So the stack simulation stays the same (value is still on top)
+                // StoreLocal pops the value, stores it, and pushes it back.
+                // Auto-pop: consume the pushed-back value so stores are pure
+                // side effects from the LIR's perspective.
+                self.bytecode.emit(Instruction::Pop);
+                self.pop();
             }
 
             LirInstr::LoadCapture { dst, index } => {
@@ -262,8 +265,10 @@ impl Emitter {
                     self.bytecode.emit_byte(0); // depth (currently unused)
                     self.bytecode.emit_byte(*index as u8);
                 }
-                // Both StoreLocal and StoreUpvalue: pop value, store, push back.
-                // Net stack effect is 0, so don't adjust simulated stack.
+                // Both StoreLocal and StoreUpvalue pop-then-push-back.
+                // Auto-pop: consume the pushed-back value.
+                self.bytecode.emit(Instruction::Pop);
+                self.pop();
             }
 
             LirInstr::LoadGlobal { dst, sym } => {
@@ -281,10 +286,12 @@ impl Emitter {
                 // Add symbol to constants with name for cross-thread portability
                 let name = self.symbol_names.get(&sym.0).cloned().unwrap_or_default();
                 let const_idx = self.bytecode.add_symbol(sym.0, &name);
-                // StoreGlobal pops the value, stores it, and pushes it back.
-                // The stack simulation stays the same (value is still on top).
                 self.bytecode.emit(Instruction::StoreGlobal);
                 self.bytecode.emit_u16(const_idx);
+                // StoreGlobal pops the value, stores it, and pushes it back.
+                // Auto-pop: consume the pushed-back value.
+                self.bytecode.emit(Instruction::Pop);
+                self.pop();
             }
 
             LirInstr::MakeClosure {
@@ -653,52 +660,12 @@ impl Emitter {
                 self.ensure_on_top(*value);
                 self.bytecode.emit(Instruction::UpdateCell);
                 // UpdateCell pops value, pops cell, pushes value back.
-                // Net stack effect: -1 (cell is consumed, value survives).
-                self.pop(); // value (will be re-pushed)
-                self.pop(); // cell (consumed)
-                self.push_reg(*value); // value pushed back by VM
-            }
-
-            LirInstr::Move { dst, src } => {
-                // Move is a logical copy - dst now refers to the same value as src.
-                // We don't emit any bytecode; we just update the register tracking.
-                // This works because in LIR, Move is used to copy a value to a result
-                // register, and the source is typically not used again.
-                //
-                // If src is tracked, dst now refers to the same stack position.
-                // If src is not tracked (e.g., after control flow merge), we assume
-                // the value is on top of the stack and track dst there.
-                if let Some(&pos) = self.reg_to_stack.get(src) {
-                    // dst now refers to the same stack position as src
-                    self.reg_to_stack.insert(*dst, pos);
-                    // Update the stack to show dst at this position
-                    if pos < self.stack.len() {
-                        self.stack[pos] = *dst;
-                    }
-                } else {
-                    // src not tracked - assume value is on top of stack
-                    // This can happen after control flow merges
-                    if !self.stack.is_empty() {
-                        let top = self.stack.len() - 1;
-                        self.stack[top] = *dst;
-                        self.reg_to_stack.insert(*dst, top);
-                    }
-                }
-            }
-
-            LirInstr::Dup { dst, src } => {
-                // Duplicate the value - actually emit a Dup instruction.
-                // This creates a new copy on the stack.
-                self.ensure_on_top(*src);
-                self.bytecode.emit(Instruction::Dup);
-                self.push_reg(*dst);
-            }
-
-            LirInstr::Pop { src } => {
-                // Pop the value from the stack (discard it).
-                self.ensure_on_top(*src);
-                self.bytecode.emit(Instruction::Pop);
-                self.pop();
+                // Unlike other stores, UpdateCell pushes the value back.
+                // We do NOT auto-pop here because lower_set needs the value.
+                self.pop(); // value (consumed by UpdateCell, re-pushed)
+                self.pop(); // cell (consumed by UpdateCell)
+                            // Value is now on the stack (pushed back by UpdateCell).
+                self.push_reg(*value);
             }
 
             LirInstr::LoadResumeValue { dst } => {

--- a/src/lir/lower/binding.rs
+++ b/src/lir/lower/binding.rs
@@ -37,11 +37,6 @@ impl Lowerer {
                     index: slot,
                     src: init_reg,
                 });
-                // StoreCapture (via StoreUpvalue) pops the value, stores it,
-                // and pushes it back. For let bindings, we don't need the
-                // pushed-back value (the body loads from the closure env),
-                // so pop it to keep the stack clean.
-                self.emit(LirInstr::Pop { src: init_reg });
             } else {
                 // Outside lambdas, use stack-based locals
                 if needs_cell {
@@ -169,7 +164,13 @@ impl Lowerer {
                 sym,
                 src: value_reg,
             });
-            Ok(value_reg)
+            // Reload: auto-pop consumed value_reg from the stack
+            let result_reg = self.fresh_reg();
+            self.emit(LirInstr::LoadGlobal {
+                dst: result_reg,
+                sym,
+            });
+            Ok(result_reg)
         } else {
             // Local define
             // Allocate the slot BEFORE lowering the value so that recursive
@@ -199,27 +200,44 @@ impl Lowerer {
                     index: slot,
                     src: value_reg,
                 });
+                let result = self.fresh_reg();
+                self.emit(LirInstr::LoadCapture {
+                    dst: result,
+                    index: slot,
+                });
+                Ok(result)
+            } else if needs_cell {
+                // The cell was already created in the Begin pre-pass
+                let cell_reg = self.fresh_reg();
+                self.emit(LirInstr::LoadLocal {
+                    dst: cell_reg,
+                    slot,
+                });
+                self.emit(LirInstr::StoreCell {
+                    cell: cell_reg,
+                    value: value_reg,
+                });
+                // Reload from cell
+                let cell_reg2 = self.fresh_reg();
+                self.emit(LirInstr::LoadLocal {
+                    dst: cell_reg2,
+                    slot,
+                });
+                let result = self.fresh_reg();
+                self.emit(LirInstr::LoadCell {
+                    dst: result,
+                    cell: cell_reg2,
+                });
+                Ok(result)
             } else {
-                // Outside lambdas (at top level), use stack-based locals
-                if needs_cell {
-                    // The cell was already created in the Begin pre-pass
-                    let cell_reg = self.fresh_reg();
-                    self.emit(LirInstr::LoadLocal {
-                        dst: cell_reg,
-                        slot,
-                    });
-                    self.emit(LirInstr::StoreCell {
-                        cell: cell_reg,
-                        value: value_reg,
-                    });
-                } else {
-                    self.emit(LirInstr::StoreLocal {
-                        slot,
-                        src: value_reg,
-                    });
-                }
+                self.emit(LirInstr::StoreLocal {
+                    slot,
+                    src: value_reg,
+                });
+                let result = self.fresh_reg();
+                self.emit(LirInstr::LoadLocal { dst: result, slot });
+                Ok(result)
             }
-            Ok(value_reg)
         }
     }
 
@@ -240,6 +258,12 @@ impl Lowerer {
                     index: slot,
                     src: value_reg,
                 });
+                let result = self.fresh_reg();
+                self.emit(LirInstr::LoadCapture {
+                    dst: result,
+                    index: slot,
+                });
+                Ok(result)
             } else if needs_cell {
                 // For local variables that need cells, load the cell and update it
                 let cell_reg = self.fresh_reg();
@@ -251,22 +275,39 @@ impl Lowerer {
                     cell: cell_reg,
                     value: value_reg,
                 });
+                let cell_reg2 = self.fresh_reg();
+                self.emit(LirInstr::LoadLocal {
+                    dst: cell_reg2,
+                    slot,
+                });
+                let result = self.fresh_reg();
+                self.emit(LirInstr::LoadCell {
+                    dst: result,
+                    cell: cell_reg2,
+                });
+                Ok(result)
             } else {
                 // For simple local variables, store directly
                 self.emit(LirInstr::StoreLocal {
                     slot,
                     src: value_reg,
                 });
+                let result = self.fresh_reg();
+                self.emit(LirInstr::LoadLocal { dst: result, slot });
+                Ok(result)
             }
         } else if target.is_global() {
+            let sym = target.name();
             self.emit(LirInstr::StoreGlobal {
-                sym: target.name(),
+                sym,
                 src: value_reg,
             });
+            let result = self.fresh_reg();
+            self.emit(LirInstr::LoadGlobal { dst: result, sym });
+            Ok(result)
         } else {
-            return Err(format!("Unknown binding: {:?}", target));
+            Err(format!("Unknown binding: {:?}", target))
         }
-        Ok(value_reg)
     }
 
     /// Lower a Destructure node: evaluate the value, then destructure into bindings.
@@ -284,11 +325,7 @@ impl Lowerer {
     }
 
     /// Recursively destructure a value into pattern bindings.
-    fn lower_destructure(
-        &mut self,
-        pattern: &HirPattern,
-        mut value_reg: Reg,
-    ) -> Result<(), String> {
+    fn lower_destructure(&mut self, pattern: &HirPattern, value_reg: Reg) -> Result<(), String> {
         match pattern {
             HirPattern::Wildcard => {
                 // Discard the value — don't bind it
@@ -301,6 +338,11 @@ impl Lowerer {
             HirPattern::List { elements, rest } => {
                 let mut current = value_reg;
                 let has_rest = rest.is_some();
+
+                // Allocate one temp slot for the entire list traversal
+                let temp_slot = self.current_func.num_locals;
+                self.current_func.num_locals += 1;
+
                 for (i, element) in elements.iter().enumerate() {
                     let is_last = i == elements.len() - 1 && !has_rest;
                     if is_last {
@@ -312,21 +354,34 @@ impl Lowerer {
                         });
                         self.lower_destructure(element, car)?;
                     } else {
-                        // Need both car and cdr. Dup first so we have
-                        // two copies — CdrOrNil consumes the original, CarOrNil
-                        // consumes the dup.
-                        let dup = self.fresh_reg();
-                        self.emit(LirInstr::Dup {
-                            dst: dup,
+                        // Store current to temp slot, reload for each extraction
+                        self.emit(LirInstr::StoreLocal {
+                            slot: temp_slot,
                             src: current,
+                        });
+
+                        let load_for_cdr = self.fresh_reg();
+                        self.emit(LirInstr::LoadLocal {
+                            dst: load_for_cdr,
+                            slot: temp_slot,
                         });
                         let cdr = self.fresh_reg();
                         self.emit(LirInstr::CdrOrNil {
                             dst: cdr,
-                            src: current,
+                            src: load_for_cdr,
+                        });
+
+                        let load_for_car = self.fresh_reg();
+                        self.emit(LirInstr::LoadLocal {
+                            dst: load_for_car,
+                            slot: temp_slot,
                         });
                         let car = self.fresh_reg();
-                        self.emit(LirInstr::CarOrNil { dst: car, src: dup });
+                        self.emit(LirInstr::CarOrNil {
+                            dst: car,
+                            src: load_for_car,
+                        });
+
                         self.lower_destructure(element, car)?;
                         current = cdr;
                     }
@@ -338,28 +393,25 @@ impl Lowerer {
                 Ok(())
             }
             HirPattern::Array { elements, rest } => {
-                let mut current = value_reg;
-                let need_rest = rest.is_some();
+                // Allocate one temp slot for the array
+                let temp_slot = self.current_func.num_locals;
+                self.current_func.num_locals += 1;
+                self.emit(LirInstr::StoreLocal {
+                    slot: temp_slot,
+                    src: value_reg,
+                });
+
                 for (i, element) in elements.iter().enumerate() {
-                    let is_last = i == elements.len() - 1 && !need_rest;
-                    let src = if is_last {
-                        // Last element, no rest: consume the array directly
-                        current
-                    } else {
-                        // Not last (or has rest): dup the array
-                        let dup = self.fresh_reg();
-                        self.emit(LirInstr::Dup {
-                            dst: dup,
-                            src: current,
-                        });
-                        let src = current;
-                        current = dup;
-                        src
-                    };
+                    // Reload from slot for each extraction
+                    let reloaded = self.fresh_reg();
+                    self.emit(LirInstr::LoadLocal {
+                        dst: reloaded,
+                        slot: temp_slot,
+                    });
                     let elem = self.fresh_reg();
                     self.emit(LirInstr::ArrayRefOrNil {
                         dst: elem,
-                        src,
+                        src: reloaded,
                         index: i as u16,
                     });
                     self.lower_destructure(element, elem)?;
@@ -368,10 +420,15 @@ impl Lowerer {
                 // For arrays, we need a slice-from-index operation.
                 // Use ArraySliceFrom instruction (to be added).
                 if let Some(rest_pat) = rest {
+                    let reloaded = self.fresh_reg();
+                    self.emit(LirInstr::LoadLocal {
+                        dst: reloaded,
+                        slot: temp_slot,
+                    });
                     let slice = self.fresh_reg();
                     self.emit(LirInstr::ArraySliceFrom {
                         dst: slice,
-                        src: current,
+                        src: reloaded,
                         index: elements.len() as u16,
                     });
                     self.lower_destructure(rest_pat, slice)?;
@@ -380,38 +437,38 @@ impl Lowerer {
             }
             HirPattern::Tuple { elements, rest } => {
                 // Tuples are immutable indexed sequences, like arrays
-                let mut current = value_reg;
-                let need_rest = rest.is_some();
+                let temp_slot = self.current_func.num_locals;
+                self.current_func.num_locals += 1;
+                self.emit(LirInstr::StoreLocal {
+                    slot: temp_slot,
+                    src: value_reg,
+                });
+
                 for (i, element) in elements.iter().enumerate() {
-                    let is_last = i == elements.len() - 1 && !need_rest;
-                    let src = if is_last {
-                        // Last element, no rest: consume the tuple directly
-                        current
-                    } else {
-                        // Not last (or has rest): dup the tuple
-                        let dup = self.fresh_reg();
-                        self.emit(LirInstr::Dup {
-                            dst: dup,
-                            src: current,
-                        });
-                        let src = current;
-                        current = dup;
-                        src
-                    };
+                    let reloaded = self.fresh_reg();
+                    self.emit(LirInstr::LoadLocal {
+                        dst: reloaded,
+                        slot: temp_slot,
+                    });
                     let elem = self.fresh_reg();
                     self.emit(LirInstr::ArrayRefOrNil {
                         dst: elem,
-                        src,
+                        src: reloaded,
                         index: i as u16,
                     });
                     self.lower_destructure(element, elem)?;
                 }
                 // Bind the remaining tuple slice to the rest pattern.
                 if let Some(rest_pat) = rest {
+                    let reloaded = self.fresh_reg();
+                    self.emit(LirInstr::LoadLocal {
+                        dst: reloaded,
+                        slot: temp_slot,
+                    });
                     let slice = self.fresh_reg();
                     self.emit(LirInstr::ArraySliceFrom {
                         dst: slice,
-                        src: current,
+                        src: reloaded,
                         index: elements.len() as u16,
                     });
                     self.lower_destructure(rest_pat, slice)?;
@@ -420,22 +477,19 @@ impl Lowerer {
             }
             HirPattern::Struct { entries } => {
                 // Structs are immutable key-value maps, like tables
-                for (i, (key, sub_pattern)) in entries.iter().enumerate() {
-                    let is_last = i == entries.len() - 1;
-                    let src = if is_last {
-                        // Last entry: consume the struct directly
-                        value_reg
-                    } else {
-                        // Not last: dup the struct
-                        let dup = self.fresh_reg();
-                        self.emit(LirInstr::Dup {
-                            dst: dup,
-                            src: value_reg,
-                        });
-                        let src = value_reg;
-                        value_reg = dup;
-                        src
-                    };
+                let temp_slot = self.current_func.num_locals;
+                self.current_func.num_locals += 1;
+                self.emit(LirInstr::StoreLocal {
+                    slot: temp_slot,
+                    src: value_reg,
+                });
+
+                for (key, sub_pattern) in entries {
+                    let reloaded = self.fresh_reg();
+                    self.emit(LirInstr::LoadLocal {
+                        dst: reloaded,
+                        slot: temp_slot,
+                    });
                     let elem = self.fresh_reg();
                     let lir_key = match key {
                         PatternKey::Keyword(k) => LirConst::Keyword(k.clone()),
@@ -443,7 +497,7 @@ impl Lowerer {
                     };
                     self.emit(LirInstr::TableGetOrNil {
                         dst: elem,
-                        src,
+                        src: reloaded,
                         key: lir_key,
                     });
                     self.lower_destructure(sub_pattern, elem)?;
@@ -451,22 +505,19 @@ impl Lowerer {
                 Ok(())
             }
             HirPattern::Table { entries } => {
-                for (i, (key, sub_pattern)) in entries.iter().enumerate() {
-                    let is_last = i == entries.len() - 1;
-                    let src = if is_last {
-                        // Last entry: consume the table directly
-                        value_reg
-                    } else {
-                        // Not last: dup the table
-                        let dup = self.fresh_reg();
-                        self.emit(LirInstr::Dup {
-                            dst: dup,
-                            src: value_reg,
-                        });
-                        let src = value_reg;
-                        value_reg = dup;
-                        src
-                    };
+                let temp_slot = self.current_func.num_locals;
+                self.current_func.num_locals += 1;
+                self.emit(LirInstr::StoreLocal {
+                    slot: temp_slot,
+                    src: value_reg,
+                });
+
+                for (key, sub_pattern) in entries {
+                    let reloaded = self.fresh_reg();
+                    self.emit(LirInstr::LoadLocal {
+                        dst: reloaded,
+                        slot: temp_slot,
+                    });
                     let elem = self.fresh_reg();
                     let lir_key = match key {
                         PatternKey::Keyword(k) => LirConst::Keyword(k.clone()),
@@ -474,7 +525,7 @@ impl Lowerer {
                     };
                     self.emit(LirInstr::TableGetOrNil {
                         dst: elem,
-                        src,
+                        src: reloaded,
                         key: lir_key,
                     });
                     self.lower_destructure(sub_pattern, elem)?;
@@ -493,9 +544,6 @@ impl Lowerer {
                 sym: binding.name(),
                 src: value_reg,
             });
-            // Pop the pushed-back value — destructuring doesn't need it
-            // as an expression result.
-            self.emit(LirInstr::Pop { src: value_reg });
             Ok(value_reg)
         } else {
             // Allocate slot if not already done (Begin pre-pass may have done it)

--- a/src/lir/lower/control.rs
+++ b/src/lir/lower/control.rs
@@ -212,59 +212,53 @@ impl Lowerer {
             return self.lower_expr(&exprs[0]);
         }
 
-        // Use a shared result register. Each branch leaves its result on the stack.
-        // At the merge point, the result is on top of the stack.
-        let result_reg = self.fresh_reg();
+        // Allocate result slot (same pattern as lower_cond/lower_if)
+        let result_slot = self.current_func.num_locals;
+        self.current_func.num_locals += 1;
         let done_label = self.fresh_label();
 
         for (i, expr) in exprs.iter().enumerate() {
             let val_reg = self.lower_expr(expr)?;
 
-            if i < exprs.len() - 1 {
-                // Not the last expression — branch on truthiness
-                // If falsy, short-circuit to done with this value
-                // If truthy, pop this value and continue to next expression
-                //
-                // Dup the value: one copy for the branch test, one for the result
-                let dup_reg = self.fresh_reg();
-                self.emit(LirInstr::Dup {
-                    dst: dup_reg,
-                    src: val_reg,
-                });
+            // Store value to result slot
+            self.emit(LirInstr::StoreLocal {
+                slot: result_slot,
+                src: val_reg,
+            });
 
-                // Use Move to track the result with result_reg
-                // This ensures the emitter knows result_reg is at the same position as val_reg
-                self.emit(LirInstr::Move {
-                    dst: result_reg,
-                    src: val_reg,
+            if i < exprs.len() - 1 {
+                // Not the last expression: reload for branch test
+                let cond_reg = self.fresh_reg();
+                self.emit(LirInstr::LoadLocal {
+                    dst: cond_reg,
+                    slot: result_slot,
                 });
 
                 let next_label = self.fresh_label();
-                // Branch on the duplicate (which will be popped by JumpIfFalse)
+                // If falsy, short-circuit to done (value already in slot)
+                // If truthy, continue to next expression
                 self.terminate(Terminator::Branch {
-                    cond: dup_reg,
+                    cond: cond_reg,
                     then_label: next_label,
                     else_label: done_label,
                 });
                 self.finish_block();
 
-                // Next block: pop the original value and continue
                 self.current_block = BasicBlock::new(next_label);
-                self.emit(LirInstr::Pop { src: result_reg });
             } else {
-                // Last expression — this is the result, jump to done
-                self.emit(LirInstr::Move {
-                    dst: result_reg,
-                    src: val_reg,
-                });
+                // Last expression: jump to done (value already in slot)
                 self.terminate(Terminator::Jump(done_label));
                 self.finish_block();
             }
         }
 
-        // Done block (continue here)
-        // The result is on top of the stack from whichever branch was taken
+        // Done block: load result from slot
         self.current_block = BasicBlock::new(done_label);
+        let result_reg = self.fresh_reg();
+        self.emit(LirInstr::LoadLocal {
+            dst: result_reg,
+            slot: result_slot,
+        });
 
         Ok(result_reg)
     }
@@ -277,59 +271,48 @@ impl Lowerer {
             return self.lower_expr(&exprs[0]);
         }
 
-        // Use a shared result register. Each branch leaves its result on the stack.
-        // At the merge point, the result is on top of the stack.
-        let result_reg = self.fresh_reg();
+        let result_slot = self.current_func.num_locals;
+        self.current_func.num_locals += 1;
         let done_label = self.fresh_label();
 
         for (i, expr) in exprs.iter().enumerate() {
             let val_reg = self.lower_expr(expr)?;
 
-            if i < exprs.len() - 1 {
-                // Not the last expression — branch on truthiness
-                // If truthy, short-circuit to done with this value
-                // If falsy, pop this value and continue to next expression
-                //
-                // Dup the value: one copy for the branch test, one for the result
-                let dup_reg = self.fresh_reg();
-                self.emit(LirInstr::Dup {
-                    dst: dup_reg,
-                    src: val_reg,
-                });
+            self.emit(LirInstr::StoreLocal {
+                slot: result_slot,
+                src: val_reg,
+            });
 
-                // Use Move to track the result with result_reg
-                // This ensures the emitter knows result_reg is at the same position as val_reg
-                self.emit(LirInstr::Move {
-                    dst: result_reg,
-                    src: val_reg,
+            if i < exprs.len() - 1 {
+                let cond_reg = self.fresh_reg();
+                self.emit(LirInstr::LoadLocal {
+                    dst: cond_reg,
+                    slot: result_slot,
                 });
 
                 let next_label = self.fresh_label();
-                // Branch on the duplicate (which will be popped by JumpIfFalse)
+                // If truthy, short-circuit to done
+                // If falsy, continue to next expression
                 self.terminate(Terminator::Branch {
-                    cond: dup_reg,
-                    then_label: done_label,
-                    else_label: next_label,
+                    cond: cond_reg,
+                    then_label: done_label, // ← inverted from lower_and
+                    else_label: next_label, // ← inverted from lower_and
                 });
                 self.finish_block();
 
-                // Next block: pop the original value and continue
                 self.current_block = BasicBlock::new(next_label);
-                self.emit(LirInstr::Pop { src: result_reg });
             } else {
-                // Last expression — this is the result, jump to done
-                self.emit(LirInstr::Move {
-                    dst: result_reg,
-                    src: val_reg,
-                });
                 self.terminate(Terminator::Jump(done_label));
                 self.finish_block();
             }
         }
 
-        // Done block (continue here)
-        // The result is on top of the stack from whichever branch was taken
         self.current_block = BasicBlock::new(done_label);
+        let result_reg = self.fresh_reg();
+        self.emit(LirInstr::LoadLocal {
+            dst: result_reg,
+            slot: result_slot,
+        });
 
         Ok(result_reg)
     }
@@ -385,10 +368,6 @@ impl Lowerer {
             slot: scrutinee_slot,
             src: value_reg,
         });
-        // Pop the pushed-back value — the scrutinee lives in the local
-        // slot and is reloaded via LoadLocal.  Leaving it on the operand
-        // stack would leak an intermediate between enclosing operands.
-        self.emit(LirInstr::Pop { src: value_reg });
 
         // Allocate result register and result slot
         let result_reg = self.fresh_reg();

--- a/src/lir/lower/expr.rs
+++ b/src/lir/lower/expr.rs
@@ -137,7 +137,11 @@ impl Lowerer {
         else_branch: &Hir,
     ) -> Result<Reg, String> {
         let cond_reg = self.lower_expr(cond)?;
+
+        // Allocate result slot (same pattern as lower_cond)
         let result_reg = self.fresh_reg();
+        let result_slot = self.current_func.num_locals;
+        self.current_func.num_locals += 1;
 
         let then_label = self.fresh_label();
         let else_label = self.fresh_label();
@@ -151,28 +155,32 @@ impl Lowerer {
         });
         self.finish_block();
 
-        // Then block
+        // Then block: store result to slot, jump to merge
         self.current_block = BasicBlock::new(then_label);
         let then_reg = self.lower_expr(then_branch)?;
-        self.emit(LirInstr::Move {
-            dst: result_reg,
+        self.emit(LirInstr::StoreLocal {
+            slot: result_slot,
             src: then_reg,
         });
         self.terminate(Terminator::Jump(merge_label));
         self.finish_block();
 
-        // Else block
+        // Else block: store result to slot, jump to merge
         self.current_block = BasicBlock::new(else_label);
         let else_reg = self.lower_expr(else_branch)?;
-        self.emit(LirInstr::Move {
-            dst: result_reg,
+        self.emit(LirInstr::StoreLocal {
+            slot: result_slot,
             src: else_reg,
         });
         self.terminate(Terminator::Jump(merge_label));
         self.finish_block();
 
-        // Merge block (continue here)
+        // Merge block: load result from slot
         self.current_block = BasicBlock::new(merge_label);
+        self.emit(LirInstr::LoadLocal {
+            dst: result_reg,
+            slot: result_slot,
+        });
 
         Ok(result_reg)
     }
@@ -232,8 +240,8 @@ impl Lowerer {
         }
         let mut last_reg = self.lower_expr(&exprs[0])?;
         for expr in exprs.iter().skip(1) {
-            // Pop the previous result before evaluating the next expression
-            self.emit(LirInstr::Pop { src: last_reg });
+            // Discard the previous result before evaluating the next expression
+            self.discard(last_reg);
             last_reg = self.lower_expr(expr)?;
         }
         Ok(last_reg)
@@ -273,7 +281,7 @@ impl Lowerer {
         } else {
             let mut last_reg = self.lower_expr(&body[0])?;
             for expr in body.iter().skip(1) {
-                self.emit(LirInstr::Pop { src: last_reg });
+                self.discard(last_reg);
                 last_reg = self.lower_expr(expr)?;
             }
             self.emit(LirInstr::StoreLocal {

--- a/src/lir/lower/lambda.rs
+++ b/src/lir/lower/lambda.rs
@@ -142,6 +142,7 @@ impl Lowerer {
         let saved_in_lambda = self.in_lambda;
         let saved_num_captures = self.num_captures;
         let saved_upvalue_bindings = std::mem::take(&mut self.upvalue_bindings);
+        let saved_discard_slot = self.discard_slot;
 
         self.next_reg = 0;
         self.next_label = 1;
@@ -153,6 +154,7 @@ impl Lowerer {
         self.current_func.num_captures = captures.len() as u16;
         self.in_lambda = true;
         self.num_captures = captures.len() as u16;
+        self.discard_slot = None;
         self.current_func.doc = doc;
         self.current_func.vararg_kind = vararg_kind.clone();
         self.current_func.num_params = params.len();
@@ -208,6 +210,7 @@ impl Lowerer {
         self.in_lambda = saved_in_lambda;
         self.num_captures = saved_num_captures;
         self.upvalue_bindings = saved_upvalue_bindings;
+        self.discard_slot = saved_discard_slot;
 
         Ok(func)
     }

--- a/src/lir/lower/mod.rs
+++ b/src/lir/lower/mod.rs
@@ -143,6 +143,10 @@ pub struct Lowerer {
     region_depth: u32,
     /// Compile-time scope allocation statistics.
     scope_stats: ScopeStats,
+    /// Scratch slot for discarding unused intermediate values.
+    /// Lazily allocated on first use. Reused across all discards
+    /// within the same function, so only one extra local slot.
+    discard_slot: Option<u16>,
 }
 
 impl Lowerer {
@@ -163,6 +167,7 @@ impl Lowerer {
             block_lower_contexts: Vec::new(),
             region_depth: 0,
             scope_stats: ScopeStats::default(),
+            discard_slot: None,
         }
     }
 
@@ -190,6 +195,7 @@ impl Lowerer {
         self.next_reg = 0;
         self.next_label = 1;
         self.binding_to_slot.clear();
+        self.discard_slot = None;
 
         let result_reg = self.lower_expr(hir)?;
         self.terminate(Terminator::Return(result_reg));
@@ -288,6 +294,23 @@ impl Lowerer {
     fn emit_region_exit(&mut self) {
         self.emit(LirInstr::RegionExit);
         self.region_depth -= 1;
+    }
+
+    /// Discard an unused value by storing it to a scratch slot.
+    /// The emitter's auto-pop after StoreLocal cleans up the value
+    /// from the operand stack. The scratch slot is lazily allocated
+    /// on first use and reused for all discards in the function.
+    fn discard(&mut self, src: Reg) {
+        let slot = match self.discard_slot {
+            Some(s) => s,
+            None => {
+                let s = self.current_func.num_locals;
+                self.current_func.num_locals += 1;
+                self.discard_slot = Some(s);
+                s
+            }
+        };
+        self.emit(LirInstr::StoreLocal { slot, src });
     }
 
     // ── Escape analysis ────────────────────────────────────────────

--- a/src/lir/lower/pattern.rs
+++ b/src/lir/lower/pattern.rs
@@ -34,7 +34,6 @@ impl Lowerer {
                     slot: result_slot,
                     src: nil_reg,
                 });
-                self.emit(LirInstr::Pop { src: nil_reg });
                 self.terminate(Terminator::Jump(done_label));
                 self.finish_block();
                 Ok(())
@@ -62,7 +61,6 @@ impl Lowerer {
                     } else {
                         self.emit(LirInstr::StoreLocal { slot, src: val_reg });
                     }
-                    self.emit(LirInstr::Pop { src: val_reg });
                 }
                 // Lower body
                 let body = &arms[*arm_index].2;
@@ -71,7 +69,6 @@ impl Lowerer {
                     slot: result_slot,
                     src: body_reg,
                 });
-                self.emit(LirInstr::Pop { src: body_reg });
                 self.terminate(Terminator::Jump(done_label));
                 self.finish_block();
                 Ok(())
@@ -98,7 +95,6 @@ impl Lowerer {
                     } else {
                         self.emit(LirInstr::StoreLocal { slot, src: val_reg });
                     }
-                    self.emit(LirInstr::Pop { src: val_reg });
                 }
                 // Evaluate guard
                 let guard_expr = arms[*arm_index]
@@ -124,7 +120,6 @@ impl Lowerer {
                     slot: result_slot,
                     src: body_reg,
                 });
-                self.emit(LirInstr::Pop { src: body_reg });
                 self.terminate(Terminator::Jump(done_label));
                 self.finish_block();
 
@@ -148,7 +143,6 @@ impl Lowerer {
                     slot: temp_slot,
                     src: value_reg,
                 });
-                self.emit(LirInstr::Pop { src: value_reg });
 
                 let default_label = self.fresh_label();
 
@@ -204,7 +198,6 @@ impl Lowerer {
                         slot: result_slot,
                         src: nil_reg,
                     });
-                    self.emit(LirInstr::Pop { src: nil_reg });
                     self.terminate(Terminator::Jump(done_label));
                     self.finish_block();
                 }
@@ -381,16 +374,23 @@ impl Lowerer {
             src: value_reg,
         });
 
+        // Reload for type check (auto-pop consumed value_reg)
+        let reloaded_for_type = self.fresh_reg();
+        self.emit(LirInstr::LoadLocal {
+            dst: reloaded_for_type,
+            slot: val_slot,
+        });
+
         let type_check_reg = self.fresh_reg();
         if is_tuple {
             self.emit(LirInstr::IsTuple {
                 dst: type_check_reg,
-                src: value_reg,
+                src: reloaded_for_type,
             });
         } else {
             self.emit(LirInstr::IsArray {
                 dst: type_check_reg,
-                src: value_reg,
+                src: reloaded_for_type,
             });
         }
 
@@ -443,7 +443,6 @@ impl Lowerer {
             slot: merge_slot,
             src: false_reg,
         });
-        self.emit(LirInstr::Pop { src: false_reg });
         self.terminate(Terminator::Jump(result_label));
         self.finish_block();
 
@@ -454,7 +453,6 @@ impl Lowerer {
             slot: merge_slot,
             src: true_reg,
         });
-        self.emit(LirInstr::Pop { src: true_reg });
         self.terminate(Terminator::Jump(result_label));
         self.finish_block();
 
@@ -582,11 +580,25 @@ impl Lowerer {
                     });
                 }
 
+                // Reload for type check (auto-pop consumed value_reg)
+                let reloaded_for_check = self.fresh_reg();
+                if self.in_lambda {
+                    self.emit(LirInstr::LoadCapture {
+                        dst: reloaded_for_check,
+                        index: temp_slot,
+                    });
+                } else {
+                    self.emit(LirInstr::LoadLocal {
+                        dst: reloaded_for_check,
+                        slot: temp_slot,
+                    });
+                }
+
                 // Check if value is a pair
                 let is_pair_reg = self.fresh_reg();
                 self.emit(LirInstr::IsPair {
                     dst: is_pair_reg,
-                    src: value_reg,
+                    src: reloaded_for_check,
                 });
 
                 let continue_label = self.fresh_label();
@@ -682,11 +694,25 @@ impl Lowerer {
                         });
                     }
 
+                    // Reload for type check (auto-pop consumed current_reg)
+                    let reloaded_for_check = self.fresh_reg();
+                    if self.in_lambda {
+                        self.emit(LirInstr::LoadCapture {
+                            dst: reloaded_for_check,
+                            index: temp_slot,
+                        });
+                    } else {
+                        self.emit(LirInstr::LoadLocal {
+                            dst: reloaded_for_check,
+                            slot: temp_slot,
+                        });
+                    }
+
                     // Check if current is a pair
                     let is_pair_reg = self.fresh_reg();
                     self.emit(LirInstr::IsPair {
                         dst: is_pair_reg,
-                        src: current_reg,
+                        src: reloaded_for_check,
                     });
 
                     let continue_label = self.fresh_label();

--- a/src/lir/types.rs
+++ b/src/lir/types.rs
@@ -276,18 +276,6 @@ pub enum LirInstr {
     /// Store value into cell
     StoreCell { cell: Reg, value: Reg },
 
-    // === Control Flow Helpers ===
-    /// Copy a register (for phi-like operations)
-    /// This is a logical copy - dst now refers to the same value as src.
-    /// No bytecode is emitted; this just updates register tracking.
-    Move { dst: Reg, src: Reg },
-    /// Duplicate a register's value on the stack.
-    /// Unlike Move, this actually emits a Dup instruction.
-    /// Use this when you need both the original and a copy.
-    Dup { dst: Reg, src: Reg },
-    /// Pop a register's value from the stack (discard it).
-    Pop { src: Reg },
-
     // === Destructuring (silent nil) ===
     /// Car with silent nil: returns nil if not a cons cell
     CarOrNil { dst: Reg, src: Reg },


### PR DESCRIPTION
## Summary

Remove `Pop`, `Move`, and `Dup` from the `LirInstr` enum. These three instructions exist solely to manage the bytecode emitter's simulated operand stack and have no semantic meaning in a register-based IR.

**Changes:**
- Emitter now auto-pops after all store instructions (`StoreLocal`, `StoreCapture`, `StoreGlobal`, `StoreCell`)
- Lowerer uses store-to-slot-then-reload pattern for phi nodes (if/and/or) and destructuring
- Lowerer uses a `discard()` helper for unused intermediate values in `begin`/`block`
- Removed 3 enum variants, 3 display arms, 3 JIT translation arms

**Benefits:**
- Decouples lowerer from emitter's stack model
- Enables future optimization passes (dead-code elimination, copy propagation)
- Cleaner IR: every instruction has semantic meaning

## Testing

✅ All examples pass:
- `examples/basics.lisp`
- `examples/control.lisp`
- `examples/destructuring.lisp`

✅ Docgen builds successfully

✅ No compilation warnings

## Commits

1. Lower if expressions via slot pattern instead of Move
2. Lower destructuring via slot pattern instead of Dup
3. Remove Pop, Move, Dup from LIR; emitter auto-pops after stores
