### PR TITLE
LLM agent subprocess library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,8 @@ ELLE_SKIP_JIT := -e NOMATCH_PLACEHOLDER
 # (eval = dynamic compilation)
 WASM_SKIP := -e eval.lisp
 
+export ELLE_BIN := $(ELLE)
+
 smoke-vm:
 	@echo "=== elle scripts (VM, JIT disabled) ==="
 	@printf '%s\n' tests/elle/*.lisp | \

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -1,31 +1,1436 @@
-# Elle Quickstart
+# Elle Language Reference
 
-Elle is a Lisp with lexical scope, closures, and a signal system.
+Elle is a Lisp with lexical scope, closures, and a signal system. This document is what you need to write correct Elle code.
 
-## Critical gotchas
+---
 
-Read these first — they cause the most bugs.
+## Critical Gotchas
 
-- **`nil` ≠ `()`** — `nil` is falsy; `()` is the empty list and is
-  truthy. Use `empty?` to check end-of-list, not `nil?`.
-- **`#` is comment, `;` is splice** — `;[1 2 3]` spreads into the
-  surrounding form.
-- **`assign` mutates; `set` creates a set** — `(assign x 10)` changes
-  `x`; `(set x 10)` creates the set `|x 10|`.
-- **Only `nil` and `false` are falsy** — `0`, `""`, and `()` are truthy.
-- **Bare = immutable; `@` = mutable** — `[1 2]` is immutable, `@[1 2]`
-  is mutable.
-- **`let` is parallel; `let*` is sequential** — use `let*` when a
-  binding depends on a previous one.
+Read these first. They are the most common sources of bugs.
 
-## Running
+### `nil` ≠ `()` — causes infinite loops
+
+`nil` is falsy. `()` (empty list) is **truthy**. Lists terminate with `()`, not `nil`.
+
+```lisp
+(nil? ())    # => false
+(empty? ())  # => true
+```
+
+**Always use `empty?` to check end-of-list.** If you use `nil?` as your loop termination condition, it will never trigger — `()` is not `nil` — and your recursion will never bottom out.
+
+These are separate values because they are genuinely distinguishable: `()` is what you get when you remove the last element from `(x)` — it's an empty container, not the absence of value. Any abstraction that conflates them is open to error.
+
+### `#` is comment, `;` is splice
+
+```lisp
+# This is a comment
+;[1 2 3]        # Splice: spreads array into surrounding form
+(f 1 ;[2 3] 4)  # => (f 1 2 3 4)
+[1 ;[2 3] 4]    # => [1 2 3 4]  — works in collection literals too
+```
+
+### `assign` mutates; `set` creates a set value
+
+```lisp
+(var x 10)
+(assign x 20)   # Correct: mutates x
+(set x 20)      # Wrong: creates a set collection
+```
+
+### Only `nil` and `false` are falsy
+
+```lisp
+(if 0   :t :f)  # => :t  (0 is truthy)
+(if ""  :t :f)  # => :t  (empty string is truthy)
+(if ()  :t :f)  # => :t  (empty list is truthy)
+(if nil :t :f)  # => :f
+```
+
+### `silence` is a compile-time declaration; `squelch` is a runtime function
+
+```lisp
+# silence: preamble inside a lambda body — constrains a parameter's signal
+(fn [f x]
+  (silence f)   # f must be completely silent at call sites
+  (f x))
+
+# squelch: primitive call — returns a NEW closure that catches signals at runtime
+(let ((safe-f (squelch f :yield)))
+  (safe-f x))
+
+# squelch accepts any signal spec: keyword, set, array, list, or integer
+(squelch f |:yield :error|)   # set of signals
+(squelch f [:yield :error])   # array also works
+
+# Wrong: squelch requires exactly 2 args
+(squelch f)     # arity error
+```
+
+### `let` is parallel; `let*` is sequential — causes "undefined variable"
+
+`let` evaluates all right-hand sides in the **outer** scope. Later bindings
+cannot see earlier ones. Use `let*` when a binding depends on a previous one.
+
+```lisp
+# WRONG: y cannot see x — "undefined variable: x"
+(let ((x 5) (y (* x 2)))
+  y)
+
+# RIGHT: let* makes x visible to y
+(let* ((x 5) (y (* x 2)))
+  y)   # => 10
+```
+
+Also works with array-style syntax:
+
+```lisp
+(let* [[url (parse-url input)]
+       [host url:host]           # host depends on url
+       [conn (tcp/connect host 80)]]  # conn depends on host
+  conn)
+```
+
+If you get "undefined variable" inside a `let` and the variable is defined
+on an earlier line of the same `let`, change `let` to `let*`.
+
+### Bare delimiters = immutable; `@`-prefix = mutable
+
+```lisp
+[1 2 3]    # array (immutable)
+@[1 2 3]   # @array (mutable)
+{:a 1}     # struct (immutable)
+@{:a 1}    # @struct (mutable)
+"hello"    # string (immutable)
+@"hello"   # @string (mutable; get/put/length/push/pop are grapheme-indexed)
+|1 2 3|    # set (immutable)
+@|1 2 3|   # @set (mutable)
+```
+
+`put` on an immutable collection returns a new copy. `put` on a mutable collection mutates in place.
+
+`freeze` and `thaw` convert between mutable and immutable forms for all collection types (strings, arrays, structs, sets). Both are shallow — nested collections keep their original mutability.
+
+### Elle has no `-e` flag and no `-` flags at all
+
+```bash
+echo '(+ 1 2)' | elle        # run one-liner
+elle script.lisp              # run file
+elle                          # REPL
+```
+
+---
+
+## Syntax
+
+### Literals
+
+```lisp
+nil                  # absence of value (falsy)
+true  false          # booleans (not #t/#f)
+42                   # integer (64-bit signed)
+3.14                 # float
+0xFF  0o755  0b1010  # hex, octal, binary
+1_000_000            # underscores ok
+:keyword             # self-evaluating keyword
+'symbol              # quoted symbol
+()                   # empty list (truthy)
+```
+
+### Collections
+
+```lisp
+[1 2 3]              # array
+@[1 2 3]             # @array (mutable)
+{:a 1 :b 2}          # struct
+@{:a 1 :b 2}         # @struct (mutable)
+"hello"              # string
+@"hello"             # @string (mutable; get/put/length/push/pop are grapheme-indexed)
+|1 2 3|              # set
+@|1 2 3|             # @set (mutable)
+(bytes 1 2 3)        # immutable bytes
+(@bytes 1 2 3)       # mutable bytes
+```
+
+### Quoting
+
+```lisp
+'(+ 1 2)             # quote — prevents evaluation
+`(+ 1 ,x)            # quasiquote — unquote with ,
+`(list ,;items)      # unquote-splice with ,;
+```
+
+---
+
+## Binding and Scope
+
+```lisp
+# Top-level immutable (top-level is under implicit letrec,
+# so defs may be mutually recursive without special declaration)
+(def x 42)
+
+# Top-level mutable
+(var x 42)
+(assign x 100)
+
+# Local (parallel bindings — each RHS sees outer scope)
+(let ((x 10) (y 20))
+  (+ x y))
+
+# Sequential (each binding sees previous)
+(let* ((x 5) (y (* x 2)))
+  (+ x y))   # => 15
+
+# Recursive
+(letrec ((f (fn [] (g)))
+         (g (fn [] 42)))
+  (f))
+```
+
+### Destructuring
+
+Destructuring is strict — missing elements or keys signal an error (no silent nil). Extra elements are silently ignored. Works in all binding forms: `def`, `var`, `let`, `let*`, `fn`, `defn`, `match`.
+
+```lisp
+# List
+(def (a b c) (list 1 2 3))
+(def (head & tail) (list 1 2 3))   # head=1, tail=(2 3)
+
+# Array (& rest collects into an array, not a list)
+(def [x y] [10 20])
+(def [first & rest] [1 2 3])       # rest = [2 3]
+
+# Struct
+(def {:x x :y y} {:x 5 :y 10})
+
+# Struct remainder — & collects unmatched keys into a struct
+(def {:a a & more} {:a 1 :b 2 :c 3})  # a=1, more={:b 2 :c 3}
+
+# Wildcard — _ discards the matched value
+(def (_ mid _) (list 10 20 30))    # mid=20
+
+# Nested — any depth, mixed types
+(def ((a b) c) (list (list 1 2) 3))
+(def {:point [_ y]} {:point [:skip :target]})   # y=:target
+
+# In function parameters
+(defn magnitude [{:x x :y y}]
+  (+ x y))
+
+# Mutable destructuring
+(var (a b) (list 1 2))
+(assign a 100)
+```
+
+---
+
+## Functions
+
+```lisp
+# Anonymous
+(fn [x y] (+ x y))
+
+# Named (defn is a macro)
+(defn add [x y] (+ x y))
+
+# With docstring
+(defn add [x y]
+  "Add two numbers."
+  (+ x y))
+
+# Variadic
+(defn sum [& nums]
+  (fold + 0 nums))
+
+# Closures capture lexical environment
+(defn make-adder [n]
+  (fn [x] (+ x n)))
+
+(def add5 (make-adder 5))
+(add5 10)   # => 15
+
+# Optional positional params (nil if omitted)
+(defn greet [name &opt greeting]
+  (println (or greeting "Hello") ", " name "!"))
+(greet "Alice")         # Hello, Alice!
+(greet "Bob" "Hey")     # Hey, Bob!
+
+# Named keyword params (nil if omitted)
+(defn connect [host port &named timeout]
+  [host port timeout])
+(connect "localhost" 8080 :timeout 30)  # => ["localhost" 8080 30]
+(connect "localhost" 8080)              # => ["localhost" 8080 nil]
+
+# Keyword args collected as a struct
+(defn request [method path &keys opts]
+  [method path opts])
+(request "GET" "/" :timeout 30 :headers {:accept "text/html"})
+# => ["GET" "/" {:timeout 30 :headers {:accept "text/html"}}]
+```
+
+---
+
+## Control Flow
+
+```lisp
+# Conditional
+(if test then else)
+
+# Multi-branch
+(cond
+  ((> x 10) :large)
+  ((> x 0)  :small)
+  (true     :zero))
+
+# One-armed
+(when   test body...)
+(unless test body...)
+
+# Equality dispatch
+(case x
+  1 :one
+  2 :two
+  :other)
+
+# Pattern matching (compiler errors on non-exhaustive match;
+# any unbound symbol works as a wildcard, not just _)
+(match value
+  ([a b c] (+ a b c))
+  ({:x x}  x)
+  (_        :default))
+
+# Sequencing (shares surrounding scope — useful in macros to collect
+# expressions without introducing a new lexical scope and its attendant
+# automatic memory management machinery)
+(begin expr1 expr2 ...)
+
+# Sequencing with a new scope
+(block
+  (var x 10)   # x is local to this block
+  x)
+
+# Named block with early exit
+(block :label
+  (each item in items
+    (when (= item target)
+      (break :label item)))
+  nil)
+
+# Loops — (break) exits while/forever directly; no label needed
+(while (< i 10)
+  (assign i (+ i 1)))
+
+(forever
+  (process)
+  (when done (break)))
+
+(repeat 5 (println "hi"))  # run body N times
+
+# break does not cross function boundaries
+
+# Iteration (prelude macro; `in` is optional sugar)
+(each x in [1 2 3]
+  (println x))
+(each x [1 2 3]
+  (println x))        # equivalent
+```
+
+---
+
+## Error Handling
+
+```lisp
+# Raise
+(error {:error :bad-input :message "expected a number"})
+
+# Catch — e is a struct with :error (keyword) and :message (string)
+(try
+  (risky-op)
+  (catch e
+    (get e :error)    # => :division-by-zero etc.
+    (get e :message)  # => "division by zero" etc.
+  ))
+
+# Capture as data — returns [ok? value]
+# protect captures errors as data; try/catch affords a body for control flow
+(def [ok? val] (protect (/ 10 0)))
+
+# Guaranteed cleanup
+(defer (close f)
+  (use f))
+
+# Resource management — with is defer with a constructor binding
+(with f (open "data.txt") close
+  (read-all f))
+```
+
+---
+
+## Collections Reference
+
+### Lists (linked)
+
+```lisp
+(list 1 2 3)
+(cons 1 (list 2 3))
+(first lst)   (second lst)   (rest lst)   (last lst)
+(length lst)
+(append lst1 lst2)
+(reverse lst)
+(take n lst)  (drop n lst)  (butlast lst)
+(empty? lst)   # use this, not nil?
+```
+
+### Arrays (immutable, indexed)
+
+```lisp
+(length [1 2 3])       # => 3
+(get [1 2 3] 1)        # => 2
+(put [1 2 3] 0 99)     # => [99 2 3]  (new array)
+```
+
+### @Arrays (mutable, indexed)
+
+```lisp
+(length @[1 2 3])
+(get @[1 2 3] 1)
+(put @[1 2 3] 0 99)    # mutates in place
+(push @[1 2 3] 4)      # appends, returns same object
+(pop @[1 2 3])         # removes and returns last element
+```
+
+### Structs (immutable)
+
+```lisp
+(get {:a 1} :a)              # => 1
+(get {:a 1} :b :default)     # => :default
+(put {:a 1} :b 2)            # => {:a 1 :b 2}  (new struct)
+(del {:a 1 :b 2} :a)         # => {:b 2}  (new struct)
+(keys {:a 1 :b 2})           # => (:a :b)
+(values {:a 1 :b 2})         # => (1 2)
+(has? {:a 1} :a)             # => true
+(length {:a 1 :b 2})         # => 2
+(merge {:x 1 :y 2} {:y 3 :z 4})  # => {:x 1 :y 3 :z 4}
+(update {:count 5} :count inc)   # => {:count 6}
+(from-pairs [[:a 1] [:b 2]])     # => {:a 1 :b 2}
+
+# Nested access and update (works on structs and arrays)
+(get-in {:a {:b 1}} [:a :b])          # => 1
+(put-in {:a {:b 1}} [:a :b] 2)        # => {:a {:b 2}}
+(update-in {:a {:b 5}} [:a :b] inc)   # => {:a {:b 6}}
+```
+
+### @Structs (mutable)
+
+```lisp
+(put @{:a 1} :b 2)     # mutates in place
+(del @{:a 1 :b 2} :a)  # mutates in place
+```
+
+### Strings (immutable, grapheme-indexed)
+
+```lisp
+(length "hello")              # => 5
+(get "hello" 0)               # => "h"  (grapheme cluster)
+(slice "hello" 1 4)           # => "ell"
+(string/join ["a" "b"] "-")   # => "a-b"
+(string/split "a,b" ",")      # => ["a" "b"]  (array)
+(string/find "hello" "ll")    # => 2  (or nil)
+(string/contains? "hello" "ll")    # => true
+(string/starts-with? "hello" "he") # => true
+(string/ends-with? "hello" "lo")   # => true
+(string/upcase "hello")       # => "HELLO"
+(string/downcase "HELLO")     # => "hello"
+(string/trim "  hi  ")        # => "hi"
+(string/replace "foo-bar" "-" "_") # => "foo_bar"  (replaces all)
+(string/repeat "-" 40)            # => "----...----"
+```
+
+**Byte length vs grapheme length:** `length` returns the grapheme count, not
+the byte count. For byte-level size (e.g. protocol framing, I/O offsets), use
+`string/size-of`:
+
+```lisp
+(length "hello\r\n")        # => 6  (\r\n is one grapheme cluster)
+(string/size-of "hello\r\n") # => 7  (byte count)
+(length "👋🏽")               # => 1  (one grapheme cluster)
+(string/size-of "👋🏽")       # => 8  (4+4 bytes UTF-8)
+```
+
+**String concatenation:** `(string ...)` converts all arguments to strings and concatenates them. This is the preferred way to build strings:
+
+```lisp
+(string "hello " "world")     # => "hello world"
+(string "count: " 42)         # => "count: 42"
+(string "key:" :foo "=" val)  # => "key:foo=123"
+```
+
+`string/join` is for joining a collection with a separator:
+
+```lisp
+(string/join ["a" "b" "c"] ",")  # => "a,b,c"
+```
+
+`string` with multiple args concatenates, coercing non-strings:
+
+```lisp
+(string "a" 3 "b")                     # => "a3b"
+(string/format "{} + {} = {}" 1 2 3)   # => "1 + 2 = 3"
+```
+
+### @Strings (mutable)
+
+`get`, `put`, `length`, `push`, and `pop` are all grapheme-indexed, consistent with immutable strings.
+
+```lisp
+(thaw "hello")         # string → @string
+(freeze @"hello")      # @string → string
+(get @"hello" 0)       # => "h"  (grapheme cluster as string)
+(put @"hello" 0 "H")   # replaces grapheme at index, returns @string
+(length @"hello")      # => 5  (grapheme count)
+(push @"hello" "!")    # appends string, returns @string
+(pop @"hello")         # removes and returns last grapheme cluster as string
+```
+
+### Sets
+
+```lisp
+|1 2 3|                      # immutable set
+@|1 2 3|                     # mutable set
+(contains? |1 2 3| 2)        # => true
+(add @|1 2 3| 4)             # mutates in place
+(del @|1 2 3| 1)             # mutates in place
+(union s1 s2)
+(intersection s1 s2)
+(difference s1 s2)
+```
+
+### Bytes
+
+```lisp
+(bytes 1 2 3)
+(bytes "hello")              # string → bytes (UTF-8)
+(get (bytes 1 2 3) 0)        # => 1
+(length (bytes 1 2 3))       # => 3
+(seq->hex (bytes 1 2 3))     # => "010203"  (canonical name)
+(bytes->hex (bytes 1 2 3))   # => "010203"  (alias for seq->hex)
+(seq->hex [1 2 3])           # => "010203"  (also works with arrays)
+(seq->hex 255)               # => "ff"      (and non-negative integers)
+(seq->hex 0)                 # => "00"
+(string (bytes 97 98 99))    # => "abc"
+```
+
+### Boxes (mutable cells)
+
+```lisp
+(box 42)
+(unbox b)
+(rebox b 99)
+```
+
+---
+
+## Higher-Order Functions
+
+```lisp
+(map    f [1 2 3])           # => (2 4 6)  — returns list
+(filter f [1 2 3 4])         # => (3 4)    — returns list
+(fold   f init [1 2 3])      # => 10
+(apply  f [1 2 3])           # => (f 1 2 3)
+(sum [1 2 3 4])              # => 10
+(product [1 2 3 4])          # => 24
+
+# Type conversion
+(->array (list 1 2 3))      # => [1 2 3]
+(->list [1 2 3])             # => (1 2 3)
+(->array "abc")              # => ["a" "b" "c"]
+
+# Mutability conversion
+(freeze @[1 2 3])            # => [1 2 3]   (shallow)
+(thaw [1 2 3])               # => @[1 2 3]  (shallow)
+(deep-freeze @[@[1] @{:a 2}])  # => [[1] {:a 2}]  (recursive)
+
+# Threading macros
+(-> 5 (+ 10) (* 2))          # => 30  (insert as first arg)
+(->> [1 2 3] (map double))   # (insert as last arg)
+```
+
+Note: `map` and `filter` always return lists, even when given arrays.
+
+### Sorting
+
+```lisp
+(sort [3 1 2])                    # => (1 2 3)  — natural order
+(sort-by length ["bb" "a" "ccc"]) # => ("a" "bb" "ccc")  — by key function
+(sort-with (fn [a b] (> a b)) [3 1 2])  # => (3 2 1)  — custom comparator
+```
+
+---
+
+## Arithmetic and Math
+
+```lisp
+(+ 1 2 3)   (- 10 3)   (* 2 3 4)
+(/ 10 2)               # integer division truncates
+(/ 7.0 2)              # => 3.5
+(mod 10 3)             # => 1   (flooring: sign follows divisor)
+(rem 10 3)             # => 1   (truncating: sign follows dividend)
+(mod -10 3)            # => 2
+(rem -10 3)            # => -1
+(abs -5)
+(min 3 1 4)  (max 3 1 4)
+(even? 4)    (odd? 3)
+
+(math/sqrt 16)   (math/cbrt 27)   (math/pow 2 10)
+(math/floor 3.7) (math/ceil 3.2)  (math/round 3.5)  (math/trunc 3.7)
+(math/sin x)     (math/cos x)     (math/tan x)
+(math/asin x)    (math/acos x)    (math/atan x)     (math/atan2 y x)
+(math/sinh x)    (math/cosh x)    (math/tanh x)
+(math/exp x)     (math/exp2 x)
+(math/log x)     (math/log2 x)    (math/log10 x)
+(math/pi)        (math/e)
+# All math/ functions have bare aliases: sqrt, sin, log2, etc.
+
+(bit/and 12 10)  (bit/or 12 10)  (bit/xor 12 10)
+(bit/not 0)      (bit/shl 1 3)   (bit/shr 16 2)
+```
+
+### Comparison and Equality
+
+```lisp
+(= 1 1)         # => true  (structural equality)
+(= [1 2] @[1 2]) # => true  (cross-mutability: same contents = equal)
+(not= 1 2)       # => true  (inequality)
+(< 1 2)         (> 2 1)
+(<= 1 1)        (>= 2 1)
+(hash :foo)      # => integer  (deterministic hash of any value)
+```
+
+### Logical Operators
+
+```lisp
+(and x y z)     # short-circuiting; returns last truthy or first falsy
+(or x y z)      # short-circuiting; returns first truthy or last falsy
+(not false)     # => true  (not is a function, not a macro)
+```
+
+---
+
+## Type System
+
+```lisp
+(type-of 42)        # => :integer
+(type-of 3.14)      # => :float
+(type-of "hi")      # => :string
+(type-of :kw)       # => :keyword
+(type-of nil)       # => :nil
+(type-of ())        # => :list
+(type-of [1 2])     # => :array
+(type-of {:a 1})    # => :struct
+(type-of true)      # => :boolean
+(type-of (fn [] 1)) # => :closure  (use fn? to test)
+(type-of +)         # => :native-fn
+(type-of ptr)       # => :ptr
+
+# Predicates
+(nil? x)      (boolean? x)   (number? x)
+(integer? x)  (float? x)     (symbol? x)
+(keyword? x)  (string? x)    (pair? x)
+(list? x)     (empty? x)     (array? x)
+(struct? x)   (bytes? x)     (set? x)
+(box? x)      (fiber? x)
+(fn? x)          # closure or native-fn (any callable)
+(closure? x)     # user-defined closures only
+(native-fn? x)   # native functions only; aliases: native?, primitive?
+(mutable? x)     # true for @array, @struct, @string, @bytes, @set, box
+(immutable? x)   # complement of mutable?
+(zero? x)        # 0 or 0.0
+(nonzero? x)     # complement of zero?
+(nonempty? x)    # complement of empty?
+(pos? x)         # number > 0
+(neg? x)         # number < 0
+(nan? x)         # float NaN
+(inf? x)         # float infinity
+
+# Conversions
+(integer "42")             (float "3.14")
+(integer "ff" 16)          # => 255  (hex, radix 2–36)
+(integer "1010" 2)         # => 10   (binary)
+(string 42)                (string 'foo)   # => "foo"
+(string :foo)              # => "foo"  (no colon)
+(string @"hello")          # => "hello"  (@string → string)
+(number->string 42)        # => "42"  (decimal)
+(number->string 255 16)    # => "ff"   (hex, radix 2–36)
+(number->string 255 2)     # => "11111111"  (binary)
+```
+
+---
+
+## Macros
+
+Macros receive unevaluated syntax and return syntax to be evaluated.
+
+### Quasiquote-based macros
+
+Use quasiquote (`` ` ``), unquote (`,`), and unquote-splice (`,;`) to construct output:
+
+```lisp
+(defmacro when [test & body]
+  `(if ,test (begin ,;body) nil))
+```
+
+### `syntax-case` — pattern-matching macros
+
+For more precise structural matching, use `syntax-case`. It matches against the macro's input syntax and binds pattern variables:
+
+```lisp
+(defmacro swap! [a b]
+  (syntax-case (list a b)
+    ([x y]
+     `(let ((tmp ,x))
+        (assign ,x ,y)
+        (assign ,y tmp)))))
+```
+
+Patterns:
+- `_` — wildcard, matches anything
+- `x` — pattern variable, binds the matched syntax
+- `(a b)` — matches a 2-element list, binds `a` and `b`
+- `(literal sym)` — matches the symbol `sym` literally
+- Guards: `(pat when guard-expr body)`
+- Multiple clauses: first match wins
+
+---
+
+## Signals and Fibers
+
+Signals are the unified mechanism for all non-local control flow. Every signal is a bit in a mask.
+
+**Built-in signals:** `:error` (bit 0), `:yield` (bit 1), `:debug` (bit 2), `:ffi` (bit 4), `:halt` (bit 8), `:io` (bit 9), `:exec` (bit 11), `:fuel` (bit 12).
+
+```lisp
+# Create a fiber (mask = SIG_YIELD = 2)
+(def f (fiber/new (fn [] (yield 42)) 2))
+
+# Resume, delivering a value; returns the next yielded value
+(fiber/resume f nil)
+
+# Inspect
+(fiber/status f)   # :new :alive :suspended :dead :error
+(fiber/value f)    # signal value
+(fiber/bits f)     # signal bits
+(fiber/mask f)     # signal mask
+
+# Terminate
+(fiber/cancel f)   # hard kill (no unwinding)
+(fiber/abort f)    # graceful (with unwinding)
+
+# The signal mask is fixed at fiber creation time.
+# Uncaught signals propagate to the parent fiber.
+# Uncaught errors crash the runtime — you don't need ev/join for propagation.
+
+# Errors are NOT implicitly unwinding. A parent that catches an error
+# can resume the errored fiber to offer restart functionality.
+
+# Signal inference: the compiler infers signal types from the body.
+# silence constrains a parameter to be silent at compile time.
+# squelch wraps a closure at runtime to catch signals.
+```
+
+---
+
+## I/O and Subprocesses
+
+### Ports (not-thread-safe)
+
+```lisp
+(port/open "file.txt" :read)
+(port/open "file.txt" :write)
+(port/read p n)          # read n bytes
+(port/write p bytes)
+(port/close p)
+(port/seek p offset)     # seek to byte offset (default: from start)
+(port/seek p off :from :end)  # seek from end
+(port/tell p)            # current byte position
+(port/lines p)           # stream of lines
+(port/chunks p n)        # stream of byte chunks
+(port/writer p)          # writable stream
+```
+
+### Subprocess
+
+```lisp
+# Run to completion — returns {:exit int :stdout string :stderr string}
+(subprocess/system "echo" ["hello"])
+# => {:exit 0 :stdout "hello\n" :stderr ""}
+
+# With options
+(subprocess/system "ls" ["-la"] {:cwd "/tmp"})
+(subprocess/system "env" [] {:env {:FOO "bar"}})
+
+# Low-level
+(def proc (subprocess/exec "cat" []))
+(subprocess/pid proc)
+(subprocess/wait proc)
+(subprocess/kill proc)
+```
+
+### Streams
+
+Streams are lazy and pull-based. Use `stream/map`, `stream/filter`, etc. to transform streams — the eager `map`/`filter` functions operate on lists, not streams.
+
+```lisp
+(stream/map    f stream)
+(stream/filter f stream)
+(stream/take   n stream)
+(stream/drop   n stream)
+(stream/concat s1 s2)
+(stream/zip    s1 s2)
+(stream/for-each f stream)
+(stream/fold   f init stream)
+(stream/collect stream)       # => list
+(stream/into-array stream)    # => array
+(stream/pipe src dst)
+```
+
+### Async I/O and Structured Concurrency
+
+User code runs inside the async scheduler automatically. Port I/O
+(`port/write`, `port/read`, etc.) yields to the scheduler — no setup needed.
+
+**Spawn and join** — the fundamental building blocks:
+
+```lisp
+# Spawn a fiber, wait for its result
+(def f (ev/spawn (fn [] (port/read-all (port/open "data.txt" :read)))))
+(def content (ev/join f))
+
+# Join a sequence — results in input order
+(def [a b] (ev/join [(ev/spawn (fn [] (fetch "/users")))
+                      (ev/spawn (fn [] (fetch "/posts")))]))
+```
+
+**Parallel map** — the most common pattern:
+
+```lisp
+(ev/map (fn [url] (http/get url)) urls)   # → [response1 response2 ...]
+```
+
+**Error handling** — `ev/join-protected` returns `[ok? value]` instead of
+raising errors:
+
+```lisp
+(let (([ok? val] (ev/join-protected (ev/spawn (fn [] (flaky-api-call))))))
+  (if ok? val (cached-fallback)))
+```
+
+**Select, race, timeout** — waiting for the first of N:
+
+```lisp
+# First to complete wins; abort the rest
+(ev/race [(ev/spawn (fn [] (query-replica-1)))
+          (ev/spawn (fn [] (query-replica-2)))])
+
+# Deadline on a computation
+(ev/timeout 5 (fn [] (http/get "https://slow-api.example.com")))
+```
+
+**Scoped concurrency** — all children must finish before scope exits:
+
+```lisp
+(ev/scope (fn [spawn]
+  (let ([users    (spawn (fn [] (fetch "/users")))]
+        [settings (spawn (fn [] (fetch "/settings")))])
+    # If /settings fails, /users is aborted automatically
+    {:users (ev/join users) :settings (ev/join settings)})))
+```
+
+Key primitives:
+
+```lisp
+(ev/spawn thunk)            # create a fiber, returns fiber handle
+(ev/join fiber-or-seq)      # wait for result(s), propagate errors
+(ev/join-protected target)  # wait without raising — returns [ok? value]
+(ev/abort fiber)            # graceful cancel (defer blocks run)
+(ev/select fibers)          # wait for first → [done remaining]
+(ev/race fibers)            # first wins, abort rest, return value
+(ev/timeout secs thunk)     # deadline — returns value or {:error :timeout}
+(ev/scope (fn [spawn] ...)) # nursery — children can't outlive scope
+(ev/map f items)            # parallel map, results in order
+(ev/map-limited f items n)  # bounded parallel map (at most n in flight)
+(ev/as-completed fibers)    # lazy iterator → [next-fn pool]
+(ev/sleep seconds)          # yield for N seconds
+
+(tcp/listen addr port)      # bind and listen, returns listener
+(tcp/accept listener)       # yields until connection, returns port
+(tcp/connect host port)     # yields until connected, returns port
+
+(port/write port data)      # async write (yields)
+(port/flush port)           # async flush (yields)
+(port/read port n)          # async read N bytes (yields)
+(port/read-line port)       # async read until \n (yields), nil on EOF
+```
+
+**Important:** `port/write` and `port/flush` signal `:yield`. `print`/`println`
+and `eprint`/`eprintln` are also async — they write to `*stdout*`/`*stderr*`
+via the same async I/O path.
+
+### Channels
+
+Crossbeam-based channels for inter-fiber (and inter-thread) messaging. Often unnecessary in single-threaded designs where a list or array suffices.
+
+```lisp
+(def [tx rx] (chan))            # unbounded channel; returns [sender receiver]
+(def [tx rx] (chan 10))         # bounded (capacity 10)
+
+(chan/send tx 42)               # non-blocking; returns [:ok], [:full], or [:disconnected]
+(chan/recv rx)                  # non-blocking; returns [:ok msg], [:empty], or [:disconnected]
+
+(chan/clone tx)                 # clone sender (multiple producers)
+(chan/close tx)                 # close sender half
+(chan/close-recv rx)            # close receiver half
+
+# Multiplex: block until one receiver has data
+(chan/select @[r1 r2])          # => [index msg] or [:disconnected]
+(chan/select @[r1 r2] 1000)    # with timeout (ms); may return [:timeout]
+```
+
+### Threads
+
+```lisp
+(def handle (sys/spawn (fn [] (+ 1 2))))  # spawn OS thread
+(sys/join handle)                          # wait for result; => 3
+(sys/thread-id)                            # current thread ID
+```
+
+### Output
+
+```lisp
+(print "no newline")           # write to *stdout*, no newline
+(println "with newline")       # write to *stdout* + newline
+(println "count: " 42)         # multiple args concatenated
+(println)                      # just a newline
+
+(eprint "no newline")          # write to *stderr*, no newline
+(eprintln "error: bad input")  # write to *stderr* + newline
+```
+
+All four respect `*stdout*`/`*stderr*` parameter rebinding.
+
+### Dynamic Parameters
+
+You can define your own dynamic parameters with `make-parameter`:
+
+```lisp
+(def *my-param* (make-parameter :default-value))
+(*my-param*)                  # => :default-value
+(parameter? *my-param*)       # => true
+
+(parameterize ((*my-param* :overridden))
+  (*my-param*))               # => :overridden
+
+# Built-in parameters include *stdout* and *stderr*
+(parameterize ((*stdout* my-port))
+  (println "goes to my-port, not terminal"))
+```
+
+`pp` pretty-prints data structures in literal form (useful for debugging):
+
+---
+
+## Modules and Imports
+
+```lisp
+# Import an Elle file (executes it, returns last value)
+(import "lib/http.lisp")
+(import-file "lib/http.lisp")   # alias
+
+# Import a plugin (.so) — returns a struct of its functions
+(def crypto (import "target/release/libelle_crypto.so"))
+```
+
+Importing a plugin returns a struct of its functions. Bind it to use them — plugin functions are **not** injected into the global scope.
+
+---
+
+## Plugins
+
+Plugins are Rust cdylib crates that extend Elle with new primitives. `import` loads the `.so` and returns a struct of its functions. Bind the result — functions are not injected into scope.
+
+**Build plugins before use:**
+```bash
+cargo build --release -p elle-crypto
+# produces target/release/libelle_crypto.so
+```
+
+**Pattern:**
+```lisp
+(def crypto (import "target/release/libelle_crypto.so"))
+(seq->hex ((get crypto :sha256) "hello"))  # seq->hex is the canonical name
+
+# Or destructure:
+(def {:sha256 sha256 :hmac-sha256 hmac} (import "target/release/libelle_crypto.so"))
+(seq->hex (sha256 "hello"))
+# (bytes->hex is an alias for seq->hex and still works)
+```
+
+### Selected Plugins
+
+Elle ships with 23+ plugins. Here are a few commonly used ones:
+
+#### `elle-crypto` — SHA-2 hashing and HMAC
+
+```lisp
+(def crypto (import "target/release/libelle_crypto.so"))
+# Keys: :sha224 :sha256 :sha384 :sha512
+#       :hmac-sha224 :hmac-sha256 :hmac-sha384 :hmac-sha512
+(seq->hex ((get crypto :sha256) "hello"))  # seq->hex is canonical
+(seq->hex ((get crypto :hmac-sha256) "key" "message"))
+```
+
+#### `elle-glob` — Filesystem glob patterns
+
+```lisp
+(def glob (import "target/release/libelle_glob.so"))
+# Keys: :glob :match? :match-path?
+((get glob :glob) "src/**/*.rs")           # => list of matching paths
+((get glob :match?) "*.lisp" "foo.lisp")   # => true
+```
+
+#### `elle-random` — Pseudo-random numbers
+
+```lisp
+(def random (import "target/release/libelle_random.so"))
+# Keys: :int :float :bool :shuffle
+((get random :int) 1 100)      # random integer in [1, 100]
+((get random :float))          # random float in [0.0, 1.0)
+((get random :shuffle) [1 2 3])
+```
+
+#### `elle-regex` — Regular expressions
+
+```lisp
+(def re (import "target/release/libelle_regex.so"))
+# Keys: :compile :match? :find :find-all :split :replace
+(def pat ((get re :compile) "\\d+"))
+((get re :match?) pat "abc123")           # => true
+((get re :find) pat "abc123def")          # => "123"
+((get re :replace) pat "a1b2" "N")        # => "aNbN"
+```
+
+#### `elle-sqlite` — SQLite database
+
+```lisp
+(def sqlite (import "target/release/libelle_sqlite.so"))
+# Keys: :open :query :exec :close
+(def db ((get sqlite :open) "data.db"))
+((get sqlite :exec) db "CREATE TABLE t (id INTEGER, name TEXT)")
+((get sqlite :query) db "SELECT * FROM t")
+# => list of structs: ({:id 1 :name "Alice"} ...)
+((get sqlite :close) db)
+```
+
+#### `elle-hash` — Universal hashing
+
+```lisp
+(def hash (import "target/release/libelle_hash.so"))
+# Keys: :md5 :sha1 :sha224 :sha256 :sha384 :sha512 :sha512-224 :sha512-256
+#       :sha3-224 :sha3-256 :sha3-384 :sha3-512
+#       :blake2b-512 :blake2s-256 :blake3 :blake3-keyed :blake3-derive
+#       :crc32 :xxh32 :xxh64 :xxh128
+
+(bytes->hex (hash:sha256 "hello"))
+# => "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+
+(bytes->hex (hash:blake3 "hello"))
+# => "ea8f163db38682925e4491c5e58d4bb3506ef8c14eb78a86e908c5624a67200f"
+
+(hash:crc32 "hello")
+# => 907060870
+
+(hash:xxh64 "hello")
+# => integer
+
+# Streaming (incremental) hashing
+(let* [[ctx (hash:new :sha256)]]
+  (hash:update ctx "hel")
+  (hash:update ctx "lo")
+  (bytes->hex (hash:finalize ctx)))
+# => same as (bytes->hex (hash:sha256 "hello"))
+
+# Compose with stream/fold and port/chunks
+(let* [[ctx (stream/fold hash:update (hash:new :sha256) (port/chunks port 8192))]]
+  (hash:finalize ctx))
+
+# Or use the convenience wrapper (lib/hash.lisp)
+(def h ((import-file "lib/hash.lisp") hash))
+(bytes->hex (h:file :sha256 "bigfile.bin"))
+```
+
+#### `elle-selkie` — Mermaid diagram rendering
+
+```lisp
+(def selkie (import "target/release/libelle_selkie.so"))
+# Keys: :render :render-to-file
+((get selkie :render) "graph TD\n  A --> B")
+((get selkie :render-to-file) "graph TD\n  A --> B" "out.svg")
+```
+
+#### `elle-tls` — TLS client and server via rustls
+
+```lisp
+(import "target/release/libelle_tls.so")
+(def tls ((import-file "lib/tls.lisp")))
+# Client: tls:connect, tls:read, tls:write, tls:read-all, tls:close
+# Server: tls:server-config, tls:accept
+(let ((conn (tls:connect "example.com" 443)))
+  (defer (tls:close conn)
+    (tls:write conn "GET / HTTP/1.1\r\nHost: example.com\r\nConnection: close\r\n\r\n")
+    (println (string (tls:read-all conn)))))
+```
+
+#### `elle-tree-sitter` — Multi-language parsing and structural queries
+
+```lisp
+(def ts (import "target/release/libelle_tree_sitter.so"))
+# Keys: :parse :query :root :children :text :kind :node-at :walk
+(def tree ((get ts :parse) :rust "fn main() { 42 }"))
+(def matches ((get ts :query) tree "(integer_literal) @num"))
+```
+
+### Plugin Gotchas
+
+- `import` returns a **struct** — functions are accessed via `get`, not called by name.
+- Plugins are **never unloaded** — the library handle is intentionally leaked.
+- Plugins have **no stable ABI** — recompile when upgrading Elle.
+- The analyzer has **no static knowledge** of plugin functions — no compile-time checking.
+- Every `import` call **reloads** the plugin — plugins follow the same strict re-interpretation code-path as modules.
+
+---
+
+## Subprocess and System Args
+
+```lisp
+# Args after the source file on the command line (includes the literal "--")
+# elle script.lisp -- foo bar baz  =>  ("--" "foo" "bar" "baz")
+# elle script.lisp                 =>  ()
+(def args (sys/args))
+(def real-args (drop 1 args))   # skip the "--" separator
+
+# Environment
+(sys/env)              # => struct of all env vars as strings
+(sys/env "HOME")       # => single var lookup, or nil if unset
+```
+
+**Example script using args:**
+```lisp
+# greet.lisp
+(def args (drop 1 (sys/args)))   # skip "--"
+(if (empty? args)
+  (println "Usage: elle greet.lisp -- <name>")
+  (println (string "Hello, " (first args) "!")))
+```
+```bash
+elle greet.lisp -- Alice   # => Hello, Alice!
+```
+
+---
+
+## Introspection and Help
+
+Elle's API has three layers:
+
+1. **VM primitives** — native functions implemented in Rust (`+`, `get`, `port/write`, etc.)
+2. **stdlib.lisp** — standard library closures and macros (`map`, `filter`, `fold`, etc.)
+3. **prelude.lisp** — higher-level abstractions (`ev/spawn`, `ev/join`, `ev/map`, `each`, `match`, etc.)
+
+`vm/list-primitives` and `vm/primitive-meta` only cover layer 1 — they do NOT
+list stdlib or prelude functions. If you don't find something in the primitive
+list, **check stdlib.lisp and prelude.lisp in the project root** — they are
+the source of truth for the full API.
+
+`doc` works across all three layers:
+
+```lisp
+# doc works on primitives
+(doc +)
+# (+ xs)
+#   Sum all arguments. Returns 0 for no arguments.
+#   arity: 0+
+#   example: (+ 1 2 3) #=> 6
+
+# doc also works on prelude functions
+(doc ev/spawn)  # => "Spawn a closure in a new fiber ..."
+(doc ev/join)   # => "Wait for a fiber or sequence of fibers ..."
+(doc each)      # => "(each (name list) body...) ..."
+
+# vm/list-primitives lists ONLY native VM primitives, not stdlib/prelude
+(vm/list-primitives)
+
+# vm/primitive-meta returns metadata for a primitive
+(vm/primitive-meta "+")
+# => {:name "+" :doc "..." :arity "0+" :params ("xs") :signal "silent+errors"
+#     :aliases () :category "arithmetic" :example "..."}
+
+# To discover stdlib/prelude functions, read the source files:
+#   stdlib.lisp   — map, filter, fold, append, reverse, etc.
+#   prelude.lisp  — ev/spawn, ev/join, ev/map, each, match, cond, etc.
+```
+
+---
+
+## Common Patterns
+
+### Tail-recursive list processing
+
+Tail call optimization is guaranteed — tail calls in Elle never grow the stack.
+
+```lisp
+(defn sum [lst acc]
+  (if (empty? lst)
+    acc
+    (sum (rest lst) (+ acc (first lst)))))
+
+(sum [1 2 3 4 5] 0)   # => 15
+```
+
+### Mutable accumulator
+
+```lisp
+# var captures in closures are semantically box-like
+(defn make-counter []
+  (var n 0)
+  (fn []
+    (assign n (+ n 1))
+    n))
+```
+
+### Safe error capture
+
+```lisp
+(def [ok? val] (protect (risky-op)))
+(if ok?
+  (use val)
+  (handle-error val))
+```
+
+### Struct update
+
+```lisp
+(update state :count inc)                    # apply function to one key
+(merge state {:count (+ (get state :count) 1)})  # merge for multiple keys
+(update-in config [:db :pool-size] inc)      # nested update
+```
+
+### Iterate with index
+
+```lisp
+(var i 0)
+(each x in items
+  (println i x)
+  (assign i (+ i 1)))
+```
+
+---
+
+## What Doesn't Exist
+
+These are things agents commonly reach for that Elle does not have:
+
+| Missing | Use instead |
+|---------|-------------|
+| `string-append` | `(string "a" x "b")` for concatenation; `string/join` for joining with separator |
+| `-e` flag | `echo '...' \| elle` |
+| `set!` / `set` for mutation | `assign` |
+| `#t` / `#f` | `true` / `false` |
+| `define` | `def` / `defn` / `var` |
+| `lambda` | `fn` |
+| `begin` as scoped sequencing | `block` (`begin` shares surrounding scope) |
+| `display` | `print` (epoch 3 renamed `display` to `print`) |
+| `write` (literal form) | `pp` for pretty-print, or `port/write` for port I/O |
+| Mutable struct field update | `put` on `@struct` |
+| `null` | `nil` |
+| `char` type | `string` and `@string` are grapheme-indexed; use `get` to extract a grapheme cluster as a string |
+| `function?` | `fn?` (callable), `closure?` (closure only), `native-fn?` (native only) |
+
+---
+
+## Deeper Understanding
+
+### `silence` vs `squelch`
+
+They solve different problems at different times:
+
+- **`silence`** is a compile-time declaration. It appears in a function preamble and means "totally silent" — no signal keywords accepted. Two forms: `(silence)` constrains the whole function body; `(silence param)` constrains a parameter. If a `(silence)` function's body may emit signals, the **compiler rejects it** at compile time. If a `(silence param)` parameter emits a signal at runtime, it becomes a `:signal-violation` error.
+
+- **`squelch`** is a runtime primitive that returns a **new closure** with a selective signal blacklist. It takes exactly two arguments: a closure and a signal spec (keyword, set, array, list, or integer). You can compose them: `(squelch (squelch f :yield) :error)`.
+
+```lisp
+# silence — total compile-time contract
+(defn safe-map [f xs]
+  (silence f)              # f must be completely silent
+  (map f xs))
+
+# squelch — selective runtime wrapper
+(defn safe-iterate [f xs]
+  (let ((safe-f (squelch f |:yield|)))  # forbid :yield only
+    (map safe-f xs)))
+```
+
+| Aspect | `silence` | `squelch` |
+|--------|-----------|-----------|
+| Type | Special form (preamble) | Runtime primitive |
+| Granularity | All-or-nothing | Per-signal keyword |
+| Checking | Compile-time (body) / runtime (params) | Runtime |
+| Returns | `nil` | New closure |
+
+### `begin` vs `block`
+
+`begin` is the default sequential form. `block` is for early exit.
+
+- **`begin`** shares the surrounding scope. Inside a function body, it performs two-pass analysis (pre-binds all `def`/`var` forms, then analyzes), enabling forward references and mutual recursion. All multi-body macros (`when`, `unless`, `let*`, etc.) desugar to `begin`.
+
+- **`block`** creates a new isolated scope and supports `break` for early exit with a value. It has more overhead (scope infrastructure, exit labels, region tracking).
+
+```lisp
+# begin — idiomatic for sequencing (used in macro expansion)
+(when ready
+  (begin
+    (process)
+    (cleanup)))
+
+# block — needed for early exit
+(block :search
+  (each item in items
+    (when (= item target)
+      (break :search item)))
+  nil)
+```
+
+Use `begin` unless you need `break`.
+
+### Fiber signal masks
+
+Signal masks accept multiple formats, but **set literals are preferred**:
+
+```lisp
+# Preferred — symbolic set literal
+(fiber/new (fn [] (yield 42)) |:yield|)
+(fiber/new thunk |:yield :io|)
+
+# Also accepted: keyword, array, integer
+(fiber/new thunk :yield)
+(fiber/new thunk [:yield :io])
+(fiber/new thunk 2)              # raw bit value (fragile)
+```
+
+Built-in signal bits: `:error` (0), `:yield` (1), `:debug` (2), `:ffi` (4), `:halt` (8), `:io` (9), `:exec` (11), `:fuel` (12), `:wait` (14). User-defined signals (via `(signal :keyword)`) get bits 16–31.
+
+The runtime resolves set literals by looking up each keyword in the signal registry and OR-ing the bits together. Use `|:yield :io|` rather than `(bit/or 2 512)`.
+
+### `import` reloads every time
+
+There is no module cache. Every `import` call reads the file, compiles it, and executes it fresh. This is intentional — it gives each import independent state:
+
+```lisp
+# Two imports of the same counter module get independent state
+(let ([c1 ((import-file "lib/counter.lisp"))]
+      [c2 ((import-file "lib/counter.lisp"))])
+  (c1:inc) (c1:inc)
+  (c1:count)   # => 2
+  (c2:count))  # => 0
+```
+
+**To avoid redundant loads**, bind the result at the top level and reuse it:
+
+```lisp
+(def utils (import-file "lib/utils.lisp"))
+(utils:helper1 x)
+(utils:helper2 y)
+```
+
+For plugins (`.so` files), the library handle is intentionally leaked (never unloaded). Importing the same plugin twice registers primitives twice, so always bind once.
+
+### Lists vs arrays
+
+`map` and `filter` always return lists because Elle follows the Lisp tradition of structural recursion with `cons`/`first`/`rest`. Lists are the natural output of recursive accumulation.
+
+**When to use which:**
+- **Lists** — functional pipelines (`map`, `filter`, `fold`), recursive processing, variable-length results
+- **Arrays** — indexed access, fixed-size data, interop with plugins expecting arrays
+
+**Getting arrays from transforms:**
+- `stream/into-array` — collect a stream into an array
+- `mapcat` on arrays — preserves array type
+- `map-indexed` on arrays — preserves array type
+- Manual: accumulate into `@[]` with `push`, then `freeze`
+
+### `protect` vs `try/catch`
+
+They have different return conventions and error propagation:
+
+```lisp
+# try/catch — handle and recover
+(try
+  (risky-op)
+  (catch e
+    (fallback e)))       # returns fallback value
+
+# protect — capture as data, never propagates
+(def [ok? val] (protect (risky-op)))
+(if ok? (use val) (handle val))
+
+# defer — guaranteed cleanup, then propagates
+(defer (cleanup)
+  (risky-op))           # error continues unwinding after cleanup
+```
+
+| Aspect | `try/catch` | `protect` | `defer` |
+|--------|------------|----------|--------|
+| On success | Body value | `[true value]` | Body value |
+| On error | Handler result | `[false error]` | Propagates |
+| Error escapes? | Only if handler re-raises | Never | Always |
+| Use case | Recovery | Safe capture | Resource cleanup |
+
+All three are macros over `fiber/new` with mask `1` (`SIG_ERROR`). The difference is what happens after the fiber completes: `try/catch` runs a handler, `protect` wraps the result, `defer` calls `fiber/propagate` to continue unwinding.
+
+### Streams are lazy coroutines
+
+Streams are **lazy, demand-driven coroutines**. Each `coro/resume` pulls exactly one value. Transforms like `stream/map` and `stream/filter` return new coroutines that wrap a source — nothing executes until you pull.
+
+```lisp
+# Infinite stream — works because it's lazy
+(defn naturals []
+  (coro/new (fn []
+    (var n 0)
+    (forever
+      (yield n)
+      (assign n (+ n 1))))))
+
+# Compose lazily, consume finitely
+(stream/collect
+  (stream/take 5
+    (stream/map (fn [x] (* x x))
+      (naturals))))
+# => (0 1 4 9 16)
+```
+
+**Sink combinators** (`stream/collect`, `stream/fold`, `stream/for-each`, `stream/into-array`) consume a stream to completion — don't call them on infinite streams without `stream/take`.
+
+**Port streams** (`port/lines`, `port/chunks`) yield `SIG_IO` under the hood. User code runs inside the async scheduler by default, so this works out of the box.
+
+---
+
+## Running and Testing
 
 ```bash
 elle script.lisp          # run a file
-elle script.md            # run literate markdown
 echo '(+ 1 2)' | elle     # one-liner
 elle                       # REPL
-make smoke                 # run all tests (~30s)
+
+make smoke                 # ~15s: run examples
+make test                  # ~2min: build + examples + unit tests
+cargo test --workspace     # ~30min: full suite (ask first)
 ```
 
 ## Language topics

