### PR TITLE
sendable channels, JIT SuspendingCall fix, worker-thread JIT

### DIFF
--- a/demos/mandelbrot/mandelbrot.lisp
+++ b/demos/mandelbrot/mandelbrot.lisp
@@ -61,6 +61,7 @@
 (def WIN_H  600)
 (def BPP    4)
 (def STRIDE (* WIDTH BPP))
+(def NCPU  (integer (or (sys/env "NCPU") "16")))
 
 (def KEY_ESC    0xff1b)
 (def KEY_q      0x71)
@@ -72,6 +73,8 @@
 (def KEY_PLUS   0x2b)
 (def KEY_MINUS  0x2d)
 (def KEY_EQUAL  0x3d)
+(def KP_ADD     0xffab)
+(def KP_SUB     0xffad)
 
 (def CAIRO_FORMAT_ARGB32 0)
 (def SCROLL_VERTICAL     2)
@@ -130,6 +133,77 @@
       (assign i (inc i)))
     p))
 
+# ── Per-row computation (JIT compiles to native x86) ─────────────
+
+(def BLACK (bit/shl 255 24))
+
+(defn compute-row [row-buf ci x-min dx max-iter]
+  (var px 0)
+  (while (< px WIDTH)
+    (def cr (+ x-min (* (float px) dx)))
+    # cardioid and period-2 bulb check — skip full iteration
+    (def q (+ (* (- cr 0.25) (- cr 0.25)) (* ci ci)))
+    (def color
+      (if (or (<= (* q (+ q (- cr 0.25))) (* 0.25 (* ci ci)))
+              (<= (+ (* (+ cr 1.0) (+ cr 1.0)) (* ci ci)) 0.0625))
+        BLACK
+        (begin
+          (var zr  0.0)
+          (var zi  0.0)
+          (var zr2 0.0)
+          (var zi2 0.0)
+          (var iter 0)
+          (while (and (< iter max-iter) (<= (+ zr2 zi2) 4.0))
+            (assign zi  (+ (* 2.0 zr zi) ci))
+            (assign zr  (+ (- zr2 zi2) cr))
+            (assign zr2 (* zr zr))
+            (assign zi2 (* zi zi))
+            (assign iter (inc iter)))
+          (if (= iter max-iter)
+            BLACK
+            (let* [[log-zn (/ (math/log (+ zr2 zi2)) 2.0)]
+                   [smooth (- (+ (float iter) 1.0) (/ (math/log log-zn) LN2))]
+                   [idx    (mod (integer (* smooth 3.0)) PALETTE_SIZE)]]
+              (palette idx))))))
+    (put row-buf px color)
+    (assign px (inc px))))
+
+# ── Thread pool ──────────────────────────────────────────────────
+
+(defn recv-blocking [rx]
+  (def result (chan/select @[rx]))
+  (result 1))
+
+(var work-txs @[])
+(var done-rx  nil)
+
+(defn init-workers []
+  (def [dtx drx] (chan))
+  (assign done-rx drx)
+  (var i 0)
+  (while (< i NCPU)
+    (def [wtx wrx] (chan))
+    (push work-txs wtx)
+    (sys/spawn (fn []
+      (def local-buf
+        (let [[r @[]]]
+          (var j 0)
+          (while (< j WIDTH) (push r 0) (assign j (inc j)))
+          r))
+      (forever
+        (def msg (recv-blocking wrx))
+        (match msg
+          ([pixel-addr y-min dy x-min dx max-iter y-start y-end]
+            (def pbuf (ptr/from-int pixel-addr))
+            (var py y-start)
+            (while (< py y-end)
+              (compute-row local-buf (+ y-min (* (float py) dy)) x-min dx max-iter)
+              (ffi/write (ptr/add pbuf (* py STRIDE)) row-type local-buf)
+              (assign py (inc py)))
+            (chan/send dtx :done))
+          (_ (chan/send dtx :skip))))))
+    (assign i (inc i))))
+
 # ── Mandelbrot computation ────────────────────────────────────────
 
 (defn compute-mandelbrot []
@@ -140,38 +214,19 @@
   (def dx     (/ view-scale (float WIDTH)))
   (def dy     (/ (* view-scale aspect) (float HEIGHT)))
 
-  (var py 0)
-  (while (< py HEIGHT)
-    (def ci (+ y-min (* (float py) dy)))
-    (var px 0)
-    (while (< px WIDTH)
-      (def cr (+ x-min (* (float px) dx)))
+  (def paddr (ptr/to-int pixel-buf))
+  (def rows-per (/ HEIGHT NCPU))
+  (var t 0)
+  (while (< t NCPU)
+    (def y-start (* t rows-per))
+    (def y-end (if (= t (- NCPU 1)) HEIGHT (* (+ t 1) rows-per)))
+    (chan/send (work-txs t) [paddr y-min dy x-min dx max-iter y-start y-end])
+    (assign t (inc t)))
 
-      (var zr  0.0)
-      (var zi  0.0)
-      (var zr2 0.0)
-      (var zi2 0.0)
-      (var iter 0)
-      (while (and (< iter max-iter) (<= (+ zr2 zi2) 4.0))
-        (assign zi  (+ (* 2.0 zr zi) ci))
-        (assign zr  (+ (- zr2 zi2) cr))
-        (assign zr2 (* zr zr))
-        (assign zi2 (* zi zi))
-        (assign iter (inc iter)))
-
-      (def color
-        (if (= iter max-iter)
-          (bit/shl 255 24)
-          (let* [[log-zn (/ (math/log (+ zr2 zi2)) 2.0)]
-                 [smooth (- (+ (float iter) 1.0) (/ (math/log log-zn) LN2))]
-                 [idx    (mod (integer (* smooth 3.0)) PALETTE_SIZE)]]
-            (palette idx))))
-
-      (put row-buf px color)
-      (assign px (inc px)))
-
-    (ffi/write (ptr/add pixel-buf (* py STRIDE)) row-type row-buf)
-    (assign py (inc py)))
+  (var i 0)
+  (while (< i NCPU)
+    (recv-blocking done-rx)
+    (assign i (inc i)))
 
   (- (now-ms) t0))
 
