### PR TITLE
docs: design philosophy, agent reasoning, and cross-linking

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,17 @@
 
 [![CI](https://github.com/elle-lisp/elle/actions/workflows/main.yml/badge.svg)](https://github.com/elle-lisp/elle/actions/workflows/main.yml)
 
-Elle is a Lisp. If you know [Janet](https://janet-lang.org), think Janet on steroids — the same practical spirit (embeddable, batteries-included, modern syntax), but with a compilation pipeline that does deep static analysis before any code runs: full binding resolution, capture analysis, and signal inference at compile time. This gives Elle a sound signal system, fully hygienic macros, colorless concurrency via fibers, and deterministic memory management — all derived from the same analysis pass.
+Elle is a Lisp with a compilation pipeline that does deep static analysis before any code runs: full binding resolution, capture analysis, and signal inference at compile time. This gives Elle a sound signal system, fully hygienic macros, colorless concurrency via fibers, and deterministic memory management — all derived from the same analysis pass.
+
+The compiler already knows what every binding refers to, what every closure captures, and what signals every function can emit. This information is available to user code at runtime via `compile/analyze` and related functions, and exposed to AI agents via:
+
+- **[Portrait](docs/analysis/portrait.md)** — Signal profiles, captures, and composition properties of a single file
+- **[MCP Server](docs/mcp.md)** — Semantic knowledge graph of the entire codebase, queryable via SPARQL
+- **[Agent Reasoning](docs/analysis/agent-reasoning.md)** — How AI agents use these tools to understand, refactor, and verify code
+
+Humans write readable code without type annotations or formal constraints. Agents query the semantic model the compiler produces. Neither compromises the other.
+
+If you know [Janet](https://janet-lang.org), think Janet on steroids — the same practical spirit (embeddable, batteries-included, modern syntax), with a compiler that understands your code deeply enough to expose it as structured data.
 
 ## Contents
 
@@ -20,6 +30,7 @@ Elle is a Lisp. If you know [Janet](https://janet-lang.org), think Janet on ster
 - [Epochs — Versioned Syntax Migration](#epochs--versioned-syntax-migration)
 - [Tooling](#tooling)
 - [Documentation](#documentation)
+- [For Agent Developers](#for-agent-developers)
 - [Coming from Another Language](#coming-from-another-language)
 - [Getting Started](#getting-started)
 - [License](#license)
@@ -828,6 +839,14 @@ Start with [QUICKSTART.md](QUICKSTART.md) for the full table of contents.
 | `docs/cookbook/` | Recipes for common codebase changes |
 | `docs/analysis/` | Testing, debugging, semantic portraits |
 | `docs/impl/` | Implementation internals (reader, HIR, LIR, VM, JIT) |
+
+## For Agent Developers
+
+The compiler computes signal inference, capture analysis, and call graphs for every file. The MCP server makes all of this queryable.
+
+- **[Agent Reasoning Guide](docs/analysis/agent-reasoning.md)** — Workflow: understand locally via `portrait`, reason globally via SPARQL, refactor via compile-aware tools
+- **[MCP Server](docs/mcp.md)** — 15 tools: `portrait`, `signal_query`, `impact`, `trace`, `compile_rename`, `compile_extract`, `compile_parallelize`, `verify_invariants`, and SPARQL
+- **[Analysis overview](docs/analysis/README.md)** — How portrait, MCP, and agent reasoning fit together
 
 ## Coming from Another Language
 

--- a/docs/analysis/README.md
+++ b/docs/analysis/README.md
@@ -1,0 +1,79 @@
+# Code Analysis and Semantic Understanding
+
+This directory contains documentation for understanding and reasoning about Elle code—both locally (within a file) and globally (across the entire codebase).
+
+## The Three Layers of Code Understanding
+
+### 1. Local Analysis: `portrait.lisp`
+
+[portrait.md](portrait.md) — Analyze a single file without executing it.
+
+Use `compile/analyze` to get:
+- Signal profiles (does it yield? do I/O? error?)
+- Capture analysis (what variables does it close over?)
+- Call graphs (what does it call?)
+- Composition properties (JIT-eligible? parallelizable? memoizable?)
+- Observations (non-obvious properties like almost-pure functions or shared mutable state)
+
+**Use case:** Understand a single function or module in depth.
+
+### 2. Global Analysis: MCP Knowledge Graph
+
+[../mcp.md](../mcp.md) — Query the entire codebase as an RDF knowledge graph.
+
+The MCP server exposes:
+- **RDF triples** — Every function, definition, import, and call in the codebase
+- **SPARQL interface** — Query the graph for patterns, dependencies, and composition
+- **Refactoring tools** — Rename, extract, parallelize (binding-aware and signal-aware)
+- **Tracing** — Follow Elle functions through Rust primitives into implementation
+
+**Use case:** Understand code structure, impact, and composition across files.
+
+### 3. Agent Reasoning
+
+[agent-reasoning.md](agent-reasoning.md) — How AI agents reason about Elle code.
+
+Combines portrait (local) + MCP (global) into a workflow:
+1. **Understand** — Use portrait to analyze a file
+2. **Query** — Use SPARQL to understand codebase-wide impact
+3. **Refactor** — Use compile-aware tools for safe changes
+
+**Use case:** Automate code understanding, refactoring, and verification.
+
+## Relationship to Language Design
+
+The compiler already computes signal inference, capture analysis, and call graphs for every file it compiles. These tools surface that information:
+
+| What the compiler knows | How it's exposed |
+|---|---|
+| Signal profiles (yields, I/O, silent) | Portrait, MCP `elle:signal-*` predicates |
+| Call graphs (what calls what) | MCP `elle:calls` triples, SPARQL queries |
+| Capture analysis (what's closed over) | Portrait captures, MCP `elle:capture` predicates |
+| Binding scope and resolution | `compile_rename`, `compile_extract` |
+| Cross-file structure | MCP knowledge graph (populated by `analyze_file`) |
+
+The language design (polymorphic-by-default, dynamic modules, per-file compilation) is sound. These tools don't compensate for gaps — they expose what the compiler already computes so that humans and agents can query it.
+
+See [philosophy.md](../../philosophy.md) and [modules.md](../modules.md) for the design rationale.
+
+## For Humans
+
+If you're reading Elle code:
+- Use [portrait.md](portrait.md) to understand a function's behavior
+- Read source code for exact semantics
+- Use [../mcp.md](../mcp.md) if you need to understand cross-file impact
+
+## For Agents
+
+If you're analyzing Elle code:
+- Use `portrait` to understand a file locally
+- Use `sparql_query` to find patterns across the codebase
+- Use `compile_rename`, `compile_extract`, `compile_parallelize` for safe refactoring
+- Use `trace` to understand cross-language behavior (Elle → Rust)
+- See [agent-reasoning.md](agent-reasoning.md) for workflows and patterns
+
+## Design Principle
+
+The compiler already knows everything these tools expose. Portrait and MCP don't add information — they make existing compiler analysis accessible outside the compilation pipeline.
+
+Everything is available to normal Elle code at runtime via `compile/analyze`, `compile/signal`, `compile/captures`, `compile/callees`, and related functions. The MCP server is itself just an Elle program that wraps these primitives in JSON-RPC. You can build your own analysis tools using the same functions.

--- a/docs/analysis/README.md
+++ b/docs/analysis/README.md
@@ -54,7 +54,7 @@ The compiler already computes signal inference, capture analysis, and call graph
 
 The language design (polymorphic-by-default, dynamic modules, per-file compilation) is sound. These tools don't compensate for gaps — they expose what the compiler already computes so that humans and agents can query it.
 
-See [philosophy.md](../../philosophy.md) and [modules.md](../modules.md) for the design rationale.
+See [philosophy.md](../philosophy.md) and [modules.md](../modules.md) for the design rationale.
 
 ## For Humans
 

--- a/docs/analysis/agent-reasoning.md
+++ b/docs/analysis/agent-reasoning.md
@@ -1,0 +1,259 @@
+# Agent Reasoning in Elle
+
+Elle is designed to be easily reasoned about by AI coding assistants. This guide explains how agents should approach code understanding, analysis, and refactoring in Elle.
+
+**Related:** [Portrait](portrait.md) (local file analysis), [MCP Server](../mcp.md) (global knowledge graph), [Analysis README](README.md) (overview of all analysis tools), [Philosophy](../philosophy.md) (design rationale).
+
+## The two-layer approach
+
+Elle separates **human interface** from **machine interface**:
+
+- **Layer 1 (Human)**: The Elle language itself—simple, readable, no formal annotations
+- **Layer 2 (Machine)**: Portrait (local analysis) + MCP (global reasoning) give agents complete semantic visibility
+
+An agent doesn't need to understand signals by reading source code. It queries the semantic graph instead.
+
+## Workflow: Understand → Query → Refactor
+
+### Step 1: Understand a function locally (Portrait)
+
+When analyzing a single file or function, use `portrait` to get its profile:
+
+```lisp
+# Analyze the file
+(def a (compile/analyze (file/read "lib/http.lisp") {:file "lib/http.lisp"}))
+
+# Get a function's portrait
+(def portrait-lib ((import "std/portrait")))
+(println (portrait-lib:render (portrait-lib:function a :make-request)))
+```
+
+This reveals:
+- **Signal profile**: Does it yield? Do I/O? Error?
+- **Composition**: JIT-eligible? Memoizable? Safe to parallelize?
+- **Captures**: What variables does it close over?
+- **Observations**: Non-obvious properties (almost-pure? Shared mutable state?)
+
+### Step 2: Understand codebase-wide impact (MCP + SPARQL)
+
+When making a change, query the global graph to understand impact:
+
+**Before renaming a function:**
+```sparql
+# Who calls this function?
+SELECT ?caller
+WHERE {
+  ?caller a <urn:elle:Fn> ;
+          <urn:elle:calls> ?target .
+  ?target <urn:elle:name> "old-name" .
+}
+```
+
+**Before optimizing a function:**
+```sparql
+# Is it JIT-eligible? Do its callers depend on its signal?
+SELECT ?name ?jit ?file
+WHERE {
+  ?fn a <urn:elle:Fn> ;
+      <urn:elle:name> "my-function" ;
+      <urn:elle:jit-eligible> ?jit ;
+      <urn:elle:file> ?file .
+}
+```
+
+**To find optimization opportunities:**
+```sparql
+# Which functions are called most frequently? (composition hotspots)
+SELECT ?name (COUNT(?caller) as ?inbound)
+WHERE {
+  ?caller a <urn:elle:Fn> ;
+          <urn:elle:calls> ?fn .
+  ?fn <urn:elle:name> ?name .
+}
+GROUP BY ?name
+ORDER BY DESC(?inbound)
+LIMIT 10
+```
+
+### Step 3: Refactor safely using compile-aware tools
+
+Don't edit text directly. Use the compile-safe tools:
+
+**Rename a function and all references:**
+```
+compile_rename(path: "lib/http.lisp", old_name: "request-handler", new_name: "handle-request")
+```
+This respects lexical scope—shadowed bindings are left alone.
+
+**Extract a code region into its own function:**
+```
+compile_extract(path: "lib/http.lisp", from: "process-request", start_line: 10, end_line: 25, name: "validate-headers")
+```
+The tool computes free variables (which become parameters) and infers the extracted function's signal.
+
+**Check if functions can run in parallel:**
+```
+compile_parallelize(path: "lib/process.lisp", functions: ["worker1", "worker2", "worker3"])
+```
+This verifies no shared mutable captures would cause data races.
+
+## Signal reasoning for agents
+
+Agents can reason about signals without reading code—just query the graph.
+
+### Signal propagation
+
+If function A calls function B, A's signal is at least as broad as B's. Query this relationship:
+
+```sparql
+# Get the transitive closure of signal implications
+SELECT ?fn1 ?fn2
+WHERE {
+  ?fn1 a <urn:elle:Fn> ;
+       <urn:elle:calls> ?fn2 .
+  ?fn1 <urn:elle:signal-yields> ?yields1 .
+  ?fn2 <urn:elle:signal-yields> ?yields2 .
+  FILTER (NOT ?yields1 && ?yields2)  # fn1 is silent but calls yielding fn2
+}
+```
+
+This finds violations—functions that claim to be silent but call yielding functions.
+
+### Finding constraints
+
+Parameter bounds create signal constraints. Query functions that take constrained callbacks:
+
+```sparql
+# Functions that take callbacks (potential for delegation)
+SELECT ?name ?captures
+WHERE {
+  ?fn a <urn:elle:Fn> ;
+      <urn:elle:name> ?name ;
+      <urn:elle:capture> ?captures .
+  FILTER (CONTAINS(STR(?captures), "f") || CONTAINS(STR(?captures), "callback"))
+}
+```
+
+Then use the `impact` tool to see downstream implications of changing those callbacks.
+
+## Cross-language understanding
+
+Use the `trace` tool to understand exactly how Elle functions map to Rust implementations:
+
+```
+trace(path: "lib/portrait.lisp", function: "classify-phase", depth: 2)
+```
+
+Returns a complete call chain showing Elle calls → Rust primitives → Rust implementation:
+
+```
+[elle] get (line 31, tail=false)
+  -> [rust] prim_get src/primitives/access.rs:44
+       [rust] resolve_index src/primitives/access.rs:11
+       [rust] get src/config.rs:27
+       [rust] error_val src/value/error.rs:10
+
+[elle] empty? (line 32, tail=false)
+  -> [rust] prim_empty src/primitives/list/mod.rs:590
+       [rust] error_val src/value/error.rs:10
+```
+
+Each line shows:
+- **Language** — Elle or Rust
+- **Function name** — what's being called
+- **Source location** — exact file and line number
+- **IRIs** — RDF identifiers for the graph
+
+### What agents can do with traces
+
+**Find performance bottlenecks:**
+1. Trace a hot function
+2. See which Rust implementations it calls
+3. Check if those Rust functions have complex logic (read the source)
+4. Look for data structure traversals, allocations, or system calls
+
+**Understand cost of operations:**
+Each Elle operation maps to one or more Rust functions. Trace shows the cost:
+- `(get struct :key)` → `prim_get` → `resolve_index` + `get` + error handling
+- The trace reveals that every struct access has error handling overhead
+
+**Identify optimization opportunities:**
+- Are certain primitives called repeatedly? Consider caching
+- Does a function call through many layers? Consider a specialized primitive
+- Is there redundant work across calls? Fusion/optimization opportunity
+
+**Cross-language debugging:**
+If behavior is unexpected, trace shows exactly which Rust code is involved.
+An agent can then read the Rust source to understand semantics.
+
+## Invariant checking
+
+Define project-level invariants as SPARQL ASK queries in `.elle-invariants.lisp`:
+
+```lisp
+# No mutable state shared across functions
+(defn check-shared-mutable []
+  '(ASK WHERE {
+     ?var a <urn:elle:Var> ;
+          <urn:elle:captured-by> ?f1 ;
+          <urn:elle:captured-by> ?f2 .
+     FILTER (?f1 != ?f2)
+   }))
+```
+
+Then verify via:
+```
+verify_invariants()
+```
+
+Agents can use this to ensure code meets invariants before committing changes.
+
+## Why this approach works for agents
+
+1. **No ambiguity** — Signals are explicit in the RDF, not inferred from reading code
+2. **Queryable** — SPARQL is expressive enough to find any structural pattern
+3. **Composable** — Small, focused tools (rename, extract, parallelize) that combine
+4. **Language-agnostic** — Agents don't need to parse Elle syntax; they query the graph
+5. **Safe** — Refactoring tools understand binding and scoping rules
+
+An agent doesn't need to understand Elle's syntax deeply. It understands the **semantic model** the tools expose.
+
+## Common agent patterns
+
+### Pattern 1: Optimize a hot path
+
+1. Query: "Which functions are called most?"
+2. Query: "Which are not JIT-eligible and why?"
+3. Use `impact` to check: "What would change if I made this silent?"
+4. Use `compile_extract` to factor out the I/O or yielding parts
+5. Verify: "Check invariants"
+
+### Pattern 2: Detect data races
+
+1. Query: "Which variables are captured by multiple functions?"
+2. Query: "Are any of those captures mutated?"
+3. Use `portrait` to understand each function's role
+4. Propose: synchronization or refactoring to remove shared state
+5. Use `compile_parallelize` to verify the fix
+
+### Pattern 3: Understand cascading changes
+
+1. Query: "Who calls this function?"
+2. For each caller: Query: "What are their callers?"
+3. Build the impact graph
+4. Use `compile_rename` for safe mass-refactoring
+5. Verify: "Check invariants"
+
+### Pattern 4: Find abstraction boundaries
+
+1. Query: "Which functions have no outbound calls?" (pure/data-processing)
+2. Query: "Which functions have no inbound calls?" (entry points)
+3. Use `compile_extract` to consolidate related functions into modules
+4. Use `portrait:module` to understand the new module's profile
+
+## See also
+
+- [portrait.md](portrait.md) — Local function analysis
+- [mcp.md](../mcp.md) — Global semantic graph and query interface
+- [signals/index.md](../signals/index.md) — Signal system design
+- [modules.md](../modules.md) — Module system and composition

--- a/docs/analysis/agent-reasoning.md
+++ b/docs/analysis/agent-reasoning.md
@@ -19,7 +19,7 @@ An agent doesn't need to understand signals by reading source code. It queries t
 
 When analyzing a single file or function, use `portrait` to get its profile:
 
-```lisp
+```text
 # Analyze the file
 (def a (compile/analyze (file/read "lib/http.lisp") {:file "lib/http.lisp"}))
 
@@ -200,7 +200,7 @@ An agent can then read the Rust source to understand semantics.
 
 Define project-level invariants as SPARQL ASK queries in `.elle-invariants.lisp`:
 
-```lisp
+```text
 # No mutable state shared across functions
 (defn check-shared-mutable []
   '(ASK WHERE {

--- a/docs/analysis/agent-reasoning.md
+++ b/docs/analysis/agent-reasoning.md
@@ -97,6 +97,16 @@ compile_parallelize(path: "lib/process.lisp", functions: ["worker1", "worker2", 
 ```
 This verifies no shared mutable captures would cause data races.
 
+### Step 4: Verify
+
+After any refactoring, re-analyze the affected files and run tests:
+
+```
+analyze_file(path: "lib/http.lisp")
+```
+
+The knowledge graph is a cache of compiler analysis. Source code is always ground truth. If the graph seems wrong, re-analyze the file. If the mismatch persists after re-analysis, it's a compiler bug — not a code error.
+
 ## Signal reasoning for agents
 
 Agents can reason about signals without reading code—just query the graph.

--- a/docs/analysis/portrait.md
+++ b/docs/analysis/portrait.md
@@ -4,6 +4,8 @@ The portrait system exposes everything the compiler knows about your code:
 signal profiles, capture analysis, composition properties, and the call graph.
 It analyzes source without executing it.
 
+**See also:** [Agent Reasoning in Elle](agent-reasoning.md) for how to use portrait + MCP together for codebase-wide analysis. For global codebase queries, see [MCP server](../mcp.md).
+
 ## Compile-time analysis
 
 ```text

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -5,6 +5,8 @@ Protocol) server that gives AI coding assistants deep, structured access
 to an Elle codebase. The server is itself written in Elle
 ([`tools/mcp-server.lisp`](../tools/mcp-server.lisp)) and communicates via JSON-RPC 2.0 on stdio.
 
+**See also:** [Agent Reasoning in Elle](analysis/agent-reasoning.md) for how to use MCP + portrait together. [Portrait](analysis/portrait.md) for local file analysis. [Analysis directory](analysis/) for an overview of code understanding tools.
+
 ## What it does
 
 The server maintains a persistent RDF knowledge graph (via the oxigraph
@@ -45,7 +47,7 @@ code through the graph rather than through ad-hoc text searches.
 
 | Tool | Description |
 |------|-------------|
-| `trace` | Trace an Elle function through primitives into the Rust implementation. Shows the full call chain: Elle code → Elle primitives → Rust functions → deeper Rust calls. Configurable depth. |
+| `trace` | Trace an Elle function through primitives into the Rust implementation. For each Elle function call, shows exactly which Rust primitive it maps to (with file/line), and what Rust functions that primitive calls. Complete end-to-end call chain with source locations. Configurable depth. |
 | `verify_invariants` | Check project invariants encoded as SPARQL ASK queries (from `.elle-invariants.lisp`). |
 
 ## Knowledge graph schema
@@ -53,14 +55,64 @@ code through the graph rather than through ad-hoc text searches.
 The graph is populated by `analyze_file` (Elle sources) and the
 supporting [`tools/elle-graph.lisp`](../tools/elle-graph.lisp) and [`tools/rust-graph.lisp`](../tools/rust-graph.lisp) scripts.
 
-### Elle entities (`urn:elle:` namespace)
+### Elle function analysis (`urn:elle:Fn`)
+
+Each function is represented with complete signal and composition metadata:
+
+| Predicate | Type | Description |
+|-----------|------|-------------|
+| `elle:name` | string | Function name |
+| `elle:file` | string | Source file path |
+| `elle:arity` | integer | Number of parameters |
+| `elle:param` | string | Parameter name (repeated) |
+| `elle:doc` | string | Docstring if present |
+| `elle:signal-yields` | boolean | True if function may yield |
+| `elle:signal-io` | boolean | True if function does I/O |
+| `elle:signal-error` | boolean | True if function may error |
+| `elle:jit-eligible` | boolean | True if JIT-compilable (silent, no I/O) |
+| `elle:calls` | IRI | Function this calls (repeated) |
+| `elle:capture` | string | Variable this captures (repeated) |
+| `elle:capture-mutated` | string | Captured variable that is mutated (repeated) |
+
+**Example query: Find all I/O functions**
+```sparql
+SELECT ?name ?file WHERE {
+  ?fn a <urn:elle:Fn> ;
+      <urn:elle:name> ?name ;
+      <urn:elle:file> ?file ;
+      <urn:elle:signal-io> true .
+}
+```
+
+**Example query: Functions that call a specific function**
+```sparql
+SELECT ?caller ?file WHERE {
+  ?caller a <urn:elle:Fn> ;
+          <urn:elle:calls> ?target ;
+          <urn:elle:file> ?file .
+  ?target <urn:elle:name> "map" .
+}
+```
+
+**Example query: Potentially shared mutable state (race condition risk)**
+```sparql
+SELECT ?var (COUNT(?fn) as ?captures)
+WHERE {
+  ?fn a <urn:elle:Fn> ;
+      <urn:elle:capture-mutated> ?var .
+}
+GROUP BY ?var
+HAVING (?captures > 1)
+```
+
+### Other Elle entities
 
 | Type | Predicates |
 |------|-----------|
-| `elle:Fn` | `elle:name`, `elle:file`, `elle:arity`, `elle:param`, `elle:doc` |
 | `elle:Def` | `elle:name`, `elle:file` |
 | `elle:Macro` | `elle:name`, `elle:file` |
 | `elle:Import` | `elle:name`, `elle:path`, `elle:file` |
+| `elle:Primitive` | `elle:name`, `elle:arity`, `elle:doc`, `elle:signal-*` (same as Fn) |
 
 ### Rust entities (`urn:rust:` namespace)
 
@@ -109,25 +161,37 @@ elle tools/rust-graph.lisp
 
 ## What can an AI agent do with it?
 
-**Understand code across language boundaries.** Ask the `trace` tool to
-follow `map` from Elle into Rust:
+**Understand code across language boundaries.** Trace a function from Elle through Rust implementations:
 
 ```
-trace(path: "stdlib.lisp", function: "map")
+trace(path: "lib/portrait.lisp", function: "classify-phase", depth: 2)
 ```
 
-Returns the full call chain: `map` (Elle) → calls `cons`, `first`,
-`rest` (primitives) → Rust `prim_cons`, `prim_first`, `prim_rest` →
-`Value::cons()`, `Cons::first`, `Cons::rest`.
+Returns the complete call chain with source locations:
 
-**Assess refactoring impact.** Before changing `prim_first`:
+```
+[elle] get (line 31, tail=false)
+  -> [rust] prim_get src/primitives/access.rs:44
+       [rust] resolve_index src/primitives/access.rs:11
+       [rust] error_val src/value/error.rs:10
+
+[elle] empty? (line 32, tail=false)
+  -> [rust] prim_empty src/primitives/list/mod.rs:590
+```
+
+Every Elle operation maps to Rust implementations with exact file/line information. Agents can:
+- Find performance bottlenecks by seeing which primitives are called
+- Understand the cost of operations (e.g., every struct access goes through error handling)
+- Read Rust source code for specific operations
+- Identify optimization opportunities (repeated patterns, unnecessary layers, etc.)
+
+**Assess cascading refactoring impact.** Before changing a primitive:
 
 ```
 impact(path: "src/primitives/list/mod.rs", function: "prim_first")
 ```
 
-Returns every Elle function that calls `first`, what their signals are,
-and whether any are JIT-compiled.
+Returns every Elle function that calls `first`, their signals, whether they're JIT-compiled, and what would change if you modified `prim_first`.
 
 **Find functions by behavior.** Which functions do I/O?
 
@@ -135,47 +199,127 @@ and whether any are JIT-compiled.
 signal_query(path: "lib/http.lisp", query: "io")
 ```
 
-**Refactor safely.** Rename a function and all its references:
+Returns all I/O-performing functions, ready for optimization or scrutiny.
+
+**Refactor safely across the codebase.** Rename a function and all references:
 
 ```
 compile_rename(path: "lib/process.lisp", old_name: "helper", new_name: "dispatch")
 ```
 
-The rename respects lexical scope — shadowed bindings are left alone.
+The tool respects lexical scope — shadowed bindings are left alone.
 
-**Query the graph directly.** Any SPARQL query works:
+**Query the semantic graph directly.** Any SPARQL query works:
 
 ```sparql
-# Which files import the most modules?
-SELECT ?file (COUNT(*) AS ?imports) WHERE {
-  ?s a <urn:elle:Import> ; <urn:elle:file> ?file
-} GROUP BY ?file ORDER BY DESC(?imports)
+# Which functions are JIT-eligible? (performance candidates)
+SELECT ?name ?file (COUNT(?caller) as ?calls)
+WHERE {
+  ?fn a <urn:elle:Fn> ;
+      <urn:elle:name> ?name ;
+      <urn:elle:file> ?file ;
+      <urn:elle:jit-eligible> true .
+  OPTIONAL {
+    ?caller a <urn:elle:Fn> ;
+            <urn:elle:calls> ?fn .
+  }
+}
+GROUP BY ?name ?file
+ORDER BY DESC(?calls)
 ```
 
-## Example SPARQL queries
+## Example SPARQL queries for agents
 
-Find all functions that can error:
-
+**Find all JIT-eligible functions (performance hotspots to optimize)**
 ```sparql
 SELECT ?name ?file WHERE {
   ?fn a <urn:elle:Fn> ;
       <urn:elle:name> ?name ;
-      <urn:elle:file> ?file .
-  # Filter by signal if the graph includes signal triples
+      <urn:elle:file> ?file ;
+      <urn:elle:jit-eligible> true .
 }
 ```
 
-Find all Rust structs:
-
+**Find entry points (functions with no callers — dead code or API boundaries)**
 ```sparql
-SELECT ?name ?file WHERE {
-  ?s a <urn:rust:Struct> ;
-     <urn:rust:name> ?name ;
-     <urn:rust:file> ?file .
+SELECT ?name ?file
+WHERE {
+  ?fn a <urn:elle:Fn> ;
+      <urn:elle:name> ?name ;
+      <urn:elle:file> ?file .
+  FILTER NOT EXISTS {
+    ?caller a <urn:elle:Fn> ;
+            <urn:elle:calls> ?fn .
+  }
 }
+ORDER BY ?file
+```
+
+**Find highly connected functions (composition complexity)**
+```sparql
+SELECT ?name (COUNT(?callee) as ?calls_count)
+WHERE {
+  ?fn a <urn:elle:Fn> ;
+      <urn:elle:name> ?name ;
+      <urn:elle:calls> ?callee .
+}
+GROUP BY ?name
+ORDER BY DESC(?calls_count)
+LIMIT 20
+```
+
+**Find functions that capture mutable state (potential correctness issues)**
+```sparql
+SELECT ?name ?var
+WHERE {
+  ?fn a <urn:elle:Fn> ;
+      <urn:elle:name> ?name ;
+      <urn:elle:capture-mutated> ?var .
+}
+ORDER BY ?var ?name
+```
+
+**Check cross-language dependencies (Elle calling Rust primitives)**
+```sparql
+SELECT ?elle_fn ?rust_fn
+WHERE {
+  ?elle_fn a <urn:elle:Fn> ;
+           <urn:elle:calls> ?calls_iri .
+  ?prim a <urn:elle:Primitive> .
+  # Match by name conversion (elle-style to rust style)
+}
+```
+
+**Find all functions in a file and their signal profiles**
+```sparql
+SELECT ?name ?yields ?io ?jit_eligible
+WHERE {
+  ?fn a <urn:elle:Fn> ;
+      <urn:elle:file> "lib/http.lisp" ;
+      <urn:elle:name> ?name ;
+      <urn:elle:signal-yields> ?yields ;
+      <urn:elle:signal-io> ?io ;
+      <urn:elle:jit-eligible> ?jit_eligible .
+}
+ORDER BY ?name
 ```
 
 See [`tools/demo-queries.lisp`](../tools/demo-queries.lisp) for more examples.
+
+## Design rationale
+
+The MCP server exposes what the compiler already computes. Elle's compilation pipeline performs signal inference, capture analysis, and binding resolution for every file. This information exists whether or not anyone queries it — the MCP server just makes it accessible over JSON-RPC.
+
+**Everything the MCP server provides is available to normal Elle code at runtime.** `compile/analyze`, `compile/signal`, `compile/captures`, `compile/callees` — these are regular Elle functions. The MCP server is just an Elle program (`tools/mcp-server.lisp`) that wraps these primitives in the Model Context Protocol. You can write your own analysis tools using the same functions:
+
+```text
+(def a (compile/analyze (file/read "my-code.lisp") {:file "my-code.lisp"}))
+(compile/signal a :my-function)    # => signal profile
+(compile/captures a :my-function)  # => captured variables
+(compile/callees a :my-function)   # => call graph
+```
+
+See [Design Philosophy](../philosophy.md) for why Elle is designed this way, and [Agent Reasoning](analysis/agent-reasoning.md) for how agents use the MCP server in practice.
 
 ## IDE integration
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -319,7 +319,7 @@ The MCP server exposes what the compiler already computes. Elle's compilation pi
 (compile/callees a :my-function)   # => call graph
 ```
 
-See [Design Philosophy](../philosophy.md) for why Elle is designed this way, and [Agent Reasoning](analysis/agent-reasoning.md) for how agents use the MCP server in practice.
+See [Design Philosophy](philosophy.md) for why Elle is designed this way, and [Agent Reasoning](analysis/agent-reasoning.md) for how agents use the MCP server in practice.
 
 ## IDE integration
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -321,6 +321,25 @@ The MCP server exposes what the compiler already computes. Elle's compilation pi
 
 See [Design Philosophy](philosophy.md) for why Elle is designed this way, and [Agent Reasoning](analysis/agent-reasoning.md) for how agents use the MCP server in practice.
 
+## The graph is a cache
+
+The knowledge graph is a snapshot of compiler analysis at the time each file was analyzed. It can become stale.
+
+**Source code is ground truth.** If the graph contradicts the source, the source wins. Re-analyze the file:
+
+```text
+analyze_file(path: "lib/http.lisp")
+```
+
+**When to re-analyze:**
+- After editing a file
+- When `portrait` or `signal_query` results seem wrong
+- Before trusting impact analysis for a refactoring decision
+
+**After refactoring:** Any change made via `compile_rename`, `compile_extract`, or manual editing should be followed by re-analysis of the affected files and a test run. The refactoring tools produce correct transformations, but the graph won't reflect the new state until those files are re-analyzed.
+
+The MCP server's `analyze_file` tool handles this — it clears old triples for the file and replaces them with fresh analysis.
+
 ## IDE integration
 
 The MCP server is designed for AI coding assistants (Claude, Cursor,

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -299,36 +299,49 @@ through `import` and both return values.
 execute, return. Everything else is Elle code and conventions.
 
 
-## Trade-offs
+## Architectural Constraints
+
+These are design choices that enable the elegance of the module system. They are constraints, not limitations.
 
 ### No .lisp caching
 
-Every `import` of a `.lisp` file recompiles and re-executes it. If two
-modules both `(import "utils.lisp")`, the file runs twice. This is
-intentional: caching would suppress side effects and create shared mutable
-state between independent callers.
+Every `import` of a `.lisp` file recompiles and re-executes it. If two modules both `(import "utils.lisp")`, the file runs twice.
 
-Stateful modules (those using `var` and `assign`) get independent state per
-import. For projects where recompilation cost matters, import once at the top
-level and pass the module value down.
+**Why**: Caching would create shared mutable state between independent callers and suppress side effects. Stateful modules (those using `var` and `assign`) must get independent state per import. This is a feature: two imports of the same module file get independent instances, just as two calls to a factory function create independent objects.
+
+**Consequence**: Recompilation cost. For projects where this matters, import once at the top level and pass the module value down the call stack.
 
 ### Circular import detection is runtime-only
 
-The VM tracks which files are currently being loaded. If file A imports file B
-which imports file A, the second import signals an error:
+The VM tracks which files are currently being loaded. If file A imports file B which imports file A, the second import signals an error:
 
 ```text
 import: circular dependency detected for 'a.lisp'
 ```
 
-This is a direct consequence of `import` being a runtime primitive. Circular
-dependencies are a design error; Elle detects them at the point of failure.
+**Why**: `import` is a runtime primitive (compiles and executes a file). Circular dependency detection happens when the cycle is actually triggered, not preemptively. This is consistent with how the module system treats all imports as dynamic: the return value is computed at runtime, so dependency analysis is runtime-only.
+
+**Consequence**: Circular import bugs surface at runtime, not compile-time. This is acceptable because circular imports are design errors, not programming mistakes—they should never happen in correct code.
+
+### Cross-file signal inference is per-file
+
+The fixpoint loop converges signal inference within a single file. Mutual recursion across imported modules doesn't benefit from cross-form convergence—each import is treated as returning a Polymorphic signal.
+
+**Why**: Fixpoint convergence requires re-analyzing all forms in the file until signals stabilize. Extending this across file boundaries would require either whole-program analysis (defeating modularity) or a module type system (adding significant complexity). Per-file convergence is a clean boundary.
+
+**Consequence for humans**: You cannot rely on cross-file signal inference. Use `(silence)` and `squelch` at module boundaries if you need performance guarantees.
+
+**Solution for agents**: This limitation is solved by the [MCP knowledge graph](../mcp.md). While each file's compilation is independent, the RDF store captures the entire codebase's call graph and signal profiles. Agents can query cross-file dependencies via SPARQL. See [Agent Reasoning in Elle](../analysis/agent-reasoning.md) for how agents reason about module composition.
 
 ### Static analysis cannot see through imports
 
-The analyzer processes one file at a time. When it encounters `(import ...)`,
-it sees a function call that returns an unknown value. No cross-file signal
-tracking, arity checking, or LSP completion for imported symbols.
+The analyzer processes one file at a time. When it encounters `(import ...)`, it sees a function call that returns an unknown value. No cross-file signal tracking, arity checking, or static IDE features for imported symbols.
+
+**Why**: Imports are fully dynamic. The return value depends on runtime parameters and computation. Static analysis would require a separate module type system or whole-program analysis, both incompatible with the goal of making modules first-class, parameterizable values.
+
+**Consequence for humans**: IDE features like completion and refactoring don't work across module boundaries. Read the documentation or source code for imported modules.
+
+**Solution for agents**: The [MCP knowledge graph](../mcp.md) provides complete cross-file visibility. When a file is analyzed, all its function definitions, calls, and captures are stored in the RDF graph. Agents can query module composition via SPARQL without relying on static type information. See [Agent Reasoning in Elle](../analysis/agent-reasoning.md) for cross-file reasoning patterns.
 
 
 ## Implementation

--- a/docs/philosophy.md
+++ b/docs/philosophy.md
@@ -71,13 +71,13 @@ Mark a function `(silence)` when:
 
 Don't mark silence on everything. It's an explicit performance contract, not a default.
 
-The compiler already knows all of this — signal inference is computed at compile time. The [portrait](docs/analysis/portrait.md) system exposes it as queryable data, and the [MCP server](docs/mcp.md) makes the entire codebase's signal structure available as an RDF knowledge graph. These tools don't fix a broken design; they surface what the compiler already computes. See [Agent Reasoning in Elle](docs/analysis/agent-reasoning.md) for how AI agents use this.
+The compiler already knows all of this — signal inference is computed at compile time. The [portrait](analysis/portrait.md) system exposes it as queryable data, and the [MCP server](mcp.md) makes the entire codebase's signal structure available as an RDF knowledge graph. These tools don't fix a broken design; they surface what the compiler already computes. See [Agent Reasoning in Elle](analysis/agent-reasoning.md) for how AI agents use this.
 
 ---
 
 ## See also
 
-- [Module system](docs/modules.md) — Architectural constraints of the module system and their rationale
-- [Signal inference](docs/signals/inference.md) — How signals are inferred, bounded, and enforced
-- [Agent Reasoning](docs/analysis/agent-reasoning.md) — How AI agents analyze and refactor Elle code
-- [MCP Server](docs/mcp.md) — Semantic knowledge graph and querying interface
+- [Module system](modules.md) — Architectural constraints of the module system and their rationale
+- [Signal inference](signals/inference.md) — How signals are inferred, bounded, and enforced
+- [Agent Reasoning](analysis/agent-reasoning.md) — How AI agents analyze and refactor Elle code
+- [MCP Server](mcp.md) — Semantic knowledge graph and querying interface

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -117,6 +117,13 @@ is intentional — Expanders are not cached or reused across top-level calls.
 Used by `compile_file`, `eval_all` (via `compile_file`), and `analyze_file` to
 correctly infer signals for mutually recursive top-level definitions.
 
+The signal inference computed here is exposed to tools and agents via:
+- **`compile/signal`** — Get the inferred signal of a function
+- **`portrait`** — Semantic portrait showing signal profile, composition properties, and observations
+- **MCP server** — RDF knowledge graph with signal predicates (`elle:signal-yields`, `elle:signal-io`, etc.)
+
+See [MCP server documentation](../docs/mcp.md) and [Agent Reasoning](../docs/analysis/agent-reasoning.md) for how to query this information.
+
 ### Problem
 
 When compiling `(def f (fn (x) (g x)))` followed by `(def g (fn (x) (f x)))`,

--- a/docs/signals/inference.md
+++ b/docs/signals/inference.md
@@ -165,6 +165,71 @@ When a concrete function is passed to a parameter with a bound, the analyzer che
 # => error: argument violates signal bound
 ```
 
+## Cross-File Signal Inference: Design Constraint
+
+Elle's signal inference operates within a single file via the **fixpoint loop** (see [pipeline.md](../pipeline.md)). This enables accurate inference for mutually recursive top-level definitions within a file. Mutual recursion across file boundaries is a different problem.
+
+**Note for agents:** This per-file limitation is mitigated by the global [MCP knowledge graph](../mcp.md). While each file's signal inference is independent, the RDF store captures the entire codebase's structure, allowing agents to reason about cross-file impact via SPARQL queries. See [Agent Reasoning in Elle](../analysis/agent-reasoning.md) for how to query cross-file dependencies and understand cascading changes.
+
+### The Limitation
+
+When module A imports module B:
+- The return value of `(import "b.lisp")` is unknown to the analyzer (it depends on runtime computation)
+- A call to a function from module B is treated as `Polymorphic` signal — the analyzer cannot see B's signal inference
+- Even if B's functions are actually silent, A will treat them as yielding
+
+**Example:**
+```text
+# b.lisp
+(defn silent-add [x y]
+  (silence)
+  (+ x y))
+
+# Returns a struct of functions
+(fn [] {:add silent-add})
+```
+
+```text
+# a.lisp
+(def b ((import "b.lisp")))
+
+(defn use-b [x y]
+  (silence)                 # error! This contradicts the call below
+  (b:add x y))              # => treated as Polymorphic, not Silent
+# => Compile error: function must be silent but calls polymorphic function
+```
+
+### Why: Preserving Dynamic Module Semantics
+
+The module system intentionally allows:
+1. **Parameterized module creation** — `(import "module") :config :value`
+2. **Dynamic instantiation** — different instantiations have different state
+3. **Stateful modules** — modules with `var` and `assign` (independent per import)
+
+These features require treating imports as fully dynamic: the return value is unknown until runtime. To enable cross-file signal inference, Elle would need either:
+
+- **Whole-program analysis** — defeats the purpose of separate files
+- **Module type system** — adds significant complexity to declare module signatures
+- **Import result caching with signal annotation** — complicates state independence
+
+The tradeoff: Single-file fixpoint convergence is simple and gives accurate signal inference for mutually recursive definitions within a file. Across files, treat imports conservatively (Polymorphic).
+
+### Workaround: Explicit Bounds
+
+If you need a function from an imported module to be used in a silence-bounded context, use `squelch` to enforce the boundary at the call site:
+
+```text
+# a.lisp
+(def b ((import "b.lisp")))
+
+(defn use-b [x y]
+  (silence)
+  # Dynamically enforce that b:add must not yield
+  ((squelch b:add |:yield :io|) x y))
+```
+
+This gives you runtime assurance without changing the module system's design.
+
 
 ## Runtime Verification
 

--- a/philosophy.md
+++ b/philosophy.md
@@ -1,0 +1,83 @@
+# Design Philosophy
+
+This document explains the reasoning behind Elle's core architectural decisions.
+
+## Design Goal: Frictionless Async, Explicit Performance
+
+Elle's default is **polymorphic** — functions may yield, spawn fibers, or do I/O unless explicitly marked `(silence)`. This is not a shortcoming; it's a deliberate choice reflecting Elle's primary use case: building concurrent systems with fibers, signals, and async I/O.
+
+### Why Polymorphic-by-Default?
+
+The alternative—defaulting to `(silence)` and requiring explicit opt-in for async code—would be aggressively friction-full:
+
+```text
+# Silent by default: every higher-order function requires explicit opt-in
+(defn filter [predicate items]
+  (allow-yield predicate)                    # <- required boilerplate
+  (each items (fn [x] (allow-yield x) ...))) # <- required everywhere
+
+# Every callback, spawn, I/O operation: explicitly allowed to yield
+(ev/spawn (allow-yield (fn [] ...)))
+(map/call (allow-yield transform) data)
+```
+
+In Elle's actual use case—concurrent systems, fiber-based concurrency, signal-driven I/O—this would mean marking 90% of user code as explicitly allowing async. Frictionless development is more important than compile-time performance defaults for the systems Elle is designed to build.
+
+Polymorphic-by-default keeps the path of least resistance aligned with Elle's semantics: "this is async code that may yield."
+
+### Shifting Performance to the 10% Case
+
+The minority case—tight numerical loops, performance-critical inner functions—explicitly uses `(silence)`:
+
+```lisp
+(defn add [x y]
+  (silence)
+  (+ x y))
+
+(add 1 2)
+```
+
+This is similar to how Rust puts `unsafe` on unsafe code, or how Python puts `@jit` on hot code. The burden of intent is acceptable when applied to the minority case, not the majority.
+
+## The Semantic Gap: Visibility, Not Design
+
+The challenge is not that polymorphic-by-default is wrong—it's that **signal implications are invisible in source code**. While the signal system is mathematically elegant, it creates a gap between the developer's expectations and the runtime behavior.
+
+### 1. The Hidden Performance Cliff
+Because the default is polymorphic, a developer may write code that appears synchronous and tight but silently yields. A single data-dependent branch triggering `SIG_YIELD` can transform an $O(N)$ loop into expensive context switches, without visual indication.
+
+### 2. The Visibility Problem
+There is no syntax highlighting, gutter icon, or visual marker showing that a function yields. The polymorphic signal is invisible until you learn it at runtime through performance testing.
+
+### 3. The Hardening Friction
+When performance becomes critical, converting a flexible system to hardened-with-silence is labor-intensive. You discover late which code actually needs to be silent. This is analogous to retrofitting type annotations in Python or satisfying the borrow checker in Rust—it's the cost of changing constraints after the fact.
+
+---
+
+## Reasoning About Signals
+
+A function is polymorphic unless marked `(silence)`. When you call a function, consider:
+
+- Does it take higher-order functions (callbacks, predicates)? Then it's polymorphic unless those parameters are bounded by `(silence)`.
+- Does it use I/O (ports, subprocesses)? Then it yields.
+- Does it use fibers (`ev/spawn`, `ev/join`)? Then it yields.
+- Does it call other functions? It's at least as broad as they are.
+
+Mark a function `(silence)` when:
+
+1. **Performance is critical** — tight loops, hot paths, algorithms where yield overhead matters
+2. **You're confident it won't yield** — you've read the callees, you know they're silent
+3. **The contract is important** — you want to guarantee to callers that this function won't suspend
+
+Don't mark silence on everything. It's an explicit performance contract, not a default.
+
+The compiler already knows all of this — signal inference is computed at compile time. The [portrait](docs/analysis/portrait.md) system exposes it as queryable data, and the [MCP server](docs/mcp.md) makes the entire codebase's signal structure available as an RDF knowledge graph. These tools don't fix a broken design; they surface what the compiler already computes. See [Agent Reasoning in Elle](docs/analysis/agent-reasoning.md) for how AI agents use this.
+
+---
+
+## See also
+
+- [Module system](docs/modules.md) — Architectural constraints of the module system and their rationale
+- [Signal inference](docs/signals/inference.md) — How signals are inferred, bounded, and enforced
+- [Agent Reasoning](docs/analysis/agent-reasoning.md) — How AI agents analyze and refactor Elle code
+- [MCP Server](docs/mcp.md) — Semantic knowledge graph and querying interface


### PR DESCRIPTION

- Add philosophy.md explaining why polymorphic-by-default is the right
  choice, the semantic gap as a visibility issue (not a design flaw),
  and how to reason about signals

- Add docs/analysis/agent-reasoning.md: workflow guide for AI agents
  using portrait (local) + MCP (global) + compile-safe refactoring

- Add docs/analysis/README.md tying together portrait, MCP, and agent
  reasoning as three layers of code understanding

- Rewrite README opening to establish what Elle computes and how that
  analysis is exposed to user code and agents

- Expand docs/mcp.md with full RDF schema (signal predicates, call
  graphs, captures), real SPARQL examples, trace tool documentation,
  and note that everything MCP exposes is available to normal Elle code

- Reframe docs/modules.md tradeoffs as architectural constraints with
  Why/Consequence structure and links to MCP for cross-file reasoning

- Add cross-file signal inference section to docs/signals/inference.md

- Add tool exposure note to docs/pipeline.md fixpoint loop section

- Cross-link all documents so the story flows: design rationale →
  implementation mechanics → tool exposure → agent usage