--- a/lib/AGENTS.md
+++ b/lib/AGENTS.md
@@ -18,7 +18,7 @@ depend on other modules or plugins take them as arguments.
 | `lua.lisp` | Lua standard library compatibility prelude |
 | `process.lisp` | Erlang-style processes + GenServer, Actor, Supervisor |
 | `sync.lisp` | Concurrency primitives: lock, semaphore, condvar, rwlock, barrier, latch, once, queue, monitor (built on futex) |
-| `agent.lisp` | LLM agent subprocess abstraction (Claude Code / OpenCode) |
+| `agent.lisp` | LLM agent subprocess abstraction (Claude Code / OpenCode / Pi) |
 
 ---
 
@@ -28,9 +28,10 @@ Agent guide for `lib/agent.lisp` — LLM agent subprocess abstraction.
 
 ## Purpose
 
-Runtime abstraction over Claude Code and OpenCode subprocesses. One subprocess
-per turn, session continuation via `--resume` (Claude) or `--session --continue`
-(OpenCode). The handle is mutable and tracks the session ID across sends.
+Runtime abstraction over Claude Code, OpenCode, and Pi subprocesses. One
+subprocess per turn, session continuation via `--resume` (Claude) or
+`--session --continue` (OpenCode / Pi). The handle is mutable and tracks
+the session ID across sends.
 
 ## Data flow
 
