### PR TITLE
Capability enforcement, emit special form, defmacro &opt

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,8 +60,10 @@ bytecode. Error messages include file:line:col information.
 - **`stdlib`** — Standard library functions (`stdlib.lisp`, loaded at startup).
   See [`docs/stdlib.md`](docs/stdlib.md).
 - **`arithmetic`** — Unified arithmetic operations (shared by VM and primitives)
-- **`signals`** — Signal type (`Silent`, `Yields`, `Polymorphic`), signal
-  registry for keyword-to-bit mapping;
+- **`signals`** — Signal type (`{ bits: SignalBits, propagates: u32 }`),
+  signal registry for keyword-to-bit mapping, `CAP_MASK` for capability
+  enforcement; `emit` is a special form for literal keywords/sets,
+  `yield` is a macro expanding to `(emit :yield val)`;
   includes `SIG_EXEC` (bit 11) for subprocess operations and `SIG_FUEL`
   (bit 12) for instruction budget exhaustion
 - **`io`** — I/O request types, backends, timeout handling;
@@ -159,8 +161,8 @@ These must remain true. Violating them breaks the system:
 
 2. **Closures capture by value into their environment.** Immutable captured
    locals are captured directly. Mutable captured locals and mutated parameters
-   use `LocalLBox` for indirection. The `lbox_params_mask` on `Closure` tracks
-   which parameters need lbox wrapping.
+   use `CaptureCell` for indirection. The `capture_params_mask` on
+   `ClosureTemplate` tracks which parameters need wrapping.
 
 3. **Signals are inferred, not declared — except when `silence` provides
    explicit bounds.** The `Signal` type (`Silent`, `Yields`, `Polymorphic`)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,6 +179,14 @@ These must remain true. Violating them breaks the system:
    forbidden. If you catch an error, you must either handle it meaningfully or
    propagate it.
 
+## Writing Elle code
+
+**Read [`QUICKSTART.md`](QUICKSTART.md) before writing any Elle code.**
+It is the complete language reference: syntax, special forms, data types,
+control flow, macros, fibers, signals, and the standard library. Elle
+looks like a Lisp but has significant differences from Scheme/Clojure/CL
+that will trip you up if you guess. Do not guess; read the reference.
+
 ## Intentional oddities
 
 The 4 most critical (agents get these wrong):

--- a/docs/analysis/agent-reasoning.md
+++ b/docs/analysis/agent-reasoning.md
@@ -19,7 +19,7 @@ An agent doesn't need to understand signals by reading source code. It queries t
 
 When analyzing a single file or function, use `portrait` to get its profile:
 
-```lisp
+```text
 # Analyze the file
 (def a (compile/analyze (file/read "lib/http.lisp") {:file "lib/http.lisp"}))
 
@@ -200,7 +200,7 @@ An agent can then read the Rust source to understand semantics.
 
 Define project-level invariants as SPARQL ASK queries in `.elle-invariants.lisp`:
 