@@ -239,10 +294,10 @@
       ((= keyval KEY_RIGHT)  (assign view-cx (+ view-cx step)) (refresh) 1)
       ((= keyval KEY_UP)     (assign view-cy (- view-cy step)) (refresh) 1)
       ((= keyval KEY_DOWN)   (assign view-cy (+ view-cy step)) (refresh) 1)
-      ((or (= keyval KEY_PLUS) (= keyval KEY_EQUAL))
+      ((or (= keyval KEY_PLUS) (= keyval KEY_EQUAL) (= keyval KP_ADD))
         (assign max-iter (* max-iter 2))
         (refresh) 1)
-      ((= keyval KEY_MINUS)
+      ((or (= keyval KEY_MINUS) (= keyval KP_SUB))
         (when (> max-iter 16)
           (assign max-iter (/ max-iter 2)))
         (refresh) 1)
@@ -290,6 +345,7 @@
   (b:gtk-window-set-child win da)
   (b:gtk-window-present win)
 
+  (init-workers)
   (compute-mandelbrot)
   (update-title)
   (gtk-queue-draw da))

--- a/src/jit/helpers.rs
+++ b/src/jit/helpers.rs
@@ -80,6 +80,9 @@ impl<'a> FunctionTranslator<'a> {
                 let p = builder.ins().iconst(I64, v.payload as i64);
                 (t, p)
             }
+            LirConst::ClosureRef(_) => {
+                panic!("bug: ClosureRef in JIT — should have been patched during reconstruction")
+            }
         }
     }
 

--- a/src/jit/translate.rs
+++ b/src/jit/translate.rs
@@ -954,9 +954,11 @@ impl<'a> FunctionTranslator<'a> {
                     self.def_var_pair(builder, dst.0, rt, rp);
                 }
                 self.emit_exception_check_after_call(builder)?;
-                let idx = self.call_site_index;
-                self.call_site_index += 1;
-                self.emit_yield_check_after_call(builder, idx)?;
+                if self.lir.signal.may_suspend() {
+                    let idx = self.call_site_index;
+                    self.call_site_index += 1;
+                    self.emit_yield_check_after_call(builder, idx)?;
+                }
             }
 
             LirInstr::ArrayMutExtend { dst, array, source } => {

--- a/src/lir/display.rs
+++ b/src/lir/display.rs
@@ -78,6 +78,7 @@ impl fmt::Display for LirConst {
             LirConst::String(s) => write!(f, "\"{}\"", s),
             LirConst::Symbol(sid) => write!(f, "sym({})", sid.0),
             LirConst::Keyword(k) => write!(f, ":{}", k),
+            LirConst::ClosureRef(idx) => write!(f, "closure-ref({})", idx),
         }
     }
 }

--- a/src/lir/emit/mod.rs
+++ b/src/lir/emit/mod.rs
@@ -1106,6 +1106,11 @@ impl Emitter {
                 self.bytecode.emit(Instruction::LoadConst);
                 self.bytecode.emit_u16(idx);
             }
+            LirConst::ClosureRef(_) => {
+                panic!(
+                    "bug: ClosureRef in emitter — should have been patched during reconstruction"
+                )
+            }
         }
     }
 }

--- a/src/lir/mod.rs
+++ b/src/lir/mod.rs
@@ -18,6 +18,7 @@ pub use display::terminator_kind;
 pub use emit::Emitter;
 pub use lower::{Lowerer, ScopeStats};
 pub use types::{
-    BasicBlock, BinOp, CallSiteInfo, ClosureId, CmpOp, Label, LirConst, LirFunction, LirInstr,
-    LirModule, Reg, SpannedInstr, SpannedTerminator, Terminator, UnaryOp, YieldPointInfo,
+    closure_value_const_count, BasicBlock, BinOp, CallSiteInfo, ClosureId, CmpOp, Label, LirConst,
+    LirFunction, LirInstr, LirModule, Reg, SpannedInstr, SpannedTerminator, Terminator, UnaryOp,
+    YieldPointInfo,
 };

