### PR TITLE
Fix MCP server startup + plugin ABI bug; add test-mcp integration test

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,10 +83,42 @@ expected failures. Do not rationalize failures away. Fix them.
 | Command | Runtime | What it does |
 |---------|---------|-------------|
 | `make smoke` | ~30s | Elle scripts (VM, JIT, WASM) + doctests + docgen |
-| `make test` | ~3min | smoke + fmt + clippy + rustdoc + unit tests |
+| `make test` | ~3min | smoke + MCP integration + fmt + clippy + rustdoc + unit tests |
 
 See [AGENTS.md](AGENTS.md) and [docs/testing.md](docs/testing.md) for
 test organization, helpers, and how to add tests.
+
+## Plugins and the single-cargo-invocation rule
+
+Every plugin in `plugins/` is a `cdylib` that depends on the `elle`
+library crate. This creates a subtle trap: if you build the elle binary
+and a plugin in *separate* `cargo build` invocations, cargo's feature
+resolver may pick different feature sets for transitive dependencies
+(notably `wasmtime`). That produces two different compilations of the
+elle crate — two different `libelle-*.rlib` files with two different
+`HeapObject` enum layouts.
+
+The symptom is spectacular: the plugin's `Value::native_fn(f)` values
+survive the cross-dylib handoff by pointer, and the tag word on the
+`Value` side reads correctly (`(native-fn? f)` returns `true`), but when
+the main binary dereferences the heap pointer it reads a different
+`HeapObject` variant — typically `LibHandle`. Calling the value fails
+with `type-error: Cannot call <heap:...>`, and `(type f)` returns
+`"library-handle"` even though `(native-fn? f)` just said `true`.
+
+**The rule:** always build elle and its plugins in a single `cargo
+build` invocation. For example:
+
+```sh
+cargo build -p elle -p elle-oxigraph -p elle-syn
+```
+
+The `test-mcp` target in the Makefile already follows this rule. If
+you add a new target that depends on a plugin, do the same. Never
+chain `cargo build -p elle` followed by `cargo build -p elle-X` as
+separate steps — the chain looks harmless but produces a broken
+binary that only fails when the plugin's functions are actually
+called.
 
 ## Conventions
 

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,16 @@
-.PHONY: all elle dev plugins docs docgen smoke test plugin-tests test-git check-plugin-list clean help \
+.PHONY: all elle dev plugins docs docgen smoke test plugin-tests test-git test-mcp check-plugin-list clean help \
        smoke-vm smoke-jit smoke-wasm plugin-tests-vm plugin-tests-jit doctest
 
 .DEFAULT_GOAL := all
 
 ifdef GITHUB_ACTIONS
-  JOBS    ?= 4
-  ELLE    ?= ./target/release/elle
+  JOBS          ?= 4
+  ELLE          ?= ./target/release/elle
+  CARGO_PROFILE := --release
 else
-  JOBS    ?= 16
-  ELLE    ?= ./target/debug/elle
+  JOBS          ?= 16
+  ELLE          ?= ./target/debug/elle
+  CARGO_PROFILE :=
   plugin-tests: plugins
 endif
 TIMEOUT ?= 30s
@@ -46,10 +48,16 @@ dev:  ## Build the Elle binary (debug, fast compile)
 	cargo build -p elle
 
 plugins:  ## Build all native plugins (.so)
-	cargo build --release $(addprefix -p elle-,$(PLUGINS))
+	@# Build elle alongside every plugin so cargo's feature resolver
+	@# produces a SINGLE shared compilation of the elle crate. See
+	@# CONTRIBUTING.md — building plugins alone yields a second elle
+	@# rlib with a different HeapObject layout, and plugin functions
+	@# crash with "Cannot call <heap:...>" when invoked.
+	cargo build --release -p elle $(addprefix -p elle-,$(PLUGINS))
 
 plugin-%:  ## Build a single plugin by bare name (e.g., make plugin-crypto)
-	cargo build --release -p elle-$*
+	@# Always co-build elle; see the comment on the `plugins` target.
+	cargo build --release -p elle -p elle-$*
 
 # ── Docs ────────────────────────────────────────────────────────────
 
