### PR TITLE
jit: track and report why closures are rejected from JIT compilation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,7 @@ bytecode. Error messages include file:line:col information.
 | `primitives` | Built-in functions; includes `port/path`, `string/size-of`, `with-traits`, `traits`, `process/exec`, `process/wait`, `process/kill`, `process/pid`, `syntax-pair?`, `syntax-list?`, `syntax-symbol?`, `syntax-keyword?`, `syntax-nil?`, `syntax->list`, `syntax-first`, `syntax-rest`, `syntax-e` |
 | `stdlib` | Standard library functions (loaded at startup); includes stream combinators (`port/lines`, `port/chunks`, `port/writer`, `stream/map`, `stream/filter`, `stream/take`, `stream/drop`, `stream/concat`, `stream/zip`, `stream/for-each`, `stream/fold`, `stream/collect`, `stream/into-array`, `stream/pipe`) and subprocess convenience (`process/system`) |
 | `ffi` | C interop via libloading/bindgen |
-| `jit` | JIT compilation via Cranelift |
+| `jit` | JIT compilation via Cranelift; `JitRejectionInfo` tracks why closures were rejected |
 | `formatter` | Code formatting for Elle source |
 | `plugin` | Dynamic plugin loading for Rust cdylib primitives |
 | `path` | UTF-8 path operations |

--- a/src/jit/mod.rs
+++ b/src/jit/mod.rs
@@ -78,3 +78,13 @@ impl fmt::Display for JitError {
 }
 
 impl std::error::Error for JitError {}