--- a/src/lir/types.rs
+++ b/src/lir/types.rs
@@ -3,6 +3,25 @@
 use crate::signals::Signal;
 use crate::syntax::Span;
 use crate::value::{Arity, SymbolId, Value};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+/// Number of closure-valued `ValueConst` instructions converted to
+/// `ClosureRef` by `convert_value_consts_for_send` during the lifetime
+/// of this process.
+///
+/// This path is exercised whenever user code references a stdlib
+/// function (registered as a primitive via `update_cache_with_stdlib`)
+/// from inside a closure that is sent across a `sys/spawn` boundary.
+/// Exposed to Elle via the `lir/closure-value-const-count` primitive
+/// and printed by `--stats`.
+static CLOSURE_VALUE_CONST_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+/// Returns the lifetime count of closure-valued `ValueConst` instructions
+/// serialized across `sys/spawn` boundaries. Reported by `--stats` and
+/// exposed as an Elle primitive for regression tests.
+pub fn closure_value_const_count() -> usize {
+    CLOSURE_VALUE_CONST_COUNT.load(Ordering::Relaxed)
+}
 
 /// Virtual register
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -186,6 +205,64 @@ impl LirFunction {
                 .iter()
                 .any(|si| matches!(si.instr, LirInstr::SuspendingCall { .. }))
         })
+    }
+
+    /// Convert ValueConst instructions to Const (LirConst) for safe cross-thread transfer.
+    /// NativeFn ValueConsts are safe to keep as-is (function pointers are Send+Sync).
+    /// Closure ValueConsts are converted to `ClosureRef(idx)` using the intern table.
+    /// Returns false if any ValueConst contains a non-sendable, non-closure heap value.
+    pub fn convert_value_consts_for_send(
+        &mut self,
+        visited: &std::collections::HashMap<u64, usize>,
+    ) -> bool {
+        for block in &mut self.blocks {
+            for si in &mut block.instructions {
+                if let LirInstr::ValueConst { dst, value } = &si.instr {
+                    if value.is_native_fn() {
+                        continue; // function pointers are thread-safe
+                    }
+                    let dst = *dst;
+                    if let Some(lir_const) = value_to_lir_const(*value) {
+                        si.instr = LirInstr::Const {
+                            dst,
+                            value: lir_const,
+                        };
+                    } else if value.is_closure() {
+                        // Closure ValueConst: look up in intern table.
+                        //
+                        // This branch fires whenever a closure being sent
+                        // across a `sys/spawn` boundary contains, in its
+                        // LIR, a `ValueConst` holding a closure Value. That
+                        // happens because stdlib functions are registered
+                        // as primitives (see
+                        // `src/primitives/module_init.rs::register_stdlib_exports`
+                        // which calls `update_cache_with_stdlib`), so user
+                        // code referencing a stdlib function inside a
+                        // lambda lowers the reference to `ValueConst` via
+                        // `immutable_values` in the lowerer. A spawned
+                        // closure that transitively calls e.g. `inc` or
+                        // `map` from stdlib will trip this branch.
+                        //
+                        // `CLOSURE_VALUE_CONST_COUNT` tracks the live count;
+                        // see the `lir/closure-value-const-count` primitive
+                        // and `--stats` output.
+                        CLOSURE_VALUE_CONST_COUNT.fetch_add(1, Ordering::Relaxed);
+                        if let Some(&idx) = visited.get(&value.payload) {
+                            si.instr = LirInstr::Const {
+                                dst,
+                                value: LirConst::ClosureRef(idx),
+                            };
+                        } else {
+                            return false;
+                        }
+                    } else {
+                        // unsendable ValueConst (compound heap value)
+                        return false;
+                    }
+                }
+            }
+        }
+        true
     }
 }
 