@@ -135,8 +143,23 @@ plugin-tests-jit:  ## Run plugin tests (JIT enabled)
 plugin-tests: plugin-tests-vm plugin-tests-jit  ## Run plugin tests (VM then JIT)
 
 test-git:  ## Run git plugin integration tests (requires git, no network)
-	cargo build -p elle-git
+	@# Co-build elle + elle-git in one cargo invocation; see
+	@# CONTRIBUTING.md on the single-cargo-invocation rule.
+	cargo build $(CARGO_PROFILE) -p elle -p elle-git
 	$(ELLE) tests/git.lisp
+
+test-mcp:  ## Run the MCP server integration test
+	@echo "=== MCP server integration test ==="
+	@# elle and its plugins MUST be built in a SINGLE cargo invocation so
+	@# that cargo's feature resolver produces one shared compilation of
+	@# the elle crate. Building them in separate `cargo build -p X` calls
+	@# yields two `libelle-*.rlib` artifacts with different HeapObject
+	@# layouts; the plugin's `Value::native_fn` values then deref as
+	@# garbage `LibHandle` in the main binary and calls fail with
+	@# `type-error: Cannot call <heap:...>`. See CONTRIBUTING.md.
+	cargo build $(CARGO_PROFILE) -p elle -p elle-oxigraph -p elle-syn
+	@$(ELLE) tools/test-mcp.lisp $(ELLE) \
+		|| { echo "FAILED: MCP server integration test"; exit 1; }
 
 check-plugin-list:  ## Assert every workspace plugin is in PLUGINS
 	@ws=$$(sed -n 's/.*"plugins\/\([^"]*\)".*/\1/p' Cargo.toml | sort); \
@@ -150,7 +173,7 @@ check-plugin-list:  ## Assert every workspace plugin is in PLUGINS
 		exit 1; \
 	fi
 
-test: smoke  ## Rust unit tests + clippy + fmt + rustdoc after smoke
+test: smoke test-mcp  ## Rust unit tests + clippy + fmt + rustdoc after smoke
 	cargo fmt --check
 	cargo clippy --workspace --all-targets -- -D warnings
 	RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,6 +3,39 @@
 This directory contains language references, design documents, and contributor
 guides. See [QUICKSTART.md](../QUICKSTART.md) for the full table of contents.
 