@@ -53,19 +54,19 @@ send handle prompt → build-args → subprocess/exec → port/read-line loop
 
 ## Config keys
 
-| Key | Type | Claude flag | OpenCode flag |
-|-----|------|-------------|---------------|
-| `:backend` | `:claude`/`:opencode` | — | — |
-| `:model` | string | `--model` | `-m` |
-| `:system-prompt` | string | `--system-prompt` | `--prompt` |
-| `:allowed-tools` | array | `--allowedTools` | — |
-| `:denied-tools` | array | `--disallowedTools` | — |
-| `:skip-permissions` | bool | `--dangerously-skip-permissions` | — |
-| `:dir` | string | `--add-dir` | `--dir` |
-| `:effort` | keyword | `--effort` | `--variant` |
-| `:max-budget` | float | `--max-budget-usd` | — |
-| `:opts` | array | passthrough | passthrough |
-| `:command` | array | overrides build-args | for testing |
+| Key | Type | Claude flag | OpenCode flag | Pi flag |
+|-----|------|-------------|---------------|----------|
+| `:backend` | `:claude`/`:opencode`/`:pi` | — | — | — |
+| `:model` | string | `--model` | `-m` | `--model` |
+| `:system-prompt` | string | `--system-prompt` | `--prompt` | `--system-prompt` |
+| `:allowed-tools` | array | `--allowedTools` (each) | — | `--tools` (comma-joined) |
+| `:denied-tools` | array | `--disallowedTools` | — | — |
+| `:skip-permissions` | bool | `--dangerously-skip-permissions` | — | — |
+| `:dir` | string | `--add-dir` | `--dir` | — |
+| `:effort` | keyword | `--effort` | `--variant` | `--thinking` |
+| `:max-budget` | float | `--max-budget-usd` | — | — |
+| `:opts` | array | passthrough | passthrough | passthrough |
+| `:command` | array | overrides build-args | for testing | for testing |
 
 ## Chunk types
 