@@ -490,4 +567,31 @@ pub enum LirConst {
     String(String),
     Symbol(SymbolId),
     Keyword(String),
+    /// Placeholder for a closure during cross-thread LIR transfer.
+    /// The usize is the index into `SendBundle::closures`.
+    /// Patched back to `ValueConst` during reconstruction.
+    ClosureRef(usize),
+}
+
+/// Convert a runtime Value to a LirConst for safe cross-thread transfer.
+/// Returns None for compound heap values (cons, arrays, closures, etc.)
+/// that can't be represented as LirConst.
+pub fn value_to_lir_const(v: Value) -> Option<LirConst> {
+    if v.is_nil() {
+        Some(LirConst::Nil)
+    } else if v.is_empty_list() {
+        Some(LirConst::EmptyList)
+    } else if let Some(b) = v.as_bool() {
+        Some(LirConst::Bool(b))
+    } else if let Some(n) = v.as_int() {
+        Some(LirConst::Int(n))
+    } else if let Some(f) = v.as_float() {
+        Some(LirConst::Float(f))
+    } else if let Some(id) = v.as_symbol() {
+        Some(LirConst::Symbol(SymbolId(id)))
+    } else if let Some(name) = v.as_keyword_name() {
+        Some(LirConst::Keyword(name))
+    } else {
+        v.with_string(|s| s.to_string()).map(LirConst::String)
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -288,6 +288,10 @@ fn main() {
             eprint!("{}", scope_stats);
         }
         print_jit_stats(&vm);
+        let cvc = elle::lir::closure_value_const_count();
+        if cvc > 0 {
+            eprintln!("[stats] closure-valued ValueConsts serialized: {}", cvc);
+        }
     }
 
     if !read_stdin && files.is_empty() {

--- a/src/primitives/access.rs
+++ b/src/primitives/access.rs
@@ -732,7 +732,7 @@ pub(crate) fn prim_put(args: &[Value]) -> (SignalBits, Value) {
         error_val(
             "type-error",
             format!(
-                "put: expected collection (array, @array, string, @string, or struct), got {}",
+                "put: expected array, struct, set, bytes, or string, got {}",
                 args[0].type_name()
             ),
         ),

--- a/src/primitives/chan.rs
+++ b/src/primitives/chan.rs
@@ -16,7 +16,7 @@ use crate::value::{error_val, Value};
 /// `Value` contains `Rc` (not `Send`). For single-threaded schedulers
 /// (the common case) this is trivially safe. For cross-thread use the
 /// scheduler is responsible for only sending immutable data.
-struct SendableValue(Value);
+pub(crate) struct SendableValue(Value);
 
 // SAFETY: The scheduler contract guarantees that values sent through
 // channels are either immutable or will not be accessed from the
@@ -24,10 +24,36 @@ struct SendableValue(Value);
 unsafe impl Send for SendableValue {}
 
 /// Sender half of a channel, wrapped for `Value::external`.
-struct ChanSender(RefCell<Option<crossbeam_channel::Sender<SendableValue>>>);
+pub(crate) struct ChanSender(pub(crate) RefCell<Option<crossbeam_channel::Sender<SendableValue>>>);
 
 /// Receiver half of a channel, wrapped for `Value::external`.
-struct ChanReceiver(RefCell<Option<crossbeam_channel::Receiver<SendableValue>>>);
+pub(crate) struct ChanReceiver(
+    pub(crate) RefCell<Option<crossbeam_channel::Receiver<SendableValue>>>,
+);
+
+/// Clone the crossbeam sender from a channel sender Value.
+/// Returns None if the value is not a chan/sender or is already closed.
+pub(crate) fn clone_sender(v: &Value) -> Option<crossbeam_channel::Sender<SendableValue>> {
+    v.as_external::<ChanSender>()
+        .and_then(|cs| cs.0.borrow().as_ref().map(|s| s.clone()))
+}
+
+/// Clone the crossbeam receiver from a channel receiver Value.
+/// Returns None if the value is not a chan/receiver or is already closed.
+pub(crate) fn clone_receiver(v: &Value) -> Option<crossbeam_channel::Receiver<SendableValue>> {
+    v.as_external::<ChanReceiver>()
+        .and_then(|cr| cr.0.borrow().as_ref().map(|r| r.clone()))
+}
+
+/// Create a chan/sender Value from a raw crossbeam sender.
+pub(crate) fn sender_value(tx: crossbeam_channel::Sender<SendableValue>) -> Value {
+    Value::external("chan/sender", ChanSender(RefCell::new(Some(tx))))
+}
+
+/// Create a chan/receiver Value from a raw crossbeam receiver.
+pub(crate) fn receiver_value(rx: crossbeam_channel::Receiver<SendableValue>) -> Value {
+    Value::external("chan/receiver", ChanReceiver(RefCell::new(Some(rx))))
+}
 
 /// Helper: extract `&ChanSender` from a Value or return a type error.
 fn extract_sender<'a>(

--- a/src/primitives/introspection.rs
+++ b/src/primitives/introspection.rs
@@ -272,6 +272,32 @@ pub(crate) fn prim_keyword(args: &[Value]) -> (SignalBits, Value) {
     }
 }
 
+/// (lir/closure-value-const-count) — number of closure-valued `ValueConst`
+/// instructions converted to `ClosureRef` by the LIR cross-thread
+/// serializer during this process's lifetime.
+///
+/// Used by regression tests to assert the ClosureRef LIR-transfer fix
+/// is actually firing on real spawn patterns. See
+/// `src/lir/types.rs::convert_value_consts_for_send`.
+pub(crate) fn prim_closure_value_const_count(args: &[Value]) -> (SignalBits, Value) {
+    if !args.is_empty() {
+        return (
+            SIG_ERROR,
+            error_val(
+                "arity-error",
+                format!(
+                    "lir/closure-value-const-count: expected 0 arguments, got {}",
+                    args.len()
+                ),
+            ),
+        );
+    }
+    (
+        SIG_OK,
+        Value::int(crate::lir::closure_value_const_count() as i64),
+    )
+}
+
 /// (jit/rejections) — list closures rejected from JIT compilation with reasons
 ///
 /// Returns a list of structs, each with :name, :reason, and :calls keys.
@@ -439,6 +465,17 @@ pub(crate) const PRIMITIVES: &[PrimitiveDef] = &[
         params: &[],
         category: "meta",
         example: "(jit/rejections)",
+        aliases: &[],
+    },
+    PrimitiveDef {
+        name: "lir/closure-value-const-count",
+        func: prim_closure_value_const_count,
+        signal: Signal::silent(),
+        arity: Arity::Exact(0),
+        doc: "Number of closure-valued ValueConst instructions converted to ClosureRef by the LIR cross-thread serializer. Used by regression tests to assert the ClosureRef LIR-transfer fix fires.",
+        params: &[],
+        category: "meta",
+        example: "(lir/closure-value-const-count)",
         aliases: &[],
     },
     PrimitiveDef {

--- a/src/value/send.rs
+++ b/src/value/send.rs
@@ -48,6 +48,9 @@ pub struct SendableClosure {
     pub name: Option<String>,
     pub squelch_mask: SignalBits,
     pub env: Vec<SendValue>,
+    /// LIR function for JIT compilation in spawned threads.
+    /// Stripped of doc/syntax (not sendable), but retains all JIT-relevant fields.
+    pub lir_function: Option<crate::lir::LirFunction>,
 }
 
 /// A thread-safe wrapper around Value that deep-copies heap data.
@@ -120,6 +123,14 @@ pub enum SendValue {
     /// Back-reference into `SendBundle::closures` by index.
     /// Meaningful only within a `SendBundle`; a bare `Ref` without a bundle is invalid.
     Ref(usize),
+
+    /// Cloned crossbeam channel sender (Send + Clone).
+    #[allow(private_interfaces)]
+    ChanSender(crossbeam_channel::Sender<crate::primitives::chan::SendableValue>),
+
+    /// Cloned crossbeam channel receiver (Send + Clone).
+    #[allow(private_interfaces)]
+    ChanReceiver(crossbeam_channel::Receiver<crate::primitives::chan::SendableValue>),
 }
 
 /// Unit of cross-thread value transfer.
@@ -314,6 +325,7 @@ fn from_value_inner(value: Value, ctx: &mut SerContext) -> Result<SendValue, Str
                 name: None,
                 squelch_mask: SignalBits::EMPTY,
                 env: Vec::new(),
+                lir_function: None,
             });
             ctx.visited.insert(key, idx);
 
@@ -358,6 +370,19 @@ fn from_value_inner(value: Value, ctx: &mut SerContext) -> Result<SendValue, Str
                 name: closure_rc.template.name.as_ref().map(|s| s.to_string()),
                 squelch_mask: closure_rc.squelch_mask,
                 env,
+                // Clone LIR for JIT in spawned threads.
+                // Strip doc (Value/Rc) and syntax (Rc<Syntax>).
+                // Convert ValueConst → Const to avoid cross-thread raw pointers.
+                lir_function: closure_rc.template.lir_function.as_ref().and_then(|lir| {
+                    let mut lir = (**lir).clone();
+                    lir.doc = None;
+                    lir.syntax = None;
+                    if lir.convert_value_consts_for_send(&ctx.visited) {
+                        Some(lir)
+                    } else {
+                        None
+                    }
+                }),
             };
 
             Ok(SendValue::Ref(idx))
