### PR TITLE
feat: native-fn? predicate, :native-fn type, remove function?

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -1,0 +1,33 @@
+## Type Predicates
+
+| Predicate | Matches | Notes |
+|-----------|---------|-------|
+| `(fn? x)` | closure or native-fn | any callable value |
+| `(closure? x)` | user-defined closures only | `(fn ...)` forms |
+| `(native-fn? x)` | native (built-in) functions only | aliases: `native?`, `primitive?` |
+| `(nil? x)` | nil | |
+| `(boolean? x)` | true or false | alias: `bool?` |
+| `(integer? x)` | 48-bit signed integers | alias: `int?` |
+| `(float? x)` | IEEE 754 doubles | |
+| `(number? x)` | integer or float | |
+| `(string? x)` | immutable or mutable strings | |
+| `(symbol? x)` | symbols | |
+| `(keyword? x)` | keywords | |
+| `(pair? x)` | cons cells | |
+| `(list? x)` | cons cells or empty list | |
+| `(array? x)` | immutable or mutable arrays | alias: `tuple?` |
+| `(struct? x)` | immutable or mutable structs | alias: `table?` |
+| `(bytes? x)` | immutable or mutable bytes | |
+| `(mutable? x)` | any mutable collection | |
+
+### type-of
+
+`(type-of x)` returns the type as a keyword:
+
+```lisp
+(type-of 42)        #=> :integer
+(type-of "hello")   #=> :string
+(type-of +)         #=> :native-fn
+(type-of (fn [x] x)) #=> :closure
+(type-of nil)       #=> :nil
+```

--- a/src/primitives/types.rs
+++ b/src/primitives/types.rs
@@ -246,15 +246,12 @@ pub(crate) fn prim_is_struct(args: &[Value]) -> (SignalBits, Value) {
     )
 }
 