+
+/// Record of a closure that was rejected from JIT compilation.
+/// One entry per closure template, deduplicated by bytecode pointer.
+#[derive(Debug, Clone)]
+pub struct JitRejectionInfo {
+    /// Function name (from `LirFunction.name`), if available.
+    pub name: Option<String>,
+    /// Why the JIT rejected this closure.
+    pub reason: JitError,
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,6 +35,8 @@ fn print_help() {
     println!("Options:");
     println!("  -h, --help    Show this help");
     println!("  -             Read from stdin\n");
+    println!("Environment:");
+    println!("  ELLE_JIT_STATS=1  Print JIT compilation stats to stderr on exit\n");
     print!("{}", elle::primitives::help_text());
 }
 
@@ -357,6 +359,27 @@ fn run_repl_fallback(vm: &mut VM, symbols: &mut SymbolTable) -> bool {
     had_errors
 }
 
+fn print_jit_stats(vm: &VM) {
+    let compiled = vm.jit_cache.len();
+    let rejected = vm.jit_rejections.len();
+
+    eprintln!("JIT stats:");
+    eprintln!("  compiled: {}", compiled);
+    eprintln!("  rejected: {}", rejected);
+
+    if rejected > 0 {
+        // Sort by call count ascending
+        let mut entries: Vec<_> = vm.jit_rejections.iter().collect();
+        entries.sort_by_key(|(ptr, _)| vm.closure_call_counts.get(ptr).copied().unwrap_or(0));
+
+        for (ptr, info) in &entries {
+            let name = info.name.as_deref().unwrap_or("<anon>");
+            let calls = vm.closure_call_counts.get(ptr).copied().unwrap_or(0);
+            eprintln!("    {:<24} {}  [called {}x]", name, info.reason, calls);
+        }
+    }
+}
+
 fn main() {
     let args: Vec<String> = env::args().collect();
 
@@ -428,6 +451,10 @@ fn main() {
     }
 
     clear_vm_context();
+
+    if env::var_os("ELLE_JIT_STATS").is_some() {
+        print_jit_stats(&vm);
+    }
 
     if args.len() == 1 {
         println!();

--- a/src/primitives/AGENTS.md
+++ b/src/primitives/AGENTS.md
@@ -116,7 +116,7 @@ pub fn register_arithmetic(vm: &mut VM, symbols: &mut SymbolTable) {
 | `time.rs` | `clock/monotonic`, `clock/realtime`, `clock/cpu`, `time/sleep` |
 | `time_def.rs` | `time/stopwatch`, `time/elapsed` (Elle definitions via `eval`) |
 | `meta.rs` | `gensym`, `datum->syntax`, `syntax->datum`, `syntax-pair?`, `syntax-list?`, `syntax-symbol?`, `syntax-keyword?`, `syntax-nil?`, `syntax->list`, `syntax-first`, `syntax-rest`, `syntax-e` |
-| `introspection.rs` | `closure?`, `jit?`, `silent?`, `coroutine?`, `fn/mutates-params?`, `fn/errors?`, `fn/arity`, `fn/captures`, `fn/bytecode-size`, `doc`, `vm/query`, `keyword` (alias: `string->keyword`) |
+| `introspection.rs` | `closure?`, `jit?`, `silent?`, `coroutine?`, `fn/mutates-params?`, `fn/errors?`, `fn/arity`, `fn/captures`, `fn/bytecode-size`, `doc`, `vm/query`, `jit/rejections`, `keyword` (alias: `string->keyword`) |
 | `disassembly.rs` | `fn/disasm`, `fn/disasm-jit`, `fn/flow`, `vm/list-primitives`, `vm/primitive-meta` |
 | `arena.rs` | `arena/count`, `arena/stats`, `arena/set-object-limit`, `arena/object-limit`, `arena/bytes`, `arena/checkpoint`, `arena/reset`, `arena/allocs`, `arena/peak`, `arena/reset-peak`, `environment` |
 | `debug.rs` | `debug/print`, `debug/trace`, `debug/memory` |

--- a/src/primitives/introspection.rs
+++ b/src/primitives/introspection.rs
@@ -264,6 +264,26 @@ pub(crate) fn prim_keyword(args: &[Value]) -> (SignalBits, Value) {
     }
 }
 
+/// (jit/rejections) — list closures rejected from JIT compilation with reasons
+///
+/// Returns a list of structs, each with :name, :reason, and :calls keys.
+/// Sorted by call count ascending (coldest first).
+pub(crate) fn prim_jit_rejections(args: &[Value]) -> (SignalBits, Value) {
+    if !args.is_empty() {
+        return (
+            SIG_ERROR,
+            error_val(
+                "arity-error",
+                format!("jit/rejections: expected 0 arguments, got {}", args.len()),
+            ),
+        );
+    }
+    (
+        SIG_QUERY,
+        Value::cons(Value::keyword("jit/rejections"), Value::NIL),
+    )
+}
+
 /// Declarative primitive definitions for introspection operations.
 pub(crate) const PRIMITIVES: &[PrimitiveDef] = &[
     PrimitiveDef {
@@ -396,6 +416,17 @@ pub(crate) const PRIMITIVES: &[PrimitiveDef] = &[
         params: &[],
         category: "meta",
         example: "(signals)",
+        aliases: &[],
+    },
+    PrimitiveDef {
+        name: "jit/rejections",
+        func: prim_jit_rejections,
+        signal: Signal { bits: SignalBits::new(SIG_QUERY.0 | SIG_ERROR.0), propagates: 0 },
+        arity: Arity::Exact(0),
+        doc: "List closures rejected from JIT compilation. Returns list of {:name :reason :calls} structs sorted by call count ascending.",
+        params: &[],
+        category: "meta",
+        example: "(jit/rejections)",
         aliases: &[],
     },
     PrimitiveDef {

--- a/src/vm/AGENTS.md
+++ b/src/vm/AGENTS.md
@@ -94,7 +94,7 @@ dispatches the return signal in `handle_primitive_signal()` (`signal.rs`):
 - `SIG_RESUME` → dispatch to fiber handler
 - `SIG_PROPAGATE` → propagate child fiber's signal, preserve child chain
 - `SIG_CANCEL` → inject error into target fiber
-- `SIG_QUERY` → dispatch to `dispatch_query()`, push result to stack. Operations: `arena/allocs` (re-entrant, handled before dispatch), `arena/stats` (0-arg: current fiber; 1-arg: suspended fiber; includes scope-enter/dtor counts), `call-count`, `doc`, `global?`, `fiber/self`, `list-primitives`, `primitive-meta`
+- `SIG_QUERY` → dispatch to `dispatch_query()`, push result to stack. Operations: `arena/allocs` (re-entrant, handled before dispatch), `arena/stats` (0-arg: current fiber; 1-arg: suspended fiber; includes scope-enter/dtor counts), `call-count`, `doc`, `global?`, `fiber/self`, `jit/rejections`, `list-primitives`, `primitive-meta`
 
 All SIG_RESUME primitives (including coroutine wrappers) return
 `(SIG_RESUME, fiber_value)`. The VM uses `FiberHandle::take()`/`put()` to swap
@@ -150,6 +150,7 @@ On resume, the VM wires up the parent/child chain (Janet semantics):
 | `globals` | `Vec<Value>` | Global bindings by SymbolId |
 | `defined_globals` | `Vec<bool>` | Tracks which global slots have been assigned (shadows `globals`) |
 | `jit_cache` | `FxHashMap<*const u8, Rc<JitCode>>` | JIT code cache (FxHash for pointer keys) |
+| `jit_rejections` | `FxHashMap<*const u8, JitRejectionInfo>` | JIT rejection log: first rejection per closure template |
 | `closure_call_counts` | `FxHashMap<*const u8, usize>` | JIT hotness profiling (FxHash for pointer keys) |
 | `pending_tail_call` | `Option<TailCallInfo>` | Rc-based tail call info (transient) |
 | `env_cache` | `Vec<Value>` | Reusable buffer for `build_closure_env` (avoids alloc per call) |

--- a/src/vm/core.rs
+++ b/src/vm/core.rs
@@ -11,7 +11,7 @@ use rustc_hash::FxHashMap;
 use std::collections::HashMap;
 use std::rc::Rc;
 
-use crate::jit::JitCode;
+use crate::jit::{JitCode, JitRejectionInfo};
 
 pub(crate) struct TailCallInfo {
     pub bytecode: Rc<Vec<u8>>,
@@ -55,6 +55,10 @@ pub struct VM {
     /// Documentation for all named forms (primitives, special forms, macros).
     /// Keyed by name string for direct lookup via `doc` and `vm/primitive-meta`.
     pub docs: HashMap<String, Doc>,
+    /// JIT rejection log: bytecode pointer → rejection info.
+    /// Records first rejection per closure template. Used by
+    /// `(jit/rejections)` primitive and `ELLE_JIT_STATS` env var.
+    pub jit_rejections: FxHashMap<*const u8, JitRejectionInfo>,
     /// Cached Expander for runtime `eval`. Avoids re-loading the prelude
     /// on every eval call. Taken out during eval, put back after.
     pub eval_expander: Option<crate::syntax::Expander>,
@@ -114,6 +118,7 @@ impl VM {
             pending_tail_call: None,
             error_loc: None,
             jit_cache: FxHashMap::default(),
+            jit_rejections: FxHashMap::default(),
             docs: HashMap::new(),
             eval_expander: None,
         }
@@ -139,6 +144,7 @@ impl VM {
         self.pending_tail_call = None;
         self.error_loc = None;
         self.closure_call_counts.clear();
+        self.jit_rejections.clear();
         self.location_map = LocationMap::new();
         self.loading_modules.clear();
     }

--- a/src/vm/jit_entry.rs
+++ b/src/vm/jit_entry.rs
@@ -6,7 +6,7 @@
 //! - Batch JIT compilation for call peers
 //! - Fallback to interpreter on compilation failure
 
-use crate::jit::{JitCode, JitCompiler, TAIL_CALL_SENTINEL, YIELD_SENTINEL};
+use crate::jit::{JitCode, JitCompiler, JitRejectionInfo, TAIL_CALL_SENTINEL, YIELD_SENTINEL};
 use crate::value::{SignalBits, SymbolId, Value, SIG_ERROR, SIG_HALT, SIG_YIELD};
 use std::rc::Rc;
 
@@ -57,12 +57,10 @@ impl VM {
                             return Some(self.run_jit(&jit_code, closure, args, func));
                         }
                         Err(e) => match &e {
-                            crate::jit::JitError::UnsupportedInstruction(_) => {
-                                // MakeClosure and other instructions not yet in JIT.
-                                // Fall back to interpreter — the function still works.
-                            }
-                            crate::jit::JitError::Polymorphic => {
-                                // Polymorphic — fall through to interpreter
+                            crate::jit::JitError::UnsupportedInstruction(_)
+                            | crate::jit::JitError::Polymorphic => {
+                                // Expected rejection — record and fall back to interpreter.
+                                self.record_jit_rejection(bytecode_ptr, closure, e);
                             }
                             _ => {
                                 panic!(
@@ -269,6 +267,29 @@ impl VM {
         }
 
         None
+    }
+
+    /// Record a JIT rejection for a closure. Only the first rejection per
+    /// closure template is stored (deduplicated by bytecode pointer).
+    fn record_jit_rejection(
+        &mut self,
+        bytecode_ptr: *const u8,
+        closure: &crate::value::Closure,
+        error: crate::jit::JitError,
+    ) {
+        self.jit_rejections.entry(bytecode_ptr).or_insert_with(|| {
+            // Prefer LIR name, fall back to closure template name.
+            let name = closure
+                .template
+                .lir_function
+                .as_ref()
+                .and_then(|f| f.name.clone())
+                .or_else(|| closure.template.name.as_ref().map(|n| n.to_string()));
+            JitRejectionInfo {
+                name,
+                reason: error,
+            }
+        });
     }
 
     /// Find the SymbolId for a closure matching the given bytecode pointer.

--- a/src/vm/signal.rs
+++ b/src/vm/signal.rs
@@ -459,6 +459,39 @@ impl VM {
                     }
                 }
             }
+            "jit/rejections" => {
+                use crate::value::heap::TableKey;
+                use std::collections::BTreeMap;
+
+                // Sort by call count ascending (coldest first, hottest last).
+                let mut entries: Vec<_> = self.jit_rejections.iter().collect();
+                entries.sort_by_key(|(ptr, _)| {
+                    self.closure_call_counts.get(ptr).copied().unwrap_or(0)
+                });
+
+                let structs: Vec<Value> = entries
+                    .into_iter()
+                    .map(|(ptr, info)| {
+                        let mut fields = BTreeMap::new();
+                        let name = info.name.as_deref().unwrap_or("<anon>");
+                        fields.insert(
+                            TableKey::Keyword("name".to_string()),
+                            Value::string(name.to_string()),
+                        );
+                        fields.insert(
+                            TableKey::Keyword("reason".to_string()),
+                            Value::string(info.reason.to_string()),
+                        );
+                        let calls = self.closure_call_counts.get(ptr).copied().unwrap_or(0);
+                        fields.insert(
+                            TableKey::Keyword("calls".to_string()),
+                            Value::int(calls as i64),
+                        );
+                        Value::struct_from(fields)
+                    })
+                    .collect();
+                (SIG_OK, crate::value::list(structs))
+            }
             _ => (
                 SIG_ERROR,
                 error_val(

--- a/tests/elle/jit-rejections.lisp
+++ b/tests/elle/jit-rejections.lisp
@@ -1,0 +1,43 @@
+## jit/rejections — test JIT rejection tracking
+
+## Before any hot functions, jit/rejections returns empty list
+(assert (= (jit/rejections) ()) "jit/rejections empty on fresh VM")
+
+## A function containing MakeClosure gets rejected when hot.
+(defn has-closure (n)
+  (let ((f (fn (x) (+ x 1))))
+    (if (<= n 0) 0
+      (+ (f n) (has-closure (- n 1))))))
+
+(has-closure 20)
+
+(var rejections (jit/rejections))
+
+## At least one rejection recorded
+(assert (>= (length rejections) 1)
+  "expected at least 1 rejection")
+
+## Each rejection is a struct with :name, :reason, :calls
+(var r (first rejections))
+(assert (has-key? r :name) "rejection has :name")
+(assert (has-key? r :reason) "rejection has :reason")
+(assert (has-key? r :calls) "rejection has :calls")
+
+## Reason mentions MakeClosure
+(assert (string/contains? (get r :reason) "MakeClosure")
+  "reason mentions MakeClosure")
+
+## Call count is at least the JIT threshold (10)
+(assert (>= (get r :calls) 10) ":calls >= JIT threshold")
+
+## Name is a string
+(assert (string? (get r :name)) ":name is a string")
+
+## A pure hot function should NOT appear in rejections
+(defn pure-hot (n)
+  (if (<= n 0) 0 (pure-hot (- n 1))))
+(pure-hot 20)
+
+## Rejections should not have grown (pure-hot compiles successfully)
+(assert (= (length (jit/rejections)) (length rejections))
+  "pure hot function does not add to rejections")


### PR DESCRIPTION
## Summary

- Adds `(jit/rejections)` primitive: returns a list of `{:name :reason :calls}` structs for every closure rejected from JIT compilation, sorted by call count ascending
- Adds `ELLE_JIT_STATS=1` env var: prints compiled/rejected counts and per-rejection details to stderr at exit
- Rejections are deduplicated by bytecode pointer (one entry per closure template, first rejection only)
- Expected rejection reasons (`UnsupportedInstruction`, `Polymorphic`) are recorded; all others remain panics

## Changes

| File | What |
|------|------|
| `src/jit/mod.rs` | `JitRejectionInfo` struct (name + reason) |
| `src/vm/core.rs` | `jit_rejections` field on VM, cleared on `reset_fiber` |
| `src/vm/jit_entry.rs` | `record_jit_rejection()` helper, deduped by bytecode pointer |
| `src/vm/signal.rs` | `"jit/rejections"` SIG_QUERY operation |
| `src/primitives/introspection.rs` | `(jit/rejections)` primitive |
| `src/main.rs` | `ELLE_JIT_STATS=1` env var + help text |
| `tests/elle/jit-rejections.lisp` | Elle tests |