@@ -384,8 +409,16 @@ fn from_value_inner(value: Value, ctx: &mut SerContext) -> Result<SendValue, Str
         // Unsafe: managed pointers (lifecycle state is not thread-safe with Cell)
         HeapObject::ManagedPointer { .. } => Err("Cannot send managed pointer".to_string()),
 
-        // Unsafe: external objects (contain Rc<dyn Any>, not thread-safe)
-        HeapObject::External { .. } => Err("Cannot send external object".to_string()),
+        // External objects: channels are sendable, others are not
+        HeapObject::External { obj, .. } => match obj.type_name {
+            "chan/sender" => crate::primitives::chan::clone_sender(&value)
+                .map(SendValue::ChanSender)
+                .ok_or_else(|| "Cannot send closed channel sender".to_string()),
+            "chan/receiver" => crate::primitives::chan::clone_receiver(&value)
+                .map(SendValue::ChanReceiver)
+                .ok_or_else(|| "Cannot send closed channel receiver".to_string()),
+            _ => Err(format!("Cannot send external object: {}", obj.type_name)),
+        },
 
         // Unsafe: parameters (fiber-local state)
         HeapObject::Parameter { .. } => Err("Cannot send parameter".to_string()),
@@ -561,6 +594,8 @@ impl SendValue {
                 })
             }
             SendValue::NativeFn(f) => Value::native_fn(f),
+            SendValue::ChanSender(tx) => crate::primitives::chan::sender_value(tx),
+            SendValue::ChanReceiver(rx) => crate::primitives::chan::receiver_value(rx),
             SendValue::Closure(_box_val) => {
                 panic!("bug: bare SendValue::Closure; use SendBundle::into_value")
             }
@@ -740,6 +775,8 @@ fn into_value_inner(sv: SendValue, ctx: &mut DeserContext) -> Value {
             })
         }
         SendValue::NativeFn(f) => Value::native_fn(f),
+        SendValue::ChanSender(tx) => crate::primitives::chan::sender_value(tx),
+        SendValue::ChanReceiver(rx) => crate::primitives::chan::receiver_value(rx),
 
         // Closure variant: only appears stored directly in SendBundle::closures.
         // At the top-level call it means the bundle was constructed incorrectly.
