### PR TITLE
fix: cond/match register corruption in variadic calls

### DIFF
--- a/src/lir/emit/mod.rs
+++ b/src/lir/emit/mod.rs
@@ -94,14 +94,27 @@ impl Emitter {
         self.current_func_may_suspend = func.signal.may_suspend();
         self.current_func_num_locals = func.num_locals;
 
-        // First pass: record label offsets (simplified - emit all blocks in order)
-        // Second pass handled inline since we emit sequentially
-
-        // Sort blocks by label for deterministic output
-        let mut blocks: Vec<_> = func.blocks.iter().collect();
-        blocks.sort_by_key(|b| b.label.0);
-
-        for block in &blocks {
+        // Emit blocks in the order they were appended by the lowerer.
+        //
+        // The lowerer appends blocks by calling finish_block(), which means
+        // predecessor blocks are always appended before their successors —
+        // EXCEPT for merge/done blocks, which are left as `current_block`
+        // and appended last (after all blocks that jump to them). This
+        // guarantees that by the time the emitter processes a done/merge
+        // block, all predecessors have already emitted their Jump/Branch
+        // terminators and saved their stack state into yield_stack_state.
+        //
+        // Do NOT sort by label number. Labels are allocated in creation
+        // order, not emission order. Constructs like `cond` and `match`
+        // allocate the done_label first (giving it a low number) and the
+        // arm blocks later (higher numbers). Sorting by label would cause
+        // the done block to be emitted before its predecessors, losing the
+        // stack state they carry.
+        //
+        // Invariant: func.blocks[0] is always the entry block (Label 0),
+        // because the lowerer always starts with BasicBlock::new(Label(0))
+        // and finish_block() appends it when the first branch is encountered.
+        for block in &func.blocks {
             self.label_offsets
                 .insert(block.label, self.bytecode.current_pos());
             self.emit_block(block, func);

--- a/tests/elle/bugfixes.lisp
+++ b/tests/elle/bugfixes.lisp
@@ -259,4 +259,53 @@
           (assert-eq (get server-got 0) "ping"
             "server received data from client (Bug 7)")
           (assert-eq (get client-got 0) "pong"
-            "client received response from server (Bug 7)"))))))
+            "client received response from server (Bug 7)")))))) 
+
+# ============================================================================
+# Bug 612: cond/match corrupt previously-evaluated arguments in variadic calls
+#
+# When cond or match appeared as a non-first argument to a variadic native
+# function, the emitter emitted the done/merge block before the arm blocks
+# (because done_label was allocated first, giving it a lower label number
+# than the arm blocks, and blocks were sorted by label). The done block's
+# stack state was then cleared (no predecessor had yet saved it), causing
+# previously-evaluated arguments to be invisible to the Call instruction.
+#
+# Fix: the emitter now emits blocks in append order (the order finish_block
+# was called) rather than sorted by label. Merge/done blocks are always
+# appended last, so their predecessor arm blocks have already emitted their
+# Jump terminators and saved the correct stack state before the done block
+# is processed.
+# ============================================================================
+
+# cond as non-first arg to native variadic call
+(assert-eq (path/join "a" (cond (true "b"))) "a/b"
+  "cond as second arg to path/join")
+
+# match as non-first arg to native variadic call
+(assert-eq (path/join "a" (match 1 (1 "b") (_ "c"))) "a/b"
+  "match as second arg to path/join")
+
+# cond in second position of three-arg list
+(assert-list-eq (list 1 (cond (true 2)) 3) (list 1 2 3)
+  "cond as second arg in list")
+
+# cond in third position of three-arg list
+(assert-list-eq (list 1 2 (cond (true 3))) (list 1 2 3)
+  "cond as third arg in list")
+
+# match in second position of three-arg list
+(assert-list-eq (list 1 (match 1 (1 2) (_ 0)) 3) (list 1 2 3)
+  "match as second arg in list")
+
+# match in third position (wildcard arm)
+(assert-list-eq (list 1 2 (match 5 (1 "nope") (_ 3))) (list 1 2 3)
+  "match wildcard as third arg in list")
+
+# cond with multiple clauses, non-first arg
+(assert-eq (path/join "a" (cond (false "x") (true "b"))) "a/b"
+  "cond with two clauses as second arg to path/join")
+
+# cond as first arg still works (was never broken)
+(assert-eq (path/join (cond (true "a")) "b") "a/b"
+  "cond as first arg to path/join (regression guard)")