-/// Check if value is a function (closure or primitive)
-pub(crate) fn prim_is_function(args: &[Value]) -> (SignalBits, Value) {
+/// Check if value is callable (closure or native function)
+pub(crate) fn prim_is_fn(args: &[Value]) -> (SignalBits, Value) {
     if args.len() != 1 {
         return (
             SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("function?: expected 1 argument, got {}", args.len()),
-            ),
+            error_val("arity-error", "fn?: expected 1 argument"),
         );
     }
     (
@@ -263,15 +260,12 @@ pub(crate) fn prim_is_function(args: &[Value]) -> (SignalBits, Value) {
     )
 }
 
-/// Check if value is a built-in primitive function
-pub(crate) fn prim_is_primitive(args: &[Value]) -> (SignalBits, Value) {
+/// Check if value is a native (built-in) function
+pub(crate) fn prim_is_native_fn(args: &[Value]) -> (SignalBits, Value) {
     if args.len() != 1 {
         return (
             SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("primitive?: expected 1 argument, got {}", args.len()),
-            ),
+            error_val("arity-error", "native-fn?: expected 1 argument"),
         );
     }
     (SIG_OK, Value::bool(args[0].is_native_fn()))
@@ -480,26 +474,26 @@ pub(crate) const PRIMITIVES: &[PrimitiveDef] = &[
         aliases: &[],
     },
     PrimitiveDef {
-        name: "function?",
-        func: prim_is_function,
-        signal: Signal::errors(),
+        name: "fn?",
+        func: prim_is_fn,
+        signal: Signal::silent(),
         arity: Arity::Exact(1),
-        doc: "Check if value is a function (closure or primitive).",
-        params: &["value"],
-        category: "predicate",
-        example: "(function? +) #=> true\n(function? 42) #=> false",
-        aliases: &["fn?"],
+        doc: "Returns true if value is callable (closure or native function).",
+        params: &["x"],
+        category: "types",
+        example: "(fn? +) #=> true\n(fn? (fn [x] x)) #=> true\n(fn? 42) #=> false",
+        aliases: &[],
     },
     PrimitiveDef {
-        name: "primitive?",
-        func: prim_is_primitive,
-        signal: Signal::errors(),
+        name: "native-fn?",
+        func: prim_is_native_fn,
+        signal: Signal::silent(),
         arity: Arity::Exact(1),
-        doc: "Check if value is a built-in primitive function.",
-        params: &["value"],
-        category: "predicate",
-        example: "(primitive? +) #=> true\n(primitive? (fn (x) x)) #=> false",
-        aliases: &[],
+        doc: "Returns true if value is a native (built-in) function.",
+        params: &["x"],
+        category: "types",
+        example: "(native-fn? +) #=> true\n(native-fn? (fn [x] x)) #=> false",
+        aliases: &["native?", "primitive?"],
     },
     PrimitiveDef {
         name: "mutable?",

--- a/src/value/heap.rs
+++ b/src/value/heap.rs
@@ -381,7 +381,7 @@ impl HeapObject {
             HeapObject::LBytesMut { .. } => "@bytes",
             HeapObject::LBox { .. } => "box",
             HeapObject::Float(_) => "float",
-            HeapObject::NativeFn(_) => "native-function",
+            HeapObject::NativeFn(_) => "native-fn",
             HeapObject::LibHandle(_) => "library-handle",
             HeapObject::ThreadHandle { .. } => "thread-handle",
             HeapObject::Fiber { .. } => "fiber",

--- a/tests/unittests/primitives.rs
+++ b/tests/unittests/primitives.rs
@@ -1996,102 +1996,6 @@ fn test_doc_bare_symbol_macro() {
 }
 
 #[test]
-fn test_function_predicate() {
-    let (_vm, mut symbols, meta) = setup();
-    let fn_pred = get_primitive(&meta, &mut symbols, "function?");
-
-    // Native fn is a function
-    let native = get_primitive(&meta, &mut symbols, "+");
-    assert_eq!(
-        call_primitive(&fn_pred, &[native]).unwrap(),
-        Value::bool(true)
-    );
-
-    // Closure is a function
-    let closure = Value::closure(Closure {
-        template: std::rc::Rc::new(ClosureTemplate {
-            bytecode: std::rc::Rc::new(vec![0u8]),
-            arity: elle::value::Arity::Exact(1),
-            num_locals: 0,
-            num_captures: 0,
-            num_params: 1,
-            constants: std::rc::Rc::new(vec![]),
-            signal: elle::signals::Signal::silent(),
-            lbox_params_mask: 0,
-            lbox_locals_mask: 0,
-            symbol_names: std::rc::Rc::new(std::collections::HashMap::new()),
-            location_map: std::rc::Rc::new(elle::error::LocationMap::new()),
-            jit_code: None,
-            lir_function: None,
-            doc: None,
-            syntax: None,
-            vararg_kind: elle::hir::VarargKind::List,
-            name: None,
-        }),
-        env: std::rc::Rc::new(vec![]),
-        squelch_mask: 0,
-    });
-    assert_eq!(
-        call_primitive(&fn_pred, &[closure]).unwrap(),
-        Value::bool(true)
-    );
-
-    // Number is not a function
-    assert_eq!(
-        call_primitive(&fn_pred, &[Value::int(42)]).unwrap(),
-        Value::bool(false)
-    );
-}
-
-#[test]
-fn test_primitive_predicate() {
-    let (_vm, mut symbols, meta) = setup();
-    let prim_pred = get_primitive(&meta, &mut symbols, "primitive?");
-
-    // Native fn is a primitive
-    let native = get_primitive(&meta, &mut symbols, "+");
-    assert_eq!(
-        call_primitive(&prim_pred, &[native]).unwrap(),
-        Value::bool(true)
-    );
-
-    // Closure is not a primitive
-    let closure = Value::closure(Closure {
-        template: std::rc::Rc::new(ClosureTemplate {
-            bytecode: std::rc::Rc::new(vec![0u8]),
-            arity: elle::value::Arity::Exact(1),
-            num_locals: 0,
-            num_captures: 0,
-            num_params: 1,
-            constants: std::rc::Rc::new(vec![]),
-            signal: elle::signals::Signal::silent(),
-            lbox_params_mask: 0,
-            lbox_locals_mask: 0,
-            symbol_names: std::rc::Rc::new(std::collections::HashMap::new()),
-            location_map: std::rc::Rc::new(elle::error::LocationMap::new()),
-            jit_code: None,
-            lir_function: None,
-            doc: None,
-            syntax: None,
-            vararg_kind: elle::hir::VarargKind::List,
-            name: None,
-        }),
-        env: std::rc::Rc::new(vec![]),
-        squelch_mask: 0,
-    });
-    assert_eq!(
-        call_primitive(&prim_pred, &[closure]).unwrap(),
-        Value::bool(false)
-    );
-
-    // Number is not a primitive
-    assert_eq!(
-        call_primitive(&prim_pred, &[Value::int(42)]).unwrap(),
-        Value::bool(false)
-    );
-}
-
-#[test]
 fn test_zero_predicate() {
     let (_vm, mut symbols, meta) = setup();
     let zero_pred = get_primitive(&meta, &mut symbols, "zero?");
@@ -2132,27 +2036,36 @@ fn test_zero_predicate() {
     );
 }
 
+fn run(input: &str) -> String {
+    eval_full(input)
+        .map(|v| format!("{}", v))
+        .unwrap_or_else(|e| panic!("eval failed: {}", e))
+}
+
 #[test]
-fn test_fn_alias() {
-    let (_vm, mut symbols, meta) = setup();
+fn test_fn_predicate() {
+    // fn? is true for both closures and native functions
+    assert_eq!(run("(fn? +)"), "true");
+    assert_eq!(run("(fn? (fn [x] x))"), "true");
+    assert_eq!(run("(fn? 42)"), "false");
+    assert_eq!(run("(fn? nil)"), "false");
+}
 
-    // fn? and function? should both resolve to native functions
-    let fn_pred = get_primitive(&meta, &mut symbols, "fn?");
-    let function_pred = get_primitive(&meta, &mut symbols, "function?");
+#[test]
+fn test_native_fn_predicate() {
+    assert_eq!(run("(native-fn? +)"), "true");
+    assert_eq!(run("(native-fn? (fn [x] x))"), "false");
+    assert_eq!(run("(native-fn? 42)"), "false");
+}
 
-    // Both should be native fns
-    assert!(fn_pred.as_native_fn().is_some());
-    assert!(function_pred.as_native_fn().is_some());
+#[test]
+fn test_native_fn_aliases() {
+    assert_eq!(run("(native? +)"), "true");
+    assert_eq!(run("(primitive? +)"), "true");
+    assert_eq!(run("(native? (fn [x] x))"), "false");
+}
 
-    // Both should give the same result
-    let native = get_primitive(&meta, &mut symbols, "+");
-    assert_eq!(
-        call_primitive(&fn_pred, &[native]).unwrap(),
-        call_primitive(&function_pred, &[native]).unwrap()
-    );
-
-    assert_eq!(
-        call_primitive(&fn_pred, &[Value::int(42)]).unwrap(),
-        call_primitive(&function_pred, &[Value::int(42)]).unwrap()
-    );
+#[test]
+fn test_type_of_native_fn() {
+    assert_eq!(run("(type-of +)"), ":native-fn");
 }


### PR DESCRIPTION
## Summary

- Renames `:native-function` type to `:native-fn` (one line in `heap.rs`)
- Adds `native-fn?` predicate (true for native functions only); aliases: `native?`, `primitive?`
- `fn?` is now a standalone primary predicate (true for closure or native-fn — the broad callable test)
- Removes `function?` (was an alias for `fn?`; name reserved for a future `:function` type)
- `closure?` unchanged

## Breaking changes

- `(type-of +)` now returns `:native-fn` instead of `:native-function`
- `function?` no longer exists; use `fn?` for the same behavior