@@ -777,6 +814,13 @@ fn into_value_inner(sv: SendValue, ctx: &mut DeserContext) -> Value {
 
             let doc = sc.doc.map(|sv| into_value_inner(*sv, ctx));
 
+            // Patch ClosureRef entries in the LIR: ensure referenced closures
+            // are reconstructed, then replace ClosureRef with ValueConst.
+            let lir_function = sc.lir_function.map(|mut lir| {
+                patch_lir_closure_refs(&mut lir, ctx);
+                Rc::new(lir)
+            });
+
             let template = Rc::new(ClosureTemplate {
                 bytecode: Rc::new(sc.bytecode),
                 arity: sc.arity,
@@ -790,7 +834,7 @@ fn into_value_inner(sv: SendValue, ctx: &mut DeserContext) -> Value {
                 symbol_names: Rc::new(sc.symbol_names),
                 location_map: Rc::new(sc.location_map),
                 rotation_safe: false,
-                lir_function: None,
+                lir_function,
                 doc,
                 syntax: None,
                 vararg_kind: sc.vararg_kind,
@@ -807,6 +851,38 @@ fn into_value_inner(sv: SendValue, ctx: &mut DeserContext) -> Value {
             });
             ctx.states[idx] = ReconState::Done(val);
             val
+        }
+    }
+}
+
+/// Patch `ClosureRef(idx)` entries in a LIR function back to `ValueConst`.
+/// Forces reconstruction of any referenced closures that haven't been built yet.
+fn patch_lir_closure_refs(lir: &mut crate::lir::LirFunction, ctx: &mut DeserContext) {
+    use crate::lir::LirConst;
+    use crate::lir::LirInstr;
+
+    for block in &mut lir.blocks {
+        for si in &mut block.instructions {
+            if let LirInstr::Const {
+                dst,
+                value: LirConst::ClosureRef(ref_idx),
+            } = &si.instr
+            {
+                let ref_idx = *ref_idx;
+                let dst = *dst;
+                // Ensure the referenced closure is reconstructed.
+                let closure_val = match ctx.states[ref_idx] {
+                    ReconState::Done(v) => v,
+                    _ => {
+                        // Force reconstruction via a Ref lookup.
+                        into_value_inner(SendValue::Ref(ref_idx), ctx)
+                    }
+                };
+                si.instr = LirInstr::ValueConst {
+                    dst,
+                    value: closure_val,
+                };
+            }
         }
     }
 }
@@ -862,5 +938,168 @@ impl SendBundle {
         }
 
         result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::LocationMap;
