### PR TITLE
ci: run and publish memory benchmarks on main merge (#537)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -185,6 +185,10 @@ jobs:
         run: cargo bench --bench benchmarks -- --sample-size 10 --warm-up-time 1 --measurement-time 2 --nresamples 100 --output-format bencher | tee output.txt
         env:
           RAYON_NUM_THREADS: 1
+      - name: Run memory benchmarks
+        run: cargo bench --bench memory | tee memory-output.txt
+        env:
+          RAYON_NUM_THREADS: 1
       - name: Upload benchmark reports
         if: always()
         uses: actions/upload-artifact@v4
@@ -192,7 +196,7 @@ jobs:
           name: criterion-reports
           path: target/criterion/
           retention-days: 30
-      - name: Store benchmark result
+      - name: Store Criterion benchmark result
         uses: benchmark-action/github-action-benchmark@v1
         with:
           name: Elle Benchmarks
@@ -201,4 +205,14 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           auto-push: true
           benchmark-data-dir-path: dev/bench
+          gh-pages-branch: gh-pages
+      - name: Store memory benchmark result
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: Elle Memory Benchmarks
+          tool: cargo
+          output-file-path: memory-output.txt
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: true
+          benchmark-data-dir-path: dev/bench/memory
           gh-pages-branch: gh-pages


### PR DESCRIPTION
Adds the memory benchmark (`benches/memory.rs`) to the `benchmarks-publish` job so allocation metrics are run and published to GitHub Pages on every merge to main, alongside the existing Criterion results.

- Run `cargo bench --bench memory` and capture output
- Publish to `dev/bench/memory` on gh-pages via `benchmark-action/github-action-benchmark`
- Rename existing "Store benchmark result" step to "Store Criterion benchmark result" for clarity
- Criterion history path (`dev/bench`) preserved to avoid breaking existing charts

Closes #537