+## These files are programs
+
+Every `.md` file in this directory is simultaneously a piece of documentation
+**and** a runnable Elle program. The reader recognizes `.md` as a first-class
+source format: when you run
+
+```sh
+elle docs/control.md
+```
+
+the reader extracts every fenced code block tagged ` ```lisp ` or ` ```elle `,
+replaces all other lines (prose, tables, other code fences) with blank lines
+so source positions line up with the original markdown, and feeds the result
+to the standard s-expression reader. Error messages point back to the exact
+`.md` line and column.
+
+This means these files serve three roles at once:
+
+- **Documentation** — readable on GitHub, in your editor, or rendered on the
+  generated site.
+- **Demos and examples** — every code sample is real code that was executed
+  the last time the tests ran; there are no stale snippets that "used to work".
+- **Tests** — `make doctest` runs every `.md` file under `docs/` and fails
+  loudly if anything stops working. When you change an interface, the doc
+  for that interface either updates or breaks the build.
+
+Write docs the same way you'd write a test: pick something to demonstrate,
+show the code, assert the result. Anything you put in a ` ```lisp ` block
+is code the build will execute. Anything outside a fenced block is prose
+that the reader will skip. See [`impl/reader.md`](impl/reader.md) for the
+full pipeline and [`../src/reader/mod.rs`](../src/reader/mod.rs)'s
+`strip_markdown` for the exact extraction rules.
+
 ## Language Topics
 
 Focused files covering one topic each, all runnable via `elle docs/<file>.md`.

--- a/tools/mcp-server.lisp
+++ b/tools/mcp-server.lisp
@@ -30,9 +30,9 @@
 (def saved-stdout (*stdout*))
 (def saved-stderr (*stderr*))
 
-(def ox (import "oxigraph"))
-(def syn (import "syn"))
-(def glob-plugin (import "glob"))
+(def ox (import "plugin/oxigraph"))
+(def syn (import "plugin/syn"))
+(def glob ((import "std/glob")))
 (def portrait-lib ((import "std/portrait")))
 (def rdf ((import "std/rdf")))
 (def rust-rdf ((import "tools/rust-rdf-lib") syn))
@@ -53,7 +53,7 @@
 
 (defn nuke-store [path]
   "Delete a corrupt store directory so it can be recreated fresh."
-  (each entry in (glob-plugin:glob (string path "/*"))
+  (each entry in (glob:glob (string path "/*"))
     (file/delete entry))
   nil)
 
@@ -81,7 +81,7 @@
 
 (defn populate-rust []
   "Parse all .rs files, load Rust triples and primitive cross-links."
-  (var files (glob-plugin:glob "**/*.rs"))
+  (var files (glob:glob "**/*.rs"))
   (var count 0)
   (each file in files
     (let [[[ok? _err] (protect

--- a/tools/test-mcp.lisp
+++ b/tools/test-mcp.lisp
@@ -1,113 +1,208 @@
 #!/usr/bin/env elle
-## test-mcp.lisp — smoke test for the MCP server
+## test-mcp.lisp — integration test for tools/mcp-server.lisp
 ##
-## Spawns the MCP server as a subprocess, sends JSON-RPC messages via
-## its stdin, reads responses from its stdout, and asserts correctness.
+## Spawns the MCP server as a subprocess against a freshly-nuked store,
+## exercises initialize/tools-list/ping, verifies the startup-population
+## of Elle primitives and Rust function triples, then populates, queries,
+## and resets user-loaded RDF data through the public tool surface.
 ##
-## Run:  elle test-mcp.lisp
+## Usage:
+##   elle tools/test-mcp.lisp                   # uses "elle" in PATH
+##   elle tools/test-mcp.lisp ./target/debug/elle
+##   ELLE_BIN=./target/debug/elle elle tools/test-mcp.lisp
+
 (elle/epoch 5)
 
+## ── Configuration ────────────────────────────────────────────────────────
+##
+## Argument resolution: the first positional arg is the elle binary to test
+## against (the test spawns mcp-server.lisp as a subprocess using this
+## binary). Fall back to $ELLE_BIN, then to "elle" in PATH.
+
+(def test-args (sys/args))
+
+(def elle-bin
+  (cond
+    ((not (empty? test-args)) (first test-args))
+    ((sys/env "ELLE_BIN")     (sys/env "ELLE_BIN"))
+    (true                     "elle")))
+
+(def test-store "./target/elle-mcp-test-store")
+
+## ── Test harness ─────────────────────────────────────────────────────────
+
 (defn test [name ok? msg]
+  "Assert a condition; abort the whole suite on first failure."
   (if ok?
-    (println (string/format "  PASS  {}" name))
+    (println "  PASS  " name)
     (begin
-      (println (string/format "  FAIL  {} — {}" name msg))
-      (error {:error :test-failure :message msg}))))
+      (println "  FAIL  " name " — " msg)
+      (error {:error :test-failure :message (string name ": " msg)}))))
+
+(defn rm-rf [path]
+  "Recursively delete a path via /bin/rm -rf. No-op if it fails."
+  (let [[[ok? _] (protect (subprocess/system "rm" ["-rf" path]))]]
+    nil))
+
+## ── JSON-RPC I/O helpers ────────────────────────────────────────────────
 
 (defn send [pin msg]
-  "Send a JSON-RPC message to the server."
+  "Send a single JSON-RPC message to the server."
   (port/write pin (json/serialize msg))
   (port/write pin "\n")
   (port/flush pin))
 
-(defn recv [pout]
-  "Read a JSON-RPC response from the server."
-  (let [[line (port/read-line pout)]]
-    (when (nil? line)
-      (error {:error :eof :message "server closed stdout"}))
-    (json/parse line)))
+(defn recv-response [pout want-id]
+  "Read JSON-RPC messages until one with id=want-id arrives. Notifications
+   (messages without an id) are skipped — they come from the watcher fiber
+   and aren't responses to our requests."
+  (var result nil)
+  (while (nil? result)
+    (let [[line (port/read-line pout)]]
+      (when (nil? line)
+        (error {:error :eof :message "server closed stdout"}))
+      (let [[msg (json/parse line)]]
+        (var msg-id (get msg "id"))
+        (when (and (not (nil? msg-id)) (= msg-id want-id))
+          (assign result msg)))))
+  result)
 
-(def proc (subprocess/exec "elle" ["tools/mcp-server.lisp"]))
-  (def pin  (get proc :stdin))
-  (def pout (get proc :stdout))
-  (def perr (get proc :stderr))
+(defn call-tool [pin pout id name args]
+  "Send a tools/call request and wait for the matching response."
+  (send pin {:jsonrpc "2.0" :id id :method "tools/call"
+             :params {:name name :arguments args}})
+  (recv-response pout id))
 
-  (defer (subprocess/kill proc)
+(defn tool-text [response]
+  "Extract the first content[0].text from a tools/call response."
+  (get (get (get (get response "result") "content") 0) "text"))
 
-    # ── 1. Initialize ─────────────────────────────────────────────────
-    (send pin {:jsonrpc "2.0" :id 1 :method "initialize"
-               :params {:protocolVersion "2025-03-26"
-                        :capabilities {}
-                        :clientInfo {:name "test" :version "0.1"}}})
-    (let [[r (recv pout)]]
-      (test "initialize: has result"
-        (not (nil? (get r "result"))) "missing result")
-      (test "initialize: protocol version"
-        (= (get (get r "result") "protocolVersion") "2025-03-26")
-        "wrong protocol version")
-      (test "initialize: server name"
-        (= (get (get (get r "result") "serverInfo") "name") "elle-mcp-oxigraph")
-        "wrong server name"))
+## ── Main ────────────────────────────────────────────────────────────────
 
-    # Initialized notification (no response expected)
-    (send pin {:jsonrpc "2.0" :method "notifications/initialized"})
+(println "── MCP server integration test ──")
+(println "  elle-bin:  " elle-bin)
+(println "  store:     " test-store)
 
-    # ── 2. tools/list ──────────────────────────────────────────────────
-    (send pin {:jsonrpc "2.0" :id 2 :method "tools/list" :params {}})
-    (let [[r (recv pout)]]
-      (test "tools/list: has 4 tools"
-        (= (length (get (get r "result") "tools")) 4) "expected 4 tools"))
+(rm-rf test-store)
 
-    # ── 3. sparql_update — insert data ─────────────────────────────────
-    (send pin {:jsonrpc "2.0" :id 3 :method "tools/call"
-               :params {:name "sparql_update"
-                        :arguments {:update "INSERT DATA { <http://example.org/alice> <http://xmlns.com/foaf/0.1/name> \"Alice\" . <http://example.org/alice> <http://xmlns.com/foaf/0.1/knows> <http://example.org/bob> . <http://example.org/bob> <http://xmlns.com/foaf/0.1/name> \"Bob\" . }"}}})
-    (let [[r (recv pout)]]
-      (let [[content (get (get r "result") "content")]]
-        (test "sparql_update: success"
-          (string/contains? (get (get content 0) "text") "successfully")
-          (string (get (get content 0) "text")))))
+(def proc
+  (subprocess/exec elle-bin ["tools/mcp-server.lisp" "--" test-store]))
+(def pin  (get proc :stdin))
+(def pout (get proc :stdout))
 
-    # ── 4. sparql_query — read back ────────────────────────────────────
-    (send pin {:jsonrpc "2.0" :id 4 :method "tools/call"
-               :params {:name "sparql_query"
-                        :arguments {:query "SELECT ?name WHERE { ?person <http://xmlns.com/foaf/0.1/name> ?name } ORDER BY ?name"}}})
-    (let [[r (recv pout)]]
-      (let [[text (get (get (get (get r "result") "content") 0) "text")]]
-        (test "sparql_query: has Alice"
-          (string/contains? text "Alice") "missing Alice")
-        (test "sparql_query: has Bob"
-          (string/contains? text "Bob") "missing Bob")))
+(defer (begin (subprocess/kill proc) (rm-rf test-store))
 
-    # ── 5. load_rdf — bulk load ────────────────────────────────────────
-    (send pin {:jsonrpc "2.0" :id 5 :method "tools/call"
-               :params {:name "load_rdf"
-                        :arguments {:data "<http://example.org/carol> <http://xmlns.com/foaf/0.1/name> \"Carol\" .\n"
-                                    :format "ntriples"}}})
-    (let [[r (recv pout)]]
-      (let [[text (get (get (get (get r "result") "content") 0) "text")]]
-        (test "load_rdf: success"
-          (string/contains? text "successfully") text)))
+  ## ── 1. initialize ─────────────────────────────────────────────────────
+  (send pin {:jsonrpc "2.0" :id 1 :method "initialize"
+             :params {:protocolVersion "2025-03-26"
+                      :capabilities {}
+                      :clientInfo {:name "test-mcp" :version "0.1"}}})
+  (let [[r (recv-response pout 1)]]
+    (test "initialize: has result"
+      (not (nil? (get r "result"))) "missing result")
+    (test "initialize: server name is elle-mcp"
+      (= (get (get (get r "result") "serverInfo") "name") "elle-mcp")
+      (string "got " (get (get (get r "result") "serverInfo") "name"))))
 
-    # ── 6. dump_rdf — export ───────────────────────────────────────────
-    (send pin {:jsonrpc "2.0" :id 6 :method "tools/call"
-               :params {:name "dump_rdf" :arguments {:format "ntriples"}}})
-    (let [[r (recv pout)]]
-      (let [[text (get (get (get (get r "result") "content") 0) "text")]]
-        (test "dump_rdf: has Carol"
-          (string/contains? text "Carol") "missing Carol")))
+  ## initialized notification — no response expected
+  (send pin {:jsonrpc "2.0" :method "notifications/initialized"})
 
-    # ── 7. ping ────────────────────────────────────────────────────────
-    (send pin {:jsonrpc "2.0" :id 7 :method "ping" :params {}})
-    (let [[r (recv pout)]]
-      (test "ping: has result"
-        (not (nil? (get r "result"))) "missing result"))
+  ## ── 2. tools/list ─────────────────────────────────────────────────────
+  (send pin {:jsonrpc "2.0" :id 2 :method "tools/list" :params {}})
+  (let [[r (recv-response pout 2)]]
+    (let [[tools (get (get r "result") "tools")]]
+      (test "tools/list: exposes 14 tools"
+        (= (length tools) 14)
+        (string "expected 14, got " (length tools)))))
 
-    # ── 8. unknown method ──────────────────────────────────────────────
-    (send pin {:jsonrpc "2.0" :id 8 :method "bogus/method" :params {}})
-    (let [[r (recv pout)]]
-      (test "unknown method: returns error"
-        (not (nil? (get r "error"))) "expected error response"))
+  ## ── 3. ping ───────────────────────────────────────────────────────────
+  (send pin {:jsonrpc "2.0" :id 3 :method "ping" :params {}})
+  (let [[r (recv-response pout 3)]]
+    (test "ping: has result"
+      (not (nil? (get r "result"))) "missing result"))
 
-    (println "")
-    (println "all MCP tests passed."))
+  ## ── 4. startup populated Elle primitives ──────────────────────────────
+  ## populate-primitives runs at server startup and loads one
+  ## urn:elle:Primitive triple per built-in. If the import of std/rdf or
+  ## the oxigraph plugin regresses, this COUNT query returns 0 and the
+  ## test fails loudly.
+  (let [[r (call-tool pin pout 4 "sparql_query"
+             {:query (string "SELECT (COUNT(?p) AS ?n) WHERE { "
+                             "?p <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> "
+                             "<urn:elle:Primitive> }")})]]
+    (let [[text (tool-text r)]]
+      (test "startup: elle primitives are queryable"
+        (and (not (nil? text))
+             (not (string/contains? text "No results"))
+             (not (string/contains? text "SPARQL error")))
+        (string "got: " text))))
+
+  ## ── 5. startup populated Rust fn triples ──────────────────────────────
+  ## populate-rust iterates all .rs files via std/glob. If either the
+  ## glob or syn plugin regresses, rust triples never make it in.
+  (let [[r (call-tool pin pout 5 "sparql_query"
+             {:query (string "SELECT (COUNT(?f) AS ?n) WHERE { "
+                             "?f <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> "
+                             "<urn:rust:Fn> }")})]]
+    (let [[text (tool-text r)]]
+      (test "startup: rust functions are queryable"
+        (and (not (nil? text))
+             (not (string/contains? text "No results"))
+             (not (string/contains? text "SPARQL error")))
+        (string "got: " text))))
+
+  ## ── 6. populate: load_rdf with user-owned test triples ────────────────
+  (let [[r (call-tool pin pout 6 "load_rdf"
+             {:data (string "<http://test/alice> <http://test/name> \"Alice\" .\n"
+                            "<http://test/bob> <http://test/name> \"Bob\" .\n")
+              :format "ntriples"})]]
+    (test "populate: load_rdf succeeded"
+      (string/contains? (tool-text r) "successfully")
+      (tool-text r)))
+
+  ## ── 7. query: the just-loaded data is visible ────────────────────────
+  (let [[r (call-tool pin pout 7 "sparql_query"
+             {:query "SELECT ?name WHERE { ?p <http://test/name> ?name } ORDER BY ?name"})]]
+    (let [[text (tool-text r)]]
+      (test "query: Alice is present"
+        (string/contains? text "Alice") text)
+      (test "query: Bob is present"
+        (string/contains? text "Bob") text)))
+
+  ## ── 8. reset: sparql_update DELETE clears the user triples ────────────
+  (let [[r (call-tool pin pout 8 "sparql_update"
+             {:update "DELETE WHERE { ?s <http://test/name> ?o }"})]]
+    (test "reset: sparql_update delete succeeded"
+      (string/contains? (tool-text r) "successfully")
+      (tool-text r)))
+
+  ## ── 9. query: user triples are gone after reset ──────────────────────
+  (let [[r (call-tool pin pout 9 "sparql_query"
+             {:query "SELECT ?name WHERE { ?p <http://test/name> ?name }"})]]
+    (let [[text (tool-text r)]]
+      (test "reset: user triples are cleared"
+        (and (not (string/contains? text "Alice"))
+             (not (string/contains? text "Bob")))
+        (string "store still has data: " text))))
+
+  ## ── 10. startup-loaded data survives the reset ───────────────────────
+  ## The DELETE above was scoped to http://test/name triples, so elle
+  ## primitives must still be present.
+  (let [[r (call-tool pin pout 10 "sparql_query"
+             {:query (string "SELECT (COUNT(?p) AS ?n) WHERE { "
+                             "?p <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> "
+                             "<urn:elle:Primitive> }")})]]
+    (let [[text (tool-text r)]]
+      (test "reset: startup data is not clobbered"
+        (and (not (nil? text))
+             (not (string/contains? text "No results")))
+        (string "got: " text))))
+
+  ## ── 11. unknown method returns a JSON-RPC error ──────────────────────
+  (send pin {:jsonrpc "2.0" :id 11 :method "bogus/method" :params {}})
+  (let [[r (recv-response pout 11)]]
+    (test "unknown method: returns error object"
+      (not (nil? (get r "error"))) "expected error response"))
+
+  (println "")
+  (println "all MCP tests passed."))


### PR DESCRIPTION
The MCP server crashed at startup because it imported the `glob` plugin, which was deleted in #715 in favor of `lib/glob.lisp`. Replace with `((import "std/glob"))` and switch `oxigraph`/`syn` to the profile-aware `plugin/` prefix so debug elle picks up debug plugins.

While adding an integration test for the MCP server, surfaced a deeper bug: plugin functions invoked through the MCP server's import path crashed with `type-error: Cannot call <heap:...>` under debug elle, even with matching-profile plugins. Root cause is that `cargo build -p elle` and `cargo build -p elle-oxigraph` as separate invocations produce two different compilations of the elle crate (different transitive wasmtime feature sets → different `HeapObject` layouts). The plugin's `Value::native_fn(f)` values then deref as garbage `LibHandle` in the main binary. Release was green by layout-luck.

Fix: always build elle alongside its plugins in a single cargo invocation. Applied to `plugins`, `plugin-<name>`, `test-git`, and the new `test-mcp` target. Document the rule in CONTRIBUTING.md with the exact symptom so the next person doesn't burn a day on it.

New `test-mcp` target runs a 13-assertion integration test: initialize, tools/list (14 tools), ping, startup-populated Elle primitives + Rust fn triples via SPARQL, load_rdf populate, query, sparql_update DELETE reset, reset-survives-startup-data, unknown method. Spawns the server as a subprocess against a freshly nuked temporary store, matches `\$(CARGO_PROFILE)` to `\$(ELLE)` so it works both locally (debug) and in CI (release). Wired into `test: smoke test-mcp`.

Counter-factual verified: with the `glob` import regression re-introduced, the test fails at `server closed stdout` (the server crashes before sending the initialize response).