+    use crate::lir::{
+        BasicBlock, Label, LirConst, LirFunction, LirInstr, Reg, SpannedInstr, SpannedTerminator,
+        Terminator,
+    };
+    use crate::signals::Signal;
+    use crate::syntax::Span;
+    use crate::value::closure::{Closure, ClosureTemplate};
+    use crate::value::fiber::SignalBits;
+    use crate::value::heap::HeapObject;
+    use crate::value::types::Arity;
+    use std::collections::HashMap;
+    use std::rc::Rc;
+
+    /// Build a minimal closure Value with an attached LIR function.
+    /// Used by the ClosureRef round-trip test.
+    fn make_test_closure(name: &str, lir: Option<LirFunction>) -> Value {
+        let template = Rc::new(ClosureTemplate {
+            bytecode: Rc::new(vec![]),
+            arity: Arity::Exact(1),
+            num_locals: 1,
+            num_captures: 0,
+            num_params: 1,
+            constants: Rc::new(vec![]),
+            signal: Signal::silent(),
+            capture_params_mask: 0,
+            capture_locals_mask: 0,
+            symbol_names: Rc::new(HashMap::new()),
+            location_map: Rc::new(LocationMap::new()),
+            rotation_safe: false,
+            lir_function: lir.map(Rc::new),
+            doc: None,
+            syntax: None,
+            vararg_kind: crate::hir::VarargKind::List,
+            name: Some(Rc::from(name)),
+            result_is_immediate: false,
+            has_outward_heap_set: false,
+            wasm_func_idx: None,
+        });
+        let closure = Closure {
+            template,
+            env: Rc::new(vec![]),
+            squelch_mask: SignalBits::EMPTY,
+        };
+        crate::value::heap::alloc(HeapObject::Closure {
+            closure: Rc::new(closure),
+            traits: Value::NIL,
+        })
+    }
+
+    /// Build a minimal LIR function consisting of a single block that
+    /// loads a closure-valued ValueConst and returns it.
+    fn make_lir_with_closure_value_const(closure_val: Value) -> LirFunction {
+        let mut lir = LirFunction::new(Arity::Exact(1));
+        lir.num_params = 1;
+        lir.num_locals = 1;
+        lir.num_regs = 1;
+        let mut block = BasicBlock::new(Label(0));
+        block.instructions.push(SpannedInstr::new(
+            LirInstr::ValueConst {
+                dst: Reg(0),
+                value: closure_val,
+            },
+            Span::synthetic(),
+        ));
+        block.terminator = SpannedTerminator::new(Terminator::Return(Reg(0)), Span::synthetic());
+        lir.blocks.push(block);
+        lir.entry = Label(0);
+        lir
+    }
+
+    /// Directly verifies the ClosureRef serialization path: a closure
+    /// whose LIR contains a ValueConst referencing another closure must
+    /// round-trip through SendBundle with its LIR preserved, and the
+    /// ClosureRef placeholder must be patched back to a valid ValueConst.
+    #[test]
+    fn test_send_bundle_patches_closure_value_const_in_lir() {
+        // 1. Build an inner closure (the "target" of the ValueConst).
+        let inner = make_test_closure("inner", None);
+
+        // 2. Build an outer closure whose LIR contains a ValueConst
+        //    referencing `inner`. Store `inner` in the outer closure's
+        //    env so it's reachable via the SendBundle intern table.
+        let lir = make_lir_with_closure_value_const(inner);
+        let outer_template = Rc::new(ClosureTemplate {
+            bytecode: Rc::new(vec![]),
+            arity: Arity::Exact(0),
+            num_locals: 0,
+            num_captures: 1,
+            num_params: 0,
+            constants: Rc::new(vec![]),
+            signal: Signal::silent(),
+            capture_params_mask: 0,
+            capture_locals_mask: 0,
+            symbol_names: Rc::new(HashMap::new()),
+            location_map: Rc::new(LocationMap::new()),
+            rotation_safe: false,
+            lir_function: Some(Rc::new(lir)),
+            doc: None,
+            syntax: None,
+            vararg_kind: crate::hir::VarargKind::List,
+            name: Some(Rc::from("outer")),
+            result_is_immediate: false,
+            has_outward_heap_set: false,
+            wasm_func_idx: None,
+        });
+        let outer_closure = Closure {
+            template: outer_template,
+            env: Rc::new(vec![inner]), // make `inner` reachable from the bundle
+            squelch_mask: SignalBits::EMPTY,
+        };
+        let outer_val = crate::value::heap::alloc(HeapObject::Closure {
+            closure: Rc::new(outer_closure),
+            traits: Value::NIL,
+        });
+
+        // 3. Round-trip through SendBundle.
+        let bundle = SendBundle::from_value(outer_val).expect("should serialize");
+        let restored = bundle.into_value();
+
+        // 4. The reconstructed outer closure should still have an LIR.
+        let restored_rc = restored
+            .as_closure()
+            .expect("restored value should be a closure");
+        let restored_lir = restored_rc
+            .template
+            .lir_function
+            .as_ref()
+            .expect("LIR must be preserved across SendBundle round-trip");
+
+        // 5. The LIR should contain a ValueConst (not a ClosureRef) whose
+        //    value is a closure — specifically the reconstructed `inner`.
+        let mut found_closure_vc = false;
+        for block in &restored_lir.blocks {
+            for si in &block.instructions {
+                match &si.instr {
+                    LirInstr::Const {
+                        value: LirConst::ClosureRef(_),
+                        ..
+                    } => {
+                        panic!("ClosureRef should have been patched during reconstruction");
+                    }
+                    LirInstr::ValueConst { value, .. } => {
+                        assert!(
+                            value.as_closure().is_some(),
+                            "patched ValueConst should hold a closure"
+                        );
+                        found_closure_vc = true;
+                    }
+                    _ => {}
+                }
+            }
+        }
+        assert!(
+            found_closure_vc,
+            "restored LIR must contain the patched closure ValueConst"
+        );
     }
 }

