### PR TITLE
fix: ffi/signature accepts immutable arrays as arg-types

### DIFF
--- a/src/primitives/loading.rs
+++ b/src/primitives/loading.rs
@@ -140,6 +140,8 @@ pub(crate) fn prim_ffi_signature(args: &[Value]) -> (SignalBits, Value) {
     // Parse argument types from array or list
     let arg_vals = if let Some(arr) = args[1].as_array_mut() {
         arr.borrow().clone()
+    } else if let Some(arr) = args[1].as_array() {
+        arr.to_vec()
     } else {
         match args[1].list_to_vec() {
             Ok(v) => v,

--- a/tests/elle/ffi.lisp
+++ b/tests/elle/ffi.lisp
@@ -348,3 +348,20 @@
 (ffi/defbind getpid libc "getpid" :int @[])
 (def pid (getpid))
 (assert-true (> pid 0) "ffi/defbind zero args")
+
+## ── ffi/signature and ffi/defbind with immutable array arg-types ─
+
+# Regression test for issue #560: ffi/signature must accept immutable arrays.
+
+(def libc (ffi/native nil))
+(ffi/defbind abs libc "abs" :int [:int])
+(assert-eq (abs -42) 42 "ffi/defbind immutable array arg-types")
+
+(def libc (ffi/native nil))
+(def ptr (ffi/lookup libc "abs"))
+(def sig (ffi/signature :int [:int]))
+(assert-eq (ffi/call ptr sig -7) 7 "ffi/signature with immutable array")
+
+(def libc (ffi/native nil))
+(ffi/defbind getpid libc "getpid" :int [])
+(assert-true (> (getpid) 0) "ffi/defbind empty immutable array")


### PR DESCRIPTION
# Fix: ffi/signature accepts immutable arrays as arg-types

## The Bug

`ffi/signature` and `ffi/defbind` rejected immutable array literals (`[...]`) when passed as argument type specifications. The error message was confusing:

```
ffi/signature: expected array or list for arg types, got array
```

This occurred because the `ffi/defbind` macro expands `[:int]` into a runtime immutable array, but `prim_ffi_signature` only accepted:
- Mutable arrays (`@[...]`) via `as_array_mut()`
- Lists via `list_to_vec()`

Immutable arrays fell through to the error case.

## What Changed

**Single change in `src/primitives/loading.rs`** (lines 140–159):

Added one `else if` branch to accept immutable arrays:

```rust
} else if let Some(arr) = args[1].as_array() {
    arr.to_vec()
```

This branch sits between the existing mutable-array check and the list check. `Value::as_array()` returns `Option<&[Value]>`, and `.to_vec()` produces the owned `Vec<Value>` needed downstream.

## Tests Added

Three regression tests appended to `tests/elle/ffi.lisp`:

1. **`ffi/defbind` with immutable array** — the original reproduction case:
   ```elle
   (ffi/defbind abs libc "abs" :int [:int])
   (assert-eq (abs -42) 42 "ffi/defbind immutable array arg-types")
   ```

2. **`ffi/signature` called directly with immutable array** — unit-level verification:
   ```elle
   (def sig (ffi/signature :int [:int]))
   (assert-eq (ffi/call ptr sig -7) 7 "ffi/signature with immutable array")
   ```

3. **`ffi/defbind` with empty immutable array** — zero-argument edge case:
   ```elle
   (ffi/defbind getpid libc "getpid" :int [])
   (assert-true (> (getpid) 0) "ffi/defbind empty immutable array")
   ```

## Scope

- **Files changed:** 2
  - `src/primitives/loading.rs` — 2 lines added
  - `tests/elle/ffi.lisp` — 17 lines added
- **No prelude changes** — the `ffi/defbind` macro was already correct
- **No documentation changes** — the docstring example already showed `[...]` syntax

Closes #560
