### PR TITLE
ci: move rust tests to PR, keep merge queue fast

### DIFF
--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -12,28 +12,6 @@ env:
   RUST_BACKTRACE: 1
 
 jobs:
-  fmt:
-    name: Rustfmt
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt
-      - run: cargo fmt -- --check
-
-  clippy:
-    name: Clippy
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy
-      - uses: Swatinem/rust-cache@v2
-      - name: Run clippy on workspace
-        run: cargo clippy --workspace --all-targets --all-features -- -D warnings
-
   examples:
     name: Examples
     runs-on: ubuntu-latest
@@ -91,32 +69,21 @@ jobs:
           echo "=============================================="
           echo "Results: $PASSED/$TOTAL passed, $FAILED failed"
 
-           if [ $FAILED -gt 0 ]; then
-             echo "✗ Some examples failed"
-             exit 1
-           else
-             echo "✓ All examples passed"
-            fi
+          if [ $FAILED -gt 0 ]; then
+            echo "✗ Some examples failed"
+            exit 1
+          else
+            echo "✓ All examples passed"
+          fi
       - name: Run Elle script tests
         run: |
           echo "Running Elle script tests:"
           echo "=========================="
           for f in tests/elle/*.lisp; do
             echo "  $f"
-           ./target/release/elle "$f" || exit 1
-           done
-           echo "✓ All Elle script tests passed"
-
-  tests:
-    name: Rust Tests
-    needs: examples
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-      - name: Run all tests (integration + property)
-        run: cargo test --workspace
+            ./target/release/elle "$f" || exit 1
+          done
+          echo "✓ All Elle script tests passed"
 
   audit:
     name: Dependency Audit
@@ -133,21 +100,12 @@ jobs:
 
   all-checks:
     name: All Checks Passed
-    needs: [fmt, clippy, examples, tests, audit]
+    needs: [examples, audit]
     runs-on: ubuntu-latest
     if: always()
     steps:
-      - name: Check fmt
-        if: needs.fmt.result == 'failure'
-        run: exit 1
-      - name: Check clippy
-        if: needs.clippy.result == 'failure'
-        run: exit 1
       - name: Check examples
         if: needs.examples.result == 'failure'
-        run: exit 1
-      - name: Check tests
-        if: needs.tests.result == 'failure'
         run: exit 1
       - name: Check audit
         if: needs.audit.result == 'failure'

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -136,6 +136,32 @@ jobs:
           done
           echo "✓ All Elle script tests passed"
 
+  tests-integration:
+    name: Integration Tests
+    needs: changes
+    runs-on: ubuntu-latest
+    if: needs.changes.outputs.source == 'true'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Run integration and unit tests
+        run: cargo test --lib && cargo test --test '*' --skip property
+
+  tests-property:
+    name: Property Tests
+    needs: changes
+    runs-on: ubuntu-latest
+    if: needs.changes.outputs.source == 'true'
+    env:
+      PROPTEST_CASES: 8
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Run property tests
+        run: cargo test --test property
+
   benchmarks:
     name: Benchmarks
     needs: changes
@@ -185,7 +211,7 @@ jobs:
 
   all-checks:
     name: All Checks Passed
-    needs: [changes, fmt, clippy, examples, benchmarks]
+    needs: [changes, fmt, clippy, examples, tests-integration, tests-property, benchmarks]
     runs-on: ubuntu-latest
     if: always()
     steps:
@@ -197,6 +223,12 @@ jobs:
         run: exit 1
       - name: Check examples
         if: needs.examples.result == 'failure'
+        run: exit 1
+      - name: Check integration tests
+        if: needs.tests-integration.result == 'failure'
+        run: exit 1
+      - name: Check property tests
+        if: needs.tests-property.result == 'failure'
         run: exit 1
       - name: Check benchmarks
         if: needs.benchmarks.result == 'failure'


### PR DESCRIPTION
Restructure CI for faster merge queue feedback:

- Move integration and property tests from merge queue to PR checks
- Run them in parallel with examples/Elle tests on PR
- Merge queue now runs only examples, Elle tests, and audit (~2 mins)
- Property tests limited to 8 cases on PR for faster feedback
- Tests still run before merge, just not in the critical path
