### PR TITLE
fix: vm/list-primitives returns symbols; vm/primitive-meta accepts symbols

### DIFF
--- a/demos/docgen/generate.lisp
+++ b/demos/docgen/generate.lisp
@@ -597,7 +597,7 @@ tbody tr:nth-child(even) {
             (let* ((meta (vm/primitive-meta name))
                    (canonical (get meta :name)))
               ## Skip aliases: name passed in doesn't match canonical name
-              (if (not (= name canonical))
+              (if (not (= (string name) canonical))
                 groups
                 (let* ((cat (get meta :category))
                        (existing (get groups cat))

--- a/src/primitives/disassembly.rs
+++ b/src/primitives/disassembly.rs
@@ -395,7 +395,7 @@ pub(crate) const PRIMITIVES: &[PrimitiveDef] = &[
         func: prim_list_primitives,
         signal: Signal { bits: SignalBits::new(SIG_QUERY.0 | SIG_ERROR.0), propagates: 0 },
         arity: Arity::Range(0, 1),
-        doc: "List registered names as a sorted list of strings. Optional category filter.",
+        doc: "List registered names as a sorted list of symbols. Optional category filter.",
         params: &["category?"],
         category: "meta",
         example: "(vm/list-primitives)\n(vm/list-primitives :math)\n(vm/list-primitives :\"special form\")",

--- a/src/vm/signal.rs
+++ b/src/vm/signal.rs
@@ -298,8 +298,20 @@ impl VM {
                     self.docs.keys().collect()
                 };
                 names.sort();
-                let values: Vec<Value> =
-                    names.iter().map(|n| Value::string(n.to_string())).collect();
+                let values: Vec<Value> = unsafe {
+                    let symbols_ptr = crate::context::get_symbol_table();
+                    names
+                        .iter()
+                        .map(|n| {
+                            if let Some(ptr) = symbols_ptr {
+                                let id = (*ptr).intern(n);
+                                Value::symbol(id.0)
+                            } else {
+                                Value::string(n.to_string())
+                            }
+                        })
+                        .collect()
+                };
                 (SIG_OK, crate::value::list(values))
             }
             "primitive-meta" => {
@@ -307,12 +319,28 @@ impl VM {
                     s
                 } else if let Some(s) = arg.as_keyword_name() {
                     s
+                } else if let Some(sym_id) = arg.as_symbol() {
+                    match crate::context::resolve_symbol_name(sym_id) {
+                        Some(s) => s,
+                        None => {
+                            return (
+                                SIG_ERROR,
+                                error_val(
+                                    "internal-error",
+                                    format!(
+                                        "primitive-meta: symbol ID {} not found in symbol table",
+                                        sym_id
+                                    ),
+                                ),
+                            );
+                        }
+                    }
                 } else {
                     return (
                         SIG_ERROR,
                         error_val(
                             "type-error",
-                            "primitive-meta: expected string or keyword".to_string(),
+                            "primitive-meta: expected string, keyword, or symbol".to_string(),
                         ),
                     );
                 };

--- a/tests/elle/vm.lisp
+++ b/tests/elle/vm.lisp
@@ -1,0 +1,21 @@
+(def {:assert-eq assert-eq :assert-true assert-true :assert-false assert-false :assert-err assert-err} ((import-file "tests/elle/assert.lisp")))
+
+## === vm/list-primitives returns symbols ===
+
+(assert-eq (type-of (first (vm/list-primitives))) :symbol "list-primitives elements are symbols")
+
+## === vm/primitive-meta accepts symbols ===
+
+(assert-true (struct? (vm/primitive-meta (quote +))) "primitive-meta accepts symbol")
+
+## === vm/primitive-meta still accepts keywords ===
+
+(assert-true (struct? (vm/primitive-meta :+)) "primitive-meta accepts keyword")
+
+## === vm/primitive-meta still accepts strings ===
+
+(assert-true (struct? (vm/primitive-meta "+")) "primitive-meta accepts string")
+
+## === vm/primitive-meta type error on wrong type ===
+
+(assert-err (fn () (vm/primitive-meta 42)) "primitive-meta rejects integer")


### PR DESCRIPTION
## Summary

- `vm/list-primitives` now returns a list of symbols instead of strings — you can pass them directly to `vm/primitive-meta`
- `vm/primitive-meta` now accepts symbols in addition to strings and keywords
- `demos/docgen/generate.lisp` updated: coerces symbol to string for the alias-skip equality check
- New test file `tests/elle/vm.lisp` covering both primitives

## Before

```lisp
(vm/primitive-meta (first (vm/list-primitives)))  ; type-error: expected string or keyword
```

## After

```lisp
(vm/primitive-meta (first (vm/list-primitives)))  ; works
```
