### PR TITLE
ci: rename main branch job to CI for badge

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,8 +13,8 @@ env:
   RUST_BACKTRACE: 1
 
 jobs:
-  examples:
-    name: Examples
+  ci:
+    name: CI
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Rename the main branch CI job from 'Examples' to 'CI' so the status badge uses the correct job name.