-```lisp
+```text
 # No mutable state shared across functions
 (defn check-shared-mutable []
   '(ASK WHERE {

--- a/docs/analysis/agent-reasoning.md
+++ b/docs/analysis/agent-reasoning.md
@@ -19,7 +19,7 @@ An agent doesn't need to understand signals by reading source code. It queries t
 
 When analyzing a single file or function, use `portrait` to get its profile:
 
-```text
+```lisp
 # Analyze the file
 (def a (compile/analyze (file/read "lib/http.lisp") {:file "lib/http.lisp"}))
 
@@ -200,7 +200,7 @@ An agent can then read the Rust source to understand semantics.
 
 Define project-level invariants as SPARQL ASK queries in `.elle-invariants.lisp`:
 
-```text
+```lisp
 # No mutable state shared across functions
 (defn check-shared-mutable []
   '(ASK WHERE {

--- a/docs/analysis/debugging.md
+++ b/docs/analysis/debugging.md
@@ -25,7 +25,7 @@ get information about it. All are `NativeFn`. Primitives that need VM access use
 | `jit?` | `(jit? value)` | `true` or `false` | True if value is a closure with JIT-compiled native code |
 | `silent?` | `(silent? value)` | `true` or `false` | True if value is a closure that does not suspend (no yield/debug/polymorphic signal) |
 | `coro?` | `(coro? value)` | `true` or `false` | True if value is a closure with the yield signal bit set |
-| `mutates-params?` | `(mutates-params? value)` | `true` or `false` | True if value is a closure whose body mutates any of its own parameters (i.e., `lbox_params_mask != 0`) |
+| `mutates-params?` | `(mutates-params? value)` | `true` or `false` | True if value is a closure whose body mutates any of its own parameters (i.e., `capture_params_mask != 0`) |
 | `closure?` | `(closure? value)` | `true` or `false` | True if value is a closure (bytecode, not native/vm-aware) |
 
 Implementation: each is a simple predicate that examines the `Value` and,
@@ -34,14 +34,14 @@ for closures, reads fields on the `Closure` struct.
 - `jit?` checks `closure.jit_code.is_some()`
 - `silent?` checks `!closure.signal.may_suspend()` (no yield/debug bits and propagates == 0)
 - `coro?` checks `closure.signal.bits & SIG_YIELD != 0`
-- `mutates-params?` checks `closure.lbox_params_mask != 0` (any lbox-wrapped params)
+- `mutates-params?` checks `closure.template.capture_params_mask != 0` (any capture-wrapped params)
 - `closure?` checks `value.as_closure().is_some()`
 - `global?` takes a symbol, always returns `false` (no runtime globals exist)
 
-Note: `lbox_params_mask` tracks which *parameters* are mutated inside the
-closure body and need `LocalLBox` wrapping. It does **not** indicate whether
+Note: `capture_params_mask` tracks which *parameters* are mutated inside the
+closure body and need capture cell wrapping. It does **not** indicate whether
 the closure captures mutable bindings from an outer scope. Those are
-`LocalLBox` values in the closure's `env` vector — detecting them would
+`CaptureCell` values in the closure's `env` vector — detecting them would
 require scanning `env`, which is a different (and more expensive) operation.
 
 ### 1.2 Error signal tracking: `fn/errors?`

--- a/docs/analysis/portrait.md
+++ b/docs/analysis/portrait.md
@@ -8,7 +8,7 @@ It analyzes source without executing it.
 
 ## Compile-time analysis
 
-```lisp
+```text
 (def src "(defn validate [data]
   (when (nil? (get data :name))
     (error {:error :validation-error :message \"missing name\"}))
@@ -19,7 +19,7 @@ It analyzes source without executing it.
 
 ## Signal queries
 
-```lisp
+```text
 # Query a function's inferred signal profile
 (compile/signal a :validate)
 # => {:silent false :jit-eligible true :propagates ... }
@@ -41,7 +41,7 @@ It analyzes source without executing it.
 The `lib/portrait.lisp` library wraps the raw analysis APIs into
 structured reports.
 
-```lisp
+```text
 (def portrait ((import "std/portrait.lisp")))
 
 # Function portrait — signal profile, captures, callees

--- a/docs/analysis/portrait.md
+++ b/docs/analysis/portrait.md
@@ -8,7 +8,7 @@ It analyzes source without executing it.
 
 ## Compile-time analysis
 
-```text
+```lisp
 (def src "(defn validate [data]
   (when (nil? (get data :name))
     (error {:error :validation-error :message \"missing name\"}))
@@ -19,7 +19,7 @@ It analyzes source without executing it.
 
 ## Signal queries
 
-```text
+```lisp
 # Query a function's inferred signal profile
 (compile/signal a :validate)
 # => {:silent false :jit-eligible true :propagates ... }
@@ -41,7 +41,7 @@ It analyzes source without executing it.
 The `lib/portrait.lisp` library wraps the raw analysis APIs into
 structured reports.
 
-```text
+```lisp
 (def portrait ((import "std/portrait.lisp")))
 
 # Function portrait — signal profile, captures, callees

--- a/docs/coming-from.md
+++ b/docs/coming-from.md
@@ -285,7 +285,7 @@ Elle wraps C libraries directly via FFI — no binding generators,
 no wrapper crates. See [docs/ffi.md](ffi.md) and the `lib/sqlite.lisp`,
 `lib/compress.lisp`, `lib/git.lisp` modules for real-world examples.
 
-```
+```lisp
 (def libc (ffi/native "libc.so.6"))
 (ffi/defbind c-getpid libc "getpid" :int @[])
 (println (c-getpid))

--- a/docs/coming-from.md
+++ b/docs/coming-from.md
@@ -285,7 +285,7 @@ Elle wraps C libraries directly via FFI — no binding generators,
 no wrapper crates. See [docs/ffi.md](ffi.md) and the `lib/sqlite.lisp`,
 `lib/compress.lisp`, `lib/git.lisp` modules for real-world examples.
 
-```lisp
+```text
 (def libc (ffi/native "libc.so.6"))
 (ffi/defbind c-getpid libc "getpid" :int @[])
 (println (c-getpid))

--- a/docs/concurrency.md
+++ b/docs/concurrency.md
@@ -126,7 +126,7 @@ On top of the core process API, the module provides:
 - **Task** — one-shot async work as a monitored process
 - **EventManager** — pub/sub event dispatching
 
-```elle
+```lisp
 (def process ((import "std/process")))
 
 (process:start (fn []
@@ -142,7 +142,7 @@ On top of the core process API, the module provides:
 
 ### GenServer example
 
-```elle
+```lisp
 (def process ((import "std/process")))
 
 (process:start (fn []
@@ -160,7 +160,7 @@ On top of the core process API, the module provides:
 
 ### Supervisor example
 
-```elle
+```lisp
 (def process ((import "std/process")))
 
 (process:start (fn []

--- a/docs/concurrency.md
+++ b/docs/concurrency.md
@@ -7,7 +7,7 @@ For CPU parallelism across cores, see [threads.md](threads.md).
 
 ## Spawn and join
 
-```lisp
+```text
 # Spawn a fiber, wait for its result
 (def f (ev/spawn (fn [] (+ 1 2))))
 (ev/join f)                # => 3
@@ -21,7 +21,7 @@ For CPU parallelism across cores, see [threads.md](threads.md).
 
 The most common pattern:
 
-```lisp
+```text
 (ev/map (fn [x] (* x x)) [1 2 3 4])   # => [1 4 9 16]
 
 # Bounded parallelism (at most n in flight)
@@ -32,14 +32,14 @@ The most common pattern:
 
 `ev/join-protected` returns `[ok? value]` instead of raising errors:
 
-```lisp
+```text
 (let [[[ok? val] (ev/join-protected (ev/spawn (fn [] (+ 1 2))))]]
   (if ok? val :failed))   # => 3
 ```
 
 ## Select, race, timeout
 
-```lisp
+```text
 # First to complete wins; abort the rest
 (ev/race [(ev/spawn (fn [] :fast))
           (ev/spawn (fn [] (ev/sleep 1) :slow))])  # => :fast
@@ -53,7 +53,7 @@ The most common pattern:
 All children must finish before scope exits. If one child fails, the
 others are aborted.
 
-```lisp
+```text
 (ev/scope (fn [spawn]
   (let [[a (spawn (fn [] :users))]
         [b (spawn (fn [] :settings))]]
@@ -62,7 +62,7 @@ others are aborted.
 
 ## Primitives reference
 
-```lisp
+```text
 # (ev/spawn thunk)            — create fiber, returns handle
 # (ev/join fiber-or-seq)      — wait for result(s), propagate errors
 # (ev/join-protected target)  — wait without raising: [ok? value]
@@ -79,7 +79,7 @@ others are aborted.
 
 ## TCP
 
-```lisp
+```text
 # (tcp/listen addr port)      — bind and listen, returns listener
 # (tcp/accept listener)       — yield until connection, returns port
 # (tcp/connect host port)     — yield until connected, returns port
@@ -91,7 +91,7 @@ others are aborted.
 `ev/futex-wait` and `ev/futex-wake`. These cooperate with the async
 scheduler — waiting fibers yield rather than blocking the thread.
 
-```lisp
+```text
 (def sync ((import "std/sync")))
 
 (def lock (sync:make-lock))
@@ -126,7 +126,7 @@ On top of the core process API, the module provides:
 - **Task** — one-shot async work as a monitored process
 - **EventManager** — pub/sub event dispatching
 
-```lisp
+```text
 (def process ((import "std/process")))
 
 (process:start (fn []
@@ -142,7 +142,7 @@ On top of the core process API, the module provides:
 
 ### GenServer example
 
-```lisp
+```text
 (def process ((import "std/process")))
 
 (process:start (fn []
@@ -160,7 +160,7 @@ On top of the core process API, the module provides:
 
 ### Supervisor example
 
-```lisp
+```text
 (def process ((import "std/process")))
 
 (process:start (fn []

--- a/docs/impl/lir.md
+++ b/docs/impl/lir.md
@@ -13,7 +13,7 @@ basic blocks, and explicit control flow.
 - **`Label`** — block label for control flow
 - **`LirInstr`** — individual operations (load const, add, call, etc.)
 - **`Terminator`** — block-ending instruction (return, jump,
-  branch, tail call)
+  branch, emit, tail call)
 - **`LirConst`** — compile-time constants (int, float, string,
   keyword, nil, true, false)
 
@@ -29,11 +29,11 @@ The lowerer (`src/lir/lower/`) transforms HIR trees into LIR:
 4. **Escape analysis** — determines which scopes can use region-based
    allocation (RegionEnter/RegionExit)
 
-## Yield metadata
+## Emit metadata
 
-LIR collects yield-site and call-site information during emission.
+LIR collects emit-site and call-site information during emission.
 The JIT uses this for yield-through-call support — knowing which
-calls might yield so it can emit proper save/restore sequences.
+calls might emit so it can generate proper save/restore sequences.
 
 ## Files
 

--- a/docs/impl/vm.md
+++ b/docs/impl/vm.md
@@ -42,8 +42,9 @@ Specialized fast paths exist for common sequences (e.g., `LoadLocal` +
 
 ## Fiber integration
 
-- **Yield** — saves the current frame as a `SuspendedFrame`, returns
-  control to the parent fiber or scheduler
+- **Emit** (`Instruction::Emit` with a u16 signal bits operand) — saves
+  the current frame as a `SuspendedFrame`, returns control to the parent
+  fiber or scheduler
 - **Signal emission** — checks the fiber's signal mask to decide
   whether to propagate or catch
 - **Fuel** — decrements a counter per instruction; when zero, emits

--- a/docs/libraries.md
+++ b/docs/libraries.md
@@ -62,14 +62,14 @@ pattern and are imported via `(import "std/<name>")`.
 
 Libraries are parametric modules. Import and call the closure:
 
-```lisp
+```text
 (def http ((import "std/http")))
 (http:get "https://example.com")
 ```
 
 Libraries that depend on native plugins take the plugin as a parameter:
 
-```lisp
+```text
 (def tls-plugin (import "plugin/tls"))
 (def tls ((import "std/tls") tls-plugin))
 (tls:connect "example.com" 443)

--- a/docs/libraries.md
+++ b/docs/libraries.md
@@ -62,14 +62,14 @@ pattern and are imported via `(import "std/<name>")`.
 
 Libraries are parametric modules. Import and call the closure:
 
-```text
+```lisp
 (def http ((import "std/http")))
 (http:get "https://example.com")
 ```
 
 Libraries that depend on native plugins take the plugin as a parameter:
 
-```text
+```lisp
 (def tls-plugin (import "plugin/tls"))
 (def tls ((import "std/tls") tls-plugin))
 (tls:connect "example.com" 443)

--- a/docs/macros.md
+++ b/docs/macros.md
@@ -294,7 +294,7 @@ with the lexical context of `context`. The result is marked
 not override the context's scopes. This enables anaphoric macros —
 macros that intentionally introduce bindings visible at the call site.
 
-```text
+```lisp
 (defmacro aif (test then else)
   `(let ((,(datum->syntax test 'it) ,test))
      (if ,(datum->syntax test 'it) ,then ,else)))

--- a/docs/macros.md
+++ b/docs/macros.md
@@ -11,7 +11,7 @@ compiled and executed in the real VM via `pipeline::eval_syntax()`.
 The full language is available in macro bodies: `if`, `let`, closures,
 list operations, recursion — everything.
 
-```lisp
+```text
 (defmacro my-when (test body)
   `(if ,test ,body nil))
 
@@ -294,7 +294,7 @@ with the lexical context of `context`. The result is marked
 not override the context's scopes. This enables anaphoric macros —
 macros that intentionally introduce bindings visible at the call site.
 
-```lisp
+```text
 (defmacro aif (test then else)
   `(let ((,(datum->syntax test 'it) ,test))
      (if ,(datum->syntax test 'it) ,then ,else)))

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -312,7 +312,7 @@ The MCP server exposes what the compiler already computes. Elle's compilation pi
 
 **Everything the MCP server provides is available to normal Elle code at runtime.** `compile/analyze`, `compile/signal`, `compile/captures`, `compile/callees` — these are regular Elle functions. The MCP server is just an Elle program (`tools/mcp-server.lisp`) that wraps these primitives in the Model Context Protocol. You can write your own analysis tools using the same functions:
 
-```text
+```lisp
 (def a (compile/analyze (file/read "my-code.lisp") {:file "my-code.lisp"}))
 (compile/signal a :my-function)    # => signal profile
 (compile/captures a :my-function)  # => captured variables

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -312,7 +312,7 @@ The MCP server exposes what the compiler already computes. Elle's compilation pi
 
 **Everything the MCP server provides is available to normal Elle code at runtime.** `compile/analyze`, `compile/signal`, `compile/captures`, `compile/callees` — these are regular Elle functions. The MCP server is just an Elle program (`tools/mcp-server.lisp`) that wraps these primitives in the Model Context Protocol. You can write your own analysis tools using the same functions:
 
-```lisp
+```text
 (def a (compile/analyze (file/read "my-code.lisp") {:file "my-code.lisp"}))
 (compile/signal a :my-function)    # => signal profile
 (compile/captures a :my-function)  # => captured variables

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -6,7 +6,7 @@ use `import` with the `std/` prefix and require no compilation.
 
 ## Usage pattern
 
-```
+```lisp
 ## Plugin (Rust cdylib)
 (def crypto (import "plugin/crypto"))
 (seq->hex (crypto:sha256 "hello"))

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -6,7 +6,7 @@ use `import` with the `std/` prefix and require no compilation.
 
 ## Usage pattern
 
-```lisp
+```text
 ## Plugin (Rust cdylib)
 (def crypto (import "plugin/crypto"))
 (seq->hex (crypto:sha256 "hello"))

--- a/docs/processes.md
+++ b/docs/processes.md
@@ -8,7 +8,7 @@ wrapper), Supervisor (automatic restart), and Task (one-shot async work).
 
 ## Loading
 
-```lisp
+```text
 (def process ((import "std/process")))
 ```
 
@@ -17,7 +17,7 @@ wrapper), Supervisor (automatic restart), and Task (one-shot async work).
 `process:start` creates a scheduler and runs a closure as the first
 process. It blocks until all processes complete and returns the scheduler.
 
-```lisp
+```text
 (def process ((import "std/process")))
 
 (process:start (fn []
@@ -26,7 +26,7 @@ process. It blocks until all processes complete and returns the scheduler.
 
 Use `process:run` when you need a pre-configured or shared scheduler:
 
-```lisp
+```text
 (def sched (process:make-scheduler :fuel 500))
 (process:run sched (fn [] (println "on existing scheduler")))
 ```
@@ -36,7 +36,7 @@ Use `process:run` when you need a pre-configured or shared scheduler:
 Every process has a mailbox. `send` delivers a message; `recv` blocks
 until one arrives.
 
-```lisp
+```text
 (def process ((import "std/process")))
 
 (process:start (fn []
@@ -51,7 +51,7 @@ until one arrives.
 parent (crash propagation). `spawn-monitor` monitors without linking
 (death notification without crashing the parent).
 
-```lisp
+```text
 (def process ((import "std/process")))
 
 (process:start (fn []
@@ -69,7 +69,7 @@ parent (crash propagation). `spawn-monitor` monitors without linking
 `recv-match` takes a predicate and returns the first message that
 matches, leaving non-matching messages in the mailbox in order.
 
-```lisp
+```text
 (def process ((import "std/process")))
 
 (process:start (fn []
@@ -87,7 +87,7 @@ matches, leaving non-matching messages in the mailbox in order.
 `recv-timeout` returns `:timeout` if no message arrives within the
 given number of scheduler ticks.
 
-```lisp
+```text
 (def process ((import "std/process")))
 
 (process:start (fn []
@@ -99,7 +99,7 @@ given number of scheduler ticks.
 Linked processes crash together. When a linked child crashes, the parent
 crashes too — unless the parent is trapping exits.
 
-```lisp
+```text
 (def process ((import "std/process")))
 
 (process:start (fn []
@@ -120,7 +120,7 @@ crashes too — unless the parent is trapping exits.
 Monitors deliver a `[:DOWN ref pid reason]` message when the monitored
 process dies, without affecting the monitoring process.
 
-```lisp
+```text
 (def process ((import "std/process")))
 
 (process:start (fn []
@@ -139,7 +139,7 @@ process dies, without affecting the monitoring process.
 Processes can register under a keyword name. `whereis` looks up PIDs
 by name; `send-named` sends to a registered name.
 
-```lisp
+```text
 (def process ((import "std/process")))
 
 (process:start (fn []
@@ -162,7 +162,7 @@ by name; `send-named` sends to a registered name.
 Each process has a private key-value store. Useful for per-process
 configuration that doesn't belong in the main state.
 
-```lisp
+```text
 (def process ((import "std/process")))
 
 (process:start (fn []
@@ -179,7 +179,7 @@ Processes are cooperatively scheduled with fuel budgets. A CPU-bound
 process gets preempted after exhausting its fuel, allowing other
 processes to run.
 
-```lisp
+```text
 (def process ((import "std/process")))
 
 (process:start (fn []
@@ -216,7 +216,7 @@ down after replying.
 
 ## Key-value store example
 
-```lisp
+```text
 (def process ((import "std/process")))
 
 (process:start (fn []
@@ -239,7 +239,7 @@ down after replying.
 `gen-server-stop` requests graceful shutdown. The server's `:terminate`
 callback runs before it exits.
 
-```lisp
+```text
 (def process ((import "std/process")))
 
 (process:start (fn []
@@ -277,7 +277,7 @@ from `handle-call` and use `gen-server-reply` later:
 Actor wraps GenServer with a simpler API: just an init function and
 get/update operations on state.
 
-```lisp
+```text
 (def process ((import "std/process")))
 
 (process:start (fn []
@@ -295,7 +295,7 @@ get/update operations on state.
 Task runs a one-shot function as a supervised process and returns the
 result. Like `ev/spawn` but the work has a PID and can be monitored.
 
-```lisp
+```text
 (def process ((import "std/process")))
 
 (process:start (fn []
@@ -337,7 +337,7 @@ Each child is a struct with:
 
 ## Basic supervisor
 
-```lisp
+```text
 (def process ((import "std/process")))
 
 (process:start (fn []
@@ -377,7 +377,7 @@ infinite restart loop. The `:max-restarts` and `:max-ticks` options
 set a sliding window: if a child restarts more than N times within M
 scheduler ticks, the supervisor stops restarting it.
 
-```lisp
+```text
 (process:supervisor-start-link children
   :max-restarts 3    # at most 3 restarts...
   :max-ticks 5)      # ...within 5 scheduler ticks
@@ -387,7 +387,7 @@ scheduler ticks, the supervisor stops restarting it.
 
 Pass a `:logger` callback to receive structured lifecycle events:
 
-```lisp
+```text
 (process:supervisor-start-link children
   :logger (fn [event]
     (println "supervisor:" (get event :event) (get event :id))))
@@ -410,7 +410,7 @@ By default, children start concurrently. When a child spec includes
 startup ordering — for example, a ZMQ bridge must bind its endpoints
 before clients connect.
 
-```lisp
+```text
 (process:supervisor-start-link
   [{:id :bridge :restart :permanent :ready true
     :start (fn []
@@ -431,7 +431,7 @@ the death and proceeds without deadlocking.
 
 Add and remove children at runtime:
 
-```lisp
+```text
 (process:supervisor-start-child :sup
   {:id :dynamic-1 :restart :temporary
    :start (fn [] (forever (process:recv))})
@@ -448,7 +448,7 @@ subprocess under a supervisor. The child process spawns the subprocess,
 blocks on `subprocess/wait`, then crashes on non-zero exit to trigger
 supervisor restart.
 
-```lisp
+```text
 (process:supervisor-start-link
   [(process:make-subprocess-child :nginx "/usr/sbin/nginx" ["-g" "daemon off;"])
    (process:make-subprocess-child :redis "/usr/bin/redis-server" ["--port" "6380"]
@@ -461,7 +461,7 @@ supervisor restart.
 
 This replaces the manual bridge pattern:
 
-```lisp
+```text
 # Before: every user writes this glue
 {:id :my-daemon :restart :permanent
  :start (fn []
@@ -476,7 +476,7 @@ This replaces the manual bridge pattern:
 Options passed to `subprocess/exec` (environment, working directory)
 go in the `:opts` named argument:
 
-```lisp
+```text
 (process:make-subprocess-child :worker "/usr/bin/worker" []
   :opts {:cwd "/var/lib/worker" :env {:PORT "8080"}})
 ```
@@ -487,7 +487,7 @@ go in the `:opts` named argument:
 EventManager provides pub/sub event dispatching. Handlers are modules
 with `:init`, `:handle-event`, and optional `:terminate` callbacks.
 
-```lisp
+```text
 (def handler-mod
   {:init         (fn [_] @[])
    :handle-event (fn [event state]
@@ -507,7 +507,7 @@ with `:init`, `:handle-event`, and optional `:terminate` callbacks.
 `ev/spawn` and `ev/join` work inside processes. Sub-fibers are
 tracked by the scheduler and participate in I/O completion.
 
-```lisp
+```text
 (def process ((import "std/process")))
 
 (process:start (fn []

--- a/docs/processes.md
+++ b/docs/processes.md
@@ -8,7 +8,7 @@ wrapper), Supervisor (automatic restart), and Task (one-shot async work).
 
 ## Loading
 
-```text
+```lisp
 (def process ((import "std/process")))
 ```
 
@@ -17,7 +17,7 @@ wrapper), Supervisor (automatic restart), and Task (one-shot async work).
 `process:start` creates a scheduler and runs a closure as the first
 process. It blocks until all processes complete and returns the scheduler.
 
-```elle
+```lisp
 (def process ((import "std/process")))
 
 (process:start (fn []
@@ -26,7 +26,7 @@ process. It blocks until all processes complete and returns the scheduler.
 
 Use `process:run` when you need a pre-configured or shared scheduler:
 
-```text
+```lisp
 (def sched (process:make-scheduler :fuel 500))
 (process:run sched (fn [] (println "on existing scheduler")))
 ```
@@ -36,7 +36,7 @@ Use `process:run` when you need a pre-configured or shared scheduler:
 Every process has a mailbox. `send` delivers a message; `recv` blocks
 until one arrives.
 
-```elle
+```lisp
 (def process ((import "std/process")))
 
 (process:start (fn []
@@ -51,7 +51,7 @@ until one arrives.
 parent (crash propagation). `spawn-monitor` monitors without linking
 (death notification without crashing the parent).
 
-```elle
+```lisp
 (def process ((import "std/process")))
 
 (process:start (fn []
@@ -69,7 +69,7 @@ parent (crash propagation). `spawn-monitor` monitors without linking
 `recv-match` takes a predicate and returns the first message that
 matches, leaving non-matching messages in the mailbox in order.
 
-```elle
+```lisp
 (def process ((import "std/process")))
 
 (process:start (fn []
@@ -87,7 +87,7 @@ matches, leaving non-matching messages in the mailbox in order.
 `recv-timeout` returns `:timeout` if no message arrives within the
 given number of scheduler ticks.
 
-```elle
+```lisp
 (def process ((import "std/process")))
 
 (process:start (fn []
@@ -99,7 +99,7 @@ given number of scheduler ticks.
 Linked processes crash together. When a linked child crashes, the parent
 crashes too — unless the parent is trapping exits.
 
-```elle
+```lisp
 (def process ((import "std/process")))
 
 (process:start (fn []
@@ -120,7 +120,7 @@ crashes too — unless the parent is trapping exits.
 Monitors deliver a `[:DOWN ref pid reason]` message when the monitored
 process dies, without affecting the monitoring process.
 
-```elle
+```lisp
 (def process ((import "std/process")))
 
 (process:start (fn []
@@ -139,7 +139,7 @@ process dies, without affecting the monitoring process.
 Processes can register under a keyword name. `whereis` looks up PIDs
 by name; `send-named` sends to a registered name.
 
-```elle
+```lisp
 (def process ((import "std/process")))
 
 (process:start (fn []
@@ -162,7 +162,7 @@ by name; `send-named` sends to a registered name.
 Each process has a private key-value store. Useful for per-process
 configuration that doesn't belong in the main state.
 
-```elle
+```lisp
 (def process ((import "std/process")))
 
 (process:start (fn []
@@ -179,7 +179,7 @@ Processes are cooperatively scheduled with fuel budgets. A CPU-bound
 process gets preempted after exhausting its fuel, allowing other
 processes to run.
 
-```elle
+```lisp
 (def process ((import "std/process")))
 
 (process:start (fn []
@@ -216,7 +216,7 @@ down after replying.
 
 ## Key-value store example
 
-```elle
+```lisp
 (def process ((import "std/process")))
 
 (process:start (fn []
@@ -239,7 +239,7 @@ down after replying.
 `gen-server-stop` requests graceful shutdown. The server's `:terminate`
 callback runs before it exits.
 
-```elle
+```lisp
 (def process ((import "std/process")))
 
 (process:start (fn []
@@ -277,7 +277,7 @@ from `handle-call` and use `gen-server-reply` later:
 Actor wraps GenServer with a simpler API: just an init function and
 get/update operations on state.
 
-```elle
+```lisp
 (def process ((import "std/process")))
 
 (process:start (fn []
@@ -295,7 +295,7 @@ get/update operations on state.
 Task runs a one-shot function as a supervised process and returns the
 result. Like `ev/spawn` but the work has a PID and can be monitored.
 
-```elle
+```lisp
 (def process ((import "std/process")))
 
 (process:start (fn []
@@ -337,7 +337,7 @@ Each child is a struct with:
 
 ## Basic supervisor
 
-```elle
+```lisp
 (def process ((import "std/process")))
 
 (process:start (fn []
@@ -377,7 +377,7 @@ infinite restart loop. The `:max-restarts` and `:max-ticks` options
 set a sliding window: if a child restarts more than N times within M
 scheduler ticks, the supervisor stops restarting it.
 
-```text
+```lisp
 (process:supervisor-start-link children
   :max-restarts 3    # at most 3 restarts...
   :max-ticks 5)      # ...within 5 scheduler ticks
@@ -387,7 +387,7 @@ scheduler ticks, the supervisor stops restarting it.
 
 Pass a `:logger` callback to receive structured lifecycle events:
 
-```text
+```lisp
 (process:supervisor-start-link children
   :logger (fn [event]
     (println "supervisor:" (get event :event) (get event :id))))
@@ -410,7 +410,7 @@ By default, children start concurrently. When a child spec includes
 startup ordering — for example, a ZMQ bridge must bind its endpoints
 before clients connect.
 
-```text
+```lisp
 (process:supervisor-start-link
   [{:id :bridge :restart :permanent :ready true
     :start (fn []
@@ -431,7 +431,7 @@ the death and proceeds without deadlocking.
 
 Add and remove children at runtime:
 
-```text
+```lisp
 (process:supervisor-start-child :sup
   {:id :dynamic-1 :restart :temporary
    :start (fn [] (forever (process:recv))})
@@ -448,7 +448,7 @@ subprocess under a supervisor. The child process spawns the subprocess,
 blocks on `subprocess/wait`, then crashes on non-zero exit to trigger
 supervisor restart.
 
-```text
+```lisp
 (process:supervisor-start-link
   [(process:make-subprocess-child :nginx "/usr/sbin/nginx" ["-g" "daemon off;"])
    (process:make-subprocess-child :redis "/usr/bin/redis-server" ["--port" "6380"]
@@ -461,7 +461,7 @@ supervisor restart.
 
 This replaces the manual bridge pattern:
 
-```text
+```lisp
 # Before: every user writes this glue
 {:id :my-daemon :restart :permanent
  :start (fn []
@@ -476,7 +476,7 @@ This replaces the manual bridge pattern:
 Options passed to `subprocess/exec` (environment, working directory)
 go in the `:opts` named argument:
 
-```text
+```lisp
 (process:make-subprocess-child :worker "/usr/bin/worker" []
   :opts {:cwd "/var/lib/worker" :env {:PORT "8080"}})
 ```
@@ -487,7 +487,7 @@ go in the `:opts` named argument:
 EventManager provides pub/sub event dispatching. Handlers are modules
 with `:init`, `:handle-event`, and optional `:terminate` callbacks.
 
-```text
+```lisp
 (def handler-mod
   {:init         (fn [_] @[])
    :handle-event (fn [event state]
@@ -507,7 +507,7 @@ with `:init`, `:handle-event`, and optional `:terminate` callbacks.
 `ev/spawn` and `ev/join` work inside processes. Sub-fibers are
 tracked by the scheduler and participate in I/O completion.
 
-```elle
+```lisp
 (def process ((import "std/process")))
 
 (process:start (fn []

--- a/docs/signals/capabilities.md
+++ b/docs/signals/capabilities.md
@@ -1,0 +1,158 @@
+# Capability enforcement
+
+Capabilities flow down. A fiber's parent decides what the fiber is
+permitted to do. Operations the fiber can't perform become signals the
+parent can catch.
+
+## Creating a restricted fiber
+
+`fiber/new` accepts `:deny` after the mask argument:
+
+```lisp
+# Deny IO — child can't call IO primitives
+(fiber/new body |:io :error| :deny |:io|)
+
+# Deny IO and FFI
+(fiber/new body |:io :ffi :error| :deny |:io :ffi|)
+
+# No restrictions (default — unchanged existing API)
+(fiber/new body |:error|)
+```
+
+The mask (second argument) controls signal routing — what the parent
+catches. The `:deny` keyword controls enforcement — what the child
+can't do. They're independent:
+
+| | mask has `:io` | mask lacks `:io` |
+|---|---|---|
+| **deny has `:io`** | blocked; parent catches denial | blocked; denial propagates |
+| **deny lacks `:io`** | child does IO; parent catches signal | child does IO silently |
+
+## Deniable capabilities
+
+The following signal keywords can be denied:
+
+| Keyword | Bit | Effect when denied |
+|---------|-----|--------------------|
+| `:error` | 0 | Blocks primitives that may error (~66% of all) |
+| `:yield` | 1 | Blocks cooperative suspension |
+| `:debug` | 2 | Blocks breakpoints/tracing |
+| `:ffi` | 4 | Blocks foreign function calls |
+| `:halt` | 8 | Blocks VM termination |
+| `:io` | 9 | Blocks I/O operations |
+| `:exec` | 11 | Blocks subprocess execution |
+
+VM-internal signals (resume, propagate, abort, query, terminal,
+switch, wait) cannot be denied.
+
+## What happens on denial
+
+When a fiber calls a primitive whose declared signal bits overlap
+with the fiber's withheld capabilities, the primitive does not run.
+Instead, the fiber emits a signal with:
+
+- **Bits**: the blocked capability bits (e.g., `:io`)
+- **Payload**: a struct describing the denial
+
+```lisp
+{:error :capability-denied
+ :denied |:io|
+ :primitive "port/read-line"
+ :func <native-fn>
+ :args ["arg1" "arg2"]}
+```
+
+The parent catches this signal through the normal mask routing.
+
+## Introspection
+
+```lisp
+(fiber/caps)      # current fiber's capabilities
+(fiber/caps f)    # specific fiber's capabilities
+```
+
+Returns a keyword set of active capabilities — everything in the
+capability space that is NOT withheld:
+
+```lisp
+(fiber/caps)
+# => |:error :yield :debug :ffi :halt :io :exec|
+
+(let ([f (fiber/new (fn [] 42) |:error| :deny |:io :ffi|)])
+  (fiber/caps f))
+# => |:error :yield :debug :halt :exec|
+```
+
+## Transitivity
+
+Withheld capabilities propagate from parent to child at resume time.
+A child inherits its parent's restrictions plus any `:deny` of its own:
+
+```lisp
+(let ([outer (fiber/new
+               (fn []
+                 # inner denies :ffi, inherits :io denial from outer
+                 (let ([inner (fiber/new (fn [] (fiber/caps))
+                                        |:error| :deny |:ffi|)])
+                   (fiber/resume inner)))
+               |:error|
+               :deny |:io|)])
+  (fiber/resume outer))
+# => |:error :yield :debug :halt :exec|
+# (missing :io from parent, missing :ffi from own deny)
+```
+
+A child can never gain capabilities its parent lacks. Requesting to
+deny something the parent already withholds is a no-op (silently
+absorbed).
+
+## Mediation
+
+The parent can catch a denial, perform the operation on the child's
+behalf, and resume the child with the result:
+
+```lisp
+(let ([f (fiber/new
+           (fn [] (length "hello"))
+           |:error|
+           :deny |:error|)])
+  (let ([denial (fiber/resume f)])
+    # denial is {:error :capability-denied :primitive "length" ...}
+    (let ([val (fiber/value f)])
+      (let ([result (apply length (val :args))])
+        (fiber/resume f result)))))
+```
+
+## Specialized instructions
+
+Arithmetic operations (`+`, `-`, `*`, `/`, comparisons) are compiled
+to specialized bytecode instructions that bypass the primitive dispatch
+path. These are not subject to capability checks. `:deny |:error|`
+blocks `length` but not `+`.
+
+## Examples
+
+```lisp
+# Pure computation sandbox — no IO, no FFI, no subprocess
+(let ([f (fiber/new compute |:io :ffi :exec :error|
+                    :deny |:io :ffi :exec|)])
+  (fiber/resume f))
+
+# Capability-check a plugin before running it
+(let ([f (fiber/new plugin-init |:error| :deny |:exec :ffi|)])
+  (let ([result (fiber/resume f)])
+    (if (= (fiber/status f) :dead)
+      result
+      (do (println "plugin tried:" ((fiber/value f) :primitive))
+          (fiber/cancel f)))))
+
+# Nested sandbox: outer denies IO, inner denies errors
+(let ([outer (fiber/new
+               (fn []
+                 (let ([inner (fiber/new worker |:error| :deny |:error|)])
+                   (fiber/resume inner)))
+               |:io :error|
+               :deny |:io|)])
+  (fiber/resume outer))
+# inner has neither IO (from outer) nor error (from own deny)
+```

--- a/docs/signals/capabilities.md
+++ b/docs/signals/capabilities.md
@@ -8,7 +8,7 @@ parent can catch.
 
 `fiber/new` accepts `:deny` after the mask argument:
 
-```lisp
+```text
 # Deny IO — child can't call IO primitives
 (fiber/new body |:io :error| :deny |:io|)
 
@@ -54,7 +54,7 @@ Instead, the fiber emits a signal with:
 - **Bits**: the blocked capability bits (e.g., `:io`)
 - **Payload**: a struct describing the denial
 
-```lisp
+```text
 {:error :capability-denied
  :denied |:io|
  :primitive "port/read-line"
@@ -66,7 +66,7 @@ The parent catches this signal through the normal mask routing.
 
 ## Introspection
 
-```lisp
+```text
 (fiber/caps)      # current fiber's capabilities
 (fiber/caps f)    # specific fiber's capabilities
 ```
@@ -74,7 +74,7 @@ The parent catches this signal through the normal mask routing.
 Returns a keyword set of active capabilities — everything in the
 capability space that is NOT withheld:
 
-```lisp
+```text
 (fiber/caps)
 # => |:error :yield :debug :ffi :halt :io :exec|
 
@@ -88,7 +88,7 @@ capability space that is NOT withheld:
 Withheld capabilities propagate from parent to child at resume time.
 A child inherits its parent's restrictions plus any `:deny` of its own:
 
-```lisp
+```text
 (let ([outer (fiber/new
                (fn []
                  # inner denies :ffi, inherits :io denial from outer
@@ -111,7 +111,7 @@ absorbed).
 The parent can catch a denial, perform the operation on the child's
 behalf, and resume the child with the result:
 
-```lisp
+```text
 (let ([f (fiber/new
            (fn [] (length "hello"))
            |:error|
@@ -132,7 +132,7 @@ blocks `length` but not `+`.
 
 ## Examples
 
-```lisp
+```text
 # Pure computation sandbox — no IO, no FFI, no subprocess
 (let ([f (fiber/new compute |:io :ffi :exec :error|
                     :deny |:io :ffi :exec|)])

--- a/docs/signals/design.md
+++ b/docs/signals/design.md
@@ -198,12 +198,8 @@ This is capability-based security applied to control flow:
 - **A signal means a boundary was hit.** The callee couldn't proceed without
   something it wasn't granted. The handler decides what happens next.
 
-**Note on implementation phases**: Phases 1–5 of the migration (below) implement
-signal routing and signal tracking. Capability enforcement — checking what a
-fiber is allowed to do and signaling when it exceeds its grant — is future work
-requiring a different mechanism (likely a capability field on fibers and checks
-at signal emission points). The vision is complete, but the early phases focus
-on the signal infrastructure that makes capability enforcement possible.
+Capability enforcement is implemented. See
+[`capabilities.md`](capabilities.md) for the full surface.
 
 ### Examples
 

--- a/docs/signals/emit.md
+++ b/docs/signals/emit.md
@@ -1,0 +1,115 @@
+# emit
+
+`emit` is the single mechanism for all signal emission in Elle. Every
+signal — yields, errors, I/O requests, user-defined signals — goes
+through `emit`.
+
+## Syntax
+
+```lisp
+(emit :keyword value)       # emit a single signal
+(emit |:kw1 :kw2| value)    # emit compound signal bits
+(emit :keyword)             # emit with nil payload
+```
+
+The first argument must be a literal keyword or keyword set. The
+compiler extracts the signal bits at compile time. The second argument
+is the payload (defaults to nil).
+
+## Common signals
+
+```lisp
+(emit :yield 42)            # cooperative suspension, payload 42
+(emit :error {:error :type-error :message "boom"})  # error signal
+(emit :io request)          # I/O request to scheduler
+(emit |:yield :io| data)    # compound: yield + I/O
+```
+
+## yield and error are macros
+
+`yield` and `error` are prelude macros that expand to `emit`:
+
+```lisp
+(yield 42)     # => (emit :yield 42)
+(yield)        # => (emit :yield nil)
+(error "boom") # => (emit :error "boom")
+(error)        # => (emit :error nil)
+```
+
+There is nothing special about `:yield` or `:error` as signal keywords.
+They are ordinary entries in the signal registry. `emit` treats all
+keywords uniformly.
+
+## Fiber masks catch emitted signals
+
+When a fiber emits a signal, the parent catches it if the signal bits
+overlap the fiber's mask:
+
+```lisp
+(let ([f (fiber/new (fn [] (emit :yield 42)) |:yield|)])
+  (fiber/resume f))   # => 42
+
+(let ([f (fiber/new (fn [] (emit :yield 42)) 0)])
+  (fiber/resume f))   # signal propagates (mask doesn't catch :yield)
+```
+
+## Suspension vs error
+
+`emit` distinguishes two behaviors based on the signal bits:
+
+- **Error signals** (bits containing `:error`): the fiber stops and the
+  error propagates through the call stack. The fiber is not resumable
+  from the emit point. This is how `(error val)` works.
+
+- **Suspension signals** (everything else: `:yield`, `:io`, user-defined):
+  the fiber suspends with a `SuspendedFrame`. The parent can resume the
+  fiber, and the resume value becomes the result of the `(emit ...)`
+  expression.
+
+```lisp
+# Suspension: emit :yield, get resume value back
+(let ([x (emit :yield :waiting)])
+  # x is whatever the parent passes to fiber/resume
+  (+ x 1))
+
+# Error: emit :error, no resume
+(emit :error {:error :oops :message "something went wrong"})
+# control never returns here
+```
+
+## User-defined signals
+
+Any keyword can be a signal. Register it with `signal/register` and
+use it with `emit`:
+
+```lisp
+(signal/register :heartbeat)
+(emit :heartbeat {:timestamp (clock/monotonic)})
+```
+
+The parent catches it through the mask like any other signal:
+
+```lisp
+(fiber/new body |:heartbeat|)
+```
+
+## Dynamic emit (primitive fallback)
+
+When the first argument is not a literal keyword or set, `emit` falls
+through to the runtime primitive. This supports dynamic signal selection:
+
+```lisp
+(emit some-variable value)   # runtime dispatch, not compile-time
+```
+
+This is rare. Prefer literal keywords for compile-time signal inference.
+
+## Capability interaction
+
+If a fiber has denied capabilities (via `:deny` on `fiber/new`), the
+`emit` instruction itself is not affected — `emit` is a bytecode
+instruction, not a primitive call. A fiber with `:deny |:error|` can
+still `(emit :yield val)`. Capability enforcement applies to primitive
+calls, not to `emit`.
+
+See [capabilities.md](capabilities.md) for the full capability system.

--- a/docs/signals/emit.md
+++ b/docs/signals/emit.md
@@ -6,7 +6,7 @@ through `emit`.
 
 ## Syntax
 
-```lisp
+```text
 (emit :keyword value)       # emit a single signal
 (emit |:kw1 :kw2| value)    # emit compound signal bits
 (emit :keyword)             # emit with nil payload
@@ -18,7 +18,7 @@ is the payload (defaults to nil).
 
 ## Common signals
 
-```lisp
+```text
 (emit :yield 42)            # cooperative suspension, payload 42
 (emit :error {:error :type-error :message "boom"})  # error signal
 (emit :io request)          # I/O request to scheduler
@@ -29,7 +29,7 @@ is the payload (defaults to nil).
 
 `yield` and `error` are prelude macros that expand to `emit`:
 
-```lisp
+```text
 (yield 42)     # => (emit :yield 42)
 (yield)        # => (emit :yield nil)
 (error "boom") # => (emit :error "boom")
@@ -45,7 +45,7 @@ keywords uniformly.
 When a fiber emits a signal, the parent catches it if the signal bits
 overlap the fiber's mask:
 
-```lisp
+```text
 (let ([f (fiber/new (fn [] (emit :yield 42)) |:yield|)])
   (fiber/resume f))   # => 42
 
@@ -66,7 +66,7 @@ overlap the fiber's mask:
   fiber, and the resume value becomes the result of the `(emit ...)`
   expression.
 
-```lisp
+```text
 # Suspension: emit :yield, get resume value back
 (let ([x (emit :yield :waiting)])
   # x is whatever the parent passes to fiber/resume
@@ -82,14 +82,14 @@ overlap the fiber's mask:
 Any keyword can be a signal. Register it with `signal/register` and
 use it with `emit`:
 
-```lisp
+```text
 (signal/register :heartbeat)
 (emit :heartbeat {:timestamp (clock/monotonic)})
 ```
 
 The parent catches it through the mask like any other signal:
 
-```lisp
+```text
 (fiber/new body |:heartbeat|)
 ```
 
@@ -98,7 +98,7 @@ The parent catches it through the mask like any other signal:
 When the first argument is not a literal keyword or set, `emit` falls
 through to the runtime primitive. This supports dynamic signal selection:
 
-```lisp
+```text
 (emit some-variable value)   # runtime dispatch, not compile-time
 ```
 

--- a/docs/signals/fibers.md
+++ b/docs/signals/fibers.md
@@ -9,18 +9,20 @@ Fibers are Elle's unified control-flow mechanism.
 pub struct Fiber {
     pub stack: SmallVec<[Value# 256]>,       // operand stack
     pub frames: Vec<Frame>,                   // call frames (closure + ip + base)
-    pub status: FiberStatus,                  // New, Alive, Suspended, Dead, Error
+    pub status: FiberStatus,                  // New, Alive, Paused, Dead, Error
     pub mask: SignalBits,                     // which signals parent catches from this fiber
     pub parent: Option<WeakFiberHandle>,      // weak back-pointer (avoids Rc cycles)
     pub parent_value: Option<Value>,          // cached Value for parent
     pub child: Option<FiberHandle>,           // most recently resumed child
     pub child_value: Option<Value>,           // cached Value for child
     pub closure: Rc<Closure>,                 // the closure this fiber wraps
-    pub env: Option<HashMap<u32, Value>>,     // dynamic bindings (future)
+    pub param_frames: Vec<Vec<(u32, Value)>>, // dynamic parameter bindings
     pub signal: Option<(SignalBits, Value)>,  // signal payload or return value
     pub suspended: Option<Vec<SuspendedFrame>>, // frames for resumption
     pub call_depth: usize,                    // stack overflow detection
     pub call_stack: Vec<CallFrame>,           // for stack traces
+    pub fuel: Option<u32>,                    // instruction budget (None = unlimited)
+    pub withheld: SignalBits,                 // denied capabilities (see capabilities.md)
 }
 ```
 
@@ -46,7 +48,7 @@ back-pointers, avoiding Rc cycles.
 |--------|---------|
 | `New` | Created but never resumed |
 | `Alive` | Currently executing on the VM |
-| `Suspended` | Waiting for resume (signaled or yielded) |
+| `Paused` | Waiting for resume (signaled or yielded) |
 | `Dead` | Completed normally |
 | `Error` | Terminated by unhandled error |
 
@@ -112,19 +114,26 @@ handle, not the callee.
 ### SuspendedFrame
 
 ```rust
-pub struct SuspendedFrame {
-    pub bytecode: Rc<Vec<u8>>,      // Rc clone, not data copy
-    pub constants: Rc<Vec<Value>>,  // Rc clone, not data copy
-    pub env: Rc<Vec<Value>>,        // closure environment
-    pub ip: usize,                  // instruction pointer to resume at
-    pub stack: Vec<Value>,          // operand stack (empty for signal suspension)
+pub enum SuspendedFrame {
+    Bytecode(BytecodeFrame),
+    FiberResume { handle: FiberHandle, fiber_value: Value },
+}
+
+pub struct BytecodeFrame {
+    pub bytecode: Rc<Vec<u8>>,
+    pub constants: Rc<Vec<Value>>,
+    pub env: Rc<Vec<Value>>,
+    pub ip: usize,
+    pub stack: Vec<Value>,
+    pub location_map: Rc<LocationMap>,
+    pub push_resume_value: bool,
 }
 ```
 
-`SuspendedFrame` captures everything needed to resume bytecode execution.
-It replaces the former `SavedContext` and `ContinuationFrame` types with a
-single representation. Bytecode and constants are `Rc` clones — no data
-copying on suspension.
+`SuspendedFrame` is an enum: `Bytecode` captures everything needed to resume
+bytecode execution; `FiberResume` resumes a sub-fiber (used by `defer`/`protect`
+when a sub-fiber's I/O signal propagates through its parent). `push_resume_value`
+controls whether the resume value is pushed onto the stack before continuing.
 
 ### Two suspension modes
 
@@ -173,10 +182,10 @@ Bytecode and constants flow through the dispatch loop as `&Rc<Vec<u8>>`
 and `&Rc<Vec<Value>>`. This eliminates data copying:
 
 - `execute_bytecode` wraps raw slices in `Rc` once at the public boundary
-- `execute_bytecode_from_ip` / `execute_bytecode_coroutine` take `&Rc`
+- `execute_bytecode_from_ip` / `execute_bytecode_saving_stack` take `&Rc`
 - `TailCallInfo` is `(Rc<Vec<u8>>, Rc<Vec<Value>>, Rc<Vec<Value>>)` —
   tail calls clone the Rc (cheap), not the Vec
-- `handle_yield` / `handle_call` clone the Rc into `SuspendedFrame`
+- `handle_emit` / `handle_call` clone the Rc into `SuspendedFrame`
 - Individual instruction handlers dereference to `&[u8]` / `&[Value]` —
   they don't need the Rc
 

--- a/docs/signals/index.md
+++ b/docs/signals/index.md
@@ -5,6 +5,8 @@ control flow: errors, yields, I/O, fuel exhaustion.
 
 | File | Content |
 |------|---------|
+| [emit](emit.md) | `emit` special form, yield/error macros, signal emission |
+| [capabilities](capabilities.md) | Capability enforcement, `:deny`, `fiber/caps` |
 | [design](design.md) | Motivation, prior art, terminology, core insight |
 | [protocol](protocol.md) | Signal protocol, registry, user signals |
 | [inference](inference.md) | Compile-time verification, restrictions |

--- a/docs/signals/inference.md
+++ b/docs/signals/inference.md
@@ -25,7 +25,7 @@ Declares signal bounds on a function or its parameters. Appears as a preamble de
 - Duplicate restrictions for the same parameter: the last one wins
 
 **Outside lambda bodies**, `silence` is a call to the stdlib `silence` function, which signals `:error` at runtime. `silence` is implemented as:
-```
+```lisp
 (defn silence [& _]
   (error {:error :invalid-silence
           :message "silence must appear in a function body preamble"}))
@@ -179,7 +179,7 @@ When module A imports module B:
 - Even if B's functions are actually silent, A will treat them as yielding
 
 **Example:**
-```text
+```lisp
 # b.lisp
 (defn silent-add [x y]
   (silence)
@@ -189,7 +189,7 @@ When module A imports module B:
 (fn [] {:add silent-add})
 ```
 
-```text
+```lisp
 # a.lisp
 (def b ((import "b.lisp")))
 
@@ -218,7 +218,7 @@ The tradeoff: Single-file fixpoint convergence is simple and gives accurate sign
 
 If you need a function from an imported module to be used in a silence-bounded context, use `squelch` to enforce the boundary at the call site:
 
-```text
+```lisp
 # a.lisp
 (def b ((import "b.lisp")))
 

--- a/docs/signals/inference.md
+++ b/docs/signals/inference.md
@@ -25,14 +25,14 @@ Declares signal bounds on a function or its parameters. Appears as a preamble de
 - Duplicate restrictions for the same parameter: the last one wins
 
 **Outside lambda bodies**, `silence` is a call to the stdlib `silence` function, which signals `:error` at runtime. `silence` is implemented as:
-```lisp
+```text
 (defn silence [& _]
   (error {:error :invalid-silence
           :message "silence must appear in a function body preamble"}))
 ```
 
 **Examples:**
-```lisp
+```text
 # Silent function
 (defn add (x y)
   (silence)
@@ -74,7 +74,7 @@ Declares signal bounds on a function or its parameters. Appears as a preamble de
 `squelch` is a **runtime blacklist** (open-world): `(squelch f :yield)` returns a new closure that forbids `:yield` at the call boundary. Everything else is allowed, including user-defined signals not listed. It is a primitive function that can appear anywhere an expression is valid.
 
 **Examples:**
-```lisp
+```text
 (defn f [] (yield 42))
 
 # Squelch a single signal
@@ -112,7 +112,7 @@ The `inferred_signals: Signal` field is always present and contains the minimum 
 **Silence bounds (total suppression):** The programmer-supplied ceiling constraint from `(silence)` declares that the function must emit no signals. When a `silence` bound is present, the compiler checks that `inferred_signals.bits == 0`. If the check fails, compile-time error.
 
 **Example:**
-```lisp
+```text
 # Function with parameter bound
 (defn apply-silent (f x)
   (silence f)  # f must be silent
@@ -134,7 +134,7 @@ The `inferred_signals: Signal` field is always present and contains the minimum 
 A function with `(silence f)` is no longer polymorphic with respect to `f`. The compiler knows `f` must be silent, so the function's signal is determined by its own body only, not by what `f` might do.
 
 **Example:**
-```lisp
+```text
 # Without bound: polymorphic
 (defn map-any (f xs)
   (map f xs))
@@ -152,7 +152,7 @@ A function with `(silence f)` is no longer polymorphic with respect to `f`. The 
 When a concrete function is passed to a parameter with a bound, the analyzer checks the argument's signal against the bound at compile time.
 
 **Example:**
-```lisp
+```text
 (defn apply-silent (f x)
   (silence f)
   (f x))
@@ -179,7 +179,7 @@ When module A imports module B:
 - Even if B's functions are actually silent, A will treat them as yielding
 
 **Example:**
-```lisp
+```text
 # b.lisp
 (defn silent-add [x y]
   (silence)
@@ -189,7 +189,7 @@ When module A imports module B:
 (fn [] {:add silent-add})
 ```
 
-```lisp
+```text
 # a.lisp
 (def b ((import "b.lisp")))
 
@@ -218,7 +218,7 @@ The tradeoff: Single-file fixpoint convergence is simple and gives accurate sign
 
 If you need a function from an imported module to be used in a silence-bounded context, use `squelch` to enforce the boundary at the call site:
 
-```lisp
+```text
 # a.lisp
 (def b ((import "b.lisp")))
 
@@ -243,7 +243,7 @@ When a closure is passed to a function with a signal bound, the runtime checks t
 - If the check fails, the VM signals `:error` with a descriptive message
 
 **Example:**
-```lisp
+```text
 (defn apply-silent (f x)
   (silence f)
   (f x))
@@ -264,7 +264,7 @@ When a closure is passed to a function with a signal bound, the runtime checks t
 - Non-squelched signals pass through normally; errors are never affected by squelch
 
 **Example:**
-```lisp
+```text
 # Squelch a yielding closure — signal-violation at boundary
 (def squelched (squelch (fn [] (yield 1)) :yield))
 (try (squelched) (catch e (get e :error)))  # => :signal-violation
@@ -284,7 +284,7 @@ When a closure is passed to a function with a signal bound, the runtime checks t
 
 ### Fiber Primitives
 
-```lisp
+```text
 # === Creation and control ===
 # (fiber/new fn mask) => fiber
 # (fiber/resume fiber value) => signal-bits
@@ -303,7 +303,7 @@ When a closure is passed to a function with a signal bound, the runtime checks t
 
 ### Sugar and Aliases
 
-```lisp
+```text
 # try/catch
 # (try body (catch e handler))
 
@@ -318,7 +318,7 @@ When a closure is passed to a function with a signal bound, the runtime checks t
 
 ### Signal Restrictions
 
-```lisp
+```text
 # Compile-time silence bounds
 (defn silent-add (x y)
   (silence)           # no signals — silent

--- a/docs/signals/jit.md
+++ b/docs/signals/jit.md
@@ -39,7 +39,7 @@ Signal bounds enable further JIT optimizations:
 2. **Inlining**: silent callbacks can be inlined more aggressively
 3. **Elimination of polymorphism**: silence bounds simplify compilation
 
-```text
+```lisp
 # Without bounds: JIT cannot specialize
 (defn map-any [f xs]
   (map f xs))

--- a/docs/signals/jit.md
+++ b/docs/signals/jit.md
@@ -39,7 +39,7 @@ Signal bounds enable further JIT optimizations:
 2. **Inlining**: silent callbacks can be inlined more aggressively
 3. **Elimination of polymorphism**: silence bounds simplify compilation
 
-```lisp
+```text
 # Without bounds: JIT cannot specialize
 (defn map-any [f xs]
   (map f xs))

--- a/docs/signals/primitives.md
+++ b/docs/signals/primitives.md
@@ -107,7 +107,7 @@ frame execution, no defer/protect unwinding. The fiber is dead.
   it propagates through all masks including `protect` and `defer`
 - Other-cancel returns `SIG_OK` with the error value
 
-```text
+```lisp
 (def f (fiber/new (fn [] (defer (print :cleanup) (yield) :done)) |:error :yield|))
 (fiber/resume f)          # f is now :paused
 (fiber/cancel f :reason)  # f is now :error, :cleanup never printed
@@ -125,7 +125,7 @@ child's actual outcome determines what the parent sees.
 - No post-hoc status stomp: if the fiber's protect catches and recovers,
   the fiber may end up `:dead` instead of `:error`
 
-```elle
+```lisp
 (def f (fiber/new (fn [] (defer (print :cleanup) (yield) :done)) |:error :yield|))
 (fiber/resume f)          # f is now :paused
 (fiber/abort f :reason)   # :cleanup printed, f is now :error

--- a/docs/signals/primitives.md
+++ b/docs/signals/primitives.md
@@ -32,7 +32,7 @@ to perform the context switch.
 A coroutine is a usage pattern, not a type. It's a fiber whose closure
 yields:
 
-```lisp
+```text
 (def gen (fiber/new (fn () (yield 1) (yield 2) (yield 3)) |:yield|))
 (fiber/resume gen nil)  # → SIG_YIELD, (fiber/value gen) → 1
 (fiber/resume gen nil)  # → SIG_YIELD, (fiber/value gen) → 2
@@ -107,7 +107,7 @@ frame execution, no defer/protect unwinding. The fiber is dead.
   it propagates through all masks including `protect` and `defer`
 - Other-cancel returns `SIG_OK` with the error value
 
-```lisp
+```text
 (def f (fiber/new (fn [] (defer (print :cleanup) (yield) :done)) |:error :yield|))
 (fiber/resume f)          # f is now :paused
 (fiber/cancel f :reason)  # f is now :error, :cleanup never printed
@@ -125,7 +125,7 @@ child's actual outcome determines what the parent sees.
 - No post-hoc status stomp: if the fiber's protect catches and recovers,
   the fiber may end up `:dead` instead of `:error`
 
-```lisp
+```text
 (def f (fiber/new (fn [] (defer (print :cleanup) (yield) :done)) |:error :yield|))
 (fiber/resume f)          # f is now :paused
 (fiber/abort f :reason)   # :cleanup printed, f is now :error

--- a/docs/signals/recovery.md
+++ b/docs/signals/recovery.md
@@ -159,32 +159,6 @@ At the root fiber, signals translate to program outcomes:
 - Normal return → value printed or returned
 - `:error` signal → error message displayed, non-zero exit
 
-
-
-## Migration Status
-
-Steps 1–3 are complete. Steps 4–7 are future work.
-
-1. ✅ **Fibers as execution context.** Fiber struct, FiberHandle,
-   parent/child chain, signal mask, all fiber primitives implemented.
-   Coroutines are fibers that yield.
-
-2. ✅ **Unified signals.** Error and yield are signal types. Errors are
-   `[:keyword "message"]` tuples.
-
-3. ✅ **Signal-bits-based Signal type.** `Signal { bits: SignalBits,
-   propagates: u32 }`. Inference tracks signal bits per function.
-
-4. ❌ **Relax JIT restrictions.** JIT still restricted to silent functions.
-   Signal-aware calling convention not yet implemented.
-
-5. ❌ **User-defined signals.** Bit positions 16–31 reserved but no
-   allocation API.
-
-6. ✅ **Signal restrictions.** `silence` forms for signal contracts implemented.
-
-7. ❌ **Erlang-style processes.** Fibers on an event loop with a scheduler.
-
 ---
 
 ## See also

--- a/prelude.lisp
+++ b/prelude.lisp
@@ -97,6 +97,12 @@
 (defmacro default (name value)
   `(when (nil? ,name) (assign ,name ,value)))
 
+## yield - cooperative suspension
+## (yield) => (emit :yield nil)
+## (yield value) => (emit :yield value)
+(defmacro yield (&opt v)
+  `(emit :yield ,v))
+
 ## error - signal a fiber error
 ## (error) => (emit :error nil)
 ## (error value) => (emit :error value)

--- a/src/compiler/bytecode.rs
+++ b/src/compiler/bytecode.rs
@@ -153,8 +153,9 @@ pub enum Instruction {
     /// Update a capture cell's value
     UpdateCapture,
 
-    /// Yield (suspends execution)
-    Yield,
+    /// Emit a signal (suspends execution). Operand: u16 signal bits.
+    /// `(emit :yield val)` emits SIG_YIELD; `(emit :io val)` emits SIG_IO.
+    Emit,
 
     /// Empty list constant
     EmptyList,

--- a/src/hir/AGENTS.md
+++ b/src/hir/AGENTS.md
@@ -83,6 +83,9 @@ Lowerer (&BindingArena) — read-only access to binding metadata
 
 4. **Signals combine upward.** A `begin` has the combined signal of its
    children. A `fn` body's signal is stored but the fn itself is Silent.
+   Signal emission uses `HirKind::Emit { signal: SignalBits, value: Box<Hir> }`
+   (replaces the old `HirKind::Yield`). `yield` is now a macro that expands
+   to `(emit :yield val)`.
 
 5. **Captures are computed per-fn.** Each `HirKind::Lambda` carries its
    own `Vec<CaptureInfo>` listing what it captures and how.
@@ -216,7 +219,7 @@ Lowerer (&BindingArena) — read-only access to binding metadata
 | `analyze/binding.rs` | ~425 | Binding forms: `let`, `letrec`, `def`/`var`, `set` |
 | `analyze/destructure.rs` | ~215 | Destructuring pattern analysis, define-form detection, rest-pattern splitting |
 | `analyze/lambda.rs` | ~160 | Lambda/fn analysis with captures, params, signals |
-| `analyze/special.rs` | ~210 | Special forms: `match`, `yield` |
+| `analyze/special.rs` | ~210 | Special forms: `match`, `emit` |
 | `analyze/call.rs` | ~200 | Call analysis and signal tracking |
 | `expr.rs` | ~180 | `Hir`, `HirKind` |
 | `binding.rs` | ~40 | `Binding(u32)` index type, `CaptureInfo`, `CaptureKind` |

--- a/src/hir/analyze/AGENTS.md
+++ b/src/hir/analyze/AGENTS.md
@@ -94,7 +94,7 @@ This prevents accidental capture in macros while allowing intentional capture vi
 
 2. **`Binding` identity is integer equality.** Two references to the same binding site have the same `u32` index. `Binding` implements `Hash`/`Eq` via the derived `u32` comparison.
 
-3. **`needs_capture()` determines lbox boxing.** A local binding needs an lbox if captured. A parameter needs an lbox if mutated. Globals never need lboxes.
+3. **`needs_capture()` determines lbox boxing.** A local binding needs an lbox if captured AND mutated. A parameter needs an lbox if mutated. Globals never need lboxes.
 
 4. **Signals combine upward.** A `begin` has the combined signal of its children. A `fn` body's signal is stored but the fn itself is Silent.
 

--- a/src/hir/analyze/forms.rs
+++ b/src/hir/analyze/forms.rs
@@ -332,7 +332,16 @@ impl<'a> Analyzer<'a> {
                             let value = items[1].to_value(self.symbols);
                             return Ok(Hir::silent(HirKind::Quote(value), span));
                         }
-                        "yield" => return self.analyze_yield(items, span),
+                        "emit"
+                            if (items.len() == 2 || items.len() == 3)
+                                && matches!(
+                                    items[1].kind,
+                                    crate::syntax::SyntaxKind::Keyword(_)
+                                        | crate::syntax::SyntaxKind::Set(_)
+                                ) =>
+                        {
+                            return self.analyze_emit(items, span);
+                        }
                         "match" => return self.analyze_match(items, span),
                         "cond" => return self.analyze_cond(items, span),
                         "eval" => return self.analyze_eval(items, span),

--- a/src/hir/analyze/special.rs
+++ b/src/hir/analyze/special.rs
@@ -91,26 +91,101 @@ impl<'a> Analyzer<'a> {
         ))
     }
 
-    pub(crate) fn analyze_yield(&mut self, items: &[Syntax], span: Span) -> Result<Hir, String> {
-        if items.len() > 2 {
-            return Err(format!("{}: yield expects 0 or 1 arguments", span));
+    /// `(emit <signal> <value>)` — general signal emission.
+    ///
+    /// The first argument must be a compile-time constant: a literal keyword
+    /// (`:yield`, `:error`, `:io`, etc.) or a literal set of keywords
+    /// (`|:yield :io|`). The analyzer extracts the signal bits at compile
+    /// time and records them in the HIR node.
+    pub(crate) fn analyze_emit(&mut self, items: &[Syntax], span: Span) -> Result<Hir, String> {
+        if items.len() < 2 || items.len() > 3 {
+            return Err(format!(
+                "{}: emit requires 1 or 2 arguments (signal [value])",
+                span
+            ));
         }
 
-        let value = if items.len() == 2 {
-            self.analyze_expr(&items[1])?
+        // Extract signal bits from the first argument (must be literal keyword or set)
+        let signal_bits = self.resolve_static_signal(&items[1])?;
+
+        let value = if items.len() == 3 {
+            self.analyze_expr(&items[2])?
         } else {
-            // (yield) with no args yields nil
             Hir::silent(HirKind::Nil, span.clone())
         };
 
-        // Track that this lambda has a direct yield (not from calling a parameter)
+        // Track direct signal emission (generalizes has_direct_yield)
         self.current_signal_sources.has_direct_yield = true;
 
+        let signal = Signal {
+            bits: signal_bits,
+            propagates: 0,
+        };
+
         Ok(Hir::new(
-            HirKind::Yield(Box::new(value)),
+            HirKind::Emit {
+                signal: signal_bits,
+                value: Box::new(value),
+            },
             span,
-            Signal::yields(), // Yield always has Yields signal
+            signal,
         ))
+    }
+
+    /// Resolve a static signal specifier (keyword or set literal) to SignalBits.
+    ///
+    /// Accepts:
+    /// - A literal keyword: `:yield` → SIG_YIELD
+    /// - A literal set of keywords: `|:yield :io|` → SIG_YIELD | SIG_IO
+    ///
+    /// Rejects non-literal arguments at compile time.
+    fn resolve_static_signal(
+        &self,
+        syntax: &Syntax,
+    ) -> Result<crate::value::fiber::SignalBits, String> {
+        use crate::syntax::SyntaxKind;
+        use crate::value::fiber::SignalBits;
+
+        match &syntax.kind {
+            SyntaxKind::Keyword(name) => {
+                let registry = crate::signals::registry::global_registry().lock().unwrap();
+                match registry.to_signal_bits(name) {
+                    Some(bits) => Ok(bits),
+                    None => Err(format!(
+                        "{}: emit: unknown signal keyword :{}",
+                        syntax.span, name
+                    )),
+                }
+            }
+            SyntaxKind::Set(elements) => {
+                let registry = crate::signals::registry::global_registry().lock().unwrap();
+                let mut bits = SignalBits::EMPTY;
+                for elem in elements {
+                    match &elem.kind {
+                        SyntaxKind::Keyword(name) => match registry.to_signal_bits(name) {
+                            Some(b) => bits |= b,
+                            None => {
+                                return Err(format!(
+                                    "{}: emit: unknown signal keyword :{}",
+                                    elem.span, name
+                                ))
+                            }
+                        },
+                        _ => {
+                            return Err(format!(
+                                "{}: emit: set elements must be keywords",
+                                elem.span
+                            ))
+                        }
+                    }
+                }
+                Ok(bits)
+            }
+            _ => Err(format!(
+                "{}: emit: first argument must be a signal keyword or keyword set, got {:?}",
+                syntax.span, syntax.kind
+            )),
+        }
     }
 
     pub(crate) fn analyze_match(&mut self, items: &[Syntax], span: Span) -> Result<Hir, String> {

--- a/src/hir/expr.rs
+++ b/src/hir/expr.rs
@@ -196,8 +196,15 @@ pub enum HirKind {
     And(Vec<Hir>),
     Or(Vec<Hir>),
 
-    // === Coroutines ===
-    Yield(Box<Hir>),
+    // === Signal emission ===
+    /// `(emit <signal> <value>)` — general signal emission.
+    /// `signal` is compile-time signal bits (from a literal keyword or set).
+    /// `value` is the payload expression. Replaces the old `Yield` variant;
+    /// `(yield val)` is now a macro expanding to `(emit :yield val)`.
+    Emit {
+        signal: crate::value::fiber::SignalBits,
+        value: Box<Hir>,
+    },
 
     // === Quote ===
     /// Quote stores a pre-computed Value (converted at analysis time)

--- a/src/hir/lint.rs
+++ b/src/hir/lint.rs
@@ -209,7 +209,7 @@ impl HirLinter {
                 }
             }
 
-            HirKind::Yield(expr) => {
+            HirKind::Emit { value: expr, .. } => {
                 self.check(expr, symbols, arena);
             }
 

--- a/src/hir/symbols.rs
+++ b/src/hir/symbols.rs
@@ -241,7 +241,7 @@ impl<'a> HirSymbolExtractor<'a> {
                 }
             }
 
-            HirKind::Yield(e) => {
+            HirKind::Emit { value: e, .. } => {
                 self.walk(e, index, symbols);
             }
 

--- a/src/hir/tailcall.rs
+++ b/src/hir/tailcall.rs
@@ -178,8 +178,8 @@ fn mark(hir: &mut Hir, in_tail: bool, tail_blocks: &HashSet<BlockId>) {
             mark(value, false, tail_blocks);
         }
 
-        // Yield: value is not in tail position
-        HirKind::Yield(expr) => {
+        // Emit: value is not in tail position
+        HirKind::Emit { value: expr, .. } => {
             mark(expr, false, tail_blocks);
         }
 
@@ -316,7 +316,7 @@ mod tests {
             HirKind::Assign { value, .. }
             | HirKind::Define { value, .. }
             | HirKind::Destructure { value, .. }
-            | HirKind::Yield(value) => {
+            | HirKind::Emit { value, .. } => {
                 collect_calls(value, calls);
             }
             HirKind::Eval { expr, env } => {

--- a/src/jit/compiler.rs
+++ b/src/jit/compiler.rs
@@ -720,8 +720,10 @@ impl JitCompiler {
             translator.init_locally_defined_vars(&mut builder, num_locally_defined)?;
         }
 
-        // Allocate shared spill slot for yield/call sites (if any)
-        if lir.signal.may_suspend() {
+        // Allocate shared spill slot for emit/call sites (if any).
+        // Check yield_points (emit terminators) and call_sites directly,
+        // not may_suspend() — emit can emit any signal, not just :yield.
+        if !lir.yield_points.is_empty() || !lir.call_sites.is_empty() {
             translator.allocate_shared_spill_slot(&mut builder);
         }
 

--- a/src/jit/compiler.rs
+++ b/src/jit/compiler.rs
@@ -1134,7 +1134,8 @@ mod tests {
             Span::synthetic(),
         ));
         b0.terminator = SpannedTerminator::new(
-            Terminator::Yield {
+            Terminator::Emit {
+                signal: crate::value::fiber::SIG_YIELD,
                 value: Reg(0),
                 resume_label: Label(1),
             },

--- a/src/jit/suspend.rs
+++ b/src/jit/suspend.rs
@@ -33,6 +33,7 @@ pub extern "C" fn elle_jit_yield(
     vm: u64, // *mut () as u64
     closure_tag: u64,
     closure_payload: u64,
+    signal_bits: u64,
 ) -> JitValue {
     let vm = unsafe { &mut *(vm as *mut crate::vm::VM) };
     let yielded = Value {
@@ -80,20 +81,22 @@ pub extern "C" fn elle_jit_yield(
         stack.push(unsafe { *spilled_values.add(i) });
     }
 
-    let frame = SuspendedFrame::Bytecode(BytecodeFrame {
-        bytecode: closure.template.bytecode.clone(),
-        constants: closure.template.constants.clone(),
-        env,
-        ip: yield_meta.resume_ip,
-        stack,
-        location_map: closure.template.location_map.clone(),
-        // JIT yield: on resume, the resume argument becomes the result of
-        // the (yield ...) expression — push it onto the restored stack.
-        push_resume_value: true,
-    });
+    let sig = crate::value::fiber::SignalBits::new(signal_bits as u32);
+    vm.fiber.signal = Some((sig, yielded));
 
-    vm.fiber.signal = Some((crate::value::fiber::SIG_YIELD, yielded));
-    vm.fiber.suspended = Some(vec![frame]);
+    if !sig.contains(crate::value::fiber::SIG_ERROR) {
+        // Suspension: build a frame for later resumption.
+        let frame = SuspendedFrame::Bytecode(BytecodeFrame {
+            bytecode: closure.template.bytecode.clone(),
+            constants: closure.template.constants.clone(),
+            env,
+            ip: yield_meta.resume_ip,
+            stack,
+            location_map: closure.template.location_map.clone(),
+            push_resume_value: true,
+        });
+        vm.fiber.suspended = Some(vec![frame]);
+    }
 
     YIELD_SENTINEL
 }
@@ -379,6 +382,7 @@ mod tests {
             &mut vm as *mut crate::vm::VM as *mut () as u64,
             closure_val.tag,
             closure_val.payload,
+            crate::value::fiber::SIG_YIELD.raw() as u64,
         );
 
         assert_eq!(result, YIELD_SENTINEL);
@@ -430,6 +434,7 @@ mod tests {
             &mut vm as *mut crate::vm::VM as *mut () as u64,
             closure_val.tag,
             closure_val.payload,
+            crate::value::fiber::SIG_YIELD.raw() as u64,
         );
 
         assert_eq!(result, YIELD_SENTINEL);
@@ -461,6 +466,7 @@ mod tests {
             &mut vm as *mut crate::vm::VM as *mut () as u64,
             closure_val.tag,
             closure_val.payload,
+            crate::value::fiber::SIG_YIELD.raw() as u64,
         );
 
         let frame = as_bytecode_frame(&vm.fiber.suspended.as_ref().unwrap()[0]);
@@ -490,6 +496,7 @@ mod tests {
             &mut vm as *mut crate::vm::VM as *mut () as u64,
             closure_val.tag,
             closure_val.payload,
+            crate::value::fiber::SIG_YIELD.raw() as u64,
         );
 
         let frame = as_bytecode_frame(&vm.fiber.suspended.as_ref().unwrap()[0]);
@@ -523,6 +530,7 @@ mod tests {
             &mut vm as *mut crate::vm::VM as *mut () as u64,
             closure_val.tag,
             closure_val.payload,
+            crate::value::fiber::SIG_YIELD.raw() as u64,
         );
 
         let frame = as_bytecode_frame(&vm.fiber.suspended.as_ref().unwrap()[0]);
@@ -576,6 +584,7 @@ mod tests {
             &mut vm as *mut crate::vm::VM as *mut () as u64,
             closure_val.tag,
             closure_val.payload,
+            crate::value::fiber::SIG_YIELD.raw() as u64,
         );
 
         let frame = as_bytecode_frame(&vm.fiber.suspended.as_ref().unwrap()[0]);
@@ -612,6 +621,7 @@ mod tests {
             &mut vm as *mut crate::vm::VM as *mut () as u64,
             closure_val.tag,
             closure_val.payload,
+            crate::value::fiber::SIG_YIELD.raw() as u64,
         );
 
         let frame = as_bytecode_frame(&vm.fiber.suspended.as_ref().unwrap()[0]);
@@ -664,6 +674,7 @@ mod tests {
             &mut vm as *mut crate::vm::VM as *mut () as u64,
             closure_val.tag,
             closure_val.payload,
+            crate::value::fiber::SIG_YIELD.raw() as u64,
         );
 
         let frame = as_bytecode_frame(&vm.fiber.suspended.as_ref().unwrap()[0]);

--- a/src/jit/translate.rs
+++ b/src/jit/translate.rs
@@ -1191,16 +1191,19 @@ impl<'a> FunctionTranslator<'a> {
                     .brif(is_falsy, *else_block, &[], *then_block, &[]);
             }
 
-            Terminator::Yield {
+            Terminator::Emit {
+                signal: _,
                 value,
                 resume_label: _,
             } => {
+                // TODO: pass signal bits to jit_yield so JIT-compiled emit
+                // can emit arbitrary signals, not just SIG_YIELD
                 let (yt, yp) = self.use_var_pair(builder, value.0);
                 let vm = self
                     .vm_ptr
-                    .ok_or_else(|| JitError::InvalidLir("Yield without vm pointer".to_string()))?;
+                    .ok_or_else(|| JitError::InvalidLir("Emit without vm pointer".to_string()))?;
                 let (self_tag, self_payload) = self.self_tag_payload.ok_or_else(|| {
-                    JitError::InvalidLir("Yield without self_tag_payload".to_string())
+                    JitError::InvalidLir("Emit without self_tag_payload".to_string())
                 })?;
 
                 let yield_index = self.yield_point_index;

--- a/src/jit/translate.rs
+++ b/src/jit/translate.rs
@@ -1192,12 +1192,10 @@ impl<'a> FunctionTranslator<'a> {
             }
 
             Terminator::Emit {
-                signal: _,
+                signal,
                 value,
                 resume_label: _,
             } => {
-                // TODO: pass signal bits to jit_yield so JIT-compiled emit
-                // can emit arbitrary signals, not just SIG_YIELD
                 let (yt, yp) = self.use_var_pair(builder, value.0);
                 let vm = self
                     .vm_ptr
@@ -1219,7 +1217,8 @@ impl<'a> FunctionTranslator<'a> {
                 let spilled_ptr = self.spill_locals_and_operands(builder, stack_regs)?;
                 let yield_idx_val = builder.ins().iconst(I64, yield_index as i64);
 
-                // Call elle_jit_yield(ytag, ypay, spilled_ptr, yield_index, vm, ctag, cpay)
+                let sig_val = builder.ins().iconst(I64, signal.raw() as i64);
+
                 let func_ref = self
                     .module
                     .declare_func_in_func(self.helpers.jit_yield, builder.func);
@@ -1233,6 +1232,7 @@ impl<'a> FunctionTranslator<'a> {
                         vm,
                         self_tag,
                         self_payload,
+                        sig_val,
                     ],
                 );
                 let rt = builder.inst_results(call)[0];

--- a/src/jit/vtable.rs
+++ b/src/jit/vtable.rs
@@ -377,8 +377,12 @@ pub(crate) fn declare_helpers(module: &mut JITModule) -> Result<RuntimeHelpers, 
     let call_array_sig = make_sig(module, &[I64, I64, I64, I64, I64], &[I64, I64]);
     // cons: (car_tag, car_pay, cdr_tag, cdr_pay) -> (tag, payload)
     let cons_sig = make_sig(module, &[I64, I64, I64, I64], &[I64, I64]);
-    // jit_yield: (ytag, ypay, spilled_ptr, yield_idx, vm, ctag, cpay) -> (tag, payload)
-    let yield_sig = make_sig(module, &[I64, I64, I64, I64, I64, I64, I64], &[I64, I64]);
+    // jit_yield: (ytag, ypay, spilled_ptr, yield_idx, vm, ctag, cpay, signal_bits) -> (tag, payload)
+    let yield_sig = make_sig(
+        module,
+        &[I64, I64, I64, I64, I64, I64, I64, I64],
+        &[I64, I64],
+    );
     // jit_yield_through_call: (spilled_ptr, call_site_idx, vm, ctag, cpay) -> (tag, payload)
     let ytc_sig = make_sig(module, &[I64, I64, I64, I64, I64], &[I64, I64]);
     // void -> (tag, payload)  (no arguments, returns NIL)

--- a/src/lir/AGENTS.md
+++ b/src/lir/AGENTS.md
@@ -24,7 +24,7 @@ Does NOT:
 | `LirInstr` | Individual operation |
 | `SpannedInstr` | `LirInstr` + `Span` for source tracking |
 | `SpannedTerminator` | `Terminator` + `Span` for source tracking |
-| `Terminator` | How block exits: `Return`, `Jump`, `Branch`, `Yield` |
+| `Terminator` | How block exits: `Return`, `Jump`, `Branch`, `Emit` |
 | `Reg` | Virtual register |
 | `Label` | Basic block identifier |
 | `YieldPointInfo` | Metadata for a yield point: resume IP and live registers |
@@ -95,7 +95,7 @@ stored in `Closure.location_map` and used by the VM for error reporting.
 1. **Each register assigned exactly once.** SSA form. If you see a register
     used before definition, lowering is broken.
 
-2. **Every block ends with a terminator.** `Return`, `Jump`, `Branch`, `Yield`,
+2. **Every block ends with a terminator.** `Return`, `Jump`, `Branch`, `Emit`,
     or `Unreachable`. No fall-through.
 
 3. **`binding_to_slot` maps all accessed bindings.** If lowering fails with
@@ -116,8 +116,8 @@ stored in `Closure.location_map` and used by the VM for error reporting.
      use this mask (it lbox-wraps all locals unconditionally). Both masks
      are limited to 64 entries (`u64`).
 
-7. **Yield is a block terminator, not an instruction.** `Terminator::Yield`
-    splits the block: the current block ends with yield, and a new resume block
+7. **Emit is a block terminator, not an instruction.** `Terminator::Emit { signal: SignalBits, value: Reg, resume_label: Label }`
+    splits the block: the current block ends with emit, and a new resume block
     begins. The resume block starts with `LoadResumeValue` to capture the value
     passed to `coro/resume`.
 
@@ -126,7 +126,7 @@ stored in `Closure.location_map` and used by the VM for error reporting.
       `HirKind::Lambda.syntax` during lowering. The emitter preserves both
       into `Closure.doc` and `Closure.syntax` without encoding them in bytecode.
 
-9. **Yield point metadata is collected during emission.** `Emitter::emit()`
+9. **Emit point metadata is collected during emission.** `Emitter::emit()`
      returns `(Bytecode, Vec<YieldPointInfo>, Vec<CallSiteInfo>)`. The caller
      must attach these to `LirFunction.yield_points` and `LirFunction.call_sites`
      before storing the function on a `Closure`. The JIT reads this metadata
@@ -164,17 +164,17 @@ stored in `Closure.location_map` and used by the VM for error reporting.
 | `RegionEnter` | (none) | Push scope mark on FiberHeap (effective for all fibers including root) |
 | `RegionExit` | (none) | Pop scope mark and release scoped objects (effective for all fibers including root) |
 
-## Yield and Call Site Metadata
+## Emit and Call Site Metadata
 
 The emitter collects two types of metadata during bytecode emission:
 
 ### YieldPointInfo
 
-Recorded when a `Terminator::Yield` is emitted:
-- `resume_ip: usize` — Bytecode offset to resume at (the instruction after the Yield opcode)
-- `stack_regs: Vec<Reg>` — Virtual registers on the operand stack at yield time, bottom-to-top
+Recorded when a `Terminator::Emit` is emitted:
+- `resume_ip: usize` — Bytecode offset to resume at (the instruction after the Emit opcode)
+- `stack_regs: Vec<Reg>` — Virtual registers on the operand stack at emit time, bottom-to-top
 
-The JIT uses this to spill live registers to a stack slot and call the yield runtime helper.
+The JIT uses this to spill live registers to a stack slot and call the emit runtime helper.
 
 ### CallSiteInfo
 
@@ -247,23 +247,23 @@ unsafe-result, outward-set, break). Access via `lowerer.scope_stats()`
 after `lower()` completes. Set `ELLE_SCOPE_STATS=1` to print stats to
 stderr during compilation.
 
-## Yield as terminator
+## Emit as terminator
 
-`Terminator::Yield { value, resume_label }` correctly models that yield
+`Terminator::Emit { signal, value, resume_label }` correctly models that emit
 suspends execution and resumes in a new block. The lowerer:
 
-1. Emits `Terminator::Yield` to end the current block
+1. Emits `Terminator::Emit` to end the current block
 2. Creates a new block at `resume_label`
 3. Emits `LoadResumeValue` as the first instruction of the resume block
 
-The emitter preserves stack state across the yield boundary via
-`yield_stack_state`. This ensures intermediate values computed before yield
-(e.g., the `1` in `(+ 1 (yield 2) 3)`) survive into the resume block.
+The emitter preserves stack state across the emit boundary via
+`yield_stack_state`. This ensures intermediate values computed before emit
+(e.g., the `1` in `(+ 1 (emit :yield 2) 3)`) survive into the resume block.
 
-**Yield point metadata:** When the emitter encounters a `Terminator::Yield`,
+**Emit point metadata:** When the emitter encounters a `Terminator::Emit`,
 it records a `YieldPointInfo` containing:
-- `resume_ip`: Bytecode offset to resume at (the instruction after Yield)
-- `stack_regs`: Virtual registers on the operand stack at yield time
+- `resume_ip`: Bytecode offset to resume at (the instruction after Emit)
+- `stack_regs`: Virtual registers on the operand stack at emit time
 
 This metadata is collected in `Emitter.yield_points` and returned alongside
 the bytecode. The JIT uses this to generate side-exit code that spills live

--- a/src/lir/display.rs
+++ b/src/lir/display.rs
@@ -257,11 +257,12 @@ impl fmt::Display for Terminator {
                 then_label,
                 else_label,
             } => write!(f, "branch {} → {} / {}", cond, then_label, else_label),
-            Terminator::Yield {
+            Terminator::Emit {
+                signal,
                 value,
                 resume_label,
             } => {
-                write!(f, "yield {} → {}", value, resume_label)
+                write!(f, "emit {} {} → {}", signal, value, resume_label)
             }
             Terminator::Unreachable => f.write_str("unreachable"),
         }
@@ -275,7 +276,7 @@ pub fn terminator_kind(t: &Terminator) -> &'static str {
         Terminator::Return(_) => "return",
         Terminator::Jump(_) => "jump",
         Terminator::Branch { .. } => "branch",
-        Terminator::Yield { .. } => "yield",
+        Terminator::Emit { .. } => "emit",
         Terminator::Unreachable => "unreachable",
     }
 }
@@ -438,12 +439,13 @@ mod tests {
     }
 
     #[test]
-    fn test_terminator_yield() {
-        let term = Terminator::Yield {
+    fn test_terminator_emit() {
+        let term = Terminator::Emit {
+            signal: crate::value::fiber::SIG_YIELD,
             value: Reg(0),
             resume_label: Label(5),
         };
-        assert_eq!(format!("{}", term), "yield r0 → block5");
+        assert_eq!(format!("{}", term), "emit 0x2 r0 → block5");
     }
 
     #[test]

--- a/src/lir/emit/mod.rs
+++ b/src/lir/emit/mod.rs
@@ -987,46 +987,36 @@ impl Emitter {
                 self.pending_jumps.push((then_pos, *then_label));
             }
 
-            Terminator::Yield {
+            Terminator::Emit {
+                signal,
                 value,
                 resume_label,
             } => {
                 self.ensure_on_top(*value);
-                self.bytecode.emit(Instruction::Yield);
-                // Pop the yielded value from the simulated stack
+                // Emit instruction with signal bits as u16 operand.
+                // Signal bits fit in u16 (bits 0-15 are built-in,
+                // 16-31 are user-defined; u16 truncates user bits
+                // but those are rare in emit — revisit if needed).
+                self.bytecode.emit(Instruction::Emit);
+                self.bytecode.emit_u16(signal.raw() as u16);
                 self.pop();
 
-                // The resume IP is the current bytecode position (right after
-                // the Yield opcode byte). This is what the interpreter stores
-                // in SuspendedFrame.ip.
                 let resume_ip = self.bytecode.current_pos();
 
-                // Record yield point metadata for JIT.
-                // num_locals is needed so the JIT can spill local variable
-                // values into the SuspendedFrame stack, matching the
-                // interpreter's layout: [locals..., operands...].
                 self.yield_points.push(YieldPointInfo {
                     resume_ip,
                     stack_regs: self.stack.clone(),
                     num_locals: self.current_func_num_locals,
                 });
 
-                // Save stack state for the resume block.
-                // The resume block will start with this stack state,
-                // plus the resume value on top (added by LoadResumeValue).
                 self.yield_stack_state.insert(
                     *resume_label,
                     (self.stack.clone(), self.reg_to_stack.clone()),
                 );
 
-                // Emit a jump to the resume block.
-                // This is necessary because blocks are sorted by label number,
-                // so the resume block may not be immediately after the yield.
-                // When the coroutine is resumed, the VM continues from the IP
-                // after the yield, which is this jump instruction.
                 self.bytecode.emit(Instruction::Jump);
                 let pos = self.bytecode.current_pos();
-                self.bytecode.emit_i16(0); // placeholder
+                self.bytecode.emit_i16(0);
                 self.pending_jumps.push((pos, *resume_label));
             }
 

--- a/src/lir/emit/tests.rs
+++ b/src/lir/emit/tests.rs
@@ -107,7 +107,8 @@ fn test_yield_point_info_collected() {
         synthetic_span(),
     ));
     b0.terminator = SpannedTerminator::new(
-        Terminator::Yield {
+        Terminator::Emit {
+            signal: crate::value::fiber::SIG_YIELD,
             value: Reg(0),
             resume_label: Label(1),
         },

--- a/src/lir/lower/control.rs
+++ b/src/lir/lower/control.rs
@@ -372,23 +372,23 @@ impl<'a> Lowerer<'a> {
         Ok(dst)
     }
 
-    pub(super) fn lower_yield(&mut self, value: &Hir) -> Result<Reg, String> {
+    pub(super) fn lower_emit(
+        &mut self,
+        signal: crate::value::fiber::SignalBits,
+        value: &Hir,
+    ) -> Result<Reg, String> {
         let value_reg = self.lower_expr(value)?;
 
-        // Allocate the resume block label
         let resume_label = self.fresh_label();
 
-        // Terminate current block with Yield
-        self.terminate(Terminator::Yield {
+        self.terminate(Terminator::Emit {
+            signal,
             value: value_reg,
             resume_label,
         });
 
-        // Start the resume block
         self.start_new_block(resume_label);
 
-        // The resume value is on the stack when execution resumes.
-        // Load it into a register.
         let dst = self.fresh_reg();
         self.emit(LirInstr::LoadResumeValue { dst });
 

--- a/src/lir/lower/escape.rs
+++ b/src/lir/lower/escape.rs
@@ -100,12 +100,15 @@ impl<'a> Lowerer<'a> {
                 //
                 // We use a sentinel Hir whose result_is_safe is false,
                 // representing "heap-allocated inside the scope".
-                // Yield is always unsafe in result_is_safe.
+                // Emit is always unsafe in result_is_safe.
                 let sentinel = Hir::silent(
-                    HirKind::Yield(Box::new(Hir::silent(
-                        HirKind::Nil,
-                        crate::syntax::Span::synthetic(),
-                    ))),
+                    HirKind::Emit {
+                        signal: crate::value::fiber::SIG_YIELD,
+                        value: Box::new(Hir::silent(
+                            HirKind::Nil,
+                            crate::syntax::Span::synthetic(),
+                        )),
+                    },
                     crate::syntax::Span::synthetic(),
                 );
                 let mut extended: Vec<(Binding, &Hir)> = scope_bindings.to_vec();
@@ -483,7 +486,7 @@ impl<'a> Lowerer<'a> {
                     })
             }
 
-            HirKind::Yield(expr) => self.walk_for_outward_set(expr, scope_bindings),
+            HirKind::Emit { value: expr, .. } => self.walk_for_outward_set(expr, scope_bindings),
 
             HirKind::Quote(_) => false,
 
@@ -632,7 +635,9 @@ impl<'a> Lowerer<'a> {
                     })
             }
 
-            HirKind::Yield(expr) => self.hir_break_values_safe(expr, target_id, scope_bindings),
+            HirKind::Emit { value: expr, .. } => {
+                self.hir_break_values_safe(expr, target_id, scope_bindings)
+            }
 
             HirKind::Destructure { value, .. } => {
                 self.hir_break_values_safe(value, target_id, scope_bindings)
@@ -759,7 +764,7 @@ impl<'a> Lowerer<'a> {
                     })
             }
 
-            HirKind::Yield(expr) => Self::walk_for_escaping_break(expr, inner_blocks),
+            HirKind::Emit { value: expr, .. } => Self::walk_for_escaping_break(expr, inner_blocks),
 
             HirKind::Destructure { value, .. } => {
                 Self::walk_for_escaping_break(value, inner_blocks)
@@ -864,7 +869,7 @@ impl<'a> Lowerer<'a> {
                     })
             }
 
-            HirKind::Yield(expr) => self.all_breaks_have_safe_values(expr),
+            HirKind::Emit { value: expr, .. } => self.all_breaks_have_safe_values(expr),
 
             HirKind::Destructure { value, .. } => self.all_breaks_have_safe_values(value),
 
@@ -1000,7 +1005,7 @@ impl<'a> Lowerer<'a> {
                     || args.iter().any(|a| self.body_escapes_heap_values(&a.expr))
             }
             HirKind::Lambda { .. } => false,
-            HirKind::Yield(value) => {
+            HirKind::Emit { value, .. } => {
                 !self.result_is_safe(value, &[]) || self.body_escapes_heap_values(value)
             }
             HirKind::Int(_)

--- a/src/lir/lower/expr.rs
+++ b/src/lir/lower/expr.rs
@@ -75,7 +75,7 @@ impl<'a> Lowerer<'a> {
             HirKind::And(exprs) => self.lower_and(exprs),
             HirKind::Or(exprs) => self.lower_or(exprs),
 
-            HirKind::Yield(value) => self.lower_yield(value),
+            HirKind::Emit { signal, value } => self.lower_emit(*signal, value),
             HirKind::Quote(value) => self.emit_value_const(*value),
             HirKind::Cond {
                 clauses,

--- a/src/lir/types.rs
+++ b/src/lir/types.rs
@@ -549,9 +549,15 @@ pub enum Terminator {
         then_label: Label,
         else_label: Label,
     },
-    /// Yield control with a value. Execution resumes at resume_label
-    /// with the resume value on the stack.
-    Yield { value: Reg, resume_label: Label },
+    /// Emit a signal with compile-time signal bits and a runtime value.
+    /// Execution resumes at resume_label with the resume value on the stack.
+    /// Replaces the old `Yield` terminator; `(yield val)` becomes
+    /// `Emit { signal: SIG_YIELD, ... }`.
+    Emit {
+        signal: crate::value::fiber::SignalBits,
+        value: Reg,
+        resume_label: Label,
+    },
     /// Unreachable (for incomplete blocks)
     Unreachable,
 }

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -79,10 +79,7 @@ pub fn register_and_build(
     for def in primitives {
         ctx.register(def);
         let short_name = def.name.strip_prefix(prefix).unwrap_or(def.name);
-        fields.insert(
-            TableKey::Keyword(short_name.into()),
-            Value::native_fn(def.func),
-        );
+        fields.insert(TableKey::Keyword(short_name.into()), Value::native_fn(def));
     }
     Value::struct_from(fields)
 }
@@ -104,10 +101,7 @@ pub fn register_and_build_refs(
     for def in primitives {
         ctx.register(def);
         let short_name = def.name.strip_prefix(prefix).unwrap_or(def.name);
-        fields.insert(
-            TableKey::Keyword(short_name.into()),
-            Value::native_fn(def.func),
-        );
+        fields.insert(TableKey::Keyword(short_name.into()), Value::native_fn(def));
     }
     Value::struct_from(fields)
 }

--- a/src/primitives/AGENTS.md
+++ b/src/primitives/AGENTS.md
@@ -14,7 +14,9 @@ Implement Elle's standard library of built-in functions:
 - Introspection and debugging
 
 Does NOT:
-- Define special forms (those are in `hir/analyze.rs`)
+- Define special forms (those are in `hir/analyze.rs`). Note: `emit` is a special
+  form when the first argument is a literal keyword or keyword set; dynamic
+  `(emit var val)` falls through to the primitive.
 - Execute bytecode (that's `vm`)
 - Compile code (that's `compiler`, `hir`, `lir`)
 
@@ -27,7 +29,7 @@ Does NOT:
 
 ## Function type
 
-**NativeFn**: `fn(&[Value]) -> (SignalBits, Value)`
+**NativeFn**: `&'static PrimitiveDef` (the bare function pointer type is `PrimFn`: `fn(&[Value]) -> (SignalBits, Value)`)
 
 All primitives use a single unified type. No primitive has VM access.
 Return values:

--- a/src/primitives/compile.rs
+++ b/src/primitives/compile.rs
@@ -162,7 +162,7 @@ fn collect_fn_signals(
                 collect_fn_signals(body, arena, symbols, map);
             }
         }
-        HirKind::Yield(expr) | HirKind::Break { value: expr, .. } => {
+        HirKind::Emit { value: expr, .. } | HirKind::Break { value: expr, .. } => {
             collect_fn_signals(expr, arena, symbols, map);
         }
         HirKind::Cond {
@@ -357,7 +357,7 @@ fn collect_call_edges(
                 collect_call_edges(body, arena, symbols, edges, current_fn);
             }
         }
-        HirKind::Yield(expr) | HirKind::Break { value: expr, .. } => {
+        HirKind::Emit { value: expr, .. } | HirKind::Break { value: expr, .. } => {
             collect_call_edges(expr, arena, symbols, edges, current_fn);
         }
         HirKind::Cond {
@@ -579,7 +579,7 @@ fn find_named_lambda<'a>(
                 None
             })
         }
-        HirKind::Yield(e) | HirKind::Break { value: e, .. } => {
+        HirKind::Emit { value: e, .. } | HirKind::Break { value: e, .. } => {
             find_named_lambda(e, arena, symbols, target)
         }
         HirKind::Cond {
@@ -700,7 +700,7 @@ fn collect_vars_in_range(
                 collect_vars_in_range(b, start, end, referenced, defined, signal);
             }
         }
-        HirKind::Yield(e) | HirKind::Break { value: e, .. } => {
+        HirKind::Emit { value: e, .. } | HirKind::Break { value: e, .. } => {
             collect_vars_in_range(e, start, end, referenced, defined, signal);
         }
         HirKind::Cond {
@@ -1314,7 +1314,7 @@ fn find_lambda_captures(
             }
             None
         }
-        HirKind::Yield(e) | HirKind::Break { value: e, .. } => {
+        HirKind::Emit { value: e, .. } | HirKind::Break { value: e, .. } => {
             find_lambda_captures(e, arena, symbols, target)
         }
         HirKind::Cond {
@@ -1497,7 +1497,7 @@ fn find_capturers(
                 find_capturers(body, arena, symbols, target, results);
             }
         }
-        HirKind::Yield(e) | HirKind::Break { value: e, .. } => {
+        HirKind::Emit { value: e, .. } | HirKind::Break { value: e, .. } => {
             find_capturers(e, arena, symbols, target, results);
         }
         HirKind::Cond {

--- a/src/primitives/def.rs
+++ b/src/primitives/def.rs
@@ -5,7 +5,7 @@
 //! primitives with the VM and build the metadata maps.
 
 use crate::signals::Signal;
-use crate::value::types::{Arity, NativeFn};
+use crate::value::types::{Arity, PrimFn};
 use crate::value::{SymbolId, Value};
 use std::collections::HashMap;
 
@@ -19,7 +19,7 @@ pub struct PrimitiveDef {
     /// The Elle-facing name (e.g., "math/sin", "cons").
     pub name: &'static str,
     /// The Rust implementation.
-    pub func: NativeFn,
+    pub func: PrimFn,
     /// Signal (errors, yields, etc.).
     pub signal: Signal,
     /// Argument count constraint.
@@ -62,6 +62,31 @@ const fn _default_prim(
 ) -> (crate::value::fiber::SignalBits, crate::value::Value) {
     panic!("PrimitiveDef::DEFAULT func called — this is a bug")
 }
+
+/// No-op primitive: returns (SIG_OK, nil). Used by ad-hoc Value::native_fn
+/// creation in tests and FFI wrappers.
+fn _noop_prim(
+    _args: &[crate::value::Value],
+) -> (crate::value::fiber::SignalBits, crate::value::Value) {
+    (
+        crate::value::fiber::SignalBits::EMPTY,
+        crate::value::Value::NIL,
+    )
+}
+
+/// A silent, no-op PrimitiveDef for ad-hoc `Value::native_fn` creation.
+/// Used by tests and FFI wrappers that need a `&'static PrimitiveDef`.
+pub static NOOP_PRIM: PrimitiveDef = PrimitiveDef {
+    name: "<noop>",
+    func: _noop_prim,
+    signal: Signal::silent(),
+    arity: Arity::AtLeast(0),
+    doc: "",
+    params: &[],
+    category: "",
+    example: "",
+    aliases: &[],
+};
 
 /// Documentation info for a named form (primitive, special form, or macro).
 /// Stored at runtime for `doc` lookup.

--- a/src/primitives/disassembly.rs
+++ b/src/primitives/disassembly.rs
@@ -281,7 +281,7 @@ fn flow_from_closure(closure: &std::rc::Rc<crate::value::heap::Closure>) -> (Sig
                         Value::int(else_label.0 as i64),
                     ]
                 }
-                Terminator::Yield { resume_label, .. } => {
+                Terminator::Emit { resume_label, .. } => {
                     vec![Value::int(resume_label.0 as i64)]
                 }
             };

--- a/src/primitives/fiber_introspect.rs
+++ b/src/primitives/fiber_introspect.rs
@@ -13,7 +13,7 @@
 use crate::primitives::def::PrimitiveDef;
 use crate::signals::Signal;
 use crate::value::fiber::{
-    FiberStatus, SignalBits, SIG_ABORT, SIG_ERROR, SIG_OK, SIG_PROPAGATE, SIG_TERMINAL,
+    FiberStatus, SignalBits, SIG_ABORT, SIG_ERROR, SIG_OK, SIG_PROPAGATE, SIG_QUERY, SIG_TERMINAL,
 };
 use crate::value::types::Arity;
 use crate::value::{error_val, Value};
@@ -356,6 +356,51 @@ pub(crate) fn prim_fiber_abort(args: &[Value]) -> (SignalBits, Value) {
     }
 }
 
+/// (fiber/caps) → set
+/// (fiber/caps fiber) → set
+///
+/// Returns the active capabilities of the current or specified fiber as a
+/// keyword set. Capabilities are `~withheld & CAP_MASK`.
+///
+/// 0 args: queries the current fiber via SIG_QUERY.
+/// 1 arg: reads the specified fiber's withheld field directly.
+pub(crate) fn prim_fiber_caps(args: &[Value]) -> (SignalBits, Value) {
+    if args.is_empty() {
+        // 0-arg form: query current fiber via SIG_QUERY
+        return (
+            SIG_QUERY,
+            Value::cons(Value::keyword("fiber/caps"), Value::NIL),
+        );
+    }
+    if args.len() != 1 {
+        return (
+            SIG_ERROR,
+            error_val(
+                "arity-error",
+                format!("fiber/caps: expected 0-1 arguments, got {}", args.len()),
+            ),
+        );
+    }
+
+    let handle = match args[0].as_fiber() {
+        Some(h) => h,
+        None => {
+            return (
+                SIG_ERROR,
+                error_val(
+                    "type-error",
+                    format!("fiber/caps: expected fiber, got {}", args[0].type_name()),
+                ),
+            );
+        }
+    };
+
+    let caps = handle.with(|fiber| crate::signals::CAP_MASK.subtract(fiber.withheld));
+    let registry = crate::signals::registry::global_registry().lock().unwrap();
+    let keywords = registry.bits_to_keywords(caps);
+    (SIG_OK, Value::set(keywords.into_iter().collect()))
+}
+
 /// Declarative primitive definitions for fiber introspection and management
 pub(crate) const PRIMITIVES: &[PrimitiveDef] = &[
     PrimitiveDef {
@@ -439,6 +484,20 @@ pub(crate) const PRIMITIVES: &[PrimitiveDef] = &[
         params: &["fiber"],
         category: "fiber",
         example: "(fiber/propagate f)",
+        aliases: &[],
+    },
+    PrimitiveDef {
+        name: "fiber/caps",
+        func: prim_fiber_caps,
+        signal: Signal {
+            bits: SIG_ERROR.union(SIG_QUERY),
+            propagates: 0,
+        },
+        arity: Arity::Range(0, 1),
+        doc: "Get the fiber's active capabilities as a keyword set",
+        params: &["fiber?"],
+        category: "fiber",
+        example: "(fiber/caps)\n(fiber/caps f)",
         aliases: &[],
     },
     PrimitiveDef {

--- a/src/primitives/fibers.rs
+++ b/src/primitives/fibers.rs
@@ -175,17 +175,24 @@ pub(crate) fn resolve_signal_bits(
     ))
 }
 
-/// (fiber/new fn mask) → fiber
+/// (fiber/new fn mask [:deny bits]) → fiber
 ///
 /// Create a fiber from a closure and a signal mask. The mask determines
 /// which signals the parent catches when resuming this fiber.
+///
+/// Optional `:deny` keyword arg withholds capabilities from the fiber.
+/// The child's `withheld` is the union of the explicit deny bits and the
+/// parent's withheld (propagated at resume time by the VM).
 pub(crate) fn prim_fiber_new(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 2 {
+    if args.len() < 2 {
         return (
             SIG_ERROR,
             error_val(
                 "arity-error",
-                format!("fiber/new: expected 2 arguments, got {}", args.len()),
+                format!(
+                    "fiber/new: expected at least 2 arguments, got {}",
+                    args.len()
+                ),
             ),
         );
     }
@@ -208,7 +215,40 @@ pub(crate) fn prim_fiber_new(args: &[Value]) -> (SignalBits, Value) {
         Err(err) => return err,
     };
 
-    let fiber = Fiber::new(closure, mask);
+    // Parse optional keyword arguments after the required (closure, mask) pair.
+    let mut deny_bits = SignalBits::EMPTY;
+    let mut i = 2;
+    while i < args.len() {
+        if args[i].as_keyword_name().as_deref() == Some("deny") {
+            if i + 1 >= args.len() {
+                return (
+                    SIG_ERROR,
+                    error_val("arity-error", "fiber/new: :deny requires a value"),
+                );
+            }
+            deny_bits = match resolve_signal_bits(&args[i + 1], "fiber/new :deny") {
+                Ok(bits) => bits,
+                Err(err) => return err,
+            };
+            i += 2;
+        } else {
+            return (
+                SIG_ERROR,
+                error_val(
+                    "argument-error",
+                    format!(
+                        "fiber/new: unexpected keyword argument :{}",
+                        args[i]
+                            .as_keyword_name()
+                            .unwrap_or_else(|| args[i].type_name().to_string())
+                    ),
+                ),
+            );
+        }
+    }
+
+    let mut fiber = Fiber::new(closure, mask);
+    fiber.withheld = deny_bits;
     (SIG_OK, Value::fiber(fiber))
 }
 
@@ -504,11 +544,11 @@ pub(crate) const PRIMITIVES: &[PrimitiveDef] = &[
         name: "fiber/new",
         func: prim_fiber_new,
         signal: Signal::errors(),
-        arity: Arity::Exact(2),
-        doc: "Create a fiber from a closure with a signal mask",
+        arity: Arity::AtLeast(2),
+        doc: "Create a fiber with a signal mask. Optional :deny withholds capabilities.",
         params: &["closure", "mask"],
         category: "fiber",
-        example: "(fiber/new (fn [] 42) 0)",
+        example: "(fiber/new (fn [] 42) |:error| :deny |:io|)",
         aliases: &["fiber"],
     },
     PrimitiveDef {

--- a/src/primitives/json/mod.rs
+++ b/src/primitives/json/mod.rs
@@ -457,8 +457,7 @@ mod tests {
         });
         assert!(serialize_value(&closure).is_err());
 
-        let native_fn: crate::value::NativeFn = |_| (crate::value::fiber::SIG_OK, Value::NIL);
-        let fn_val = Value::native_fn(native_fn);
+        let fn_val = Value::native_fn(&crate::primitives::def::NOOP_PRIM);
         assert!(serialize_value(&fn_val).is_err());
     }
 

--- a/src/primitives/registration.rs
+++ b/src/primitives/registration.rs
@@ -72,7 +72,7 @@ pub fn register_primitives(vm: &mut VM, symbols: &mut SymbolTable) -> PrimitiveM
     for table in ALL_TABLES {
         for def in *table {
             let sym_id = symbols.intern(def.name);
-            let native_val = Value::native_fn(def.func);
+            let native_val = Value::native_fn(def);
             meta.signals.insert(sym_id, def.signal);
             meta.arities.insert(sym_id, def.arity);
             meta.functions.insert(sym_id, native_val);
@@ -91,7 +91,7 @@ pub fn register_primitives(vm: &mut VM, symbols: &mut SymbolTable) -> PrimitiveM
 
             for alias in def.aliases {
                 let alias_id = symbols.intern(alias);
-                let alias_val = Value::native_fn(def.func);
+                let alias_val = Value::native_fn(def);
                 meta.signals.insert(alias_id, def.signal);
                 meta.arities.insert(alias_id, def.arity);
                 meta.functions.insert(alias_id, alias_val);
@@ -118,13 +118,13 @@ pub fn build_primitive_meta(symbols: &mut SymbolTable) -> PrimitiveMeta {
             let sym_id = symbols.intern(def.name);
             meta.signals.insert(sym_id, def.signal);
             meta.arities.insert(sym_id, def.arity);
-            meta.functions.insert(sym_id, Value::native_fn(def.func));
+            meta.functions.insert(sym_id, Value::native_fn(def));
 
             for alias in def.aliases {
                 let alias_id = symbols.intern(alias);
                 meta.signals.insert(alias_id, def.signal);
                 meta.arities.insert(alias_id, def.arity);
-                meta.functions.insert(alias_id, Value::native_fn(def.func));
+                meta.functions.insert(alias_id, Value::native_fn(def));
             }
         }
     }

--- a/src/signals/AGENTS.md
+++ b/src/signals/AGENTS.md
@@ -4,7 +4,10 @@ Signal system for tracking which signals a function may emit. Includes the globa
 
 ## Responsibility
 
-1. Define the `Signal` type and provide signal inference for the emit/fiber system
+1. Define the `Signal` type and provide signal inference for the emit/fiber system.
+   `emit` is a special form when the first argument is a literal keyword or keyword set;
+   it replaces the old `yield` special form. `yield` is now a macro (defined in prelude.lisp)
+   that expands to `(emit :yield val)`.
 2. Maintain the global signal registry mapping signal keywords to bit positions
 3. Track which signals a function might emit (error, yield, debug, ffi, io, halt, user-defined)
 4. Track which parameter indices propagate their callee's signals
@@ -17,8 +20,8 @@ Signal system for tracking which signals a function may emit. Includes the globa
 | `Signal` | `{ bits: SignalBits, propagates: u32 }` — Copy, const fn constructors |
 | `Signal::silent()` | No signals |
 | `Signal::errors()` | May error (SIG_ERROR) |
-| `Signal::yields()` | May yield (SIG_YIELD) |
-| `Signal::yields_errors()` | May yield and error |
+| `Signal::yields()` | May yield (SIG_YIELD) — being phased out in favor of literal `Signal { bits: SIG_YIELD, propagates: 0 }` |
+| `Signal::yields_errors()` | May yield and error — being phased out in favor of literal construction |
 | `Signal::ffi()` | Calls foreign code (SIG_FFI) |
 | `Signal::ffi_errors()` | FFI + may error |
 | `Signal::halts()` | May halt (SIG_HALT) |

--- a/src/signals/mod.rs
+++ b/src/signals/mod.rs
@@ -64,6 +64,23 @@ pub const SIG_FUEL: SignalBits = SignalBits::new(1 << 12); // instruction budget
 pub const SIG_SWITCH: SignalBits = SignalBits::new(1 << 13); // fiber switch trampoline (VM-internal)
 pub const SIG_WAIT: SignalBits = SignalBits::new(1 << 14); // structured concurrency wait request
 
+/// Capability mask: which signal bits represent deniable operations.
+///
+/// These are the bits checked during capability enforcement. A primitive's
+/// signal bits AND the fiber's `withheld` AND this mask determines whether
+/// the primitive is blocked.
+///
+/// Includes: error (0), yield (1), debug (2), ffi (4), halt (8), io (9), exec (11).
+/// Excludes VM-internal infrastructure: resume (3), propagate (5), abort (6),
+/// query (7), terminal (10), fuel (12), switch (13), wait (14).
+pub const CAP_MASK: SignalBits = SIG_ERROR
+    .union(SIG_YIELD)
+    .union(SIG_DEBUG)
+    .union(SIG_FFI)
+    .union(SIG_HALT)
+    .union(SIG_IO)
+    .union(SIG_EXEC);
+
 /// Signal classification for expressions and functions.
 ///
 /// Two fields:

--- a/src/signals/registry.rs
+++ b/src/signals/registry.rs
@@ -127,6 +127,21 @@ impl SignalRegistry {
             .map(crate::value::fiber::SignalBits::from_bit)
     }
 
+    /// Convert signal bits to a Vec of keyword Values.
+    ///
+    /// Used by `fiber/caps` and capability denial payloads to produce
+    /// keyword sets from signal bitmasks.
+    pub fn bits_to_keywords(
+        &self,
+        bits: crate::value::fiber::SignalBits,
+    ) -> Vec<crate::value::Value> {
+        self.entries
+            .iter()
+            .filter(|e| bits.has_bit(e.bit_position))
+            .map(|e| crate::value::Value::keyword(&e.name))
+            .collect()
+    }
+
     /// Format signal bits as a human-readable string.
     ///
     /// Returns a string like `"{:error, :yield}"` for multiple bits, or `"{}"` for empty.

--- a/src/syntax/convert.rs
+++ b/src/syntax/convert.rs
@@ -382,7 +382,7 @@ mod tests {
     #[test]
     fn test_from_value_rejects_closure() {
         let result = Syntax::from_value(
-            &Value::native_fn(|_| (crate::value::SIG_OK, Value::NIL)),
+            &Value::native_fn(&crate::primitives::def::NOOP_PRIM),
             &SymbolTable::new(),
             test_span(),
         );

--- a/src/syntax/expand/macro_expand.rs
+++ b/src/syntax/expand/macro_expand.rs
@@ -66,23 +66,35 @@ impl Expander {
         symbols: &mut SymbolTable,
         vm: &mut VM,
     ) -> Result<Syntax, String> {
-        // Check arity
+        // Check arity: required params must be present, optional and rest are flexible
+        let min_args = macro_def.params.len();
+        let max_args = min_args + macro_def.optional_params.len();
         if macro_def.rest_param.is_some() {
-            if args.len() < macro_def.params.len() {
+            if args.len() < min_args {
                 return Err(format!(
                     "Macro '{}' expects at least {} arguments, got {}",
                     macro_def.name,
-                    macro_def.params.len(),
+                    min_args,
                     args.len()
                 ));
             }
-        } else if args.len() != macro_def.params.len() {
-            return Err(format!(
-                "Macro '{}' expects {} arguments, got {}",
-                macro_def.name,
-                macro_def.params.len(),
-                args.len()
-            ));
+        } else if args.len() < min_args || args.len() > max_args {
+            if min_args == max_args {
+                return Err(format!(
+                    "Macro '{}' expects {} arguments, got {}",
+                    macro_def.name,
+                    min_args,
+                    args.len()
+                ));
+            } else {
+                return Err(format!(
+                    "Macro '{}' expects {}-{} arguments, got {}",
+                    macro_def.name,
+                    min_args,
+                    max_args,
+                    args.len()
+                ));
+            }
         }
 
         // Recursion guard
@@ -125,12 +137,21 @@ impl Expander {
             if let Some(v) = cached {
                 v
             } else {
-                // Build the fn parameter list, including rest param if present.
+                // Build the fn parameter list: required, &opt optional, & rest.
                 let mut param_items: Vec<Syntax> = macro_def
                     .params
                     .iter()
                     .map(|p| Syntax::new(SyntaxKind::Symbol(p.clone()), span.clone()))
                     .collect();
+                if !macro_def.optional_params.is_empty() {
+                    param_items.push(Syntax::new(
+                        SyntaxKind::Symbol("&opt".to_string()),
+                        span.clone(),
+                    ));
+                    for p in &macro_def.optional_params {
+                        param_items.push(Syntax::new(SyntaxKind::Symbol(p.clone()), span.clone()));
+                    }
+                }
                 if let Some(ref rest_name) = macro_def.rest_param {
                     param_items.push(Syntax::new(
                         SyntaxKind::Symbol("&".to_string()),
@@ -191,11 +212,20 @@ impl Expander {
                 .map(wrap_macro_arg_value)
                 .collect();
 
+            // Collect optional param arg values (those provided).
+            // Missing optional args are handled by the fn's &opt default (nil).
+            let opt_start = macro_def.params.len();
+            let opt_end = opt_start + macro_def.optional_params.len();
+            let opt_provided = args.len().min(opt_end);
+            for arg in &args[opt_start..opt_provided] {
+                arg_values.push(wrap_macro_arg_value(arg));
+            }
+
             // Collect rest args — the closure's arity is AtLeast(n) with a rest param,
             // and VM's populate_env with VarargKind::List collects remaining args into
             // an Elle list automatically. Pass them as individual Values.
             if macro_def.rest_param.is_some() {
-                for arg in &args[macro_def.params.len()..] {
+                for arg in &args[opt_end..] {
                     arg_values.push(wrap_macro_arg_value(arg));
                 }
             }

--- a/src/syntax/expand/mod.rs
+++ b/src/syntax/expand/mod.rs
@@ -22,6 +22,8 @@ const MAX_MACRO_EXPANSION_DEPTH: usize = 200;
 pub struct MacroDef {
     pub name: String,
     pub params: Vec<String>,
+    /// Optional parameters (after `&opt`, before any `&` rest).
+    pub optional_params: Vec<String>,
     pub rest_param: Option<String>,
     pub template: Syntax,
     #[allow(dead_code)] // set during construction; read access planned for hygiene
@@ -239,14 +241,21 @@ impl Expander {
             }
         })?;
 
-        // Parse params, recognizing & as rest separator
+        // Parse params: required* (&opt optional*)? (& rest)?
         let mut fixed_params = Vec::new();
+        let mut optional_params = Vec::new();
         let mut rest_param = None;
+        let mut in_optional = false;
         let mut i = 0;
         while i < params_syntax.len() {
             let p = params_syntax[i]
                 .as_symbol()
                 .ok_or_else(|| format!("{}: macro parameter must be a symbol", span))?;
+            if p == "&opt" {
+                in_optional = true;
+                i += 1;
+                continue;
+            }
             if p == "&" {
                 // Next symbol is the rest param
                 if i + 1 >= params_syntax.len() {
@@ -261,7 +270,11 @@ impl Expander {
                 rest_param = Some(rest_name.to_string());
                 break;
             }
-            fixed_params.push(p.to_string());
+            if in_optional {
+                optional_params.push(p.to_string());
+            } else {
+                fixed_params.push(p.to_string());
+            }
             i += 1;
         }
 
@@ -272,6 +285,7 @@ impl Expander {
         let macro_def = MacroDef {
             name: name.clone(),
             params: fixed_params,
+            optional_params,
             rest_param,
             template,
             definition_scope: ScopeId(0), // Top-level scope

--- a/src/syntax/expand/tests.rs
+++ b/src/syntax/expand/tests.rs
@@ -273,6 +273,7 @@ fn test_macro_predicate_true() {
     let macro_def = MacroDef {
         name: "my-macro".to_string(),
         params: vec!["x".to_string()],
+        optional_params: vec![],
         rest_param: None,
         template: Syntax::new(SyntaxKind::Symbol("x".to_string()), span.clone()),
         definition_scope: ScopeId(0),
@@ -390,6 +391,7 @@ fn test_expand_macro_basic() {
     let macro_def = MacroDef {
         name: "double".to_string(),
         params: vec!["x".to_string()],
+        optional_params: vec![],
         rest_param: None,
         template,
         definition_scope: ScopeId(0),

--- a/src/syntax/mod.rs
+++ b/src/syntax/mod.rs
@@ -538,6 +538,7 @@ mod tests {
         let macro_def = MacroDef {
             name: "double".to_string(),
             params: vec!["x".to_string()],
+            optional_params: vec![],
             rest_param: None,
             template,
             definition_scope: ScopeId(0),
@@ -574,6 +575,7 @@ mod tests {
         let macro_def = MacroDef {
             name: "single".to_string(),
             params: vec!["x".to_string()],
+            optional_params: vec![],
             rest_param: None,
             template,
             definition_scope: ScopeId(0),

--- a/src/value/fiber.rs
+++ b/src/value/fiber.rs
@@ -488,6 +488,12 @@ pub struct Fiber {
     /// reaches zero the VM emits `SIG_FUEL`, pausing the fiber. Refuel via
     /// `fiber/set-fuel` then call `fiber/resume` to continue.
     pub fuel: Option<u32>,
+    /// Withheld capabilities. Bits set here prevent the fiber from silently
+    /// performing the corresponding operations. When a primitive's signal bits
+    /// overlap with `withheld & CAP_MASK`, the primitive is blocked and a
+    /// denial signal is emitted instead. Default: empty (full access).
+    /// Transitive: `child.withheld = parent.withheld | deny_bits`.
+    pub withheld: SignalBits,
 }
 
 impl Fiber {
@@ -510,6 +516,7 @@ impl Fiber {
             call_depth: 0,
             call_stack: Vec::new(),
             fuel: None,
+            withheld: SignalBits::EMPTY,
         }
     }
 }

--- a/src/value/heap.rs
+++ b/src/value/heap.rs
@@ -15,7 +15,7 @@ use crate::value::Value;
 
 // Re-export types for convenience
 pub use crate::value::closure::Closure;
-pub use crate::value::types::{Arity, NativeFn, TableKey};
+pub use crate::value::types::{Arity, NativeFn, PrimFn, TableKey};
 
 /// Cons cell for list construction.
 pub struct Cons {

--- a/src/value/repr/accessors.rs
+++ b/src/value/repr/accessors.rs
@@ -417,17 +417,23 @@ impl Value {
         self.as_lbox().or_else(|| self.as_capture_cell())
     }
 
-    /// Extract as native function if this is a native function.
+    /// Extract the primitive definition if this is a native function.
     #[inline]
-    pub fn as_native_fn(&self) -> Option<&crate::value::heap::NativeFn> {
+    pub fn as_native_def(&self) -> Option<&'static crate::primitives::def::PrimitiveDef> {
         use crate::value::heap::{deref, HeapObject};
         if !self.is_native_fn() {
             return None;
         }
         match unsafe { deref(*self) } {
-            HeapObject::NativeFn(f) => Some(f),
+            HeapObject::NativeFn(def) => Some(*def),
             _ => None,
         }
+    }
+
+    /// Extract the bare function pointer if this is a native function.
+    #[inline]
+    pub fn as_native_fn(&self) -> Option<crate::value::heap::PrimFn> {
+        self.as_native_def().map(|def| def.func)
     }
 
     /// Extract as array (immutable) if this is one.

--- a/src/value/repr/constructors.rs
+++ b/src/value/repr/constructors.rs
@@ -201,12 +201,12 @@ impl Value {
         })
     }
 
-    /// Create a native function value.
+    /// Create a native function value from a static primitive definition.
     /// Uses permanent allocation — native functions outlive any arena scope.
     #[inline]
-    pub fn native_fn(f: crate::value::heap::NativeFn) -> Self {
+    pub fn native_fn(def: &'static crate::primitives::def::PrimitiveDef) -> Self {
         use crate::value::heap::{alloc_permanent, HeapObject};
-        alloc_permanent(HeapObject::NativeFn(f))
+        alloc_permanent(HeapObject::NativeFn(def))
     }
 
     /// Create an immutable array value.

--- a/src/value/send.rs
+++ b/src/value/send.rs
@@ -389,7 +389,7 @@ fn from_value_inner(value: Value, ctx: &mut SerContext) -> Result<SendValue, Str
         }
 
         // Native function pointers are inherently Send + Sync
-        HeapObject::NativeFn(f) => Ok(SendValue::NativeFn(*f)),
+        HeapObject::NativeFn(f) => Ok(SendValue::NativeFn(f)),
 
         // Unsafe: FFI handles
         HeapObject::LibHandle(_) => Err("Cannot send library handle".to_string()),

--- a/src/value/types.rs
+++ b/src/value/types.rs
@@ -274,7 +274,7 @@ impl fmt::Debug for TableKey {
     }
 }
 
-/// Unified primitive function type.
+/// Primitive function signature.
 ///
 /// All primitives return (signal_bits, value):
 /// - (SIG_OK, value) → push value onto stack
@@ -284,7 +284,11 @@ impl fmt::Debug for TableKey {
 ///
 /// No primitive has VM access. Operations that formerly needed the VM
 /// now emit signals that the VM dispatch loop handles.
-pub type NativeFn = fn(&[Value]) -> (crate::value::fiber::SignalBits, Value);
+pub type PrimFn = fn(&[Value]) -> (crate::value::fiber::SignalBits, Value);
+
+/// A reference to a static primitive definition. Stored in HeapObject::NativeFn
+/// so the VM can access signal metadata at call time for capability enforcement.
+pub type NativeFn = &'static crate::primitives::def::PrimitiveDef;
 
 #[cfg(test)]
 mod tests {

--- a/src/vm/AGENTS.md
+++ b/src/vm/AGENTS.md
@@ -357,7 +357,7 @@ to see parent-established parameter bindings.
 | `data.rs` | ~100 | Cons, Car, Cdr, MakeVector, `handle_struct_rest` |
 | `literals.rs` | ~18 | Nil, EmptyList, True, False literal handlers |
 | `eval.rs` | ~180 | Runtime eval: compile+execute datum, env wrapping |
-| `capture.rs` | Capture cell operations: MakeCaptureCell, UnlBox, UpdateLBox |
+| `capture.rs` | Capture cell operations: MakeCapture, UnwrapCapture, UpdateCapture |
 
 ## Truthiness
 

--- a/src/vm/call.rs
+++ b/src/vm/call.rs
@@ -152,8 +152,25 @@ impl VM {
         instr_ip: usize,
         location_map: &Rc<LocationMap>,
     ) -> Option<SignalBits> {
-        if let Some(f) = func.as_native_fn() {
-            let (bits, value) = f(args.as_slice());
+        if let Some(def) = func.as_native_def() {
+            let blocked = def
+                .signal
+                .bits
+                .intersection(self.fiber.withheld)
+                .intersection(crate::signals::CAP_MASK);
+            if !blocked.is_empty() {
+                return self.handle_capability_denial(
+                    def,
+                    blocked,
+                    &args,
+                    bytecode,
+                    constants,
+                    closure_env,
+                    ip,
+                    location_map,
+                );
+            }
+            let (bits, value) = (def.func)(args.as_slice());
             return self.handle_primitive_signal(
                 bits,
                 value,
@@ -494,8 +511,16 @@ impl VM {
     /// Dispatches native functions via tail signal handler, sets up pending
     /// tail call for closures with environment building.
     fn tail_call_inner(&mut self, func: Value, args: Vec<Value>) -> Option<SignalBits> {
-        if let Some(f) = func.as_native_fn() {
-            let (bits, value) = f(&args);
+        if let Some(def) = func.as_native_def() {
+            let blocked = def
+                .signal
+                .bits
+                .intersection(self.fiber.withheld)
+                .intersection(crate::signals::CAP_MASK);
+            if !blocked.is_empty() {
+                return Some(self.handle_capability_denial_tail(def, blocked, &args));
+            }
+            let (bits, value) = (def.func)(&args);
             return Some(self.handle_primitive_signal_tail(bits, value));
         }
 

--- a/src/vm/dispatch.rs
+++ b/src/vm/dispatch.rs
@@ -7,7 +7,6 @@ use crate::compiler::bytecode::Instruction;
 use crate::error::LocationMap;
 use crate::value::{
     BytecodeFrame, SignalBits, SuspendedFrame, Value, SIG_ERROR, SIG_FUEL, SIG_HALT, SIG_OK,
-    SIG_YIELD,
 };
 use std::rc::Rc;
 
@@ -390,9 +389,20 @@ impl VM {
                     capture::handle_update_capture(self);
                 }
 
-                // Yield — capture suspended frame and suspend
-                Instruction::Yield => {
-                    return self.handle_yield(bytecode, constants, closure_env, ip, location_map);
+                // Emit — exit dispatch loop for all signals.
+                // SIG_ERROR: store error, no SuspendedFrame (error propagation).
+                // Other signals: create SuspendedFrame (cooperative suspension).
+                Instruction::Emit => {
+                    let bits_raw = self.read_u16(bc, &mut ip) as u32;
+                    let signal_bits = crate::value::fiber::SignalBits::new(bits_raw);
+                    return self.handle_emit(
+                        signal_bits,
+                        bytecode,
+                        constants,
+                        closure_env,
+                        ip,
+                        location_map,
+                    );
                 }
 
                 // Runtime eval — compile and execute a datum
@@ -533,41 +543,47 @@ impl VM {
         }
     }
 
-    /// Handle the Yield instruction.
+    /// Handle the Emit instruction.
     ///
-    /// Captures a SuspendedFrame (bytecode, constants, env, IP, stack)
-    /// so that resume can continue from this exact point. Each call level
-    /// appends its frame to the suspended chain.
-    fn handle_yield(
+    /// For error signals (SIG_ERROR): stores the error in fiber.signal and
+    /// exits the dispatch loop. No SuspendedFrame — errors propagate through
+    /// the normal return/unwind path.
+    ///
+    /// For suspension signals (SIG_YIELD, user-defined): captures a
+    /// SuspendedFrame so that resume can continue from this exact point.
+    fn handle_emit(
         &mut self,
+        signal_bits: SignalBits,
         bytecode: &Rc<Vec<u8>>,
         constants: &Rc<Vec<Value>>,
         closure_env: &Rc<Vec<Value>>,
         ip: usize,
         location_map: &Rc<LocationMap>,
     ) -> (SignalBits, usize) {
-        let yielded_value = self
+        let value = self
             .fiber
             .stack
             .pop()
-            .expect("VM bug: Stack underflow on yield");
+            .expect("VM bug: Stack underflow on emit");
 
-        let saved_stack: Vec<Value> = self.fiber.stack.drain(..).collect();
+        self.fiber.signal = Some((signal_bits, value));
 
-        let frame = SuspendedFrame::Bytecode(BytecodeFrame {
-            bytecode: bytecode.clone(),
-            constants: constants.clone(),
-            env: closure_env.clone(),
-            ip,
-            stack: saved_stack,
-            location_map: location_map.clone(),
-            // Yield: on resume, the resume argument becomes the result of
-            // the (yield ...) expression — push it onto the restored stack.
-            push_resume_value: true,
-        });
+        if !signal_bits.contains(SIG_ERROR) {
+            // Suspension: save stack and create a frame for later resumption.
+            let saved_stack: Vec<Value> = self.fiber.stack.drain(..).collect();
 
-        self.fiber.signal = Some((SIG_YIELD, yielded_value));
-        self.fiber.suspended = Some(vec![frame]);
-        (SIG_YIELD, ip)
+            let frame = SuspendedFrame::Bytecode(BytecodeFrame {
+                bytecode: bytecode.clone(),
+                constants: constants.clone(),
+                env: closure_env.clone(),
+                ip,
+                stack: saved_stack,
+                location_map: location_map.clone(),
+                push_resume_value: true,
+            });
+            self.fiber.suspended = Some(vec![frame]);
+        }
+
+        (signal_bits, ip)
     }
 }

--- a/src/vm/fiber.rs
+++ b/src/vm/fiber.rs
@@ -62,6 +62,10 @@ impl VM {
         child_fiber.parent = self.current_fiber_handle.as_ref().map(|h| h.downgrade());
         child_fiber.parent_value = self.current_fiber_value;
 
+        // 2a. Propagate withheld capabilities: child inherits parent's withheld.
+        // This is idempotent (OR is monotonic) so safe on repeated resume.
+        child_fiber.withheld |= self.fiber.withheld;
+
         // 3. Swap parent out, child in; track the child's handle and value
         let parent_handle = self.current_fiber_handle.take();
         let parent_value = self.current_fiber_value.take();

--- a/src/vm/signal.rs
+++ b/src/vm/signal.rs
@@ -193,6 +193,92 @@ impl VM {
         self.fiber.signal = Some((bits, value));
         bits
     }
+
+    // ── Capability denial ─────────────────────────────────────────────
+
+    /// Handle capability denial in Call position.
+    ///
+    /// The fiber tried to call a primitive whose signal bits overlap with
+    /// the fiber's `withheld` capabilities. Instead of running the primitive,
+    /// emit a signal with the blocked bits and a denial payload struct.
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn handle_capability_denial(
+        &mut self,
+        def: &'static crate::primitives::def::PrimitiveDef,
+        blocked: SignalBits,
+        args: &[Value],
+        bytecode: &Rc<Vec<u8>>,
+        constants: &Rc<Vec<Value>>,
+        closure_env: &Rc<Vec<Value>>,
+        ip: &mut usize,
+        location_map: &Rc<crate::error::LocationMap>,
+    ) -> Option<SignalBits> {
+        let payload = Self::build_denial_payload(def, blocked, args);
+
+        // Save the stack and build a suspended frame (same as suspending signals)
+        let saved_stack: Vec<Value> = self.fiber.stack.drain(..).collect();
+        let frame = SuspendedFrame::Bytecode(BytecodeFrame {
+            bytecode: bytecode.clone(),
+            constants: constants.clone(),
+            env: closure_env.clone(),
+            ip: *ip,
+            stack: saved_stack,
+            location_map: location_map.clone(),
+            push_resume_value: true,
+        });
+        self.fiber.signal = Some((blocked, payload));
+        self.fiber.suspended = Some(vec![frame]);
+        Some(blocked)
+    }
+
+    /// Handle capability denial in TailCall position.
+    pub(super) fn handle_capability_denial_tail(
+        &mut self,
+        def: &'static crate::primitives::def::PrimitiveDef,
+        blocked: SignalBits,
+        args: &[Value],
+    ) -> SignalBits {
+        let payload = Self::build_denial_payload(def, blocked, args);
+        self.fiber.signal = Some((blocked, payload));
+        blocked
+    }
+
+    /// Build the denial payload struct.
+    ///
+    /// Returns `{:error :capability-denied :denied <keyword-set>
+    ///           :primitive <name> :func <native-fn> :args <array>}`.
+    fn build_denial_payload(
+        def: &'static crate::primitives::def::PrimitiveDef,
+        blocked: SignalBits,
+        args: &[Value],
+    ) -> Value {
+        use crate::value::heap::TableKey;
+        use std::collections::BTreeMap;
+
+        let registry = crate::signals::registry::global_registry().lock().unwrap();
+        let denied_keywords = registry.bits_to_keywords(blocked);
+
+        let mut fields = BTreeMap::new();
+        fields.insert(
+            TableKey::Keyword("error".into()),
+            Value::keyword("capability-denied"),
+        );
+        fields.insert(
+            TableKey::Keyword("denied".into()),
+            Value::set(denied_keywords.into_iter().collect()),
+        );
+        fields.insert(
+            TableKey::Keyword("primitive".into()),
+            Value::string(def.name),
+        );
+        fields.insert(TableKey::Keyword("func".into()), Value::native_fn(def));
+        fields.insert(
+            TableKey::Keyword("args".into()),
+            Value::array(args.to_vec()),
+        );
+
+        Value::struct_from(fields)
+    }
 }
 
 impl VM {
@@ -281,6 +367,12 @@ impl VM {
                 }
             }
             "fiber/self" => (SIG_OK, self.current_fiber_value.unwrap_or(Value::NIL)),
+            "fiber/caps" => {
+                let caps = crate::signals::CAP_MASK.subtract(self.fiber.withheld);
+                let registry = crate::signals::registry::global_registry().lock().unwrap();
+                let keywords = registry.bits_to_keywords(caps);
+                (SIG_OK, Value::set(keywords.into_iter().collect()))
+            }
             "list-primitives" => {
                 // arg is nil (no filter) or a keyword/string category name
                 let category_filter: Option<String> = if arg.is_nil() {

--- a/src/wasm/controlflow.rs
+++ b/src/wasm/controlflow.rs
@@ -231,7 +231,7 @@ impl WasmEmitter {
             Terminator::Unreachable => {
                 f.instruction(&Instruction::Unreachable);
             }
-            Terminator::Yield { value, .. } => {
+            Terminator::Emit { signal, value, .. } => {
                 if self.may_suspend {
                     let resume_state = lir_block_idx
                         .and_then(|idx| self.yield_state_map.get(&idx).copied())
@@ -248,7 +248,7 @@ impl WasmEmitter {
                     f.instruction(&Instruction::I32Const(ARGS_BASE));
                     f.instruction(&Instruction::I32Const(total_saved as i32));
                     f.instruction(&Instruction::I32Const(self.current_table_idx as i32));
-                    f.instruction(&Instruction::I32Const(2)); // SIG_YIELD
+                    f.instruction(&Instruction::I32Const(signal.raw() as i32));
                     f.instruction(&Instruction::Call(FN_RT_YIELD));
                     f.instruction(&Instruction::LocalGet(self.tag_local(*value)));
                     f.instruction(&Instruction::LocalGet(self.pay_local(*value)));

--- a/src/wasm/regalloc.rs
+++ b/src/wasm/regalloc.rs
@@ -378,7 +378,7 @@ fn for_each_terminator_use(term: &Terminator, mut f: impl FnMut(Reg)) {
     match term {
         Terminator::Return(reg) => f(*reg),
         Terminator::Branch { cond, .. } => f(*cond),
-        Terminator::Yield { value, .. } => f(*value),
+        Terminator::Emit { value, .. } => f(*value),
         Terminator::Jump(_) | Terminator::Unreachable => {}
     }
 }

--- a/src/wasm/suspend.rs
+++ b/src/wasm/suspend.rs
@@ -301,7 +301,7 @@ impl WasmEmitter {
         for block in &func.blocks {
             let block_idx = self.label_to_idx[&block.label];
 
-            if let Terminator::Yield { resume_label, .. } = &block.terminator.terminator {
+            if let Terminator::Emit { resume_label, .. } = &block.terminator.terminator {
                 let state_id = self.next_resume_state;
                 self.next_resume_state += 1;
                 let target_block_idx = self.label_to_idx[resume_label] as i32;

--- a/tests/elle/arena.lisp
+++ b/tests/elle/arena.lisp
@@ -126,7 +126,7 @@
 # Values allocated in a child fiber survive across yield/resume cycles
 # because the FiberHeap persists on the Fiber struct.
 (let* ((f (fiber/new (fn ()
-             (emit 2 (cons 1 2))
+             (yield (cons 1 2))
              (cons 3 4))
            2))
        (first-val (fiber/resume f))
@@ -161,7 +161,7 @@
 # test_yielding_child_yields_string
 # A yielding child allocates a string and yields it.
 # The parent should be able to read the string after resume.
-(let* ((f (fiber/new (fn () (emit 2 "hello")) 2))
+(let* ((f (fiber/new (fn () (yield "hello")) 2))
        (result (fiber/resume f)))
   (assert (= result "hello") "yielding child yields string"))
 
@@ -175,8 +175,8 @@
 # test_yield_resume_multiple_cycles
 # Fiber yields twice (two resume cycles). Both values readable.
 (let* ((f (fiber/new (fn ()
-             (emit 2 "first")
-             (emit 2 "second")
+             (yield "first")
+             (yield "second")
              "done")
            2))
        (v1 (fiber/resume f))
@@ -189,27 +189,27 @@
 # test_abc_chain_yield_through
 # A→B→C: C yields a string, B catches and re-yields to A.
 # Tests transitive shared_alloc propagation.
-(let* ((c (fiber/new (fn () (emit 2 "from-c")) 2))
+(let* ((c (fiber/new (fn () (yield "from-c")) 2))
        (b (fiber/new (fn ()
              (let* ((val (fiber/resume c)))
-               (emit 2 val)))
+               (yield val)))
            2))
        (a-result (fiber/resume b)))
   (assert (= a-result "from-c") "abc chain yield through"))
 
 # test_root_child_yield
 # Root resumes a yielding child. Child yields a string.
-(let* ((f (fiber/new (fn () (emit 2 "from-child")) 2))
+(let* ((f (fiber/new (fn () (yield "from-child")) 2))
        (result (fiber/resume f)))
   (assert (= result "from-child") "root child yield"))
 
 # test_root_child_grandchild_yield
 # Root→child→grandchild. Grandchild yields string,
 # child yields it to root.
-(let* ((gc (fiber/new (fn () (emit 2 "from-gc")) 2))
+(let* ((gc (fiber/new (fn () (yield "from-gc")) 2))
        (child (fiber/new (fn ()
                 (let* ((val (fiber/resume gc)))
-                  (emit 2 val)))
+                  (yield val)))
               2)))
   (let ((result (fiber/resume child)))
     (assert (= result "from-gc") "root child grandchild yield")))
@@ -219,7 +219,7 @@
 # The yielded string should survive child death because it's
 # in the shared allocator (owned by parent or child).
 (let* ((f (fiber/new (fn ()
-             (emit 2 "alive")
+             (yield "alive")
              "done")
            2))
        (yielded (fiber/resume f))
@@ -229,9 +229,9 @@
 # test_multi_resume_yield_basic
 # Multiple yields without letrec — tests shared alloc across resumes.
 (let* ((f (fiber/new (fn ()
-              (emit 2 0)
-              (emit 2 1)
-              (emit 2 2))
+              (yield 0)
+              (yield 1)
+              (yield 2))
             2)))
   (let ((v1 (fiber/resume f))
         (v2 (fiber/resume f))
@@ -244,9 +244,9 @@
 # Yield heap-allocated values across multiple resumes.
 # Tests that shared alloc keeps values alive for the parent.
 (let* ((f (fiber/new (fn ()
-              (emit 2 "hello")
-              (emit 2 "world")
-              (emit 2 "done"))
+              (yield "hello")
+              (yield "world")
+              (yield "done"))
             2)))
   (let ((v1 (fiber/resume f))
         (v2 (fiber/resume f))
@@ -258,9 +258,9 @@
 # test_multi_resume_yield_mixed_values
 # Yield a mix of immediate and heap values across resumes.
 (let* ((f (fiber/new (fn ()
-              (emit 2 42)
-              (emit 2 (list 1 2 3))
-              (emit 2 "end"))
+              (yield 42)
+              (yield (list 1 2 3))
+              (yield "end"))
             2)))
   (let ((v1 (fiber/resume f))
         (v2 (fiber/resume f))
@@ -273,8 +273,8 @@
 # Parent resumes two different yielding children.
 # Both yield strings. Both readable.
 # Tests owned_shared Vec growth doesn't invalidate earlier pointers.
-(let* ((f1 (fiber/new (fn () (emit 2 "from-f1")) 2))
-       (f2 (fiber/new (fn () (emit 2 "from-f2")) 2))
+(let* ((f1 (fiber/new (fn () (yield "from-f1")) 2))
+       (f2 (fiber/new (fn () (yield "from-f2")) 2))
        (v1 (fiber/resume f1))
        (v2 (fiber/resume f2)))
   (assert (= v1 "from-f1") "multiple children: first")
@@ -285,14 +285,14 @@
 # test_yield_immediate_no_shared_alloc_needed
 # Yielding an immediate (int) requires no heap allocation.
 # The shared alloc infrastructure should not interfere.
-(let* ((f (fiber/new (fn () (emit 2 42)) 2))
+(let* ((f (fiber/new (fn () (yield 42)) 2))
        (result (fiber/resume f)))
   (assert (= result 42) "yield immediate no shared alloc"))
 
 # test_yield_list_parent_traverses
 # Fiber yields a cons list. Parent traverses all elements.
 # The list cells are heap-allocated — they go to shared alloc.
-(let* ((f (fiber/new (fn () (emit 2 (list 10 20 30))) 2))
+(let* ((f (fiber/new (fn () (yield (list 10 20 30))) 2))
        (lst (fiber/resume f)))
   (assert (= (first lst) 10) "yield list: first")
   (assert (= (first (rest lst)) 20) "yield list: second")
@@ -325,7 +325,7 @@
 # Parent cancels a suspended child that has a shared allocator.
 # Mask 3 catches both error (1) and yield (2) so cancel doesn't propagate.
 (let* ((f (fiber/new (fn ()
-              (emit 2 "yielded")
+              (yield "yielded")
               "never-reached")
             3))
        (v1 (fiber/resume f)))      # child suspends
@@ -653,8 +653,8 @@
 # :shared-count is a non-negative integer. The internal tracking of shared
 # allocators is on the VM fiber's heap, not the ROOT_HEAP thread-local that
 # arena/stats reads from root context. Verify the field is structurally valid.
-(let* ((f1 (fiber/new (fn () (emit 2 "y1")) 2))
-       (f2 (fiber/new (fn () (emit 2 "y2")) 2))
+(let* ((f1 (fiber/new (fn () (yield "y1")) 2))
+       (f2 (fiber/new (fn () (yield "y2")) 2))
        (_ (fiber/resume f1))
        (_ (fiber/resume f2))
        (s (arena/stats)))

--- a/tests/elle/caps.lisp
+++ b/tests/elle/caps.lisp
@@ -1,0 +1,119 @@
+# ── Capability enforcement tests ───────────────────────────────────────
+#
+# Tests for the "capabilities down" model: fiber/new :deny, fiber/caps,
+# and runtime enforcement of withheld capabilities.
+#
+# Note: arithmetic ops (+, -, etc.) are compiled to specialized bytecode
+# instructions that bypass call_inner. Use non-specialized primitives
+# like `length`, `type-of`, `car` for enforcement tests.
+
+# ── Phase 1: Infrastructure ───────────────────────────────────────────
+
+# fiber/caps returns a keyword set with all capabilities for the root fiber
+(let ([caps (fiber/caps)])
+  (assert (set? caps) "fiber/caps returns a set")
+  (assert (caps :error) "root fiber has :error capability")
+  (assert (caps :io) "root fiber has :io capability")
+  (assert (caps :ffi) "root fiber has :ffi capability")
+  (assert (caps :exec) "root fiber has :exec capability"))
+
+# fiber/caps on a fiber argument — no deny = full caps
+(let ([f (fiber/new (fn [] 42) |:error|)])
+  (let ([caps (fiber/caps f)])
+    (assert (set? caps) "fiber/caps on new fiber returns a set")
+    (assert (caps :error) "new fiber has :error cap")
+    (assert (caps :io) "new fiber has :io cap")))
+
+# :deny creates a fiber with withheld capabilities
+(let ([f (fiber/new (fn [] (fiber/caps)) |:error| :deny |:io|)])
+  (let ([result (fiber/resume f)])
+    (assert (set? result) "child fiber/caps returns a set")
+    (assert (result :error) "child has :error (not denied)")
+    (assert (not (result :io)) "child lacks :io (denied)")
+    (assert (result :ffi) "child has :ffi (not denied)")))
+
+# fiber/caps on a denied fiber — external view matches internal view
+(let ([f (fiber/new (fn [] 42) |:error| :deny |:io :ffi|)])
+  (let ([caps (fiber/caps f)])
+    (assert (not (caps :io)) "external: child lacks :io")
+    (assert (not (caps :ffi)) "external: child lacks :ffi")
+    (assert (caps :error) "external: child has :error")))
+
+# Narrowing composes transitively
+(let ([outer (fiber/new
+               (fn []
+                 (let ([inner (fiber/new (fn [] (fiber/caps)) |:error| :deny |:ffi|)])
+                   (fiber/resume inner)))
+               |:error|
+               :deny |:io|)])
+  (let ([result (fiber/resume outer)])
+    (assert (not (result :io)) "grandchild lacks :io (from parent)")
+    (assert (not (result :ffi)) "grandchild lacks :ffi (from own deny)")
+    (assert (result :error) "grandchild has :error")))
+
+# Widening is silently absorbed (child can't gain caps parent lacks)
+(let ([outer (fiber/new
+               (fn []
+                 (let ([inner (fiber/new (fn [] (fiber/caps)) |:error|)])
+                   (fiber/resume inner)))
+               |:error|
+               :deny |:io|)])
+  (let ([result (fiber/resume outer)])
+    (assert (not (result :io)) "grandchild inherits :io denial from parent")))
+
+# ── Phase 2: Enforcement ─────────────────────────────────────────────
+
+# :deny |:error| blocks length (non-specialized, declares Signal::errors)
+(let ([f (fiber/new (fn [] (length "hello")) |:error| :deny |:error|)])
+  (let ([result (fiber/resume f)])
+    (assert (= (fiber/status f) :paused) "fiber paused after denial")
+    (let ([val (fiber/value f)])
+      (assert (= (val :error) :capability-denied) "denial payload")
+      (assert (set? (val :denied)) ":denied is a set")
+      (assert ((val :denied) :error) ":denied set contains :error")
+      (assert (= (val :primitive) "length") "denial names blocked primitive"))))
+
+# :deny |:io| blocks port/read-line (declares SIG_IO)
+(let ([f (fiber/new (fn [] (port/read-line (*stdin*))) |:io :error| :deny |:io|)])
+  (let ([result (fiber/resume f)])
+    (assert (= (fiber/status f) :paused) "fiber paused after IO denial")
+    (let ([val (fiber/value f)])
+      (assert (= (val :error) :capability-denied) "IO denial payload")
+      (assert ((val :denied) :io) ":denied set contains :io"))))
+
+# Mediation: parent catches denial, inspects payload
+(let ([f (fiber/new (fn [] (length "hello")) |:error| :deny |:error|)])
+  (let ([denial (fiber/resume f)])
+    (assert (= (fiber/status f) :paused) "child paused after denial")
+    (let ([val (fiber/value f)])
+      (assert (= (val :primitive) "length") "blocked primitive is length")
+      (assert (= (first (val :args)) "hello") "args captured correctly"))))
+
+# Mask-interaction: denied + masked = parent catches denial
+(let ([f (fiber/new (fn [] (length "x")) |:error| :deny |:error|)])
+  (let ([result (fiber/resume f)])
+    (assert (= (fiber/status f) :paused) "denied+masked: parent catches")))
+
+# Mask-interaction: denied + not masked = denial propagates
+(let ([outer (fiber/new
+               (fn []
+                 (let ([inner (fiber/new (fn [] (length "x")) 0 :deny |:error|)])
+                   (fiber/resume inner)))
+               |:error|)])
+  (let ([result (fiber/resume outer)])
+    (assert (= (fiber/status outer) :paused) "denial propagates to grandparent")))
+
+# Nesting: two levels of deny compose
+(let ([outer (fiber/new
+               (fn []
+                 (let ([inner (fiber/new (fn [] (length "x")) |:error| :deny |:error|)])
+                   (fiber/resume inner)))
+               |:error|
+               :deny |:io|)])
+  (let ([result (fiber/resume outer)])
+    (assert (= (fiber/status outer) :dead) "outer completes normally")
+    (assert (= (result :error) :capability-denied) "inner denial as return value")))
+
+# No-deny fibers work exactly as before
+(let ([f (fiber/new (fn [] (length "hello")) |:error|)])
+  (assert (= (fiber/resume f) 5) "no-deny fiber runs length normally"))

--- a/tests/elle/emit.lisp
+++ b/tests/elle/emit.lisp
@@ -1,0 +1,77 @@
+# ── emit special form tests ───────────────────────────────────────────
+#
+# (emit <signal> <value>) is a special form when the first argument is
+# a compile-time keyword or keyword set. Signal bits are extracted
+# at analysis time and encoded in the bytecode instruction.
+
+# ── Basic emit with keywords ─────────────────────────────────────────
+
+# (emit :yield val) behaves like old (yield val)
+(let ([f (fiber/new (fn [] (let ([r (emit :yield 42)]) (+ r 10))) |:yield|)])
+  (assert (= (fiber/resume f) 42) "emit :yield produces yield value")
+  (assert (= (fiber/status f) :paused) "emit :yield pauses fiber")
+  (assert (= (fiber/resume f 5) 15) "emit :yield resumes: 5 + 10 = 15"))
+
+# (emit :yield) — no implicit nil form (emit requires 2 args)
+# Use (yield) for the 0-arg form.
+
+# (emit :error val) emits an error signal
+(let ([f (fiber/new (fn [] (emit :error :boom)) |:error|)])
+  (let ([result (fiber/resume f)])
+    (assert (= (fiber/status f) :paused) "emit :error pauses")
+    (assert (= (fiber/value f) :boom) "emit :error payload is :boom")))
+
+# ── Set argument ─────────────────────────────────────────────────────
+
+# (emit |:yield :io| val) emits compound signal bits
+(let ([f (fiber/new (fn [] (emit |:yield :io| :data)) |:yield :io|)])
+  (let ([result (fiber/resume f)])
+    (assert (= result :data) "emit set: value received")
+    (let ([bits (fiber/bits f)])
+      # bits should contain both :yield (2) and :io (512)
+      (assert (not (= bits 0)) "emit set: non-zero signal bits")
+      (assert (= (bit/and bits 2) 2) "emit set: :yield bit present")
+      (assert (= (bit/and bits 512) 512) "emit set: :io bit present"))))
+
+# ── yield still works (it's still a special form for now) ────────────
+
+(let ([f (fiber/new (fn [] (yield 10) (yield 20) 30) |:yield|)])
+  (assert (= (fiber/resume f) 10) "yield works: first")
+  (assert (= (fiber/resume f) 20) "yield works: second")
+  (assert (= (fiber/resume f) 30) "yield works: final"))
+
+# (yield) with no args yields nil
+(let ([f (fiber/new (fn [] (yield) 42) |:yield|)])
+  (assert (= (fiber/resume f) nil) "yield no-arg yields nil")
+  (assert (= (fiber/resume f) 42) "yield no-arg: final value"))
+
+# ── Dynamic emit still works via primitive fallback ──────────────────
+
+# (emit 2 val) falls through to prim_emit (runtime, not special form)
+(let ([f (fiber/new (fn [] (emit 2 :dynamic)) |:yield|)])
+  (assert (= (fiber/resume f) :dynamic) "dynamic emit still works"))
+
+# ── Resume value flows back through emit ─────────────────────────────
+
+(let ([f (fiber/new (fn [] (let ([x (emit :yield 1)]) (+ x 10))) |:yield|)])
+  (assert (= (fiber/resume f) 1) "first emit value")
+  (assert (= (fiber/resume f 5) 15) "resume value 5 + 10 = 15"))
+
+# ── Multiple emits in sequence ───────────────────────────────────────
+
+(let ([f (fiber/new
+           (fn []
+             (let ([a (emit :yield :first)])
+               (let ([b (emit :yield :second)])
+                 (list a b))))
+           |:yield|)])
+  (assert (= (fiber/resume f) :first) "multi-emit: first")
+  (assert (= (fiber/resume f :a) :second) "multi-emit: second")
+  (assert (= (fiber/resume f :b) (list :a :b)) "multi-emit: collected"))
+
+# ── emit interacts correctly with capability denial ──────────────────
+
+# A fiber with :deny |:error| can still (emit :yield val) because
+# the emit instruction itself doesn't go through call_inner
+(let ([f (fiber/new (fn [] (emit :yield 42)) |:yield| :deny |:error|)])
+  (assert (= (fiber/resume f) 42) "emit :yield works despite :deny |:error|"))

--- a/tests/elle/fiber_escape.lisp
+++ b/tests/elle/fiber_escape.lisp
@@ -55,13 +55,13 @@
 # ============================================================================
 
 # Yield a string, return int
-(let [[f (fiber/new (fn [] (emit 2 "yielded") 99) |:yield|)]]
+(let [[f (fiber/new (fn [] (yield "yielded") 99) |:yield|)]]
   (let [[y (fiber/resume f)]]
     (assert (= y "yielded") "fiber yield string")
     (assert (= (fiber/resume f) 99) "fiber return after yield")))
 
 # Yield an array
-(let [[f (fiber/new (fn [] (emit 2 [1 2 3]) :done) |:yield|)]]
+(let [[f (fiber/new (fn [] (yield [1 2 3]) :done) |:yield|)]]
   (let [[y (fiber/resume f)]]
     (assert (= (length y) 3) "fiber yield array length")
     (assert (= (get y 0) 1) "fiber yield array element")))
@@ -124,8 +124,8 @@
 # ============================================================================
 
 (let [[f (fiber/new (fn []
-                      (emit 2 "first")
-                      (emit 2 "second")
+                      (yield "first")
+                      (yield "second")
                       "third")
                     |:yield|)]]
   (assert (= (fiber/resume f) "first") "multi-yield first")

--- a/tests/elle/fiber_stress.lisp
+++ b/tests/elle/fiber_stress.lisp
@@ -56,7 +56,7 @@
   (let ((f (fiber/new (fn []
               (let ((i 0))
                 (while (< i 20)
-                  (emit 2 i)
+                  (yield i)
                   (assign i (+ i 1)))
                 :done))
             2)))
@@ -94,7 +94,7 @@
   (let ((inner (fiber/new (fn []
                   (let ((i 0))
                     (while (< i 15)
-                      (emit 2 i)
+                      (yield i)
                       (assign i (+ i 1)))
                     :inner-done))
                 2)))

--- a/tests/elle/fibers.lisp
+++ b/tests/elle/fibers.lisp
@@ -9,12 +9,12 @@
 # ============================================================================
 
 # fiber_yield_resume_order: yields produce values in order
-(let ([f (fiber/new (fn [] (emit 2 1) (emit 2 2) 3) 2)])
+(let ([f (fiber/new (fn [] (yield 1) (yield 2) 3) 2)])
   (assert (= (fiber/resume f) 1) "yield order: first")
   (assert (= (fiber/resume f) 2) "yield order: second")
   (assert (= (fiber/resume f) 3) "yield order: final return"))
 
-(let ([f (fiber/new (fn [] (emit 2 -50) (emit 2 0) (emit 2 50) 999) 2)])
+(let ([f (fiber/new (fn [] (yield -50) (yield 0) (yield 50) 999) 2)])
   (assert (= (fiber/resume f) -50) "yield order: negative")
   (assert (= (fiber/resume f) 0) "yield order: zero")
   (assert (= (fiber/resume f) 50) "yield order: positive")
@@ -26,30 +26,30 @@
 
 # signal_mask_catch_behavior: mask determines whether signal is caught
 # mask=2 catches SIG_YIELD (bit 2)
-(let ([f (fiber/new (fn [] (emit 2 42)) 2)])
+(let ([f (fiber/new (fn [] (yield 42)) 2)])
   (assert (= (fiber/resume f) 42) "signal mask: yield caught by mask=2"))
 
 # mask=0 does not catch SIG_YIELD — signal propagates to parent.
 # When the parent catches it (mask=2), the child suspends rather than errors.
 # We verify the propagation by observing the wrapper catches the yield value.
-(let ([f (fiber/new (fn [] (emit 2 42)) 0)])
+(let ([f (fiber/new (fn [] (yield 42)) 0)])
   (let ([wrapper (fiber/new (fn [] (fiber/resume f)) 2)])
     (assert (= (fiber/resume wrapper) 42) "signal mask: uncaught yield propagates to parent")))
 
 # mask=1 catches SIG_ERROR (bit 1)
-(let ([f (fiber/new (fn [] (emit 1 99)) 1)])
+(let ([f (fiber/new (fn [] (emit :error 99)) 1)])
   (assert (= (fiber/resume f) 99) "signal mask: error caught by mask=1"))
 
 # mask=0 does not catch SIG_ERROR — signal propagates to parent.
 # We verify by wrapping in a fiber with mask=1 that catches the error.
-(let ([f (fiber/new (fn [] (emit 1 99)) 0)])
+(let ([f (fiber/new (fn [] (emit :error 99)) 0)])
   (let ([wrapper (fiber/new (fn [] (fiber/resume f)) 1)])
     (assert (= (fiber/resume wrapper) 99) "signal mask: uncaught error propagates to parent")))
 
 # mask=3 catches both SIG_ERROR and SIG_YIELD
-(let ([f (fiber/new (fn [] (emit 2 77)) 3)])
+(let ([f (fiber/new (fn [] (yield 77)) 3)])
   (assert (= (fiber/resume f) 77) "signal mask: yield caught by mask=3"))
-(let ([f (fiber/new (fn [] (emit 1 88)) 3)])
+(let ([f (fiber/new (fn [] (emit :error 88)) 3)])
   (assert (= (fiber/resume f) 88) "signal mask: error caught by mask=3"))
 
 # ============================================================================
@@ -68,13 +68,13 @@
     (assert (= (fiber/value f) -50) "cancel new fiber: fiber/value negative")))
 
 # cancel_delivers_value_to_suspended_fiber: cancel a suspended fiber
-(let ([f (fiber/new (fn [] (emit 2 0) 99) 3)])
+(let ([f (fiber/new (fn [] (yield 0) 99) 3)])
   (fiber/resume f)
   (let ([result (fiber/cancel f 88)])
     (assert (= result 88) "cancel suspended fiber: result is payload")
     (assert (= (fiber/value f) 88) "cancel suspended fiber: fiber/value is payload")))
 
-(let ([f (fiber/new (fn [] (emit 2 0) 99) 3)])
+(let ([f (fiber/new (fn [] (yield 0) 99) 3)])
   (fiber/resume f)
   (let ([result (fiber/cancel f -25)])
     (assert (= result -25) "cancel suspended fiber: negative payload")
@@ -97,12 +97,12 @@
 
 # propagate_succeeds_for_errored_fibers: propagate re-signals error
 (let (([ok? _] (protect ((fn []
-  (let ([f (fiber/new (fn [] (emit 1 99)) 1)])
+  (let ([f (fiber/new (fn [] (emit :error 99)) 1)])
     (fiber/resume f)
     (fiber/propagate f))))))) (assert (not ok?) "propagate re-signals error (99)"))
 
 (let (([ok? _] (protect ((fn []
-  (let ([f (fiber/new (fn [] (emit 1 -50)) 1)])
+  (let ([f (fiber/new (fn [] (emit :error -50)) 1)])
     (fiber/resume f)
     (fiber/propagate f))))))) (assert (not ok?) "propagate re-signals error (-50)"))
 
@@ -122,14 +122,14 @@
     (fiber/cancel f "too late"))))))) (assert (not ok?) "cancel rejects dead fiber (-100)"))
 
 # cancel_accepts_suspended_after_caught_error: cancel works on suspended fiber
-(let ([f (fiber/new (fn [] (emit 1 99)) 1)])
+(let ([f (fiber/new (fn [] (emit :error 99)) 1)])
   (fiber/resume f)
   (fiber/cancel f "cancelling suspended")
   (assert (= (string (fiber/status f)) "error") "cancelled suspended fiber is in error status"))
 
 # cancel_rejects_errored_fibers: cancel fails for errored fibers
 (let (([ok? _] (protect ((fn []
-  (let ([f (fiber/new (fn [] (emit 1 99)) 0)])
+  (let ([f (fiber/new (fn [] (emit :error 99)) 0)])
     (let ([wrapper (fiber/new (fn [] (fiber/resume f)) 1)])
       (fiber/resume wrapper)
       (fiber/cancel f "already errored")))))))) (assert (not ok?) "cancel rejects errored fiber"))
@@ -139,11 +139,11 @@
 # ============================================================================
 
 # nested_fiber_resume_preserves_values: A resumes B, gets B's yield value
-(let ([inner (fiber/new (fn [] (emit 2 10)) 2)])
+(let ([inner (fiber/new (fn [] (yield 10)) 2)])
   (let ([outer (fiber/new (fn [] (+ (fiber/resume inner) 5)) 0)])
     (assert (= (fiber/resume outer) 15) "nested resume: 10 + 5 = 15")))
 
-(let ([inner (fiber/new (fn [] (emit 2 -30)) 2)])
+(let ([inner (fiber/new (fn [] (yield -30)) 2)])
   (let ([outer (fiber/new (fn [] (+ (fiber/resume inner) 20)) 0)])
     (assert (= (fiber/resume outer) -10) "nested resume: -30 + 20 = -10")))
 
@@ -212,12 +212,12 @@
 # ============================================================================
 
 # three_level_nested_fiber_resume: A -> B -> C value threading
-(let ([c (fiber/new (fn [] (emit 2 10)) 2)])
+(let ([c (fiber/new (fn [] (yield 10)) 2)])
   (let ([b (fiber/new (fn [] (+ (fiber/resume c) 5)) 0)])
     (let ([a (fiber/new (fn [] (+ (fiber/resume b) 3)) 0)])
       (assert (= (fiber/resume a) 18) "3-level nested: 10 + 5 + 3 = 18"))))
 
-(let ([c (fiber/new (fn [] (emit 2 -20)) 2)])
+(let ([c (fiber/new (fn [] (yield -20)) 2)])
   (let ([b (fiber/new (fn [] (+ (fiber/resume c) 30)) 0)])
     (let ([a (fiber/new (fn [] (+ (fiber/resume b) -5)) 0)])
        (assert (= (fiber/resume a) 5) "3-level nested: -20 + 30 + -5 = 5"))))
@@ -237,7 +237,7 @@
 
 # test_fiber_propagate_yield
 (begin
-  (let ((inner (fiber/new (fn [] (emit 2 99)) 2)))
+  (let ((inner (fiber/new (fn [] (yield 99)) 2)))
     (let ((outer (fiber/new
                    (fn []
                      (fiber/resume inner)
@@ -252,7 +252,7 @@
 
 # test_fiber_cancel_suspended_fiber
 (begin
-  (let ((f (fiber/new (fn [] (emit 2 "waiting") 99) 3)))
+  (let ((f (fiber/new (fn [] (yield "waiting") 99) 3)))
     (fiber/resume f)
     (fiber/cancel f "cancelled")
     (assert (= (string (fiber/status f)) "error") "fiber cancel: suspended fiber becomes error")))
@@ -318,18 +318,18 @@
 
 # test_fiber_yield_and_resume
 (begin
-  (let ((f (fiber/new (fn [] (emit 2 10) 20) 2)))
+  (let ((f (fiber/new (fn [] (yield 10) 20) 2)))
     (assert (= (+ (fiber/resume f) (fiber/resume f)) 30) "fiber yield and resume: 10 + 20 = 30")))
 
 # test_fiber_error_caught_by_mask
 (begin
-  (let ((f (fiber/new (fn [] (emit 1 "oops")) 1)))
+  (let ((f (fiber/new (fn [] (emit :error "oops")) 1)))
     (assert (= (fiber/resume f) "oops") "fiber error caught by mask")))
 
 # test_fiber_error_propagates_without_mask
 (begin
   (let (([ok? _] (protect ((fn []
-    (let ((f (fiber/new (fn [] (emit 1 "oops")) 0)))
+    (let ((f (fiber/new (fn [] (emit :error "oops")) 0)))
       (fiber/resume f))))))) (assert (not ok?) "fiber error propagates without mask")))
 
 # ============================================================================
@@ -338,7 +338,7 @@
 
 # test_fiber_propagate_preserves_child_chain
 (begin
-  (let ((inner (fiber/new (fn [] (emit 1 "err")) 1)))
+  (let ((inner (fiber/new (fn [] (emit :error "err")) 1)))
     (let ((outer (fiber/new
                    (fn []
                      (fiber/resume inner)
@@ -349,7 +349,7 @@
 
 # test_fiber_propagate_child_identity
 (begin
-  (let ((inner (fiber/new (fn [] (emit 2 99)) 2)))
+  (let ((inner (fiber/new (fn [] (yield 99)) 2)))
     (let ((outer (fiber/new
                    (fn []
                      (fiber/resume inner)
@@ -370,7 +370,7 @@
 
 # test_fiber_resume_yield_in_tail_position
 (begin
-  (let ((inner (fiber/new (fn [] (emit 2 10) 20) 2)))
+  (let ((inner (fiber/new (fn [] (yield 10) 20) 2)))
     (let ((outer (fiber/new (fn [] (fiber/resume inner)) 0)))
       (assert (= (fiber/resume outer) 10) "fiber resume yield: tail position"))))
 
@@ -385,7 +385,7 @@
 
 # test_fiber_cancel_suspended_in_tail_position
 (begin
-  (let ((target (fiber/new (fn [] (emit 2 0) 99) 3)))
+  (let ((target (fiber/new (fn [] (yield 0) 99) 3)))
     (fiber/resume target)
     (let ((canceller (fiber/new
                        (fn [] (fiber/cancel target "stop"))
@@ -399,7 +399,7 @@
 
 # test_three_level_nested_fiber_resume
 (begin
-  (let ((c (fiber/new (fn [] (emit 2 10)) 2)))
+  (let ((c (fiber/new (fn [] (yield 10)) 2)))
     (let ((b (fiber/new
                (fn []
                  (+ (fiber/resume c) 5))
@@ -412,7 +412,7 @@
 
 # test_three_level_nested_fiber_error_propagation
 (begin
-  (let ((c (fiber/new (fn [] (emit 1 "deep error")) 0)))
+  (let ((c (fiber/new (fn [] (emit :error "deep error")) 0)))
     (let ((b (fiber/new
                (fn [] (fiber/resume c))
                0)))
@@ -439,7 +439,7 @@
 
 # test_fiber_child_identity
 (begin
-  (let ((inner (fiber/new (fn [] (emit 1 "err")) 0)))
+  (let ((inner (fiber/new (fn [] (emit :error "err")) 0)))
     (let ((outer (fiber/new
                    (fn []
                      (fiber/resume inner)
@@ -454,19 +454,19 @@
 
 # test_caught_sig_error_leaves_fiber_suspended
 (begin
-  (let ((f (fiber/new (fn [] (emit 1 "oops") "recovered") 1)))
+  (let ((f (fiber/new (fn [] (emit :error "oops") "recovered") 1)))
     (fiber/resume f)
     (assert (= (string (fiber/status f)) "paused") "caught SIG_ERROR: leaves fiber paused")))
 
 # test_caught_sig_error_fiber_is_resumable
 (begin
-  (let ((f (fiber/new (fn [] (emit 1 "oops") "recovered") 1)))
+  (let ((f (fiber/new (fn [] (emit :error "oops") "recovered") 1)))
     (fiber/resume f)
     (assert (= (fiber/resume f) "recovered") "caught SIG_ERROR: fiber is resumable")))
 
 # test_cancel_always_produces_error_status
 (begin
-  (let ((f (fiber/new (fn [] (emit 2 "waiting") 99) 3)))
+  (let ((f (fiber/new (fn [] (yield "waiting") 99) 3)))
     (fiber/resume f)
     (fiber/cancel f "stop")
     (assert (= (string (fiber/status f)) "error") "cancel: always produces error status")))
@@ -482,7 +482,7 @@
 
 # test_fiber_signal_parameter_with_valid_bits
 (begin
-  (let ((f (fiber/new (fn (s) (emit s 42)) 2)))
+  (let ((f (fiber/new (fn (s) (yield 42)) |:yield|)))
     (fiber/resume f 2)
     (assert (= (fiber/value f) 42) "fiber signal parameter: valid bits")))
 
@@ -504,7 +504,7 @@
 (begin
   (let* ((f (fiber/new (fn []
                   (letrec ((go (fn (n)
-                              (emit 2 n)
+                              (yield n)
                               (go (+ n 1)))))
                     (go 0)))
               2)))
@@ -515,7 +515,7 @@
 # test_tail_call_then_signal_preserves_state
 (begin
   (defn helper (n)
-    (emit 2 n)
+    (yield n)
     (helper (+ n 10)))
   (let* ((f (fiber/new (fn [] (helper 1)) 2)))
     (assert (= (fiber/resume f) 1) "tail call signal: first")
@@ -524,7 +524,7 @@
 
 # test_multiple_tail_calls_before_signal
 (begin
-  (defn signaler (n) (emit 2 n) (signaler (+ n 1)))
+  (defn signaler (n) (yield n) (signaler (+ n 1)))
   (defn bouncer (n) (signaler n))
   (let* ((f (fiber/new (fn [] (bouncer 100)) 2)))
     (assert (= (fiber/resume f) 100) "multiple tail calls: first")
@@ -536,7 +536,7 @@
 
 # fiber_propagate_error
 (let (([ok? _] (protect ((fn ()
-  (let ((inner (fiber/new (fn () (emit 1 "boom")) 1)))
+  (let ((inner (fiber/new (fn () (emit :error "boom")) 1)))
     (fiber/resume inner)
     (fiber/propagate inner))))))) (assert (not ok?) "fiber propagate re-signals error"))
 
@@ -564,7 +564,7 @@
 # Basic pattern: fiber created in let, stored into outer @array, accessed after scope
 (begin
   (var fibers @[])
-  (let ([f (fiber/new (fn [] (emit 2 :ping) :done) 2)])
+  (let ([f (fiber/new (fn [] (yield :ping) :done) 2)])
     (push fibers f))
   # The let scope has exited. If the escape analysis incorrectly freed f,
   # fiber/bits will crash or return the wrong type.
@@ -585,7 +585,7 @@
 (begin
   (var bucket @[])
   (let ([pid 0]
-        [f (fiber/new (fn [] (emit 2 :hello) :world) 3)])
+        [f (fiber/new (fn [] (yield :hello) :world) 3)])
     (push bucket f)
     (assign pid (length bucket)))
   (let ([f (get bucket 0)]

--- a/tests/integration/elle_scripts.rs
+++ b/tests/integration/elle_scripts.rs
@@ -64,3 +64,13 @@ fn fiber_stress() {
 fn fiber_io_stress() {
     run_elle_script("fiber_io_stress");
 }
+
+#[test]
+fn caps() {
+    run_elle_script("caps");
+}
+
+#[test]
+fn emit() {
+    run_elle_script("emit");
+}

--- a/tests/unittests/primitives.rs
+++ b/tests/unittests/primitives.rs
@@ -1733,8 +1733,7 @@ fn test_json_serialize_errors() {
     let result = call_primitive(&json_serialize, &[closure]);
     assert!(result.is_err());
 
-    let native_fn: elle::value::NativeFn = |_| (elle::value::fiber::SIG_OK, Value::NIL);
-    let fn_val = Value::native_fn(native_fn);
+    let fn_val = Value::native_fn(&elle::primitives::def::NOOP_PRIM);
     let result = call_primitive(&json_serialize, &[fn_val]);
     assert!(result.is_err());
 }


### PR DESCRIPTION

Capability enforcement:
- fiber/new :deny withholds capabilities; fiber/caps introspects them
- NativeFn stores &'static PrimitiveDef for signal metadata at call sites
- Denial check in call_inner blocks primitives whose declared signals
  overlap withheld & CAP_MASK; denial payload includes primitive name,
  args, and denied keyword set
- Withheld propagates transitively at fiber resume

emit special form:
- (emit :keyword val) and (emit |:kw1 :kw2| val) extract signal bits
  at compile time; dynamic (emit var val) falls through to primitive
- HirKind::Yield, Terminator::Yield, Instruction::Yield all replaced
  by Emit variants carrying signal bits
- yield is now a prelude macro: (defmacro yield (&opt v) `(emit :yield ,v))
- VM handle_emit distinguishes error (propagate) from suspension (frame)

defmacro &opt:
- MacroDef gains optional_params; parameter parser recognizes &opt
- Arity checking supports Range(required, required+optional)
- Transformer compilation includes &opt in generated fn expression
- Macro expansion passes optional args to transformer closure

Doc fixes: stale lbox_params_mask->capture_params_mask, Suspended->Paused,
SuspendedFrame struct->enum, method renames, capability enforcement no
longer future work.