@@ -85,16 +86,37 @@ send handle prompt → build-args → subprocess/exec → port/read-line loop
   (when (not ok?) (agent:kill handle)))
 ```
 
+## Chunk contracts
+
+Every chunk yielded by `send` is validated against a contract (via
+`lib/contract.lisp`) before being yielded. The contracts enforce:
+
+| Chunk type | Required fields | Types |
+|------------|----------------|-------|
+| `:text` | `:type`, `:text` | keyword, string |
+| `:tool-use` | `:type`, `:name`, `:id` | keyword, string, string |
+| `:tool-input` | `:type`, `:text` | keyword, string |
+| `:stderr` | `:type`, `:text` | keyword, string |
+| `:result` | `:type`, `:text`, `:cost` | keyword, string, number |
+| | `:session-id` (optional) | string or nil |
+| | `:tokens` (optional) | `{:input int :output int}` or nil |
+
+A normalizer that produces a chunk with the wrong shape gets a clear
+`:agent-error` at the validation boundary, not a mysterious failure
+downstream.
+
 ## Invariants
 
 1. One subprocess per `send` call. No long-lived child process.
-2. Session continuity via `--resume` / `--session --continue`.
+2. Session continuity via `--resume` (Claude) / `--session --continue` (OpenCode / Pi).
 3. Handle `:session-id` and `:total-cost` are updated after each result chunk.
 4. Handle `:proc` is set during `send`, cleared on completion or `kill`.
 5. Stderr is drained in parallel via `ev/spawn`; yielded as `:stderr` chunks.
 6. NDJSON parse errors are yielded as `:stderr` chunks, not swallowed.
 7. Nonzero exit without a result chunk signals `:agent-error`.
 8. Flag table drives config→CLI mapping; adding a flag is one table row.
+9. Chunk contracts are enforced at the normalizer boundary; invalid shapes
+   signal `:agent-error` immediately.
 
 ## Running tests
 

--- a/lib/AGENTS.md
+++ b/lib/AGENTS.md
@@ -18,6 +18,89 @@ depend on other modules or plugins take them as arguments.
 | `lua.lisp` | Lua standard library compatibility prelude |
 | `process.lisp` | Erlang-style processes + GenServer, Actor, Supervisor |
 | `sync.lisp` | Concurrency primitives: lock, semaphore, condvar, rwlock, barrier, latch, once, queue, monitor (built on futex) |
+| `agent.lisp` | LLM agent subprocess abstraction (Claude Code / OpenCode) |
+
+---
+
+# lib/agent
+
+Agent guide for `lib/agent.lisp` — LLM agent subprocess abstraction.
+
+## Purpose
+
+Runtime abstraction over Claude Code and OpenCode subprocesses. One subprocess
+per turn, session continuation via `--resume` (Claude) or `--session --continue`
+(OpenCode). The handle is mutable and tracks the session ID across sends.
+
+## Data flow
+
+```
+make-handle config → @{:config config :session-id nil :total-cost 0 :proc nil}
+send handle prompt → build-args → subprocess/exec → port/read-line loop
+  → normalize NDJSON → yield chunks (stdout + stderr in parallel)
+  → update session-id and total-cost from result
+```
+
+## Exported functions
+
+| Function | Signature | Returns | Notes |
+|----------|-----------|---------|-------|
+| `make-handle` | `config` | mutable handle | creates agent state |
+| `send` | `handle prompt` | stream of chunks | one subprocess per call |
+| `send-collect` | `handle prompt` | result struct | drains stream, concatenates text |
+| `kill` | `handle` | nil | kills current subprocess |
+| `build-args` | `config prompt session-id` | array of CLI args | pure |
+
+## Config keys
+
+| Key | Type | Claude flag | OpenCode flag |
+|-----|------|-------------|---------------|
+| `:backend` | `:claude`/`:opencode` | — | — |
+| `:model` | string | `--model` | `-m` |
+| `:system-prompt` | string | `--system-prompt` | `--prompt` |
+| `:allowed-tools` | array | `--allowedTools` | — |
+| `:denied-tools` | array | `--disallowedTools` | — |
+| `:skip-permissions` | bool | `--dangerously-skip-permissions` | — |
+| `:dir` | string | `--add-dir` | `--dir` |
+| `:effort` | keyword | `--effort` | `--variant` |
+| `:max-budget` | float | `--max-budget-usd` | — |
+| `:opts` | array | passthrough | passthrough |
+| `:command` | array | overrides build-args | for testing |
+
+## Chunk types
+
+| Type | Shape | Notes |
+|------|-------|-------|
+| `:text` | `{:text "partial" :type :text}` | text content delta |
+| `:tool-use` | `{:type :tool-use :name "Read" :id "tu_1"}` | tool invocation start |
+| `:tool-input` | `{:text "{\"path\":" :type :tool-input}` | partial tool input JSON |
+| `:stderr` | `{:type :stderr :text "warning..."}` | subprocess stderr line |
+| `:result` | `{:text "full" :type :result :cost 0.05 :session-id "uuid" :tokens {:input 100 :output 50}}` | final result |
+
+## Timeout pattern
+
+```lisp
+(let [[[ok? val] (protect (ev/timeout 30 (fn []
+        (stream/collect (agent:send handle "slow task")))))]]
+  (when (not ok?) (agent:kill handle)))
+```
+
+## Invariants
+
+1. One subprocess per `send` call. No long-lived child process.
+2. Session continuity via `--resume` / `--session --continue`.
+3. Handle `:session-id` and `:total-cost` are updated after each result chunk.
+4. Handle `:proc` is set during `send`, cleared on completion or `kill`.
+5. Stderr is drained in parallel via `ev/spawn`; yielded as `:stderr` chunks.
+6. NDJSON parse errors are yielded as `:stderr` chunks, not swallowed.
+7. Nonzero exit without a result chunk signals `:agent-error`.
+8. Flag table drives config→CLI mapping; adding a flag is one table row.
+
+## Running tests
+
+```bash
+./target/debug/elle tests/elle/agent.lisp
+```
 
 ---
 

--- a/lib/agent.lisp
+++ b/lib/agent.lisp
@@ -1,0 +1,263 @@
+## lib/agent.lisp — LLM agent subprocess abstraction
+##
+## Loaded via: (def agent ((import-file "lib/agent.lisp")))
+## Usage:
+##   (def handle (agent:make-handle {:backend :claude :model "sonnet"}))
+##   (stream/for-each
+##     (fn [c] (print c:text))
+##     (agent:send handle "review lib/http.lisp"))
+##
+## One subprocess per turn. Session continuation via --resume (Claude)
+## or --session + --continue (OpenCode). The handle is mutable and
+## tracks the session ID across sends.
+##
+## Chunk types: :text, :tool-use, :tool-input, :stderr, :result
+
+
+# ============================================================================
+# Flag table — config key → CLI flags per backend
+# ============================================================================
+
+# Each entry: {:key config-key :claude flag :opencode flag :type how-to-emit}
+# :type is one of:
+#   :val    — emit [flag value]
+#   :bool   — emit [flag] when truthy
+#   :each   — emit [flag item] for each item in array
+#   :coerce — emit [flag (string value)]
+
+(def flag-table
+  [{:key :model          :claude "--model"                       :opencode "-m"        :type :val}
+   {:key :system-prompt  :claude "--system-prompt"               :opencode "--prompt"   :type :val}
+   {:key :dir            :claude "--add-dir"                     :opencode "--dir"      :type :val}
+   {:key :effort         :claude "--effort"                      :opencode "--variant"  :type :coerce}
+   {:key :max-budget     :claude "--max-budget-usd"              :opencode nil          :type :coerce}
+   {:key :skip-permissions :claude "--dangerously-skip-permissions" :opencode nil       :type :bool}
+   {:key :allowed-tools  :claude "--allowedTools"                :opencode nil          :type :each}
+   {:key :denied-tools   :claude "--disallowedTools"             :opencode nil          :type :each}])
+
+
+# ============================================================================
+# build-args — config + prompt + session-id → CLI arg array
+# ============================================================================
+
+(defn build-args [config prompt session-id]
+  "Build CLI argument array from config, prompt, and optional session-id."
+  (let* [[backend (get config :backend)]
+         [args    @[]]]
+
+    # Binary and output format
+    (case backend
+      :claude   (begin (push args "claude")
+                       (push args "--output-format") (push args "stream-json")
+                       (push args "--verbose"))
+      :opencode (begin (push args "opencode")
+                       (push args "--format") (push args "json"))
+      (error {:error :agent-error
+              :message (string "unknown backend: " backend)}))
+
+    # Session resumption
+    (when (not (nil? session-id))
+      (case backend
+        :claude   (begin (push args "--resume") (push args session-id))
+        :opencode (begin (push args "--session") (push args session-id)
+                         (push args "--continue"))))
+
+    # Table-driven flags
+    (each entry in flag-table
+      (let* [[val  (get config entry:key nil)]
+             [flag (get entry backend nil)]]
+        (when (and (not (nil? val)) (not (nil? flag)))
+          (case entry:type
+            :val    (begin (push args flag) (push args val))
+            :coerce (begin (push args flag) (push args (string val)))
+            :bool   (push args flag)
+            :each   (each item in val
+                      (push args flag) (push args item))))))
+
+    # Passthrough opts
+    (when (not (nil? (get config :opts nil)))
+      (each opt in (get config :opts)
+        (push args opt)))
+
+    # Prompt last
+    (push args "-p")
+    (push args prompt)
+
+    (freeze args)))
+
+
+# ============================================================================
+# normalize-claude — JSON line → chunk or nil
+# ============================================================================
+
+(defn normalize-claude [line]
+  "Parse a Claude stream-json line into a chunk, or nil to skip."
+  (let [[obj (json/parse line :keys :keyword)]]
+    (when (not (nil? obj))
+      (case obj:type
+        "content_block_delta"
+          (let [[delta (get obj :delta {})]]
+            (case delta:type
+              "text_delta"       {:text delta:text :type :text}
+              "input_json_delta" {:text (get delta :partial_json "")
+                                  :type :tool-input}
+              nil))
+        "content_block_start"
+          (let [[cb (get obj :content_block {})]]
+            (when (= cb:type "tool_use")
+              {:type :tool-use :name cb:name :id cb:id}))
+        "result"
+          (let [[usage (get obj :usage {})]]
+            {:text       (get obj :result "")
+             :type       :result
+             :cost       (get obj :total_cost_usd 0)
+             :session-id obj:session_id
+             :tokens     {:input  (get usage :input_tokens 0)
+                          :output (get usage :output_tokens 0)}})
+        nil))))
+
+
+# ============================================================================
+# normalize-opencode — JSON line → chunk or nil
+# ============================================================================
+
+(defn normalize-opencode [line]
+  "Parse an OpenCode JSON line into a chunk, or nil to skip."
+  (let [[obj (json/parse line :keys :keyword)]]
+    (when (not (nil? obj))
+      (let [[part (get obj :part {})]]
+        (case obj:type
+          "text"        {:text part:text :type :text}
+          "step_finish" {:type   :result
+                         :cost   (get part :cost 0)
+                         :tokens (get part :tokens nil)
+                         :text   ""}
+          nil)))))
+
+
+# ============================================================================
+# make-handle — create a mutable agent handle
+# ============================================================================
+
+(defn make-handle [config]
+  "Create a mutable agent handle from config."
+  @{:config config :session-id nil :total-cost 0 :proc nil})
+
+
+# ============================================================================
+# kill — terminate the current subprocess
+# ============================================================================
+
+(defn kill [handle]
+  "Kill the current subprocess, if any."
+  (when (not (nil? handle:proc))
+    (protect (subprocess/kill handle:proc))
+    (protect (subprocess/wait handle:proc))
+    (put handle :proc nil)))
+
+
+# ============================================================================
+# send — spawn subprocess, return stream of chunks
+# ============================================================================
+
+(defn send [handle prompt]
+  "Send a prompt to the agent. Returns a stream of chunks.
+   If config has :command [program args...], uses that instead of build-args."
+  (let* [[config     handle:config]
+         [session-id handle:session-id]
+         [backend    config:backend]
+         [cmd        (get config :command nil)]
+         [args       (if (nil? cmd)
+                       (build-args config prompt session-id)
+                       cmd)]
+         [program    (first args)]
+         [rest-args  (slice args 1)]
+         [normalize  (case backend
+                       :claude   normalize-claude
+                       :opencode normalize-opencode)]]
+    (coro/new (fn []
+      # TODO: swap :null for :nil when subprocess is updated
+      (let* [[proc   (subprocess/exec program rest-args)]
+             [stdout proc:stdout]
+             [stderr proc:stderr]]
+        (put handle :proc proc)
+
+        # Drain stderr in parallel — collect lines
+        (var stderr-lines @[])
+        (var lc nil)
+        (let [[stderr-fiber (ev/spawn (fn []
+                (stream/for-each
+                  (fn [line] (push stderr-lines line))
+                  (port/lines stderr))))]]
+
+          # Drain stdout line by line
+          (while true
+            # Flush accumulated stderr as chunks
+            (each sl in stderr-lines
+              (yield {:type :stderr :text sl}))
+            (while (> (length stderr-lines) 0) (pop stderr-lines))
+
+            # Read next stdout line
+            (let [[line (port/read-line stdout)]]
+              (when (nil? line) (break))
+              (when (> (length line) 0)
+                (let [[[ok? parsed] (protect (normalize line))]]
+                  (if (not ok?)
+                    (yield {:type :stderr :text (string "parse error: " parsed)})
+                    (when (not (nil? parsed))
+                      (assign lc parsed)
+                      (yield parsed)))))))
+
+          # Join stderr fiber, flush remaining
+          (protect (ev/join stderr-fiber))
+          (each sl in stderr-lines
+            (yield {:type :stderr :text sl})))
+
+        (let [[exit (subprocess/wait proc)]]
+          (put handle :proc nil)
+          # Update session-id and accumulate cost from result chunk
+          (when (and (not (nil? lc))
+                     (= lc:type :result))
+            (when (not (nil? (get lc :session-id nil)))
+              (put handle :session-id lc:session-id))
+            (when (not (nil? (get lc :cost nil)))
+              (put handle :total-cost
+                   (+ handle:total-cost lc:cost))))
+          # Signal error on nonzero exit with no result chunk
+          (when (and (not (= exit 0))
+                     (or (nil? lc) (not (= lc:type :result))))
+            (error {:error :agent-error
+                    :message (string program " exited with code " exit)}))))))))
+
+
+# ============================================================================
+# send-collect — convenience: drain stream, return final result
+# ============================================================================
+
+(defn send-collect [handle prompt]
+  "Send a prompt and collect the full response. Returns result struct
+   with :text containing the concatenated text."
+  (var result nil)
+  (var text @"")
+  (stream/for-each
+    (fn [chunk]
+      (case chunk:type
+        :text   (push text chunk:text)
+        :result (assign result chunk)
+        nil))
+    (send handle prompt))
+  (if (nil? result)
+    {:type :result :text (freeze text) :cost 0}
+    (merge result {:text (freeze text)})))
+
+
+# ============================================================================
+# Exports
+# ============================================================================
+
+(fn []
+  {:make-handle  make-handle
+   :send         send
+   :send-collect send-collect
+   :kill         kill
+   :build-args   build-args})

--- a/lib/agent.lisp
+++ b/lib/agent.lisp
@@ -7,11 +7,46 @@
 ##     (fn [c] (print c:text))
 ##     (agent:send handle "review lib/http.lisp"))
 ##
+## Backends: :claude, :opencode, :pi
 ## One subprocess per turn. Session continuation via --resume (Claude)
-## or --session + --continue (OpenCode). The handle is mutable and
-## tracks the session ID across sends.
+## or --session + --continue (OpenCode / Pi). The handle is mutable
+## and tracks the session ID across sends.
 ##
 ## Chunk types: :text, :tool-use, :tool-input, :stderr, :result
+
+
+# ============================================================================
+# Chunk contracts — enforced at the normalizer boundary
+# ============================================================================
+
+(def cv ((import-file "lib/contract.lisp")))
+
+(def tokens-shape
+  (cv:compile-validator {:input integer? :output integer?}))
+
+(def chunk-validators
+  {:text       (cv:compile-validator {:type (cv:v/oneof :text)       :text string?})
+   :tool-use   (cv:compile-validator {:type (cv:v/oneof :tool-use)   :name string? :id string?})
+   :tool-input (cv:compile-validator {:type (cv:v/oneof :tool-input) :text string?})
+   :stderr     (cv:compile-validator {:type (cv:v/oneof :stderr)     :text string?})
+   :result     (cv:compile-validator {:type    (cv:v/oneof :result)
+                                      :text    string?
+                                      :cost    number?
+                                      :session-id (cv:v/optional string?)
+                                      :tokens  (cv:v/optional tokens-shape)})})
+
+(defn validate-chunk [chunk]
+  "Validate a chunk against its contract. Returns the chunk, or signals :agent-error."
+  (let [[v (get chunk-validators chunk:type nil)]]
+    (when (nil? v)
+      (error {:error :agent-error
+              :message (string "unknown chunk type: " chunk:type)}))
+    (let [[explanation (cv:explain v chunk)]]
+      (when (not (nil? explanation))
+        (error {:error   :agent-error
+                :message (string "invalid " chunk:type " chunk: " explanation)
+                :chunk   chunk})))
+    chunk))
 
 
 # ============================================================================
@@ -26,14 +61,14 @@
 #   :coerce — emit [flag (string value)]
 
 (def flag-table
-  [{:key :model          :claude "--model"                       :opencode "-m"        :type :val}
-   {:key :system-prompt  :claude "--system-prompt"               :opencode "--prompt"   :type :val}
-   {:key :dir            :claude "--add-dir"                     :opencode "--dir"      :type :val}
-   {:key :effort         :claude "--effort"                      :opencode "--variant"  :type :coerce}
-   {:key :max-budget     :claude "--max-budget-usd"              :opencode nil          :type :coerce}
-   {:key :skip-permissions :claude "--dangerously-skip-permissions" :opencode nil       :type :bool}
-   {:key :allowed-tools  :claude "--allowedTools"                :opencode nil          :type :each}
-   {:key :denied-tools   :claude "--disallowedTools"             :opencode nil          :type :each}])
+  [{:key :model          :claude "--model"                       :opencode "-m"        :pi "--model"          :type :val}
+   {:key :system-prompt  :claude "--system-prompt"               :opencode "--prompt"   :pi "--system-prompt"  :type :val}
+   {:key :dir            :claude "--add-dir"                     :opencode "--dir"      :pi nil                :type :val}
+   {:key :effort         :claude "--effort"                      :opencode "--variant"  :pi "--thinking"       :type :coerce}
+   {:key :max-budget     :claude "--max-budget-usd"              :opencode nil          :pi nil                :type :coerce}
+   {:key :skip-permissions :claude "--dangerously-skip-permissions" :opencode nil       :pi nil                :type :bool}
+   {:key :allowed-tools  :claude "--allowedTools"                :opencode nil          :pi nil                :type :each}
+   {:key :denied-tools   :claude "--disallowedTools"             :opencode nil          :pi nil                :type :each}])
 
 
 # ============================================================================
@@ -52,6 +87,8 @@
                        (push args "--verbose"))
       :opencode (begin (push args "opencode")
                        (push args "--format") (push args "json"))
+      :pi       (begin (push args "pi")
+                       (push args "--mode") (push args "json"))
       (error {:error :agent-error
               :message (string "unknown backend: " backend)}))
 
@@ -60,6 +97,8 @@
       (case backend
         :claude   (begin (push args "--resume") (push args session-id))
         :opencode (begin (push args "--session") (push args session-id)
+                         (push args "--continue"))
+        :pi       (begin (push args "--session") (push args session-id)
                          (push args "--continue"))))
 
     # Table-driven flags
@@ -73,6 +112,15 @@
             :bool   (push args flag)
             :each   (each item in val
                       (push args flag) (push args item))))))
+
+    # Pi-specific: --tools as comma-separated
+    (when (= backend :pi)
+      (let [[tools (get config :allowed-tools nil)]]
+        (when (not (nil? tools))
+          (push args "--tools")
+          (push args (fold (fn [acc t]
+                             (if (= acc "") t (string acc "," t)))
+                           "" tools)))))
 
     # Passthrough opts
     (when (not (nil? (get config :opts nil)))
@@ -128,10 +176,51 @@
       (let [[part (get obj :part {})]]
         (case obj:type
           "text"        {:text part:text :type :text}
-          "step_finish" {:type   :result
+          "step_finish" (let [[tok (get part :tokens nil)]]
+                        {:type   :result
                          :cost   (get part :cost 0)
-                         :tokens (get part :tokens nil)
-                         :text   ""}
+                         :tokens (if (nil? tok) nil
+                                   {:input  (get tok :input 0)
+                                    :output (get tok :output 0)})
+                         :text   ""})
+          nil)))))
+
+
+# ============================================================================
+# normalize-pi — stateful: JSON line → chunk or nil, tracks session-id
+# ============================================================================
+
+(defn make-pi-normalizer []
+  "Create a stateful pi normalizer that tracks session-id."
+  (var sid nil)
+  (fn [line]
+    (let [[obj (json/parse line :keys :keyword)]]
+      (when (not (nil? obj))
+        (case obj:type
+          "session"
+            (begin (assign sid obj:id) nil)
+          "message_update"
+            (let [[evt (get obj :assistantMessageEvent {})]]
+              (case evt:type
+                "text_delta"     {:type :text :text evt:delta}
+                "toolcall_start"
+                  (let* [[ci      (get evt :contentIndex 0)]
+                         [partial (get evt :partial {})]
+                         [content (get partial :content [])]
+                         [tc      (get content ci {})]]
+                    {:type :tool-use :name tc:name :id tc:id})
+                "toolcall_delta" {:type :tool-input :text evt:delta}
+                nil))
+          "message_end"
+            (let* [[msg   (get obj :message {})]
+                   [usage (get msg :usage {})]
+                   [cost  (get usage :cost {})]]
+              {:type       :result
+               :text       ""
+               :cost       (get cost :total 0)
+               :session-id sid
+               :tokens     {:input  (get usage :input 0)
+                            :output (get usage :output 0)}})
           nil)))))
 
 
@@ -174,7 +263,8 @@
          [rest-args  (slice args 1)]
          [normalize  (case backend
                        :claude   normalize-claude
-                       :opencode normalize-opencode)]]
+                       :opencode normalize-opencode
+                       :pi       (make-pi-normalizer))]]
     (coro/new (fn []
       # TODO: swap :null for :nil when subprocess is updated
       (let* [[proc   (subprocess/exec program rest-args)]
@@ -205,6 +295,7 @@
                   (if (not ok?)
                     (yield {:type :stderr :text (string "parse error: " parsed)})
                     (when (not (nil? parsed))
+                      (validate-chunk parsed)
                       (assign lc parsed)
                       (yield parsed)))))))
 

--- a/src/primitives/list/advanced.rs
+++ b/src/primitives/list/advanced.rs
@@ -581,7 +581,7 @@ pub(crate) fn prim_reverse(args: &[Value]) -> (SignalBits, Value) {
     (SIG_OK, list(vec))
 }
 
-/// Get the last element of a sequence
+/// Get the last element of a sequence (list, array, @array, string)
 pub(crate) fn prim_last(args: &[Value]) -> (SignalBits, Value) {
     if args.len() != 1 {
         return (
@@ -592,89 +592,144 @@ pub(crate) fn prim_last(args: &[Value]) -> (SignalBits, Value) {
             ),
         );
     }
-
-    let empty_err = (
-        SIG_ERROR,
-        error_val("argument-error", "last: empty sequence"),
-    );
-    // Cons cell — walk to end
-    if args[0].is_cons() || args[0].is_empty_list() {
-        if args[0].is_empty_list() {
-            return empty_err;
-        }
-        let mut current = args[0];
-        let mut last = Value::NIL;
-        while let Some(cons) = current.as_cons() {
-            last = cons.first;
-            current = cons.rest;
-        }
-        return (SIG_OK, last);
+    // Cons cell — walk to the last element
+    if args[0].as_cons().is_some() || args[0].is_empty_list() {
+        let vec = match args[0].list_to_vec() {
+            Ok(v) => v,
+            Err(e) => return (SIG_ERROR, error_val("type-error", format!("last: {}", e))),
+        };
+        return match vec.last().cloned() {
+            Some(v) => (SIG_OK, v),
+            None => (SIG_OK, Value::NIL),
+        };
     }
     // Array
     if let Some(elems) = args[0].as_array() {
-        return match elems.last() {
-            Some(v) => (SIG_OK, *v),
-            None => empty_err,
+        return if elems.is_empty() {
+            (SIG_OK, Value::NIL)
+        } else {
+            (SIG_OK, elems[elems.len() - 1])
         };
     }
-    // @array
+    // @Array
     if let Some(arr) = args[0].as_array_mut() {
         let borrowed = arr.borrow();
-        return match borrowed.last() {
-            Some(v) => (SIG_OK, *v),
-            None => empty_err,
+        return if borrowed.is_empty() {
+            (SIG_OK, Value::NIL)
+        } else {
+            (SIG_OK, borrowed[borrowed.len() - 1])
         };
     }
-    // String — last grapheme
+    // String / @String — last grapheme cluster
     if let Some(result) = args[0].with_string(|s| match s.graphemes(true).next_back() {
         Some(g) => (SIG_OK, Value::string(g)),
-        None => (
-            SIG_ERROR,
-            error_val("argument-error", "last: empty sequence"),
-        ),
+        None => (SIG_OK, Value::NIL),
     }) {
         return result;
     }
-    // @string — last grapheme
-    if let Some(buf_ref) = args[0].as_string_mut() {
-        let borrowed = buf_ref.borrow();
-        if let Ok(s) = std::str::from_utf8(&borrowed) {
-            return match s.graphemes(true).next_back() {
-                Some(g) => (SIG_OK, Value::string(g)),
-                None => empty_err,
-            };
-        }
-        return empty_err;
-    }
-    // Bytes — last byte as integer
+    // Bytes
     if let Some(b) = args[0].as_bytes() {
-        return match b.last() {
-            Some(&byte) => (SIG_OK, Value::int(byte as i64)),
-            None => empty_err,
+        return if b.is_empty() {
+            (SIG_OK, Value::NIL)
+        } else {
+            (SIG_OK, Value::int(b[b.len() - 1] as i64))
         };
     }
-    // @bytes — last byte as integer
+    // @Bytes
     if let Some(blob_ref) = args[0].as_bytes_mut() {
         let borrowed = blob_ref.borrow();
-        return match borrowed.last() {
-            Some(&byte) => (SIG_OK, Value::int(byte as i64)),
-            None => empty_err,
+        return if borrowed.is_empty() {
+            (SIG_OK, Value::NIL)
+        } else {
+            (SIG_OK, Value::int(borrowed[borrowed.len() - 1] as i64))
         };
     }
-
     (
         SIG_ERROR,
         error_val(
             "type-error",
-            format!(
-                "last: expected sequence (list, array, string, bytes), got {}",
-                args[0].type_name()
-            ),
+            format!("last: expected sequence, got {}", args[0].type_name()),
         ),
     )
 }
 
-/// Get all elements of a sequence except the last
+/// Get the second element of a sequence (list, array, @array, string)
+pub(crate) fn prim_second(args: &[Value]) -> (SignalBits, Value) {
+    if args.len() != 1 {
+        return (
+            SIG_ERROR,
+            error_val(
+                "arity-error",
+                format!("second: expected 1 argument, got {}", args.len()),
+            ),
+        );
+    }
+    // Cons cell
+    if let Some(cons) = args[0].as_cons() {
+        if let Some(inner) = cons.rest.as_cons() {
+            return (SIG_OK, inner.first);
+        }
+        return (SIG_OK, Value::NIL);
+    }
+    // Empty list
+    if args[0].is_empty_list() {
+        return (SIG_OK, Value::NIL);
+    }
+    // Array
+    if let Some(elems) = args[0].as_array() {
+        return if elems.len() < 2 {
+            (SIG_OK, Value::NIL)
+        } else {
+            (SIG_OK, elems[1])
+        };
+    }
+    // @Array
+    if let Some(arr) = args[0].as_array_mut() {
+        let borrowed = arr.borrow();
+        return if borrowed.len() < 2 {
+            (SIG_OK, Value::NIL)
+        } else {
+            (SIG_OK, borrowed[1])
+        };
+    }
+    // String / @String — second grapheme cluster
+    if let Some(result) = args[0].with_string(|s| {
+        let mut iter = s.graphemes(true);
+        iter.next(); // skip first
+        match iter.next() {
+            Some(g) => (SIG_OK, Value::string(g)),
+            None => (SIG_OK, Value::NIL),
+        }
+    }) {
+        return result;
+    }
+    // Bytes
+    if let Some(b) = args[0].as_bytes() {
+        return if b.len() < 2 {
+            (SIG_OK, Value::NIL)
+        } else {
+            (SIG_OK, Value::int(b[1] as i64))
+        };
+    }
+    // @Bytes
+    if let Some(blob_ref) = args[0].as_bytes_mut() {
+        let borrowed = blob_ref.borrow();
+        return if borrowed.len() < 2 {
+            (SIG_OK, Value::NIL)
+        } else {
+            (SIG_OK, Value::int(borrowed[1] as i64))
+        };
+    }
+    (
+        SIG_ERROR,
+        error_val(
+            "type-error",
+            format!("second: expected sequence, got {}", args[0].type_name()),
+        ),
+    )
+}
+
+/// Get all elements of a list except the last
 pub(crate) fn prim_butlast(args: &[Value]) -> (SignalBits, Value) {
     if args.len() != 1 {
         return (
@@ -686,97 +741,26 @@ pub(crate) fn prim_butlast(args: &[Value]) -> (SignalBits, Value) {
         );
     }
 
-    // Lists
-    if args[0].is_cons() || args[0].is_empty_list() {
-        if args[0].is_empty_list() {
-            return (SIG_OK, Value::EMPTY_LIST);
+    let vec = match args[0].list_to_vec() {
+        Ok(v) => v,
+        Err(e) => {
+            return (
+                SIG_ERROR,
+                error_val("type-error", format!("butlast: {}", e)),
+            )
         }
-        let vec = match args[0].list_to_vec() {
-            Ok(v) => v,
-            Err(e) => {
-                return (
-                    SIG_ERROR,
-                    error_val("type-error", format!("butlast: {}", e)),
-                )
-            }
-        };
-        if vec.is_empty() {
-            return (SIG_OK, Value::EMPTY_LIST);
-        }
-        return (SIG_OK, list(vec[..vec.len() - 1].to_vec()));
-    }
-    // Array
-    if let Some(elems) = args[0].as_array() {
-        if elems.is_empty() {
-            return (SIG_OK, Value::array(vec![]));
-        }
-        return (SIG_OK, Value::array(elems[..elems.len() - 1].to_vec()));
-    }
-    // @array
-    if let Some(arr) = args[0].as_array_mut() {
-        let borrowed = arr.borrow();
-        if borrowed.is_empty() {
-            return (SIG_OK, Value::array_mut(vec![]));
-        }
+    };
+    if vec.is_empty() {
         return (
-            SIG_OK,
-            Value::array_mut(borrowed[..borrowed.len() - 1].to_vec()),
-        );
-    }
-    // String — all but last grapheme
-    if let Some(result) = args[0].with_string(|s| {
-        let graphemes: Vec<&str> = s.graphemes(true).collect();
-        if graphemes.is_empty() {
-            (SIG_OK, Value::string(""))
-        } else {
-            let init: String = graphemes[..graphemes.len() - 1].concat();
-            (SIG_OK, Value::string(init))
-        }
-    }) {
-        return result;
-    }
-    // @string — all but last grapheme
-    if let Some(buf_ref) = args[0].as_string_mut() {
-        let borrowed = buf_ref.borrow();
-        if let Ok(s) = std::str::from_utf8(&borrowed) {
-            let graphemes: Vec<&str> = s.graphemes(true).collect();
-            if graphemes.is_empty() {
-                return (SIG_OK, Value::string_mut(vec![]));
-            }
-            let init: String = graphemes[..graphemes.len() - 1].concat();
-            return (SIG_OK, Value::string_mut(init.into_bytes()));
-        }
-        return (SIG_OK, Value::string_mut(vec![]));
-    }
-    // Bytes — all but last byte
-    if let Some(b) = args[0].as_bytes() {
-        if b.is_empty() {
-            return (SIG_OK, Value::bytes(vec![]));
-        }
-        return (SIG_OK, Value::bytes(b[..b.len() - 1].to_vec()));
-    }
-    // @bytes — all but last byte
-    if let Some(blob_ref) = args[0].as_bytes_mut() {
-        let borrowed = blob_ref.borrow();
-        if borrowed.is_empty() {
-            return (SIG_OK, Value::bytes_mut(vec![]));
-        }
-        return (
-            SIG_OK,
-            Value::bytes_mut(borrowed[..borrowed.len() - 1].to_vec()),
-        );
-    }
-
-    (
-        SIG_ERROR,
-        error_val(
-            "type-error",
-            format!(
-                "butlast: expected sequence (list, array, string, bytes), got {}",
-                args[0].type_name()
+            SIG_ERROR,
+            error_val(
+                "argument-error",
+                "butlast: cannot get butlast of empty list".to_string(),
             ),
-        ),
-    )
+        );
+    }
+    let init: Vec<Value> = vec[..vec.len() - 1].to_vec();
+    (SIG_OK, list(init))
 }
 
 /// Take the first n elements of a list

--- a/src/primitives/list/mod.rs
+++ b/src/primitives/list/mod.rs
@@ -11,7 +11,8 @@ use unicode_segmentation::UnicodeSegmentation;
 
 // Re-export advanced functions for use in PRIMITIVES array
 pub(crate) use advanced::{
-    prim_append, prim_butlast, prim_concat, prim_drop, prim_last, prim_reverse, prim_take,
+    prim_append, prim_butlast, prim_concat, prim_drop, prim_last, prim_reverse, prim_second,
+    prim_take,
 };
 
 /// Construct a cons cell
@@ -43,82 +44,47 @@ pub(crate) fn prim_first(args: &[Value]) -> (SignalBits, Value) {
     if let Some(cons) = args[0].as_cons() {
         return (SIG_OK, cons.first);
     }
-    // Empty list → error
+    // Empty list → nil (matches destructuring silent-nil semantics)
     if args[0].is_empty_list() {
-        return (
-            SIG_ERROR,
-            error_val("argument-error", "first: empty sequence"),
-        );
+        return (SIG_OK, Value::NIL);
     }
     // Array
     if let Some(elems) = args[0].as_array() {
         return if elems.is_empty() {
-            (
-                SIG_ERROR,
-                error_val("argument-error", "first: empty sequence"),
-            )
+            (SIG_OK, Value::NIL)
         } else {
             (SIG_OK, elems[0])
         };
     }
-    // @array
+    // Array
     if let Some(arr) = args[0].as_array_mut() {
         let borrowed = arr.borrow();
         return if borrowed.is_empty() {
-            (
-                SIG_ERROR,
-                error_val("argument-error", "first: empty sequence"),
-            )
+            (SIG_OK, Value::NIL)
         } else {
             (SIG_OK, borrowed[0])
         };
     }
-    // String — first grapheme cluster
+    // String / @String — first grapheme cluster
     if let Some(result) = args[0].with_string(|s| match s.graphemes(true).next() {
         Some(g) => (SIG_OK, Value::string(g)),
-        None => (
-            SIG_ERROR,
-            error_val("argument-error", "first: empty sequence"),
-        ),
+        None => (SIG_OK, Value::NIL),
     }) {
         return result;
     }
-    // @string — first grapheme cluster
-    if let Some(buf_ref) = args[0].as_string_mut() {
-        let borrowed = buf_ref.borrow();
-        if let Ok(s) = std::str::from_utf8(&borrowed) {
-            return match s.graphemes(true).next() {
-                Some(g) => (SIG_OK, Value::string(g)),
-                None => (
-                    SIG_ERROR,
-                    error_val("argument-error", "first: empty sequence"),
-                ),
-            };
-        }
-        return (
-            SIG_ERROR,
-            error_val("argument-error", "first: empty sequence"),
-        );
-    }
-    // Bytes — first byte as integer
+    // Bytes
     if let Some(b) = args[0].as_bytes() {
         return if b.is_empty() {
-            (
-                SIG_ERROR,
-                error_val("argument-error", "first: empty sequence"),
-            )
+            (SIG_OK, Value::NIL)
         } else {
             (SIG_OK, Value::int(b[0] as i64))
         };
     }
-    // @bytes — first byte as integer
+    // @Bytes
     if let Some(blob_ref) = args[0].as_bytes_mut() {
         let borrowed = blob_ref.borrow();
         return if borrowed.is_empty() {
-            (
-                SIG_ERROR,
-                error_val("argument-error", "first: empty sequence"),
-            )
+            (SIG_OK, Value::NIL)
         } else {
             (SIG_OK, Value::int(borrowed[0] as i64))
         };
@@ -136,113 +102,12 @@ pub(crate) fn prim_first(args: &[Value]) -> (SignalBits, Value) {
         SIG_ERROR,
         error_val(
             "type-error",
-            format!(
-                "first: expected sequence (list, array, string, bytes), got {}",
-                args[0].type_name()
-            ),
+            format!("first: expected sequence, got {}", args[0].type_name()),
         ),
     )
 }
 
-/// Get the second element of a sequence
-pub(crate) fn prim_second(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("second: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
-    let too_short = (
-        SIG_ERROR,
-        error_val(
-            "argument-error",
-            "second: sequence has fewer than 2 elements",
-        ),
-    );
-    // Cons cell — walk to second
-    if let Some(cons) = args[0].as_cons() {
-        if let Some(c2) = cons.rest.as_cons() {
-            return (SIG_OK, c2.first);
-        }
-        return too_short;
-    }
-    if args[0].is_empty_list() {
-        return too_short;
-    }
-    // Array
-    if let Some(elems) = args[0].as_array() {
-        return if elems.len() < 2 {
-            too_short
-        } else {
-            (SIG_OK, elems[1])
-        };
-    }
-    // @array
-    if let Some(arr) = args[0].as_array_mut() {
-        let borrowed = arr.borrow();
-        return if borrowed.len() < 2 {
-            too_short
-        } else {
-            (SIG_OK, borrowed[1])
-        };
-    }
-    // String — second grapheme cluster
-    if let Some(result) = args[0].with_string(|s| match s.graphemes(true).nth(1) {
-        Some(g) => (SIG_OK, Value::string(g)),
-        None => (
-            SIG_ERROR,
-            error_val(
-                "argument-error",
-                "second: sequence has fewer than 2 elements",
-            ),
-        ),
-    }) {
-        return result;
-    }
-    // @string — second grapheme cluster
-    if let Some(buf_ref) = args[0].as_string_mut() {
-        let borrowed = buf_ref.borrow();
-        if let Ok(s) = std::str::from_utf8(&borrowed) {
-            return match s.graphemes(true).nth(1) {
-                Some(g) => (SIG_OK, Value::string(g)),
-                None => too_short,
-            };
-        }
-        return too_short;
-    }
-    // Bytes — second byte as integer
-    if let Some(b) = args[0].as_bytes() {
-        return if b.len() < 2 {
-            too_short
-        } else {
-            (SIG_OK, Value::int(b[1] as i64))
-        };
-    }
-    // @bytes — second byte as integer
-    if let Some(blob_ref) = args[0].as_bytes_mut() {
-        let borrowed = blob_ref.borrow();
-        return if borrowed.len() < 2 {
-            too_short
-        } else {
-            (SIG_OK, Value::int(borrowed[1] as i64))
-        };
-    }
-    (
-        SIG_ERROR,
-        error_val(
-            "type-error",
-            format!(
-                "second: expected sequence (list, array, string, bytes), got {}",
-                args[0].type_name()
-            ),
-        ),
-    )
-}
-
-/// Get the rest of a sequence (list, array, @array, string, @string, bytes, @bytes)
+/// Get the rest of a sequence (list, array, @array, string)
 pub(crate) fn prim_rest(args: &[Value]) -> (SignalBits, Value) {
     if args.len() != 1 {
         return (
@@ -285,32 +150,6 @@ pub(crate) fn prim_rest(args: &[Value]) -> (SignalBits, Value) {
     }) {
         return result;
     }
-    // @string — skip first grapheme, return new @string
-    if let Some(buf_ref) = args[0].as_string_mut() {
-        let borrowed = buf_ref.borrow();
-        if let Ok(s) = std::str::from_utf8(&borrowed) {
-            let rest: String = s.graphemes(true).skip(1).collect();
-            return (SIG_OK, Value::string_mut(rest.into_bytes()));
-        }
-        return (SIG_OK, Value::string_mut(vec![]));
-    }
-    // Bytes — return bytes from index 1 onward
-    if let Some(b) = args[0].as_bytes() {
-        return if b.len() <= 1 {
-            (SIG_OK, Value::bytes(vec![]))
-        } else {
-            (SIG_OK, Value::bytes(b[1..].to_vec()))
-        };
-    }
-    // @bytes — return new @bytes from index 1 onward
-    if let Some(blob_ref) = args[0].as_bytes_mut() {
-        let borrowed = blob_ref.borrow();
-        return if borrowed.len() <= 1 {
-            (SIG_OK, Value::bytes_mut(vec![]))
-        } else {
-            (SIG_OK, Value::bytes_mut(borrowed[1..].to_vec()))
-        };
-    }
     // Syntax (existing behavior, preserved)
     if let Some(syntax) = args[0].as_syntax() {
         if let SyntaxKind::List(items) | SyntaxKind::Array(items) = &syntax.kind {
@@ -331,7 +170,7 @@ pub(crate) fn prim_rest(args: &[Value]) -> (SignalBits, Value) {
         error_val(
             "type-error",
             format!(
-                "rest: expected sequence (list, array, string, bytes), got {}",
+                "rest: expected sequence (list, array, or string), got {}",
                 args[0].type_name()
             ),
         ),
@@ -772,17 +611,6 @@ pub(crate) const PRIMITIVES: &[PrimitiveDef] = &[
         aliases: &[],
     },
     PrimitiveDef {
-        name: "second",
-        func: prim_second,
-        signal: Signal::errors(),
-        arity: Arity::Exact(1),
-        doc: "Get the second element of a sequence. Returns nil if fewer than 2 elements.",
-        params: &["sequence"],
-        category: "list",
-        example: "(second (list 1 2 3))",
-        aliases: &[],
-    },
-    PrimitiveDef {
         name: "rest",
         func: prim_rest,
         signal: Signal::errors(),
@@ -876,10 +704,21 @@ pub(crate) const PRIMITIVES: &[PrimitiveDef] = &[
         func: prim_last,
         signal: Signal::errors(),
         arity: Arity::Exact(1),
-        doc: "Get the last element of a list",
-        params: &["list"],
+        doc: "Get the last element of a sequence (list, array, @array, string). Returns nil for empty sequences.",
+        params: &["sequence"],
         category: "list",
-        example: "(last (list 1 2 3))",
+        example: "(last [1 2 3])",
+        aliases: &[],
+    },
+    PrimitiveDef {
+        name: "second",
+        func: prim_second,
+        signal: Signal::errors(),
+        arity: Arity::Exact(1),
+        doc: "Get the second element of a sequence (list, array, @array, string). Returns nil if fewer than 2 elements.",
+        params: &["sequence"],
+        category: "list",
+        example: "(second [1 2 3])",
         aliases: &[],
     },
     PrimitiveDef {

--- a/src/value/repr/accessors.rs
+++ b/src/value/repr/accessors.rs
@@ -279,8 +279,8 @@ impl Value {
     // Heap Value Extractors
     // =========================================================================
 
-    /// Access string contents via closure. Works for heap strings.
-    /// Returns None if this is not a string.
+    /// Access string contents via closure. Works for both string and @string.
+    /// Returns None if this is neither a string nor an @string.
     #[inline]
     pub fn with_string<R>(&self, f: impl FnOnce(&str) -> R) -> Option<R> {
         use crate::value::heap::{deref, HeapObject};
@@ -289,6 +289,11 @@ impl Value {
         }
         match unsafe { deref(*self) } {
             HeapObject::LString { s, .. } => Some(f(s)),
+            HeapObject::LStringMut { data, .. } => {
+                let borrowed = data.borrow();
+                let str_ref = std::str::from_utf8(&borrowed).unwrap_or("");
+                Some(f(str_ref))
+            }
             _ => None,
         }
     }

--- a/tests/elle/agent.lisp
+++ b/tests/elle/agent.lisp
@@ -1,0 +1,304 @@
+# Agent library tests
+
+(def agent ((import-file "lib/agent.lisp")))
+
+
+# ── build-args: flag adjacency helper ──────────────────────────────────────
+
+# Check that flag and value appear adjacent in args array
+(defn has-flag-pair [args flag value]
+  "True if flag appears immediately before value in args."
+  (var i 0)
+  (var found false)
+  (while (< i (- (length args) 1))
+    (when (and (= (get args i) flag)
+               (= (get args (+ i 1)) value))
+      (assign found true))
+    (assign i (+ i 1)))
+  found)
+
+
+# ── build-args ──────────────────────────────────────────────────────────────
+
+# Basic claude args
+(let [[args (agent:build-args {:backend :claude} "hello" nil)]]
+  (assert (= (first args) "claude") "build-args: claude binary")
+  (assert (has-flag-pair args "--output-format" "stream-json") "build-args: output format pair")
+  (assert (= (last args) "hello") "build-args: prompt is last")
+  (assert (has-flag-pair args "-p" "hello") "build-args: -p prompt pair"))
+
+# Claude with model — flag and value adjacent
+(let [[args (agent:build-args {:backend :claude :model "sonnet"} "hi" nil)]]
+  (assert (has-flag-pair args "--model" "sonnet") "build-args: --model sonnet pair"))
+
+# Claude with session resume
+(let [[args (agent:build-args {:backend :claude} "hi" "abc-123")]]
+  (assert (has-flag-pair args "--resume" "abc-123") "build-args: --resume pair"))
+
+# OpenCode basic args
+(let [[args (agent:build-args {:backend :opencode} "hello" nil)]]
+  (assert (= (first args) "opencode") "build-args: opencode binary")
+  (assert (has-flag-pair args "--format" "json") "build-args: opencode format pair"))
+
+# OpenCode with session resume
+(let [[args (agent:build-args {:backend :opencode} "hi" "sess-1")]]
+  (assert (has-flag-pair args "--session" "sess-1") "build-args: --session pair")
+  (assert (any? (fn [x] (= x "--continue")) args) "build-args: --continue flag"))
+
+# OpenCode model flag
+(let [[args (agent:build-args {:backend :opencode :model "gpt-4"} "hi" nil)]]
+  (assert (has-flag-pair args "-m" "gpt-4") "build-args: opencode -m pair"))
+
+# Claude with all options
+(let [[args (agent:build-args {:backend :claude
+                                :model "opus"
+                                :system-prompt "be helpful"
+                                :allowed-tools ["Read" "Write"]
+                                :denied-tools ["Bash"]
+                                :skip-permissions true
+                                :dir "/tmp/project"
+                                :effort :high
+                                :max-budget 1.5
+                                :opts ["--extra"]}
+                               "do stuff" nil)]]
+  (assert (has-flag-pair args "--system-prompt" "be helpful") "build-args: system-prompt pair")
+  (assert (has-flag-pair args "--allowedTools" "Read") "build-args: allowed Read")
+  (assert (has-flag-pair args "--allowedTools" "Write") "build-args: allowed Write")
+  (assert (has-flag-pair args "--disallowedTools" "Bash") "build-args: denied Bash")
+  (assert (any? (fn [x] (= x "--dangerously-skip-permissions")) args) "build-args: skip perms")
+  (assert (has-flag-pair args "--add-dir" "/tmp/project") "build-args: add-dir pair")
+  (assert (has-flag-pair args "--effort" "high") "build-args: effort pair")
+  (assert (has-flag-pair args "--max-budget-usd" "1.5") "build-args: max-budget pair")
+  (assert (any? (fn [x] (= x "--extra")) args) "build-args: passthrough opt"))
+
+# Unknown backend errors
+(let [[[ok? err] (protect (agent:build-args {:backend :unknown} "hi" nil))]]
+  (assert (not ok?) "build-args: unknown backend errors")
+  (assert (= err:error :agent-error) "build-args: error is :agent-error"))
+
+# Backend-specific flags omitted for other backend
+(let [[args (agent:build-args {:backend :opencode :skip-permissions true} "hi" nil)]]
+  (assert (not (any? (fn [x] (= x "--dangerously-skip-permissions")) args))
+          "build-args: skip-permissions ignored for opencode"))
+
+
+# ── make-handle ─────────────────────────────────────────────────────────────
+
+(let [[h (agent:make-handle {:backend :claude :model "sonnet"})]]
+  (assert (nil? h:session-id) "make-handle: session-id starts nil")
+  (assert (= (get h:config :backend) :claude) "make-handle: config preserved")
+  (assert (= (get h:config :model) "sonnet") "make-handle: model preserved"))
+
+
+# ── send via mock subprocess (Claude) ───────────────────────────────────────
+
+(def mock-script "tests/elle/agent-mock.lisp")
+
+(file/write mock-script
+  (string
+    "(println (json/serialize {\"type\" \"content_block_delta\" \"delta\" {\"type\" \"text_delta\" \"text\" \"hello\"}}))\n"
+    "(println (json/serialize {\"type\" \"content_block_delta\" \"delta\" {\"type\" \"text_delta\" \"text\" \" world\"}}))\n"
+    "(println (json/serialize {\"type\" \"system\" \"data\" \"init\"}))\n"
+    "(println (json/serialize {\"type\" \"result\" \"result\" \"hello world\" \"total_cost_usd\" 0.05 \"session_id\" \"sess-abc\" \"usage\" {\"input_tokens\" 100 \"output_tokens\" 50}}))\n"))
+
+# stream/collect to consume the stream
+(let* [[handle (agent:make-handle {:backend :claude
+                                    :command ["elle" mock-script]})]
+       [chunks (stream/collect (agent:send handle "ignored"))]]
+
+  (assert (= (length chunks) 3) "send claude: got 3 chunks (system skipped)")
+
+  (let* [[c0 (first chunks)]
+         [c1 (second chunks)]
+         [c2 (last chunks)]]
+    (assert (= c0:type :text) "send claude: chunk 0 is text")
+    (assert (= c0:text "hello") "send claude: chunk 0 text")
+    (assert (= c1:text " world") "send claude: chunk 1 text")
+    (assert (= c2:type :result) "send claude: result type")
+    (assert (= c2:cost 0.05) "send claude: result cost")
+    (assert (= c2:session-id "sess-abc") "send claude: result session-id")
+    (assert (= (get c2:tokens :input) 100) "send claude: input tokens")
+    (assert (= (get c2:tokens :output) 50) "send claude: output tokens"))
+
+  # Session-id written back to handle
+  (assert (= handle:session-id "sess-abc") "send claude: handle session-id updated"))
+
+
+# ── send via mock subprocess (OpenCode) ─────────────────────────────────────
+
+(def oc-mock "tests/elle/agent-oc-mock.lisp")
+
+(file/write oc-mock
+  (string
+    "(println (json/serialize {\"type\" \"text\" \"part\" {\"text\" \"thinking...\"}}))\n"
+    "(println (json/serialize {\"type\" \"step_start\" \"data\" {}}))\n"
+    "(println (json/serialize {\"type\" \"step_finish\" \"part\" {\"cost\" 0.03 \"tokens\" {:input 50 :output 25}}}))\n"))
+
+(let* [[handle (agent:make-handle {:backend :opencode
+                                    :command ["elle" oc-mock]})]
+       [chunks (stream/collect (agent:send handle "ignored"))]]
+
+  (assert (= (length chunks) 2) "send opencode: got 2 chunks (step_start skipped)")
+
+  (let* [[c0 (first chunks)]
+         [c1 (last chunks)]]
+    (assert (= c0:type :text) "send opencode: chunk 0 is text")
+    (assert (= c0:text "thinking...") "send opencode: chunk 0 text")
+    (assert (= c1:type :result) "send opencode: result type")
+    (assert (= c1:cost 0.03) "send opencode: result cost")))
+
+(file/delete oc-mock)
+
+
+# ── stream combinators work on send output ──────────────────────────────────
+
+# stream/for-each — the primary use case
+(let* [[handle (agent:make-handle {:backend :claude
+                                    :command ["elle" mock-script]})]
+       [texts @[]]]
+  (stream/for-each
+    (fn [chunk]
+      (when (= chunk:type :text)
+        (push texts chunk:text)))
+    (agent:send handle "ignored"))
+  (assert (= (length texts) 2) "stream/for-each: got 2 text chunks")
+  (assert (= (get texts 0) "hello") "stream/for-each: first text")
+  (assert (= (get texts 1) " world") "stream/for-each: second text"))
+
+# stream/filter + stream/collect
+(let* [[handle (agent:make-handle {:backend :claude
+                                    :command ["elle" mock-script]})]
+       [results (stream/collect
+                  (stream/filter
+                    (fn [c] (= c:type :result))
+                    (agent:send handle "ignored")))]]
+  (assert (= (length results) 1) "stream/filter: one result chunk")
+  (assert (= (get (first results) :cost) 0.05) "stream/filter: result cost"))
+
+
+# ── multi-turn: session continuation ────────────────────────────────────────
+
+(let* [[handle (agent:make-handle {:backend :claude
+                                    :command ["elle" mock-script]})]]
+  # First turn
+  (stream/for-each (fn [_] nil) (agent:send handle "first turn"))
+  (assert (= handle:session-id "sess-abc") "multi-turn: session-id set after first")
+
+  # Verify build-args would include --resume for next turn
+  (let [[args (agent:build-args handle:config "second turn" handle:session-id)]]
+    (assert (has-flag-pair args "--resume" "sess-abc") "multi-turn: --resume pair")))
+
+
+# ── send errors on nonzero exit without result ─────────────────────────────
+
+(def fail-script "tests/elle/agent-fail.lisp")
+(file/write fail-script "(sys/exit 1)\n")
+
+(let* [[handle (agent:make-handle {:backend :claude
+                                    :command ["elle" fail-script]})]
+       [[ok? err] (protect (stream/collect (agent:send handle "should fail")))]]
+  (assert (not ok?) "send fail: errors on nonzero exit")
+  (assert (= err:error :agent-error) "send fail: error is :agent-error"))
+
+(file/delete fail-script)
+
+
+# ── stderr chunks ───────────────────────────────────────────────────────────
+
+(def stderr-mock "tests/elle/agent-stderr-mock.lisp")
+(file/write stderr-mock
+  (string
+    "(eprintln \"warning: something\")\n"
+    "(println (json/serialize {\"type\" \"content_block_delta\" \"delta\" {\"type\" \"text_delta\" \"text\" \"ok\"}}))\n"
+    "(println (json/serialize {\"type\" \"result\" \"result\" \"ok\" \"total_cost_usd\" 0.01 \"session_id\" \"s2\" \"usage\" {\"input_tokens\" 1 \"output_tokens\" 1}}))\n"))
+
+(let* [[handle (agent:make-handle {:backend :claude
+                                    :command ["elle" stderr-mock]})]
+       [chunks  (stream/collect (agent:send handle "x"))]
+       [texts   (filter (fn [c] (= c:type :text)) chunks)]]
+  (assert (> (length texts) 0) "stderr: got text chunks")
+  (assert (= (get (first texts) :text) "ok") "stderr: text content"))
+
+(file/delete stderr-mock)
+
+
+# ── tool-use chunks (Claude) ───────────────────────────────────────────────
+
+(def tool-mock "tests/elle/agent-tool-mock.lisp")
+(file/write tool-mock
+  (string
+    "(println (json/serialize {\"type\" \"content_block_start\" \"content_block\" {\"type\" \"tool_use\" \"name\" \"Read\" \"id\" \"tu_1\"}}))\n"
+    "(println (json/serialize {\"type\" \"content_block_delta\" \"delta\" {\"type\" \"input_json_delta\" \"partial_json\" \"{\\\"path\\\":\"}}))\n"
+    "(println (json/serialize {\"type\" \"content_block_delta\" \"delta\" {\"type\" \"text_delta\" \"text\" \"reading file\"}}))\n"
+    "(println (json/serialize {\"type\" \"result\" \"result\" \"done\" \"total_cost_usd\" 0.02 \"session_id\" \"s3\" \"usage\" {\"input_tokens\" 10 \"output_tokens\" 5}}))\n"))
+
+(let* [[handle (agent:make-handle {:backend :claude
+                                    :command ["elle" tool-mock]})]
+       [chunks (stream/collect (agent:send handle "x"))]]
+  (let* [[tool-uses  (filter (fn [c] (= c:type :tool-use)) chunks)]
+         [tool-input (filter (fn [c] (= c:type :tool-input)) chunks)]
+         [texts      (filter (fn [c] (= c:type :text)) chunks)]]
+    (assert (= (length tool-uses) 1) "tool-use: got tool-use chunk")
+    (assert (= (get (first tool-uses) :name) "Read") "tool-use: name is Read")
+    (assert (= (get (first tool-uses) :id) "tu_1") "tool-use: id is tu_1")
+    (assert (= (length tool-input) 1) "tool-use: got tool-input chunk")
+    (assert (= (length texts) 1) "tool-use: got text chunk")))
+
+(file/delete tool-mock)
+
+
+# ── send-collect ────────────────────────────────────────────────────────────
+
+(let* [[handle (agent:make-handle {:backend :claude
+                                    :command ["elle" mock-script]})]
+       [result (agent:send-collect handle "x")]]
+  (assert (= result:text "hello world") "send-collect: concatenated text")
+  (assert (= result:cost 0.05) "send-collect: cost preserved")
+  (assert (= result:session-id "sess-abc") "send-collect: session-id preserved"))
+
+
+# ── total-cost accumulation ─────────────────────────────────────────────────
+
+(let [[handle (agent:make-handle {:backend :claude
+                                   :command ["elle" mock-script]})]]
+  (assert (= handle:total-cost 0) "total-cost: starts at 0")
+  (stream/for-each (fn [_] nil) (agent:send handle "turn 1"))
+  (assert (= handle:total-cost 0.05) "total-cost: after turn 1")
+  (stream/for-each (fn [_] nil) (agent:send handle "turn 2"))
+  (assert (= handle:total-cost 0.1) "total-cost: after turn 2"))
+
+
+# ── kill ────────────────────────────────────────────────────────────────────
+
+(def slow-mock "tests/elle/agent-slow-mock.lisp")
+(file/write slow-mock
+  (string
+    "(println (json/serialize {\"type\" \"content_block_delta\" \"delta\" {\"type\" \"text_delta\" \"text\" \"start\"}}))\n"
+    "(port/flush (port/stdout))\n"
+    "(time/sleep 60)\n"))
+
+(let [[handle (agent:make-handle {:backend :claude
+                                   :command ["elle" slow-mock]})]]
+  # Consume one chunk — proc should be set, then kill
+  (let [[co (agent:send handle "x")]]
+    (coro/resume co)
+    (assert (not (nil? handle:proc)) "kill: proc set during send")
+    (agent:kill handle)
+    (assert (nil? handle:proc) "kill: proc cleared after kill")))
+
+(file/delete slow-mock)
+
+
+# ── proc cleared after normal send ──────────────────────────────────────────
+
+(let [[handle (agent:make-handle {:backend :claude
+                                   :command ["elle" mock-script]})]]
+  (stream/for-each (fn [_] nil) (agent:send handle "x"))
+  (assert (nil? handle:proc) "proc: cleared after normal completion"))
+
+
+# ── cleanup ─────────────────────────────────────────────────────────────────
+
+(file/delete mock-script)
+
+(eprintln "all agent tests passed")

--- a/tests/elle/agent.lisp
+++ b/tests/elle/agent.lisp
@@ -2,6 +2,9 @@
 
 (def agent ((import-file "lib/agent.lisp")))
 
+# Resolve the elle binary — ELLE_BIN from Makefile, fallback to "elle"
+(def elle-bin (or (sys/env "ELLE_BIN") "elle"))
+
 
 # ── build-args: flag adjacency helper ──────────────────────────────────────
 
@@ -103,7 +106,7 @@
 
 # stream/collect to consume the stream
 (let* [[handle (agent:make-handle {:backend :claude
-                                    :command ["elle" mock-script]})]
+                                    :command [elle-bin mock-script]})]
        [chunks (stream/collect (agent:send handle "ignored"))]]
 
   (assert (= (length chunks) 3) "send claude: got 3 chunks (system skipped)")
@@ -135,7 +138,7 @@
     "(println (json/serialize {\"type\" \"step_finish\" \"part\" {\"cost\" 0.03 \"tokens\" {:input 50 :output 25}}}))\n"))
 
 (let* [[handle (agent:make-handle {:backend :opencode
-                                    :command ["elle" oc-mock]})]
+                                    :command [elle-bin oc-mock]})]
        [chunks (stream/collect (agent:send handle "ignored"))]]
 
   (assert (= (length chunks) 2) "send opencode: got 2 chunks (step_start skipped)")
@@ -154,7 +157,7 @@
 
 # stream/for-each — the primary use case
 (let* [[handle (agent:make-handle {:backend :claude
-                                    :command ["elle" mock-script]})]
+                                    :command [elle-bin mock-script]})]
        [texts @[]]]
   (stream/for-each
     (fn [chunk]
@@ -167,7 +170,7 @@
 
 # stream/filter + stream/collect
 (let* [[handle (agent:make-handle {:backend :claude
-                                    :command ["elle" mock-script]})]
+                                    :command [elle-bin mock-script]})]
        [results (stream/collect
                   (stream/filter
                     (fn [c] (= c:type :result))
@@ -179,7 +182,7 @@
 # ── multi-turn: session continuation ────────────────────────────────────────
 
 (let* [[handle (agent:make-handle {:backend :claude
-                                    :command ["elle" mock-script]})]]
+                                    :command [elle-bin mock-script]})]]
   # First turn
   (stream/for-each (fn [_] nil) (agent:send handle "first turn"))
   (assert (= handle:session-id "sess-abc") "multi-turn: session-id set after first")
@@ -195,7 +198,7 @@
 (file/write fail-script "(sys/exit 1)\n")
 
 (let* [[handle (agent:make-handle {:backend :claude
-                                    :command ["elle" fail-script]})]
+                                    :command [elle-bin fail-script]})]
        [[ok? err] (protect (stream/collect (agent:send handle "should fail")))]]
   (assert (not ok?) "send fail: errors on nonzero exit")
   (assert (= err:error :agent-error) "send fail: error is :agent-error"))
@@ -213,7 +216,7 @@
     "(println (json/serialize {\"type\" \"result\" \"result\" \"ok\" \"total_cost_usd\" 0.01 \"session_id\" \"s2\" \"usage\" {\"input_tokens\" 1 \"output_tokens\" 1}}))\n"))
 
 (let* [[handle (agent:make-handle {:backend :claude
-                                    :command ["elle" stderr-mock]})]
+                                    :command [elle-bin stderr-mock]})]
        [chunks  (stream/collect (agent:send handle "x"))]
        [texts   (filter (fn [c] (= c:type :text)) chunks)]]
   (assert (> (length texts) 0) "stderr: got text chunks")
@@ -233,7 +236,7 @@
     "(println (json/serialize {\"type\" \"result\" \"result\" \"done\" \"total_cost_usd\" 0.02 \"session_id\" \"s3\" \"usage\" {\"input_tokens\" 10 \"output_tokens\" 5}}))\n"))
 
 (let* [[handle (agent:make-handle {:backend :claude
-                                    :command ["elle" tool-mock]})]
+                                    :command [elle-bin tool-mock]})]
        [chunks (stream/collect (agent:send handle "x"))]]
   (let* [[tool-uses  (filter (fn [c] (= c:type :tool-use)) chunks)]
          [tool-input (filter (fn [c] (= c:type :tool-input)) chunks)]
@@ -250,7 +253,7 @@
 # ── send-collect ────────────────────────────────────────────────────────────
 
 (let* [[handle (agent:make-handle {:backend :claude
-                                    :command ["elle" mock-script]})]
+                                    :command [elle-bin mock-script]})]
        [result (agent:send-collect handle "x")]]
   (assert (= result:text "hello world") "send-collect: concatenated text")
   (assert (= result:cost 0.05) "send-collect: cost preserved")
@@ -260,7 +263,7 @@
 # ── total-cost accumulation ─────────────────────────────────────────────────
 
 (let [[handle (agent:make-handle {:backend :claude
-                                   :command ["elle" mock-script]})]]
+                                   :command [elle-bin mock-script]})]]
   (assert (= handle:total-cost 0) "total-cost: starts at 0")
   (stream/for-each (fn [_] nil) (agent:send handle "turn 1"))
   (assert (= handle:total-cost 0.05) "total-cost: after turn 1")
@@ -278,7 +281,7 @@
     "(time/sleep 60)\n"))
 
 (let [[handle (agent:make-handle {:backend :claude
-                                   :command ["elle" slow-mock]})]]
+                                   :command [elle-bin slow-mock]})]]
   # Consume one chunk — proc should be set, then kill
   (let [[co (agent:send handle "x")]]
     (coro/resume co)
@@ -292,7 +295,7 @@
 # ── proc cleared after normal send ──────────────────────────────────────────
 
 (let [[handle (agent:make-handle {:backend :claude
-                                   :command ["elle" mock-script]})]]
+                                   :command [elle-bin mock-script]})]]
   (stream/for-each (fn [_] nil) (agent:send handle "x"))
   (assert (nil? handle:proc) "proc: cleared after normal completion"))
 

--- a/tests/elle/agent.lisp
+++ b/tests/elle/agent.lisp
@@ -74,6 +74,38 @@
   (assert (has-flag-pair args "--max-budget-usd" "1.5") "build-args: max-budget pair")
   (assert (any? (fn [x] (= x "--extra")) args) "build-args: passthrough opt"))
 
+# Pi basic args
+(let [[args (agent:build-args {:backend :pi} "hello" nil)]]
+  (assert (= (first args) "pi") "build-args: pi binary")
+  (assert (has-flag-pair args "--mode" "json") "build-args: pi mode json")
+  (assert (= (last args) "hello") "build-args: pi prompt is last")
+  (assert (has-flag-pair args "-p" "hello") "build-args: pi -p prompt pair"))
+
+# Pi with model
+(let [[args (agent:build-args {:backend :pi :model "sonnet"} "hi" nil)]]
+  (assert (has-flag-pair args "--model" "sonnet") "build-args: pi --model pair"))
+
+# Pi with session resume
+(let [[args (agent:build-args {:backend :pi} "hi" "pi-sess-1")]]
+  (assert (has-flag-pair args "--session" "pi-sess-1") "build-args: pi --session pair")
+  (assert (any? (fn [x] (= x "--continue")) args) "build-args: pi --continue flag"))
+
+# Pi with system-prompt and effort (maps to --thinking)
+(let [[args (agent:build-args {:backend :pi
+                                :system-prompt "be brief"
+                                :effort :high}
+                               "task" nil)]]
+  (assert (has-flag-pair args "--system-prompt" "be brief") "build-args: pi system-prompt")
+  (assert (has-flag-pair args "--thinking" "high") "build-args: pi --thinking pair"))
+
+# Pi with allowed-tools (comma-separated --tools)
+(let [[args (agent:build-args {:backend :pi :allowed-tools ["read" "bash" "edit"]} "hi" nil)]]
+  (assert (has-flag-pair args "--tools" "read,bash,edit") "build-args: pi --tools comma-separated"))
+
+# Pi-only flags ignored for claude
+(let [[args (agent:build-args {:backend :claude :allowed-tools ["Read"]} "hi" nil)]]
+  (assert (not (any? (fn [x] (= x "--tools")) args)) "build-args: --tools not used for claude"))
+
 # Unknown backend errors
 (let [[[ok? err] (protect (agent:build-args {:backend :unknown} "hi" nil))]]
   (assert (not ok?) "build-args: unknown backend errors")
@@ -151,6 +183,89 @@
     (assert (= c1:cost 0.03) "send opencode: result cost")))
 
 (file/delete oc-mock)
+
+
+# ── send via mock subprocess (Pi) ───────────────────────────────────────────
+
+(def pi-mock "tests/elle/agent-pi-mock.lisp")
+
+(file/write pi-mock
+  (string
+    "(println (json/serialize {\"type\" \"session\" \"version\" 3 \"id\" \"pi-sess-1\" \"timestamp\" \"2025-01-01\" \"cwd\" \"/tmp\"}))\n"
+    "(println (json/serialize {\"type\" \"message_update\" \"assistantMessageEvent\" {\"type\" \"text_delta\" \"contentIndex\" 1 \"delta\" \"hello\"}}))\n"
+    "(println (json/serialize {\"type\" \"message_update\" \"assistantMessageEvent\" {\"type\" \"text_delta\" \"contentIndex\" 1 \"delta\" \" world\"}}))\n"
+    "(println (json/serialize {\"type\" \"message_end\" \"message\" {\"role\" \"assistant\" \"usage\" {\"input\" 100 \"output\" 50 \"cost\" {\"total\" 0.04}}}}))\n"))
+
+(let* [[handle (agent:make-handle {:backend :pi
+                                    :command [elle-bin pi-mock]})]
+       [chunks (stream/collect (agent:send handle "ignored"))]]
+
+  (assert (= (length chunks) 3) "send pi: got 3 chunks (session skipped)")
+
+  (let* [[c0 (first chunks)]
+         [c1 (second chunks)]
+         [c2 (last chunks)]]
+    (assert (= c0:type :text) "send pi: chunk 0 is text")
+    (assert (= c0:text "hello") "send pi: chunk 0 text")
+    (assert (= c1:text " world") "send pi: chunk 1 text")
+    (assert (= c2:type :result) "send pi: result type")
+    (assert (= c2:cost 0.04) "send pi: result cost")
+    (assert (= c2:session-id "pi-sess-1") "send pi: result session-id")
+    (assert (= (get c2:tokens :input) 100) "send pi: input tokens")
+    (assert (= (get c2:tokens :output) 50) "send pi: output tokens"))
+
+  # Session-id written back to handle
+  (assert (= handle:session-id "pi-sess-1") "send pi: handle session-id updated"))
+
+
+# ── pi tool-use chunks ──────────────────────────────────────────────────────
+
+(def pi-tool-mock "tests/elle/agent-pi-tool-mock.lisp")
+
+(file/write pi-tool-mock
+  (string
+    "(println (json/serialize {\"type\" \"session\" \"id\" \"pi-tool-s\"}))\n"
+    "(println (json/serialize {\"type\" \"message_update\" \"assistantMessageEvent\" {\"type\" \"toolcall_start\" \"contentIndex\" 0 \"partial\" {\"content\" [{\"type\" \"toolCall\" \"id\" \"tc_1\" \"name\" \"bash\"}]}}}))\n"
+    "(println (json/serialize {\"type\" \"message_update\" \"assistantMessageEvent\" {\"type\" \"toolcall_delta\" \"contentIndex\" 0 \"delta\" \"{\\\"command\\\": \\\"ls\\\"}\"}}))\n"
+    "(println (json/serialize {\"type\" \"message_update\" \"assistantMessageEvent\" {\"type\" \"text_delta\" \"contentIndex\" 1 \"delta\" \"done\"}}))\n"
+    "(println (json/serialize {\"type\" \"message_end\" \"message\" {\"role\" \"assistant\" \"usage\" {\"input\" 10 \"output\" 5 \"cost\" {\"total\" 0.01}}}}))\n"))
+
+(let* [[handle (agent:make-handle {:backend :pi
+                                    :command [elle-bin pi-tool-mock]})]
+       [chunks (stream/collect (agent:send handle "x"))]]
+  (let* [[tool-uses  (filter (fn [c] (= c:type :tool-use)) chunks)]
+         [tool-input (filter (fn [c] (= c:type :tool-input)) chunks)]
+         [texts      (filter (fn [c] (= c:type :text)) chunks)]]
+    (assert (= (length tool-uses) 1) "pi tool-use: got tool-use chunk")
+    (assert (= (get (first tool-uses) :name) "bash") "pi tool-use: name is bash")
+    (assert (= (get (first tool-uses) :id) "tc_1") "pi tool-use: id is tc_1")
+    (assert (= (length tool-input) 1) "pi tool-use: got tool-input chunk")
+    (assert (= (length texts) 1) "pi tool-use: got text chunk")))
+
+(file/delete pi-tool-mock)
+
+
+# ── pi send-collect ─────────────────────────────────────────────────────────
+
+(let* [[handle (agent:make-handle {:backend :pi
+                                    :command [elle-bin pi-mock]})]
+       [result (agent:send-collect handle "x")]]
+  (assert (= result:text "hello world") "pi send-collect: concatenated text")
+  (assert (= result:cost 0.04) "pi send-collect: cost preserved")
+  (assert (= result:session-id "pi-sess-1") "pi send-collect: session-id preserved"))
+
+
+# ── pi multi-turn: session continuation ─────────────────────────────────────
+
+(let [[handle (agent:make-handle {:backend :pi
+                                   :command [elle-bin pi-mock]})]]
+  (stream/for-each (fn [_] nil) (agent:send handle "first"))
+  (assert (= handle:session-id "pi-sess-1") "pi multi-turn: session-id set")
+  (let [[args (agent:build-args handle:config "second" handle:session-id)]]
+    (assert (has-flag-pair args "--session" "pi-sess-1") "pi multi-turn: --session pair")
+    (assert (any? (fn [x] (= x "--continue")) args) "pi multi-turn: --continue flag")))
+
+(file/delete pi-mock)
 
 
 # ── stream combinators work on send output ──────────────────────────────────
@@ -298,6 +413,38 @@
                                    :command [elle-bin mock-script]})]]
   (stream/for-each (fn [_] nil) (agent:send handle "x"))
   (assert (nil? handle:proc) "proc: cleared after normal completion"))
+
+
+# ── chunk contract validation ────────────────────────────────────────────────
+
+# Bad chunk: :cost is string instead of number
+(def bad-cost-mock "tests/elle/agent-bad-cost.lisp")
+(file/write bad-cost-mock
+  (string
+    "(println (json/serialize {\"type\" \"step_finish\" \"part\" {\"cost\" \"expensive\"}}))"))
+
+(let* [[handle (agent:make-handle {:backend :opencode
+                                    :command [elle-bin bad-cost-mock]})]
+       [[ok? err] (protect (stream/collect (agent:send handle "x")))]]
+  (assert (not ok?) "contract: non-number cost rejected")
+  (assert (= err:error :agent-error) "contract: cost error is :agent-error"))
+
+(file/delete bad-cost-mock)
+
+# Bad chunk: :text is integer instead of string
+(def bad-text-mock "tests/elle/agent-bad-text.lisp")
+(file/write bad-text-mock
+  (string
+    "(println (json/serialize {\"type\" \"content_block_delta\" \"delta\" {\"type\" \"text_delta\" \"text\" 42}}))\n"
+    "(println (json/serialize {\"type\" \"result\" \"result\" \"ok\" \"total_cost_usd\" 0.01 \"session_id\" \"s\" \"usage\" {\"input_tokens\" 1 \"output_tokens\" 1}}))"))
+
+(let* [[handle (agent:make-handle {:backend :claude
+                                    :command [elle-bin bad-text-mock]})]
+       [[ok? err] (protect (stream/collect (agent:send handle "x")))]]
+  (assert (not ok?) "contract: non-string text rejected")
+  (assert (= err:error :agent-error) "contract: text error is :agent-error"))
+
+(file/delete bad-text-mock)
 
 
 # ── cleanup ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION

lib/agent.lisp: runtime abstraction over Claude Code and OpenCode
subprocesses. Table-driven flag mapping, NDJSON stream normalization
(text, tool-use, tool-input, stderr, result chunks), session
continuation via --resume/--session, cost accumulation, subprocess
lifecycle (kill). send returns a stream; timeout is the caller's domain
via ev/timeout + agent:kill.