--- a/tests/integration/cond_match_args.rs
+++ b/tests/integration/cond_match_args.rs
@@ -1,0 +1,62 @@
+// Regression tests for Bug 612: cond/match corrupt previously-evaluated
+// arguments in variadic native function calls.
+use crate::common::eval_source;
+use elle::Value;
+
+#[test]
+fn test_cond_as_second_arg_to_path_join() {
+    let result = eval_source(r#"(path/join "a" (cond (true "b")))"#).unwrap();
+    assert_eq!(result, Value::string("a/b".to_string()));
+}
+
+#[test]
+fn test_cond_as_second_arg_in_list() {
+    let result = eval_source("(list 1 (cond (true 2)) 3)").unwrap();
+    let expected = eval_source("(list 1 2 3)").unwrap();
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn test_cond_as_third_arg_in_list() {
+    let result = eval_source("(list 1 2 (cond (true 3)))").unwrap();
+    let expected = eval_source("(list 1 2 3)").unwrap();
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn test_cond_multi_clause_as_second_arg() {
+    let result = eval_source(r#"(path/join "a" (cond (false "x") (true "b")))"#).unwrap();
+    assert_eq!(result, Value::string("a/b".to_string()));
+}
+
+#[test]
+fn test_match_as_second_arg_to_path_join() {
+    let result = eval_source(r#"(path/join "a" (match 1 (1 "b") (_ "c")))"#).unwrap();
+    assert_eq!(result, Value::string("a/b".to_string()));
+}
+
+#[test]
+fn test_match_as_second_arg_in_list() {
+    let result = eval_source("(list 1 (match 1 (1 2) (_ 0)) 3)").unwrap();
+    let expected = eval_source("(list 1 2 3)").unwrap();
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn test_match_wildcard_as_third_arg_in_list() {
+    let result = eval_source("(list 1 2 (match 5 (1 99) (_ 3)))").unwrap();
+    let expected = eval_source("(list 1 2 3)").unwrap();
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn test_cond_as_first_arg_still_works() {
+    let result = eval_source(r#"(path/join (cond (true "a")) "b")"#).unwrap();
+    assert_eq!(result, Value::string("a/b".to_string()));
+}
+
+#[test]
+fn test_if_as_second_arg_still_works() {
+    let result = eval_source(r#"(path/join "a" (if true "b" "c"))"#).unwrap();
+    assert_eq!(result, Value::string("a/b".to_string()));
+}

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -87,6 +87,9 @@ mod file_scope {
 mod sys_args {
     include!("sys_args.rs");
 }
+mod cond_match_args {
+    include!("cond_match_args.rs");
+}
 
 // Temporarily disabled while sorting out compilation caching.
 // mod fn_flow {


### PR DESCRIPTION
## Summary

- `cond` and `match` expressions used as non-first arguments in variadic native function calls were corrupting previously-evaluated sibling arguments, causing them to be replaced by heap objects (native functions, closures).

## Root Cause

The LIR emitter in `src/lir/emit/mod.rs` sorted basic blocks by label number before emitting bytecode. `lower_cond` and `lower_match` allocate their done/merge block **first** (lowest label number), before the arm/body blocks. With sorted order, the done block was emitted before its predecessors had saved their stack state into `yield_stack_state`, so the merge block saw an empty stack state and cleared all previously-evaluated argument registers.

`if`/`when`/`case` were unaffected because their lowerers allocate the merge block **last** (highest label number), so it was always emitted after its predecessors.

## Fix

One-line change in `src/lir/emit/mod.rs`: iterate blocks in append order instead of sorted by label. The lowerer always appends merge blocks last, so predecessors are guaranteed to be processed first.

## Tests

- 9 new Rust integration regression tests (`tests/integration/cond_match_args.rs`)
- 8 new Elle regression tests (`tests/elle/bugfixes.lisp`)

Closes #612