--- a/src/wasm/instruction.rs
+++ b/src/wasm/instruction.rs
@@ -653,7 +653,10 @@ impl WasmEmitter {
                     LirConst::Bool(false) => (TAG_FALSE as i64, 0),
                     LirConst::Int(n) => (TAG_INT as i64, *n),
                     LirConst::Float(x) => (TAG_FLOAT as i64, x.to_bits() as i64),
-                    LirConst::Symbol(_) | LirConst::Keyword(_) | LirConst::String(_) => {
+                    LirConst::Symbol(_)
+                    | LirConst::Keyword(_)
+                    | LirConst::String(_)
+                    | LirConst::ClosureRef(_) => {
                         unreachable!()
                     }
                 };

--- a/tests/elle/concurrency.lisp
+++ b/tests/elle/concurrency.lisp
@@ -189,3 +189,74 @@
 (assert (= (letrec ((even? (fn (n) (if (= n 0) true (odd? (- n 1)))))
            (odd?  (fn (n) (if (= n 0) false (even? (- n 1))))))
     (join (spawn (fn () (odd? 99))))) true) "spawn mutual recursion deep")
+
+# ============================================================================
+# JIT on spawned threads: closures capturing other closures in hot loops.
+# The spawned closure calls the captured helper enough times to exceed the
+# JIT threshold on the worker thread. Before the ClosureRef LIR-transfer fix
+# (src/lir/types.rs::convert_value_consts_for_send), LIR containing
+# closure-valued ValueConst instructions would be dropped on send, silently
+# forcing the worker into the interpreter.
+# ============================================================================
+
+(assert (= (let ((double (fn (x) (* x 2))))
+             (letrec ((loop (fn (n acc)
+                              (if (= n 0)
+                                  acc
+                                  (loop (- n 1) (+ acc (double n)))))))
+               (join (spawn (fn () (loop 100 0))))))
+           10100)
+  "spawn hot loop with captured closure (JIT on worker thread)")
+
+(assert (= (let ((inc (fn (x) (+ x 1)))
+                 (sq  (fn (x) (* x x))))
+             (letrec ((loop (fn (n acc)
+                              (if (= n 0)
+                                  acc
+                                  (loop (- n 1) (+ acc (sq (inc n))))))))
+               (join (spawn (fn () (loop 50 0))))))
+           45525)
+  "spawn hot loop with two captured closures")
+
+(assert (= (let ((compose (fn (f g) (fn (x) (f (g x))))))
+             (let ((inc (fn (x) (+ x 1)))
+                   (dbl (fn (x) (* x 2))))
+               (let ((f (compose dbl inc)))
+                 (letrec ((loop (fn (n acc)
+                                  (if (= n 0)
+                                      acc
+                                      (loop (- n 1) (+ acc (f n)))))))
+                   (join (spawn (fn () (loop 100 0))))))))
+           10300)
+  "spawn hot loop with composed closures")
+
+# ============================================================================
+# Regression test for the ClosureRef LIR-transfer fix.
+#
+# When a closure is sent across a `sys/spawn` boundary, its LIR function is
+# cloned for cross-thread transfer. If the LIR contains `ValueConst`
+# instructions holding closure Values (which happens whenever user code
+# inside the spawned closure references a stdlib function like `inc`,
+# because stdlib functions are registered as primitives and lower to
+# `ValueConst`), those Values have to be re-routed to the reconstructed
+# closure on the receiving side. The fix in
+# `src/lir/types.rs::convert_value_consts_for_send` + the
+# `LirConst::ClosureRef` placeholder + `patch_lir_closure_refs` in
+# `src/value/send.rs` does exactly that.
+#
+# Before the fix, `convert_value_consts_for_send` dropped the LIR function
+# on any closure-valued ValueConst, silently forcing the worker thread into
+# the interpreter and destroying the threaded speedup for e.g. mandelbrot.
+#
+# This test asserts the fix actually fires: it spawns a closure that calls
+# a stdlib function, joins it, and checks that the counter incremented.
+# If a future lowering change causes stdlib references to stop appearing as
+# ValueConst (or the fix regresses), the assertion will fire and point
+# directly at the broken contract.
+# ============================================================================
+
+(let [[before (lir/closure-value-const-count)]]
+  (join (sys/spawn (fn [] (inc 41))))
+  (let [[after (lir/closure-value-const-count)]]
+    (assert (> after before)
+      "ClosureRef LIR-transfer path fires when a spawned closure calls a stdlib function")))


### PR DESCRIPTION
Runtime:
- Channels (chan/sender, chan/receiver) can cross sys/spawn boundaries via new SendValue::ChanSender/ChanReceiver variants that clone the crossbeam endpoint.
- JIT: SuspendingCall in silent functions skips yield checks — these calls can't actually yield, and emitting yield-through-call code without call_sites metadata caused crashes.
- LIR transfers across sys/spawn for worker-thread JIT. SendableClosure now carries lir_function. During serialization, doc/syntax (Rc) are stripped and ValueConst instructions are rewritten to safe equivalents.
- ClosureRef LIR-transfer fix: closure-valued ValueConsts (which arise whenever user code references a stdlib function — stdlib exports are registered as primitives, so references lower to ValueConst via the immutable_values path) are converted to a new LirConst::ClosureRef(idx) placeholder that points into the SendBundle intern table. On the receiving side, patch_lir_closure_refs walks each reconstructed closure's LIR and rewrites ClosureRef back to ValueConst with the reconstructed closure. Without this, the serializer dropped lir_function on any closure whose LIR touched stdlib, forcing mandelbrot workers into the interpreter.
- CLOSURE_VALUE_CONST_COUNT atomic counter tracks how many times the closure branch fires; exposed as the lir/closure-value-const-count primitive and printed by --stats. Regression test in tests/elle/concurrency.lisp asserts the counter increments after spawning a closure that calls a stdlib function.
- put error message simplified.

Tests:
- tests/elle/concurrency.lisp gains assertions for spawn + hot-loop closures that capture other closures (JIT on worker thread) and the ClosureRef regression test above.
- src/value/send.rs gains a unit test that manually constructs LIR with a closure-valued ValueConst, round-trips through SendBundle, and verifies the LIR is preserved and all ClosureRefs are patched back.

Demo:
- Mandelbrot uses a thread pool (NCPU workers, sendable channels). compute-row with cardioid/period-2 bulb early-exit. Numpad +/-. Workers now JIT-compile compute-row thanks to the ClosureRef fix, bringing the 16-thread case from ~95ms (interpreted) down dramatically.

Build:
- make smoke-wasm now runs against ./target/release/elle explicitly, not \$(ELLE) which defaults to debug outside GitHub Actions.