### PR TITLE
Add IRC module; structured errors and style refresh across all libs

### DIFF
--- a/docs/errors.md
+++ b/docs/errors.md
@@ -5,11 +5,64 @@ are structs `{:error :keyword :message "string"}`, but `(error val)` accepts
 any value — integers, strings, lists. Catch handlers that assume struct
 shape should guard with `struct?` first.
 
+## Error struct convention
+
+Error values are structs with three standard fields:
+
+```lisp
+{:error   :http-error              # module/category — which subsystem failed
+ :reason  :malformed-header        # specific condition — what went wrong
+ :message "malformed header"}      # human-readable summary (for logs/REPL)
+```
+
+**`:error`** is the genus. Match on this for broad catch-all handling:
+"is this an HTTP problem, a DNS problem, or something else?"
+
+**`:reason`** is the species. Match on this for targeted recovery:
+"was it a malformed header, an unsupported scheme, or an EOF?"
+
+**`:message`** is prose for humans. It must never contain information
+that isn't already in a struct field. Programs should never need to
+parse the message string — every datum is in its own field.
+
+Additional fields carry context values relevant to the specific error:
+
+```text
+# Good: every datum is a field; message is a formatted summary
+{:error :dns-format-error
+ :reason :bad-rdata-length
+ :rtype :a
+ :expected 4
+ :actual 7
+ :message "A record rdata length is not 4"}
+
+# Bad: information only in the message string
+{:error :dns-error
+ :message "dns: A record rdata length is not 4"}
+```
+
+### Matching on errors
+
+```text
+# Broad: catch all HTTP errors
+(try (http:get url)
+  (catch e
+    (when (= e:error :http-error)
+      (println "HTTP failed:" e:message))))
+
+# Targeted: handle a specific condition
+(try (irc:connect host port :nick nick)
+  (catch e
+    (when (= e:reason :nick-collision)
+      (println "nick" e:nick "taken, trying another"))))
+```
+
 ## Raising errors
 
 ```lisp
 # (error val) signals an error
-# (error {:error :bad-input :message "expected a number"})
+# (error {:error :bad-input :reason :negative-age :value age
+#         :message "expected a non-negative age"})
 ```
 
 ## try / catch
@@ -89,7 +142,7 @@ On error, cleanup runs, then the error re-propagates:
 (try
   (defer (push err-log :cleanup)
     (push err-log :body)
-    (error {:error :fail :message "oops"}))
+    (error {:error :fail :reason :oops :message "oops"}))
   (catch e :caught))
 # err-log is @[:body :cleanup]
 # try returns :caught
@@ -123,7 +176,8 @@ Errors bubble up through the call stack until caught.
 ```lisp
 (defn validate [age]
   (when (< age 0)
-    (error {:error :invalid :message "negative age"}))
+    (error {:error :invalid :reason :negative-age :value age
+            :message "negative age"}))
   age)
 
 (defn make-person [name age]
@@ -132,6 +186,8 @@ Errors bubble up through the call stack until caught.
 # error propagates from validate through make-person
 (def err (try (make-person "Bob" -5) (catch e e)))
 err:error                  # => :invalid
+err:reason                 # => :negative-age
+err:value                  # => -5
 ```
 
 ## protect vs try/catch vs defer

--- a/lib/AGENTS.md
+++ b/lib/AGENTS.md
@@ -17,6 +17,7 @@ depend on other modules or plugins take them as arguments.
 | `contract.lisp` | Compositional validation for function boundaries |
 | `lua.lisp` | Lua standard library compatibility prelude |
 | `process.lisp` | Erlang-style processes + GenServer, Actor, Supervisor |
+| `irc.lisp` | IRCv3 client: CAP negotiation, SASL PLAIN, message tags, coroutine read stream |
 | `sync.lisp` | Concurrency primitives: lock, semaphore, condvar, rwlock, barrier, latch, once, queue, monitor (built on futex) |
 
 ---
@@ -430,4 +431,95 @@ Handler module: `{:init (fn [arg] state) :handle-event (fn [event state] [:ok st
 ```bash
 ./target/debug/elle tests/elle/process.lisp
 ./target/debug/elle tests/elle/genserver.lisp
+```
+
+---
+
+# lib/irc
+
+Agent guide for `lib/irc.lisp` -- IRCv3 client.
+
+## Purpose
+
+IRC client with IRCv3 capability negotiation, SASL PLAIN authentication,
+and message tags. Coroutine-based: the connection struct exposes a read
+stream and a send function. No background fibers -- the caller controls
+when messages are consumed.
+
+## Loading
+
+```lisp
+# Plain TCP
+(def irc ((import "std/irc")))
+
+# TLS (standard for modern IRC)
+(def tls ((import "std/tls") (import "plugin/tls")))
+(def irc ((import "std/irc") :tls tls))
+```
+
+## Data flow
+
+```
+irc:connect host port :nick :sasl [user pass]
+  -> TCP or TLS connect
+  -> CAP LS 302 + NICK + USER
+  -> CAP negotiation (LS/REQ/ACK)
+  -> SASL PLAIN if negotiated
+  -> CAP END
+  -> wait for 001 RPL_WELCOME
+  -> return conn struct
+```
+
+## Connection struct
+
+```lisp
+{:messages <coroutine>   # yields parsed messages, auto-PONGs
+ :send     <function>    # (conn:send "COMMAND" "param1" ...)
+ :close    <function>    # sends QUIT, closes transport
+ :nick     "nick"        # resolved nick after registration
+ :caps     |"multi-prefix" "server-time"|  # negotiated capabilities
+ :server   "irc.libera.chat"
+ :isupport {:chantypes "#&" :prefix "(ov)@+"}}
+```
+
+## Message struct
+
+```lisp
+{:tags    {:time "2024-01-01T00:00:00Z" :msgid "abc123"}
+ :source  {:nick "user" :user "ident" :host "host.com"}
+ :command "PRIVMSG"
+ :params  ["#channel" "Hello world"]}
+```
+
+## Exported functions
+
+| Function | Signature | Returns |
+|----------|-----------|---------|
+| `connect` | `(fn [host port &named nick username realname sasl])` | conn struct |
+| `parse-message` | `(fn [line])` | message struct |
+| `format-message` | `(fn [msg])` | string |
+| `parse-tags` | `(fn [raw])` | struct |
+| `parse-source` | `(fn [raw])` | struct |
+| `parse-ctcp` | `(fn [text])` | `{:command :text}` or nil |
+| `test` | `(fn [])` | true |
+
+## Invariants
+
+- `conn:messages` only yields non-PING messages; PINGs are auto-answered
+- `conn:send` formats the trailing parameter automatically (`:` prefix when needed)
+- Registration handles nick collision by appending `_` (up to 3 retries)
+- All I/O yields to the scheduler (async)
+
+## Concurrency patterns
+
+```lisp
+# Simple bot (single fiber)
+(each msg in conn:messages
+  (when (= msg:command "PRIVMSG")
+    (conn:send "PRIVMSG" (get msg:params 0) "reply")))
+
+# Background reader (multi-fiber)
+(def sync ((import "std/sync")))
+(def q (sync:make-queue 256))
+(ev/spawn (fn [] (each msg in conn:messages (q:put msg))))
 ```

--- a/lib/README.md
+++ b/lib/README.md
@@ -13,6 +13,7 @@
 | `gtk4.lisp` | GTK4 declarative UI (widgets, events, CSS, WebKit) | |
 | `gtk4/` | GTK4 sub-modules: bind, widgets, webview | |
 | `sdl.lisp` | SDL3 bindings for games/graphics | |
+| `irc.lisp` | IRCv3 client (CAP, SASL, message tags) | |
 | `zmq.lisp` | ZeroMQ bindings | | |
 
 Each module is a closure. `import` loads it; calling the result

--- a/lib/base64.lisp
+++ b/lib/base64.lisp
@@ -65,7 +65,10 @@
   (defn decode-with [data table]
     (unless (string? data)
       (error {:error :type-error
-              :message (string "base64: expected string, got " (type-of data))}))
+              :reason :wrong-type
+              :expected :string
+              :got (type-of data)
+              :message (string "expected string, got " (type-of data))}))
     (let* [[s     (strip-padding (string/trim data))]
            [slen  (length s)]
            [input (bytes s)]
@@ -74,7 +77,9 @@
                      (let [[v (table (input pos))]]
                        (when (= v -1)
                          (error {:error :base64-error
-                                 :message (string "base64/decode: invalid char at " pos)}))
+                                 :reason :invalid-char
+                                 :position pos
+                                 :message (string "invalid char at " pos)}))
                        v))]]
       (var i 0)
       (while (<= (+ i 3) (dec slen))
@@ -90,7 +95,7 @@
         [3 (let [[a (lookup i)] [b (lookup (inc i))] [c (lookup (+ i 2))]]
              (push acc (bit/or (bit/shl a 2) (bit/shr b 4)))
              (push acc (bit/and (bit/or (bit/shl b 4) (bit/shr c 2)) 255)))]
-        [_ (error {:error :base64-error :message "base64/decode: invalid length"})])
+        [_ (error {:error :base64-error :reason :invalid-length :message "invalid length"})])
       (freeze (bytes ;acc))))
 
   (defn decode [data]     "Base64-decode (standard)."   (decode-with data std-decode))

--- a/lib/cli.lisp
+++ b/lib/cli.lisp
@@ -17,7 +17,11 @@
     "Error if v is non-nil and not a string."
     (when (and v (not (string? v)))
       (error {:error :type-error
-              :message (string ctx ": :" key " must be a string, got " (type-of v))}))
+              :reason :wrong-type
+              :expected :string
+              :got (type-of v)
+              :param (keyword key)
+              :message (string ":" key " must be a string, got " (type-of v))}))
     v)
 
   ## ── Arg spec parsing ─────────────────────────────────────────────
@@ -25,26 +29,34 @@
   (defn parse-arg-spec [spec]
     "Normalize an arg spec struct into internal form."
     (unless (struct? spec)
-      (error {:error :cli-error :message "cli/parse: each arg must be a struct"}))
+      (error {:error :cli-error :reason :invalid-spec :expected :struct :got (type-of spec) :message "each arg must be a struct"}))
     (let [[name (require-string spec:name "name" "cli/parse")]]
       (unless name
-        (error {:error :cli-error :message "cli/parse: each arg must have a :name key"}))
+        (error {:error :cli-error :reason :missing-name :message "each arg must have a :name key"}))
       (let* [[long-name  (require-string spec:long "long" "cli/parse")]
              [short-name (require-string spec:short "short" "cli/parse")]
              [action-kw  (let [[v spec:action]]
                            (if (nil? v) :set
                              (if (keyword? v) v
                                (error {:error :cli-error
-                                       :message (string "cli/parse: :action must be a keyword, got "
+                                       :reason :wrong-type
+                                       :expected :keyword
+                                       :got (type-of v)
+                                       :param :action
+                                       :message (string ":action must be a keyword, got "
                                                         (type-of v))}))))]
              [default-val (require-string spec:default "default" "cli/parse")]
              [required?   spec:required]]
         (when (and short-name (not (= (length short-name) 1)))
           (error {:error :cli-error
-                  :message (string "cli/parse: :short must be a single character, got \"" short-name "\"")}))
+                  :reason :invalid-short
+                  :option short-name
+                  :message (string ":short must be a single character, got \"" short-name "\"")}))
         (unless (contains? |:set :flag :count :append| action-kw)
           (error {:error :cli-error
-                  :message (string "cli/parse: unknown action " action-kw
+                  :reason :unknown-action
+                  :action action-kw
+                  :message (string "unknown action " action-kw
                                    ", expected :set, :flag, :count, or :append")}))
         {:name name :long long-name :short short-name
          :action action-kw :default default-val :required required?})))
@@ -98,21 +110,23 @@
                     [value (slice arg (inc eq) (length arg))]
                     [spec  (find-by-long specs name)]]
                (unless spec
-                 (error {:error :cli-error :message (string "cli/parse: unknown option --" name)}))
+                 (error {:error :cli-error :reason :unknown-option :option (string "--" name) :message (string "unknown option --" name)}))
                (apply-action result spec:name spec:action value)))
             ## --long
             ((string/starts-with? arg "--")
              (let* [[name (slice arg 2 (length arg))]
                     [spec (find-by-long specs name)]]
                (unless spec
-                 (error {:error :cli-error :message (string "cli/parse: unknown option --" name)}))
+                 (error {:error :cli-error :reason :unknown-option :option (string "--" name) :message (string "unknown option --" name)}))
                (match spec:action
                  [:flag  (apply-action result spec:name :flag nil)]
                  [:count (apply-action result spec:name :count nil)]
                  [_      (assign i (inc i))
                          (when (>= i argc)
                            (error {:error :cli-error
-                                   :message (string "cli/parse: --" name " requires a value")}))
+                                   :reason :missing-value
+                                   :option (string "--" name)
+                                   :message (string "--" name " requires a value")}))
                          (apply-action result spec:name spec:action (args i))])))
             ## -x (short) — handles stacked flags like -vvv
             ((and (string/starts-with? arg "-") (> (length arg) 1))
@@ -122,7 +136,7 @@
                  (let* [[ch   (chars ci)]
                         [spec (find-by-short specs ch)]]
                    (unless spec
-                     (error {:error :cli-error :message (string "cli/parse: unknown option -" ch)}))
+                     (error {:error :cli-error :reason :unknown-option :option (string "-" ch) :message (string "unknown option -" ch)}))
                    (match spec:action
                      [:flag  (apply-action result spec:name :flag nil)]
                      [:count (apply-action result spec:name :count nil)]
@@ -135,7 +149,9 @@
                             (assign i (inc i))
                             (when (>= i argc)
                               (error {:error :cli-error
-                                      :message (string "cli/parse: -" ch " requires a value")}))
+                                      :reason :missing-value
+                                      :option (string "-" ch)
+                                      :message (string "-" ch " requires a value")}))
                             (apply-action result spec:name spec:action (args i))))]))
                  (assign ci (inc ci)))))
             ## Positional
@@ -145,14 +161,18 @@
                  (put result (keyword ((pos-specs pi) :name)) arg)
                  (assign pi (inc pi)))
                (error {:error :cli-error
-                       :message (string "cli/parse: unexpected argument \"" arg "\"")})))))
+                       :reason :unexpected-argument
+                       :argument arg
+                       :message (string "unexpected argument \"" arg "\"")})))))
         (assign i (inc i)))
       ## Check required args
       (each s in specs
         (when s:required
           (when (nil? (result (keyword s:name)))
             (error {:error :cli-error
-                    :message (string "cli/parse: missing required argument: " s:name)}))))
+                    :reason :missing-required
+                    :name s:name
+                    :message (string "missing required argument: " s:name)}))))
       result))
 
   ## ── Subcommand support ───────────────────────────────────────────
@@ -167,7 +187,9 @@
         (each s in norm-args
           (when (contains? |"command" "command-args"| s:name)
             (error {:error :cli-error
-                    :message (string "cli/parse: arg name " s:name
+                    :reason :reserved-name
+                    :name s:name
+                    :message (string "arg name " s:name
                                      " conflicts with reserved subcommand key")}))))
       (if (not has-cmds)
         (freeze (parse-argv norm-args argv))
@@ -205,12 +227,18 @@
     "Parse CLI arguments against a command spec. Returns struct of parsed values."
     (unless (struct? spec)
       (error {:error :type-error
-              :message (string "cli/parse: spec must be a struct, got " (type-of spec))}))
+              :reason :wrong-type
+              :expected :struct
+              :got (type-of spec)
+              :message (string "spec must be a struct, got " (type-of spec))}))
     (unless (or (array? argv) (pair? argv) (empty? argv))
       (error {:error :type-error
-              :message (string "cli/parse: argv must be a list or array, got " (type-of argv))}))
+              :reason :wrong-type
+              :expected :list
+              :got (type-of argv)
+              :message (string "argv must be a list or array, got " (type-of argv))}))
     (unless spec:name
-      (error {:error :cli-error :message "cli/parse: spec must have a :name key"}))
+      (error {:error :cli-error :reason :missing-name :message "spec must have a :name key"}))
     ## Skip argv[0] (program name)
     (let [[user-argv (if (> (length argv) 0) (rest argv) ())]]
       (parse-with-commands spec (->list user-argv))))

--- a/lib/contract.lisp
+++ b/lib/contract.lisp
@@ -102,7 +102,9 @@
            desc)))
       (true
        (error {:error :type-error
-               :message "compile-validator: unsupported expression type"})))))
+               :reason :unsupported-type
+               :got (type-of expr)
+               :message "unsupported expression type"})))))
 
 # ============================================================================
 # check — multiple predicate functions (all must pass, short-circuits)
@@ -115,7 +117,7 @@
    Short-circuits on the first falsy result.
    Usage: (check integer? odd?)"
     (when (= (length preds) 0)
-      (error {:error :arity-error :message "check: requires at least one predicate"}))
+      (error {:error :arity-error :reason :too-few-args :minimum 1 :message "requires at least one predicate"}))
     (let* [[descs (map string preds)]
            [desc (string/join descs " & ")]]
       (make-validator
@@ -142,7 +144,7 @@
    Does not short-circuit. Returns nil if all pass, aggregate failure if any fail.
    Usage: (v/and integer? (fn [x] (> x 0)))"
     (when (= (length exprs) 0)
-      (error {:error :arity-error :message "v/and: requires at least one expression"}))
+      (error {:error :arity-error :reason :too-few-args :minimum 1 :message "requires at least one expression"}))
     (let* [[validators (map compile-validator exprs)]
            [desc (string/join (map (fn [v] (get v :describe)) validators) " & ")]]
       (make-validator
@@ -167,7 +169,7 @@
    Short-circuits on the first pass. If all fail, returns aggregate failure.
    Usage: (v/or integer? string?)"
     (when (= (length exprs) 0)
-      (error {:error :arity-error :message "v/or: requires at least one expression"}))
+      (error {:error :arity-error :reason :too-few-args :minimum 1 :message "requires at least one expression"}))
     (let* [[validators (map compile-validator exprs)]
            [desc (string/join (map (fn [v] (get v :describe)) validators) " | ")]]
       (make-validator
@@ -197,7 +199,7 @@
    Uses = for comparison.
    Usage: (v/oneof :a :b :c)"
     (when (= (length values) 0)
-      (error {:error :arity-error :message "v/oneof: requires at least one value"}))
+      (error {:error :arity-error :reason :too-few-args :minimum 1 :message "requires at least one value"}))
     (let* [[parts (map string values)]
            [desc (append "one of: " (string/join parts ", "))]]
       (make-validator

--- a/lib/dns.lisp
+++ b/lib/dns.lisp
@@ -6,9 +6,7 @@
 ## Async/uring-first: all I/O goes through udp/send-to and udp/recv-from,
 ## which dispatch through whatever I/O backend the scheduler uses.
 
-# ============================================================================
-# Constants
-# ============================================================================
+## ── Constants ─────────────────────────────────────────────────────────
 
 (def TYPE-A     1)
 (def TYPE-AAAA  28)
@@ -35,9 +33,7 @@
 (def DEFAULT-TIMEOUT 3000)
 (def DEFAULT-RETRIES 2)
 
-# ============================================================================
-# Byte packing helpers
-# ============================================================================
+## ── Byte packing helpers ──────────────────────────────────────────────
 
 (defn u16->bytes [n]
   "Encode a 16-bit integer as 2 big-endian bytes."
@@ -57,9 +53,7 @@
     (bit/or (bit/shl (get buf (+ offset 2)) 8)
             (get buf (+ offset 3)))))
 
-# ============================================================================
-# Domain name encoding / decoding
-# ============================================================================
+## ── Domain name encoding / decoding ───────────────────────────────────
 
 (defn encode-name [name]
   "Encode a domain name as DNS wire format (length-prefixed labels + null).
@@ -69,7 +63,11 @@
             (let [[label-bytes (bytes label)]]
               (when (> (length label-bytes) 63)
                 (error {:error :dns-error
-                        :message (concat "dns: label too long: " label)}))
+                        :reason :label-too-long
+                        :label label
+                        :length (length label-bytes)
+                        :limit 63
+                        :message (concat "label too long: " label)}))
               (concat acc (bytes (length label-bytes)) label-bytes)))
           (bytes)
           (concat labels [""]))))
@@ -86,7 +84,10 @@
   (forever
     (when (>= safety 128)
       (error {:error :dns-format-error
-              :message "dns: name decode loop exceeded 128 iterations"}))
+              :reason :decode-loop
+              :iterations safety
+              :limit 128
+              :message "name decode loop exceeded 128 iterations"}))
     (assign safety (+ safety 1))
     (let [[b (get buf pos)]]
       (cond
@@ -111,9 +112,7 @@
   {:name (string/join (freeze parts) ".")
    :offset (or return-offset (+ pos 1))})
 
-# ============================================================================
-# Query building
-# ============================================================================
+## ── Query building ────────────────────────────────────────────────────
 
 (defn build-query [id name qtype]
   "Build a DNS query packet.
@@ -131,9 +130,7 @@
                           (u16->bytes CLASS-IN))]]
     (concat header question)))
 
-# ============================================================================
-# Response parsing
-# ============================================================================
+## ── Response parsing ──────────────────────────────────────────────────
 
 (defn parse-header [buf]
   "Parse a DNS response header (first 12 bytes).
@@ -141,7 +138,10 @@
             :qdcount :ancount :nscount :arcount}."
   (when (< (length buf) 12)
     (error {:error :dns-format-error
-            :message "dns: response too short for header"}))
+            :reason :short-header
+            :length (length buf)
+            :minimum 12
+            :message "response too short for header"}))
   (let [[flags (read-u16 buf 2)]]
     {:id      (read-u16 buf 0)
      :qr      (not (= 0 (bit/and flags FLAG-QR)))
@@ -202,25 +202,34 @@
            [rdata-start (+ pos2 10)]
            [rdata-end   (+ rdata-start rdlen)]]
       (let [[record
-              (cond
-                ((= rtype TYPE-A)
-                 (when (not (= rdlen 4))
-                   (error {:error :dns-format-error
-                           :message "dns: A record rdata length is not 4"}))
-                 {:type :a :name name :addr (format-ipv4 buf rdata-start) :ttl ttl})
+              (case rtype
+                TYPE-A
+                (begin
+                  (when (not (= rdlen 4))
+                    (error {:error :dns-format-error
+                            :reason :bad-rdata-length
+                            :rtype :a
+                            :expected 4
+                            :actual rdlen
+                            :message "A record rdata length is not 4"}))
+                  {:type :a :name name :addr (format-ipv4 buf rdata-start) :ttl ttl})
 
-                ((= rtype TYPE-AAAA)
-                 (when (not (= rdlen 16))
-                   (error {:error :dns-format-error
-                           :message "dns: AAAA record rdata length is not 16"}))
-                 {:type :aaaa :name name :addr (format-ipv6 buf rdata-start) :ttl ttl})
+                TYPE-AAAA
+                (begin
+                  (when (not (= rdlen 16))
+                    (error {:error :dns-format-error
+                            :reason :bad-rdata-length
+                            :rtype :aaaa
+                            :expected 16
+                            :actual rdlen
+                            :message "AAAA record rdata length is not 16"}))
+                  {:type :aaaa :name name :addr (format-ipv6 buf rdata-start) :ttl ttl})
 
-                ((= rtype TYPE-CNAME)
-                 (let [[cname-result (decode-name buf rdata-start)]]
-                   {:type :cname :name name :target cname-result:name :ttl ttl}))
+                TYPE-CNAME
+                (let [[cname-result (decode-name buf rdata-start)]]
+                  {:type :cname :name name :target cname-result:name :ttl ttl})
 
-                # Unknown record type — skip
-                (true nil))]]
+                nil)]]
         (when record (push records record)))
       (assign pos rdata-end))
     (assign i (+ i 1)))
@@ -239,9 +248,7 @@
      :authority authority:records
      :additional additional:records}))
 
-# ============================================================================
-# resolv.conf parsing
-# ============================================================================
+## ── resolv.conf parsing ───────────────────────────────────────────────
 
 (defn parse-resolv-conf [text]
   "Parse /etc/resolv.conf and return a list of nameserver IP strings."
@@ -267,9 +274,7 @@
           servers))
       ["127.0.0.1"])))
 
-# ============================================================================
-# Transaction ID generation
-# ============================================================================
+## ── Transaction ID generation ─────────────────────────────────────────
 
 (var next-txid 1)
 
@@ -279,9 +284,7 @@
     (assign next-txid (bit/and (+ id 1) 0xffff))
     id))
 
-# ============================================================================
-# DNS query execution
-# ============================================================================
+## ── DNS query execution ───────────────────────────────────────────────
 
 (defn do-query [server name qtype timeout]
   "Send a single DNS query and return the parsed response.
@@ -294,24 +297,35 @@
       (let* [[[ok? result] (protect (udp/recv-from sock 512 :timeout timeout))]]
         (unless ok?
           (error {:error :dns-timeout
-                  :message (concat "dns: timeout querying " server " for " name)}))
+                  :reason :query-timeout
+                  :server server
+                  :name name
+                  :message (concat "timeout querying " server " for " name)}))
         (let* [[resp-buf result:data]
                [resp (parse-response resp-buf)]]
           # Verify transaction ID
           (unless (= resp:header:id txid)
             (error {:error :dns-error
-                    :message "dns: transaction ID mismatch"}))
+                    :reason :txid-mismatch
+                    :expected txid
+                    :actual resp:header:id
+                    :message "transaction ID mismatch"}))
           # Check truncation
           (when resp:header:tc
             (error {:error :dns-error
-                    :message "dns: response truncated (TC bit set)"}))
+                    :reason :truncated
+                    :message "response truncated (TC bit set)"}))
           # Check RCODE
           (unless (= resp:header:rcode RCODE-OK)
             (let [[rcode-name (or (get rcode-names resp:header:rcode)
                                   (string resp:header:rcode))]]
               (error {:error :dns-error
+                      :reason :server-error
                       :rcode resp:header:rcode
-                      :message (concat "dns: server returned " rcode-name
+                      :rcode-name rcode-name
+                      :name name
+                      :server server
+                      :message (concat "server returned " rcode-name
                                        " for " name)})))
           resp)))))
 
@@ -329,11 +343,12 @@
   # All retries exhausted
   (when last-err (error last-err))
   (error {:error :dns-timeout
-          :message (concat "dns: all retries exhausted for " name)}))
+          :reason :retries-exhausted
+          :name name
+          :retries retries
+          :message (concat "retries exhausted for " name)}))
 
-# ============================================================================
-# High-level resolver
-# ============================================================================
+## ── High-level resolver ───────────────────────────────────────────────
 
 (defn resolve-type [name qtype server timeout retries]
   "Resolve a name to records of a specific type, following CNAMEs."
@@ -343,13 +358,18 @@
   (forever
     (when (>= depth MAX-CNAME-DEPTH)
       (error {:error :dns-error
-              :message (concat "dns: CNAME chain too deep for " name)}))
+              :reason :cname-too-deep
+              :name name
+              :depth depth
+              :limit MAX-CNAME-DEPTH
+              :message (concat "CNAME chain too deep for " name)}))
     (let* [[resp (query-with-retries server current-name qtype timeout retries)]
            [answers resp:answers]
            # Collect direct answers of the requested type
-           [direct (filter (fn [r] (= r:type (cond ((= qtype TYPE-A) :a)
-                                                    ((= qtype TYPE-AAAA) :aaaa)
-                                                    (true nil))))
+           [direct (filter (fn [r] (= r:type (case qtype
+                                                    TYPE-A :a
+                                                    TYPE-AAAA :aaaa
+                                                    nil)))
                            answers)]
            # Check for CNAME redirects
            [cnames (filter (fn [r] (= r:type :cname)) answers)]]
@@ -396,9 +416,7 @@
          [ret (or retries DEFAULT-RETRIES)]]
     (query-with-retries srv name qtype tmo ret)))
 
-# ============================================================================
-# Internal tests (pure, no network)
-# ============================================================================
+## ── Internal tests (pure, no network) ─────────────────────────────────
 
 (defn run-internal-tests []
   "Sanity checks on wire-format helpers. Called via (dns:test)."
@@ -600,9 +618,7 @@
 
   true)
 
-# ============================================================================
-# Exports
-# ============================================================================
+## ── Exports ───────────────────────────────────────────────────────────
 
 (fn []
   {:resolve        resolve

--- a/lib/http.lisp
+++ b/lib/http.lisp
@@ -3,16 +3,14 @@
 ## Loaded via: (def http ((import-file "./lib/http.lisp")))
 ## Usage:      (http:get "http://example.com/")
 
-# ============================================================================
-# URL parsing
-# ============================================================================
+## ── URL parsing ──────────────────────────────────────────────────────
 
 (defn parse-url [url]
   "Parse an HTTP URL string into {:scheme :host :port :path :query}.
    Only 'http' scheme is supported. Default port is 80. Default path is '/'.
    Query is nil if absent, otherwise the string after '?' without the '?'."
-  (unless (string-starts-with? url "http://")
-    (error {:error :http-error :message "unsupported scheme" :url url}))
+  (unless (string/starts-with? url "http://")
+    (error {:error :http-error :reason :unsupported-scheme :url url :message "unsupported scheme"}))
   (let* [[tail (slice url (length "http://"))]
          [slash (string/find tail "/")]
          [auth (if (nil? slash) tail (slice tail 0 slash))]
@@ -21,17 +19,15 @@
          [host (if (nil? colon) auth (slice auth 0 colon))]
          [port (if (nil? colon) 80 (integer (slice auth (inc colon))))]]
     (when (empty? tail)
-      (error {:error :http-error :message "missing host" :url url}))
+      (error {:error :http-error :reason :missing-host :url url :message "missing host"}))
     (when (empty? host)
-      (error {:error :http-error :message "empty host" :url url}))
+      (error {:error :http-error :reason :empty-host :url url :message "empty host"}))
     (let* [[q-pos (string/find path+query "?")]
            [path (if (nil? q-pos) path+query (slice path+query 0 q-pos))]
            [query (if (nil? q-pos) nil (slice path+query (inc q-pos)))]]
       {:scheme "http" :host host :port port :path path :query query})))
 
-# ============================================================================
-# Header parsing and serialization
-# ============================================================================
+## ── Header parsing and serialization ─────────────────────────────────
 
 (defn header->kw [name]
   "Convert HTTP header name string to lowercase keyword.
@@ -63,8 +59,8 @@
         (break (freeze headers)))
       (let [[colon-pos (string/find line ":")]]
         (when (nil? colon-pos)
-          (error {:error :http-error :message "malformed header"
-                  :line line}))
+          (error {:error :http-error :reason :malformed-header :line line
+                  :message "malformed header"}))
         (let* [[name (slice line 0 colon-pos)]
                [value (string/trim (slice line (inc colon-pos)))]]
           (put headers (header->kw name) value))))))
@@ -75,9 +71,7 @@
   (each [key value] in (pairs headers)
     (port/write port (string/format "{}: {}\r\n" (kw->header key) value))))
 
-# ============================================================================
-# Request and response wire format
-# ============================================================================
+## ── Request and response wire format ─────────────────────────────────
 
 (defn read-request-line [port]
   "Read and parse HTTP request line: 'GET /path HTTP/1.1'.
@@ -87,12 +81,12 @@
       nil
       (let [[parts (string/split line " ")]]
         (when (< (length parts) 3)
-          (error {:error :http-error :message "malformed request line"
-                  :line line}))
+          (error {:error :http-error :reason :malformed-request-line :line line
+                  :message "malformed request line"}))
         (let [[[method path version] parts]]
           (unless (string/starts-with? version "HTTP/")
-            (error {:error :http-error :message "invalid HTTP version"
-                    :version version}))
+            (error {:error :http-error :reason :invalid-http-version :version version
+                    :message "invalid HTTP version"}))
           {:method method :path path :version version})))))
 
 (defn write-request-line [port method path]
@@ -106,8 +100,8 @@
   (let* [[line (port/read-line port)]
          [parts (string/split line " ")]]
     (when (< (length parts) 2)
-      (error {:error :http-error :message "malformed status line"
-              :line line}))
+      (error {:error :http-error :reason :malformed-status-line :line line
+              :message "malformed status line"}))
     (let* [[[version status-str & reason-parts] parts]
            [status (integer status-str)]
            [reason (if (empty? reason-parts) "" (string/join reason-parts " "))]]
@@ -130,15 +124,13 @@
         (while (pos? n)
           (let [[chunk (port/read port n)]]
             (when (nil? chunk)
-              (error {:error :http-error :message "unexpected EOF reading HTTP body"}))
+              (error {:error :http-error :reason :unexpected-eof :phase :body :message "unexpected EOF reading body"}))
             (let [[b (if (bytes? chunk) chunk (bytes chunk))]]
               (append buf b)
               (assign n (- n (length b))))))
         (string (freeze buf))))))
 
-# ============================================================================
-# Reason phrases
-# ============================================================================
+## ── Reason phrases ───────────────────────────────────────────────────
 
 (def reason-phrases
   {200 "OK"
@@ -158,9 +150,7 @@
    502 "Bad Gateway"
    503 "Service Unavailable"})
 
-# ============================================================================
-# Response construction
-# ============================================================================
+## ── Response construction ────────────────────────────────────────────
 
 (defn http-respond [status body &named headers]
   "Build a response struct with Content-Type and Content-Length set.
@@ -172,9 +162,7 @@
                    (merge base-headers (freeze headers)))]]
     {:status status :headers merged :body body}))
 
-# ============================================================================
-# Client API
-# ============================================================================
+## ── Client API ───────────────────────────────────────────────────────
 
 (defn wants-close? [headers]
   "True if headers indicate the connection should close."
@@ -242,9 +230,7 @@
   "Close a keep-alive session."
   (port/close session:conn))
 
-# ============================================================================
-# Server API
-# ============================================================================
+## ── Server API ───────────────────────────────────────────────────────
 
 (defn read-request [conn]
   "Read a complete HTTP request from a connection port.
@@ -308,9 +294,7 @@
       (unless ok? (break))
       (ev/spawn (fn [] (connection-loop conn handler on-error))))))
 
-# ============================================================================
-# Exports
-# ============================================================================
+## ── Exports ─────────────────────────────────────────────────────────
 
 (defn run-internal-tests []
   "Sanity checks on internal wire-format helpers. Called via (http:test)."
@@ -365,9 +349,9 @@
     (port/flush p)
     (port/close p))
   (let [[content (slurp "/tmp/elle-http-test-write-headers")]]
-    (assert (string-contains? content "Content-Type: text/plain")
+    (assert (string/contains? content "Content-Type: text/plain")
       "write-headers content-type")
-    (assert (string-contains? content "Content-Length: 11")
+    (assert (string/contains? content "Content-Length: 11")
       "write-headers content-length"))
 
   # read-request-line

--- a/lib/irc.lisp
+++ b/lib/irc.lisp
@@ -1,0 +1,630 @@
+## lib/irc.lisp -- IRCv3 client for Elle
+##
+## Coroutine-based IRC client with IRCv3 capability negotiation and SASL.
+## The connection struct carries a read stream (coroutine yielding parsed
+## messages with auto-PONG) and a send function.
+##
+## Usage:
+##   (def tls ((import "std/tls") (import "plugin/tls")))
+##   (def irc ((import "std/irc") :tls tls))
+##   (def conn (irc:connect "irc.libera.chat" 6697 :nick "ellebot"))
+##   (conn:send "JOIN" "#test")
+##   (each msg in conn:messages
+##     (when (= msg:command "PRIVMSG")
+##       (let [[[target text] msg:params]]
+##         (println msg:source:nick ": " text)
+##         (conn:send "PRIVMSG" target "I heard you!"))))
+##   (conn:close)
+##
+## Connection struct:
+##   {:messages <coroutine>  -- yields parsed messages (auto-PONG)
+##    :send     <function>   -- (conn:send "COMMAND" "param1" ...)
+##    :close    <function>   -- sends QUIT, closes transport
+##    :nick     "nick"       -- resolved nick after registration
+##    :caps     |...|        -- negotiated IRCv3 capabilities
+##    :server   "hostname"   -- server name from RPL_MYINFO
+##    :isupport {...}}       -- parsed ISUPPORT (005) parameters
+##
+## Message struct:
+##   {:tags    {:time "..." :msgid "..."}  -- or nil
+##    :source  {:nick "n" :user "u" :host "h"}  -- or {:server "name"} or nil
+##    :command "PRIVMSG"                   -- always uppercase
+##    :params  ["#channel" "Hello world"]} -- array of strings
+##
+## Spawned-reader/queue pattern (for background PING handling):
+##   (def sync ((import "std/sync")))
+##   (def q (sync:make-queue 256))
+##   (ev/spawn (fn [] (each msg in conn:messages (q:put msg))))
+
+(fn [&named tls]
+
+  (def b64 ((import "std/base64")))
+
+  ## ── Constants ─────────────────────────────────────────────────────
+
+  (def DEFAULT-PORT-PLAIN 6667)
+  (def DEFAULT-PORT-TLS   6697)
+  (def SOH (string (bytes 1)))
+
+  (def DESIRED-CAPS
+    ["multi-prefix" "server-time" "echo-message" "account-notify"
+     "away-notify" "extended-join" "chghost" "userhost-in-names"
+     "message-tags" "batch" "labeled-response"])
+
+  ## ── Tag escaping ──────────────────────────────────────────────────
+
+  (defn escape-tag-value [s]
+    "Escape an IRCv3 tag value per the message-tags spec.
+     \\ -> \\\\ | ; -> \\: | space -> \\s | CR -> \\r | LF -> \\n"
+    (let* [[s (string/replace s "\\" "\\\\")]
+           [s (string/replace s ";" "\\:")]
+           [s (string/replace s " " "\\s")]
+           [s (string/replace s "\r" "\\r")]
+           [s (string/replace s "\n" "\\n")]]
+      s))
+
+  (defn unescape-tag-value [s]
+    "Unescape an IRCv3 tag value. Character-by-character scan to avoid
+     multi-pass replacement ambiguity."
+    (var result @"")
+    (var i 0)
+    (while (< i (length s))
+      (if (and (= (get s i) "\\") (< (inc i) (length s)))
+        (let [[next (get s (inc i))]]
+          (append result
+            (match next
+              [":" ";"]
+              ["s" " "]
+              ["\\" "\\"]
+              ["r" "\r"]
+              ["n" "\n"]
+              [_ next]))
+          (assign i (+ i 2)))
+        (begin
+          (append result (get s i))
+          (assign i (inc i)))))
+    (freeze result))
+
+  ## ── Message parsing ───────────────────────────────────────────────
+
+  (defn parse-tags [raw]
+    "Parse IRCv3 tags string (without leading @) into a struct.
+     'time=2024-01-01;msgid=abc;account' -> {:time '...' :msgid 'abc' :account true}"
+    (def result @{})
+    (each part in (string/split raw ";")
+      (when (> (length part) 0)
+        (let [[eq (string/find part "=")]]
+          (if eq
+            (put result (keyword (slice part 0 eq))
+                        (unescape-tag-value (slice part (inc eq))))
+            (put result (keyword part) true)))))
+    (freeze result))
+
+  (defn parse-source [raw]
+    "Parse nick!user@host or servername into a struct.
+     'nick!user@host.com' -> {:nick 'nick' :user 'user' :host 'host.com'}
+     'irc.server.net'     -> {:server 'irc.server.net'}
+     'justnick'           -> {:nick 'justnick' :user nil :host nil}"
+    (let [[bang (string/find raw "!")]]
+      (if bang
+        (let* [[nick (slice raw 0 bang)]
+               [rest (slice raw (inc bang))]
+               [at (string/find rest "@")]]
+          (if at
+            {:nick nick :user (slice rest 0 at) :host (slice rest (inc at))}
+            {:nick nick :user rest :host nil}))
+        (if (string/contains? raw ".")
+          {:server raw}
+          {:nick raw :user nil :host nil}))))
+
+  (defn parse-params [s]
+    "Parse IRC parameter string into an array of strings.
+     Middle params are space-delimited. A param starting with : is trailing
+     (contains the rest of the line as a single param)."
+    (def params @[])
+    (var rest s)
+    (forever
+      (while (and (> (length rest) 0) (= (get rest 0) " "))
+        (assign rest (slice rest 1)))
+      (when (= (length rest) 0) (break))
+      (if (= (get rest 0) ":")
+        (begin (push params (slice rest 1)) (break))
+        (let [[sp (string/find rest " ")]]
+          (if sp
+            (begin (push params (slice rest 0 sp))
+                   (assign rest (slice rest (inc sp))))
+            (begin (push params rest) (break))))))
+    (freeze params))
+
+  (defn parse-message [line]
+    "Parse an IRC protocol line into {:tags :source :command :params}.
+     Tags and source are nil if absent. Command is uppercased."
+    (var rest line)
+    (var tags nil)
+    (var source nil)
+
+    # Tags: @key=val;key2 ...
+    (when (and (> (length rest) 0) (= (get rest 0) "@"))
+      (let [[sp (string/find rest " ")]]
+        (when sp
+          (assign tags (parse-tags (slice rest 1 sp)))
+          (assign rest (slice rest (inc sp))))))
+
+    # Skip spaces
+    (while (and (> (length rest) 0) (= (get rest 0) " "))
+      (assign rest (slice rest 1)))
+
+    # Source: :nick!user@host ...
+    (when (and (> (length rest) 0) (= (get rest 0) ":"))
+      (let [[sp (string/find rest " ")]]
+        (when sp
+          (assign source (parse-source (slice rest 1 sp)))
+          (assign rest (slice rest (inc sp))))))
+
+    # Skip spaces
+    (while (and (> (length rest) 0) (= (get rest 0) " "))
+      (assign rest (slice rest 1)))
+
+    # Command and params
+    (let* [[sp (string/find rest " ")]
+           [command (if sp (slice rest 0 sp) rest)]
+           [param-str (if sp (slice rest (inc sp)) "")]]
+      {:tags tags
+       :source source
+       :command (string/upcase command)
+       :params (if (= (length param-str) 0) [] (parse-params param-str))}))
+
+  ## ── Message formatting ────────────────────────────────────────────
+
+  (defn build-line [command params]
+    "Build an IRC protocol line from command and params array.
+     Last param is auto-prefixed with : if it contains spaces, starts
+     with :, or is empty."
+    (if (= (length params) 0)
+      command
+      (let* [[n (length params)]
+             [last-param (get params (dec n))]
+             [needs-colon (or (string/contains? last-param " ")
+                             (string/starts-with? last-param ":")
+                             (= last-param ""))]]
+        (var parts @[command])
+        (each i in (range (dec n))
+          (push parts (get params i)))
+        (push parts (if needs-colon (string ":" last-param) last-param))
+        (string/join (freeze parts) " "))))
+
+  (defn format-tags [tags]
+    "Format a tags struct to key1=val1;key2 string (without leading @)."
+    (def parts @[])
+    (each [k v] in (pairs tags)
+      (push parts (if (= v true)
+                    (string k)
+                    (string k "=" (escape-tag-value (string v))))))
+    (string/join (freeze parts) ";"))
+
+  (defn format-source [source]
+    "Format a source struct to nick!user@host or servername string."
+    (if (get source :server)
+      source:server
+      (if (and source:user source:host)
+        (string source:nick "!" source:user "@" source:host)
+        (if source:user
+          (string source:nick "!" source:user)
+          source:nick))))
+
+  (defn format-message [msg]
+    "Format a parsed message struct back to an IRC protocol line.
+     Inverse of parse-message (modulo command case and optional : on trailing)."
+    (var parts @[])
+    (when msg:tags   (push parts (string "@" (format-tags msg:tags))))
+    (when msg:source (push parts (string ":" (format-source msg:source))))
+    (push parts msg:command)
+    (when (> (length msg:params) 0)
+      (let* [[n (length msg:params)]
+             [last-param (get msg:params (dec n))]
+             [needs-colon (or (string/contains? last-param " ")
+                             (string/starts-with? last-param ":")
+                             (= last-param ""))]]
+        (each i in (range (dec n))
+          (push parts (get msg:params i)))
+        (push parts (if needs-colon (string ":" last-param) last-param))))
+    (string/join (freeze parts) " "))
+
+  ## ── CTCP ──────────────────────────────────────────────────────────
+
+  (defn parse-ctcp [text]
+    "Parse CTCP from message text. Returns {:command :text} or nil.
+     CTCP messages are delimited by SOH (0x01) characters."
+    (when (and (string/starts-with? text SOH)
+               (string/ends-with? text SOH)
+               (> (length text) 1))
+      (let* [[inner (slice text 1 (dec (length text)))]
+             [sp (string/find inner " ")]]
+        (if sp
+          {:command (slice inner 0 sp) :text (slice inner (inc sp))}
+          {:command inner :text nil}))))
+
+  ## ── SASL ──────────────────────────────────────────────────────────
+
+  (defn sasl-plain-payload [authcid password]
+    "Build SASL PLAIN payload: base64(NUL + authcid + NUL + password)."
+    (def buf (@bytes))
+    (append buf (bytes 0))
+    (append buf (bytes authcid))
+    (append buf (bytes 0))
+    (append buf (bytes password))
+    (b64:encode (freeze buf)))
+
+  ## ── ISUPPORT ──────────────────────────────────────────────────────
+
+  (defn parse-isupport [tokens]
+    "Parse 005 ISUPPORT tokens into a struct.
+     'CHANTYPES=#&' -> {:chantypes '#&'}. Tokens without = are ignored."
+    (def result @{})
+    (each token in tokens
+      (let [[eq (string/find token "=")]]
+        (when eq
+          (put result
+            (keyword (string/downcase (slice token 0 eq)))
+            (slice token (inc eq))))))
+    (freeze result))
+
+  ## ── Transport ─────────────────────────────────────────────────────
+
+  (defn strip-crlf [s]
+    "Strip trailing CRLF, LF, or CR from a line.
+     CRLF is a single grapheme in Elle, so all cases strip one grapheme."
+    (if (or (string/ends-with? s "\r\n")
+            (string/ends-with? s "\n")
+            (string/ends-with? s "\r"))
+      (slice s 0 (dec (length s)))
+      s))
+
+  (defn make-transport [host port-num]
+    "Create a transport struct {:read-line :write :close} for host:port.
+     Uses TLS if the tls module was provided to the constructor."
+    (if tls
+      (let [[conn (tls:connect host port-num)]]
+        {:read-line (fn [] (let [[line (tls:read-line conn)]]
+                             (when line (strip-crlf line))))
+         :write     (fn [data] (tls:write conn (string data "\r\n")))
+         :close     (fn [] (tls:close conn))})
+      (let* [[ip (first (sys/resolve host))]
+             [port (tcp/connect ip port-num)]]
+        {:read-line (fn [] (port/read-line port))
+         :write     (fn [data] (port/write port (string data "\r\n"))
+                               (port/flush port))
+         :close     (fn [] (port/close port))})))
+
+  ## ── Registration ──────────────────────────────────────────────────
+
+  (defn register [transport nick username realname &named sasl]
+    "Perform IRC connection registration with IRCv3 CAP negotiation.
+     sasl: [authcid password] or nil. Returns registration result struct."
+    (defn send [line] ((get transport :write) line))
+    (defn recv []
+      (let [[line ((get transport :read-line))]]
+        (when line (parse-message line))))
+
+    (send (build-line "CAP" ["LS" "302"]))
+    (send (build-line "NICK" [nick]))
+    (send (build-line "USER" [username "0" "*" realname]))
+
+    (var server-caps @[])
+    (var negotiated-caps ||)
+    (var current-nick nick)
+    (var nick-retries 3)
+    (var server-name nil)
+    (var isupport-map @{})
+    (var sasl-in-progress false)
+
+    (defn handle-cap-ls [msg]
+      (let* [[has-more (and (>= (length msg:params) 4)
+                            (= (get msg:params 2) "*"))]
+             [cap-str (if has-more (get msg:params 3) (get msg:params 2))]]
+        (each cap in (string/split cap-str " ")
+          (when (> (length cap) 0)
+            (let [[eq (string/find cap "=")]]
+              (push server-caps (if eq (slice cap 0 eq) cap)))))
+        (unless has-more
+          (let* [[offered (apply set (freeze server-caps))]
+                 [desired (if sasl ["sasl" ;DESIRED-CAPS] DESIRED-CAPS)]
+                 [to-req @[]]]
+            (each cap in desired
+              (when (contains? offered cap) (push to-req cap)))
+            (if (> (length to-req) 0)
+              (send (build-line "CAP"
+                      ["REQ" (string/join (freeze to-req) " ")]))
+              (send (build-line "CAP" ["END"])))))))
+
+    (defn handle-cap-ack [msg]
+      (let [[acked (string/split
+                     (get msg:params (dec (length msg:params))) " ")]]
+        (assign negotiated-caps
+          (apply set (filter (fn [s] (> (length s) 0)) acked))))
+      (if (and sasl (contains? negotiated-caps "sasl"))
+        (begin (send "AUTHENTICATE PLAIN")
+               (assign sasl-in-progress true))
+        (send (build-line "CAP" ["END"]))))
+
+    (defn handle-cap [msg]
+      (when (>= (length msg:params) 3)
+        (match (get msg:params 1)
+          ["LS"  (handle-cap-ls msg)]
+          ["ACK" (handle-cap-ack msg)]
+          ["NAK" (send (build-line "CAP" ["END"]))]
+          [_ nil])))
+
+    (defn handle-auth [msg]
+      (when (and sasl-in-progress (= (get msg:params 0) "+"))
+        (let [[[authcid password] sasl]]
+          (send (build-line "AUTHENTICATE"
+                  [(sasl-plain-payload authcid password)])))))
+
+    (defn handle-nick-collision []
+      (when (zero? nick-retries)
+        (error {:error :irc-error :reason :nick-collision :nick current-nick :message "nick collision: retries exhausted"}))
+      (assign current-nick (string current-nick "_"))
+      (assign nick-retries (dec nick-retries))
+      (send (build-line "NICK" [current-nick])))
+
+    (defn handle-isupport [msg]
+      (when (> (length msg:params) 2)
+        (let [[tokens (slice msg:params 1 (dec (length msg:params)))]]
+          (each [k v] in (pairs (parse-isupport [;tokens]))
+            (put isupport-map k v)))))
+
+    (forever
+      (let [[msg (recv)]]
+        (when (nil? msg)
+          (error {:error :irc-error :reason :connection-closed :phase :registration :message "connection closed during registration"}))
+        (match msg:command
+          ["CAP"          (handle-cap msg)]
+          ["AUTHENTICATE" (handle-auth msg)]
+          ["903"          (assign sasl-in-progress false)
+                          (send (build-line "CAP" ["END"]))]
+          ["904"          (error {:error :irc-error :reason :sasl-failed
+                                  :message "SASL authentication failed"})]
+          ["433"          (handle-nick-collision)]
+          ["004"          (when (>= (length msg:params) 2)
+                            (assign server-name (get msg:params 1)))]
+          ["005"          (handle-isupport msg)]
+          ["PING"         (send (build-line "PONG"
+                                  [(or (get msg:params 0) "")]))]
+          ["001"          (break {:nick current-nick
+                                  :caps negotiated-caps
+                                  :server (or server-name "unknown")
+                                  :isupport (freeze isupport-map)})]
+          [_ nil]))))
+
+  ## ── Connect ───────────────────────────────────────────────────────
+
+  (defn irc/connect [host port &named nick username realname sasl]
+    "Connect to an IRC server and complete registration.
+     Returns a connection struct with :messages, :send, :close, :nick,
+     :caps, :server, :isupport.
+
+     host:     server hostname
+     port:     server port (6697 for TLS, 6667 for plain)
+     :nick     nickname (required)
+     :username ident username (default: nick)
+     :realname real name (default: nick)
+     :sasl     [authcid password] for SASL PLAIN auth"
+    (when (nil? nick)
+      (error {:error :irc-error :reason :missing-param :param :nick :message "irc:connect requires :nick"}))
+    (default username nick)
+    (default realname nick)
+
+    (let [[transport (make-transport host port)]]
+      (let [[[ok? result] (protect
+                            (register transport nick username realname
+                                      :sasl sasl))]]
+        (unless ok?
+          (protect ((get transport :close)))
+          (error result))
+
+        (let* [[write-fn (get transport :write)]
+               [read-fn  (get transport :read-line)]
+               [close-fn (get transport :close)]
+               [messages
+                (coro/new (fn []
+                  (forever
+                    (let [[line (read-fn)]]
+                      (when (nil? line) (break))
+                      (let [[msg (parse-message line)]]
+                        (if (= msg:command "PING")
+                          (write-fn (build-line "PONG"
+                                      [(or (get msg:params 0) "")]))
+                          (yield msg)))))))]]
+
+          {:messages messages
+           :send     (fn [command & params]
+                       (write-fn (build-line command [;params])))
+           :close    (fn [& args]
+                       (let [[message (or (get args 0) "Leaving")]]
+                         (protect (write-fn (build-line "QUIT" [message])))
+                         (close-fn)))
+           :nick     result:nick
+           :caps     result:caps
+           :server   result:server
+           :isupport result:isupport}))))
+
+  ## ── Internal tests ────────────────────────────────────────────────
+
+  (defn run-internal-tests []
+    "Pure tests on parsing, formatting, tag escaping, SASL. No network."
+
+    ## ── Tag escaping ──
+
+    (assert (= (escape-tag-value "hello world") "hello\\sworld")
+      "escape: space")
+    (assert (= (escape-tag-value "a;b") "a\\:b")
+      "escape: semicolon")
+    (assert (= (escape-tag-value "a\\b") "a\\\\b")
+      "escape: backslash")
+    (assert (= (escape-tag-value "plain") "plain")
+      "escape: no special chars")
+
+    (assert (= (unescape-tag-value "hello\\sworld") "hello world")
+      "unescape: space")
+    (assert (= (unescape-tag-value "a\\:b") "a;b")
+      "unescape: semicolon")
+    (assert (= (unescape-tag-value "a\\\\b") "a\\b")
+      "unescape: backslash")
+    (assert (= (unescape-tag-value "plain") "plain")
+      "unescape: no escapes")
+
+    # Roundtrip
+    (assert (= (unescape-tag-value (escape-tag-value "a;b c\\d\r\n"))
+               "a;b c\\d\r\n")
+      "tag escape roundtrip")
+
+    ## ── Tag parsing ──
+
+    (let [[tags (parse-tags "time=2024-01-01T00:00:00Z;msgid=abc123")]]
+      (assert (= tags:time "2024-01-01T00:00:00Z") "parse-tags: time")
+      (assert (= tags:msgid "abc123") "parse-tags: msgid"))
+
+    (let [[tags (parse-tags "account")]]
+      (assert (= tags:account true) "parse-tags: valueless"))
+
+    (let [[tags (parse-tags "a=hello\\sworld;b=x\\:y")]]
+      (assert (= tags:a "hello world") "parse-tags: escaped space")
+      (assert (= tags:b "x;y") "parse-tags: escaped semicolon"))
+
+    ## ── Source parsing ──
+
+    (let [[src (parse-source "nick!user@host.com")]]
+      (assert (= src:nick "nick") "parse-source: nick")
+      (assert (= src:user "user") "parse-source: user")
+      (assert (= src:host "host.com") "parse-source: host"))
+
+    (let [[src (parse-source "irc.server.net")]]
+      (assert (= src:server "irc.server.net") "parse-source: server"))
+
+    (let [[src (parse-source "justnick")]]
+      (assert (= src:nick "justnick") "parse-source: nick only")
+      (assert (nil? src:user) "parse-source: nick only no user")
+      (assert (nil? src:host) "parse-source: nick only no host"))
+
+    ## ── Message parsing ──
+
+    (let [[msg (parse-message "PING :token123")]]
+      (assert (= msg:command "PING") "parse PING command")
+      (assert (= (get msg:params 0) "token123") "parse PING token")
+      (assert (nil? msg:source) "parse PING no source")
+      (assert (nil? msg:tags) "parse PING no tags"))
+
+    (let [[msg (parse-message ":nick!user@host PRIVMSG #channel :Hello world")]]
+      (assert (= msg:command "PRIVMSG") "parse PRIVMSG command")
+      (assert (= msg:source:nick "nick") "parse PRIVMSG nick")
+      (assert (= msg:source:user "user") "parse PRIVMSG user")
+      (assert (= msg:source:host "host") "parse PRIVMSG host")
+      (assert (= (get msg:params 0) "#channel") "parse PRIVMSG target")
+      (assert (= (get msg:params 1) "Hello world") "parse PRIVMSG text"))
+
+    (let [[msg (parse-message "@time=2024-01-01T00:00:00Z :nick!u@h PRIVMSG #ch :hi")]]
+      (assert (= msg:tags:time "2024-01-01T00:00:00Z") "parse tagged: time")
+      (assert (= msg:command "PRIVMSG") "parse tagged: command")
+      (assert (= (get msg:params 1) "hi") "parse tagged: text"))
+
+    # Multiple middle params + trailing
+    (let [[msg (parse-message ":server 005 bot CHANTYPES=#& PREFIX=(ov)@+ :are supported")]]
+      (assert (= msg:command "005") "parse 005 command")
+      (assert (= (get msg:params 0) "bot") "parse 005 target")
+      (assert (= (get msg:params 1) "CHANTYPES=#&") "parse 005 chantypes")
+      (assert (= (get msg:params 2) "PREFIX=(ov)@+") "parse 005 prefix")
+      (assert (= (get msg:params 3) "are supported") "parse 005 trailing"))
+
+    # No params
+    (let [[msg (parse-message "QUIT")]]
+      (assert (= msg:command "QUIT") "parse no-param command")
+      (assert (= (length msg:params) 0) "parse no-param empty"))
+
+    # Command only with trailing
+    (let [[msg (parse-message "ERROR :Closing Link")]]
+      (assert (= msg:command "ERROR") "parse ERROR command")
+      (assert (= (get msg:params 0) "Closing Link") "parse ERROR text"))
+
+    ## ── Message formatting ──
+
+    (assert (= (build-line "JOIN" ["#test"]) "JOIN #test")
+      "format JOIN")
+    (assert (= (build-line "PRIVMSG" ["#ch" "Hello world"])
+               "PRIVMSG #ch :Hello world")
+      "format PRIVMSG with trailing")
+    (assert (= (build-line "NICK" ["bot"]) "NICK bot")
+      "format NICK")
+    (assert (= (build-line "QUIT" ["Bye bye"]) "QUIT :Bye bye")
+      "format QUIT with spaces")
+    (assert (= (build-line "PING" ["token"]) "PING token")
+      "format PING")
+
+    # Format/parse structural roundtrip
+    (let* [[original ":nick!user@host PRIVMSG #channel :Hello world"]
+           [parsed (parse-message original)]
+           [formatted (format-message parsed)]
+           [reparsed (parse-message formatted)]]
+      (assert (= reparsed:command parsed:command) "roundtrip: command")
+      (assert (= (get reparsed:params 0) (get parsed:params 0)) "roundtrip: target")
+      (assert (= (get reparsed:params 1) (get parsed:params 1)) "roundtrip: text")
+      (assert (= reparsed:source:nick parsed:source:nick) "roundtrip: nick"))
+
+    ## ── CTCP ──
+
+    (let [[ctcp (parse-ctcp (string SOH "VERSION" SOH))]]
+      (assert (= ctcp:command "VERSION") "ctcp VERSION command")
+      (assert (nil? ctcp:text) "ctcp VERSION no text"))
+
+    (let [[ctcp (parse-ctcp (string SOH "PING 12345" SOH))]]
+      (assert (= ctcp:command "PING") "ctcp PING command")
+      (assert (= ctcp:text "12345") "ctcp PING text"))
+
+    (let [[ctcp (parse-ctcp (string SOH "ACTION waves" SOH))]]
+      (assert (= ctcp:command "ACTION") "ctcp ACTION command")
+      (assert (= ctcp:text "waves") "ctcp ACTION text"))
+
+    (assert (nil? (parse-ctcp "not ctcp")) "ctcp: plain text")
+    (assert (nil? (parse-ctcp "")) "ctcp: empty string")
+
+    ## ── SASL ──
+
+    (let* [[payload (sasl-plain-payload "jilles" "sesame")]
+           [decoded (b64:decode payload)]]
+      (assert (string? payload) "sasl payload is string")
+      (assert (> (length payload) 0) "sasl payload nonempty")
+      (assert (= (get decoded 0) 0) "sasl: leading NUL")
+      (assert (= (string (slice decoded 1 7)) "jilles") "sasl: authcid")
+      (assert (= (get decoded 7) 0) "sasl: middle NUL")
+      (assert (= (string (slice decoded 8)) "sesame") "sasl: password"))
+
+    ## ── ISUPPORT ──
+
+    (let [[params (parse-isupport ["CHANTYPES=#&" "PREFIX=(ov)@+" "NETWORK=Libera"])]]
+      (assert (= params:chantypes "#&") "isupport: CHANTYPES")
+      (assert (= params:prefix "(ov)@+") "isupport: PREFIX")
+      (assert (= params:network "Libera") "isupport: NETWORK"))
+
+    (let [[params (parse-isupport ["CHANTYPES=#" "SAFELIST" "NETWORK=Test"])]]
+      (assert (= params:chantypes "#") "isupport: with value")
+      (assert (nil? (get params :safelist)) "isupport: no-value skipped")
+      (assert (= params:network "Test") "isupport: network"))
+
+    ## ── strip-crlf ──
+
+    (assert (= (strip-crlf "hello\r\n") "hello") "strip-crlf: CRLF")
+    (assert (= (strip-crlf "hello\n") "hello") "strip-crlf: LF")
+    (assert (= (strip-crlf "hello\r") "hello") "strip-crlf: CR")
+    (assert (= (strip-crlf "hello") "hello") "strip-crlf: none")
+
+    true)
+
+  ## ── Exports ───────────────────────────────────────────────────────
+
+  {:connect        irc/connect
+   :parse-message  parse-message
+   :format-message format-message
+   :parse-tags     parse-tags
+   :parse-source   parse-source
+   :parse-ctcp     parse-ctcp
+   :test           run-internal-tests})

--- a/lib/mqtt.lisp
+++ b/lib/mqtt.lisp
@@ -34,7 +34,7 @@
         (when (pred pkt) (break pkt))
         (let [[data (port/read conn:tcp 16384)]]
           (when (nil? data)
-            (error {:error :mqtt-error :message "mqtt: connection closed unexpectedly"}))
+            (error {:error :mqtt-error :reason :connection-closed :message "connection closed unexpectedly"}))
           (plugin:feed conn:mqtt data)))))
 
   (defn packet-type? [type-kw]
@@ -61,7 +61,8 @@
                          (let [[ack (drive-until conn (packet-type? :connack))]]
                            (unless (zero? ack:code)
                              (error {:error :mqtt-error
-                                     :message (concat "mqtt: CONNACK rejected, code="
+                                     :reason :connack-rejected :code ack:code
+                                     :message (concat "CONNACK rejected, code="
                                                       (string ack:code))}))))]]
         (unless ok?
           (port/close tcp-port)

--- a/lib/redis.lisp
+++ b/lib/redis.lisp
@@ -8,9 +8,7 @@
 ## Error model: manager fiber owns the port, reconnects on transient errors.
 ## Protocol: RESP2 over TCP.
 
-# ============================================================================
-# RESP2 encoder
-# ============================================================================
+## ── RESP2 encoder ─────────────────────────────────────────────────────
 
 (defn resp-encode [& args]
   "Encode a Redis command as a RESP2 array of bulk strings.
@@ -22,16 +20,14 @@
       (push buf (string "$" (string/size-of s) "\r\n" s "\r\n"))))
   (freeze buf))
 
-# ============================================================================
-# RESP2 decoder
-# ============================================================================
+## ── RESP2 decoder ─────────────────────────────────────────────────────
 
 (defn resp-read [port]
   "Read a single RESP2 reply from port. Signals on error replies.
    Returns Elle values: string, integer, array, or nil."
   (let [[line (port/read-line port)]]
     (when (nil? line)
-      (error {:error :redis-error :message "unexpected EOF from Redis"}))
+      (error {:error :redis-error :reason :unexpected-eof :message "unexpected EOF"}))
     (let [[prefix (get line 0)]
           [body   (slice line 1)]]
       (case prefix
@@ -39,7 +35,7 @@
         "+" body
 
         # Error
-        "-" (error {:error :redis-error :message body})
+        "-" (error {:error :redis-error :reason :server-error :body body :message body})
 
         # Integer
         ":" (integer body)
@@ -51,7 +47,7 @@
                 (let [[data (port/read port (+ len 2))]]
                   # data includes trailing \r\n; slice bytes first (byte-indexed), then convert
                   (when (nil? data)
-                    (error {:error :redis-error :message "unexpected EOF reading bulk string"}))
+                    (error {:error :redis-error :reason :unexpected-eof :phase :bulk-string :message "unexpected EOF reading bulk string"}))
                   (string (slice data 0 len)))))
 
         # Array
@@ -67,6 +63,7 @@
                   (freeze result))))
 
         (error {:error :redis-error
+                :reason :unexpected-prefix :prefix prefix
                 :message (string "unexpected RESP prefix: " prefix)})))))
 
 (defn resp-read-raw [port]
@@ -75,9 +72,7 @@
   (let [[[ok? val] (protect (resp-read port))]]
     (if ok? val val)))
 
-# ============================================================================
-# Command helpers
-# ============================================================================
+## ── Command helpers ───────────────────────────────────────────────────
 
 (defn resp-ok? [val]
   "Convert 'OK' string replies to true."
@@ -87,9 +82,7 @@
   "Convert integer 0/1 replies to boolean."
   (= val 1))
 
-# ============================================================================
-# Parameter for ambient port access
-# ============================================================================
+## ── Parameter for ambient port access ─────────────────────────────────
 
 (def *redis-port* (parameter nil))
 
@@ -97,14 +90,12 @@
   "Send a command on the current Redis port and read the reply."
   (let [[port (*redis-port*)]]
     (when (nil? port)
-      (error {:error :redis-error :message "no active Redis connection"}))
+      (error {:error :redis-error :reason :no-connection :message "no active Redis connection"}))
     (port/write port (apply resp-encode args))
     (port/flush port)
     (resp-read port)))
 
-# ============================================================================
-# Connection
-# ============================================================================
+## ── Connection ────────────────────────────────────────────────────────
 
 (defn redis-connect [host port]
   "Connect to Redis via TCP. Returns the raw TCP port."
@@ -119,9 +110,7 @@
    (redis:auth \"password\") or (redis:auth \"user\" \"password\")."
   (resp-ok? (apply redis-cmd (cons "AUTH" args))))
 
-# ============================================================================
-# Manager fiber
-# ============================================================================
+## ── Manager fiber ─────────────────────────────────────────────────────
 
 (defn default-terminal? [err]
   "Default predicate for terminal errors. Auth failures and protocol
@@ -167,9 +156,7 @@
     {:run        run-with-manager
      :port-param param}))
 
-# ============================================================================
-# Client — simplified connection for direct use
-# ============================================================================
+## ── Client — simplified connection for direct use ─────────────────────
 
 (defn redis-with [host port thunk]
   "Open a Redis connection, run thunk with *redis-port* bound, close on exit."
@@ -178,9 +165,7 @@
       (parameterize ((*redis-port* conn))
         (thunk)))))
 
-# ============================================================================
-# Commands — String
-# ============================================================================
+## ── Commands — String ─────────────────────────────────────────────────
 
 (defn redis-get [key]
   "GET key — returns string or nil."
@@ -235,9 +220,7 @@
   "SETNX key value — returns true if set."
   (resp-bool (redis-cmd "SETNX" key value)))
 
-# ============================================================================
-# Commands — Keys
-# ============================================================================
+## ── Commands — Keys ───────────────────────────────────────────────────
 
 (defn redis-del [& keys]
   "DEL key [key ...] — returns count of deleted keys."
@@ -287,9 +270,7 @@
   "PEXPIREAT key unix-time-ms — set expiration as absolute unix timestamp in ms."
   (resp-bool (redis-cmd "PEXPIREAT" key (string timestamp-ms))))
 
-# ============================================================================
-# Commands — Scan
-# ============================================================================
+## ── Commands — Scan ───────────────────────────────────────────────────
 
 (defn redis-scan [cursor &named match count]
   "SCAN cursor [MATCH pattern] [COUNT count] — incrementally iterate keys.
@@ -343,9 +324,7 @@
         (push acc item))))
   (freeze acc))
 
-# ============================================================================
-# Commands — Hash
-# ============================================================================
+## ── Commands — Hash ───────────────────────────────────────────────────
 
 (defn redis-hset [key field value]
   "HSET key field value — returns 1 if new field, 0 if updated."
@@ -397,9 +376,7 @@
   "HINCRBY key field increment — returns new integer value."
   (redis-cmd "HINCRBY" key field (string n)))
 
-# ============================================================================
-# Commands — List
-# ============================================================================
+## ── Commands — List ───────────────────────────────────────────────────
 
 (defn redis-lpush [key & values]
   "LPUSH key value [value ...] — returns new length."
@@ -433,9 +410,7 @@
   "LSET key index value — returns true on OK."
   (resp-ok? (redis-cmd "LSET" key (string index) value)))
 
-# ============================================================================
-# Commands — Set
-# ============================================================================
+## ── Commands — Set ────────────────────────────────────────────────────
 
 (defn redis-sadd [key & members]
   "SADD key member [member ...] — returns count of new members."
@@ -469,9 +444,7 @@
   "SDIFF key [key ...] — returns array of difference members."
   (apply redis-cmd (cons "SDIFF" keys)))
 
-# ============================================================================
-# Commands — Sorted Set
-# ============================================================================
+## ── Commands — Sorted Set ─────────────────────────────────────────────
 
 (defn redis-zadd [key score member]
   "ZADD key score member — returns count of new members."
@@ -529,9 +502,7 @@
   "ZREVRANGE key start stop WITHSCORES — returns flat array [member score ...]."
   (redis-cmd "ZREVRANGE" key (string start) (string stop) "WITHSCORES"))
 
-# ============================================================================
-# Commands — Server
-# ============================================================================
+## ── Commands — Server ─────────────────────────────────────────────────
 
 (defn redis-ping []
   "PING — returns 'PONG'."
@@ -559,9 +530,7 @@
     (redis-cmd "INFO" section)
     (redis-cmd "INFO")))
 
-# ============================================================================
-# Transactions
-# ============================================================================
+## ── Transactions ──────────────────────────────────────────────────────
 
 (defn redis-multi []
   "MULTI — start a transaction. Returns true on OK."
@@ -616,7 +585,7 @@
               (assign attempts (+ attempts 1))
               (when (>= attempts 16)
                 (error {:error :redis-error
-                        :message "redis:atomic: too many retries (WATCH conflict)"})))
+                        :reason :watch-conflict :message "too many retries (WATCH conflict)"})))
             (begin
               (assign result exec-result)
               (assign done true))))
@@ -626,9 +595,7 @@
           (error val)))))
   result)
 
-# ============================================================================
-# Lua scripting
-# ============================================================================
+## ── Lua scripting ─────────────────────────────────────────────────────
 
 (defn redis-eval [script numkeys & args]
   "EVAL script numkeys [key ...] [arg ...] — execute a Lua script.
@@ -652,9 +619,7 @@
   "SCRIPT FLUSH — clear the script cache."
   (resp-ok? (redis-cmd "SCRIPT" "FLUSH")))
 
-# ============================================================================
-# Pub/Sub
-# ============================================================================
+## ── Pub/Sub ───────────────────────────────────────────────────────────
 
 (defn redis-subscribe [port & channels]
   "Send SUBSCRIBE command on port. Returns the port (now in sub mode)."
@@ -702,9 +667,7 @@
   (each p in patterns
     (resp-read port)))
 
-# ============================================================================
-# Pipelining
-# ============================================================================
+## ── Pipelining ────────────────────────────────────────────────────────
 
 (defn redis-pipeline [& commands]
   "Send multiple commands in a batch, read all replies.
@@ -713,7 +676,7 @@
    Returns array of results."
   (let [[port (*redis-port*)]]
     (when (nil? port)
-      (error {:error :redis-error :message "no active Redis connection"}))
+      (error {:error :redis-error :reason :no-connection :message "no active Redis connection"}))
     # Send all commands
     (each cmd in commands
       (port/write port (apply resp-encode cmd)))
@@ -724,9 +687,7 @@
       (push results (resp-read-raw port)))
     (freeze results)))
 
-# ============================================================================
-# Internal self-tests (RESP encoding/decoding, no Redis needed)
-# ============================================================================
+## ── Internal self-tests (RESP encoding/decoding, no Redis needed) ─────
 
 (defn run-internal-tests []
   "Self-tests for RESP encoding and decoding."
@@ -825,9 +786,7 @@
 
   true)
 
-# ============================================================================
-# Exports
-# ============================================================================
+## ── Exports ───────────────────────────────────────────────────────────
 
 (fn []
   {# Connection

--- a/lib/tls.lisp
+++ b/lib/tls.lisp
@@ -102,7 +102,8 @@
       (let [[data (port/read port 16384)]]  # async — yields SIG_IO
         (when (nil? data)
           (error {:error :tls-error
-                  :message "tls: connection closed during handshake"}))
+                  :reason :connection-closed :phase :handshake
+                  :message "connection closed during handshake"}))
 
         # Feed into state machine. Outgoing data from this call
         # will be sent at the top of the next loop iteration.
@@ -258,7 +259,7 @@
            [plaintext (if (string? data) (bytes data) data)]
            [result (write-plaintext-fn tls plaintext)]]
       (when (= result:status :error)
-        (error {:error :tls-error :message result:message}))
+        (error {:error :tls-error :reason :write-failed :message result:message}))
       (let [[out result:outgoing]]
         (when (> (length out) 0)
           (port/write port out)))             # async

--- a/prelude.lisp
+++ b/prelude.lisp
@@ -102,7 +102,7 @@
 ## (error value) => (emit :error value)
 (defmacro error (& args)
   (if (> (length args) 1)
-    (emit :error {:error :arity-error :message "error: expected 0 or 1 arguments"})
+    (emit :error {:error :arity-error :reason :too-many-args :maximum 1 :message "expected 0 or 1 arguments"})
     `(emit :error ,(if (empty? args) nil (first args)))))
 
 ## try/catch - error handling via fibers
@@ -227,7 +227,7 @@
             (while (< idx len)
               (let ((,var (get items idx))) ,;body)
               (assign idx (+ idx 1)))))
-         (_ (error {:error :type-error :message "each: not a sequence"}))))))
+         (_ (error {:error :type-error :reason :not-a-sequence :message "not a sequence"}))))))
 
 ## case - equality dispatch (flat pairs)
 ## (case expr val1 body1 val2 body2 ... [default])

--- a/src/reader/lua_prelude.lisp
+++ b/src/reader/lua_prelude.lisp
@@ -145,7 +145,7 @@
 # lua_error: raise an error (can't use `error` — already a builtin)
 (def lua_error (fn (msg)
   (if (string? msg)
-    (error {:error :lua-error :message msg})
+    (error {:error :lua-error :reason :user-error :message msg})
     (error msg))))
 
 # ============================================================================
@@ -172,4 +172,4 @@
 (def lua_assert (fn (v msg)
   (if v v
     (error {:error :assertion-failed
-            :message (if (nil? msg) "assertion failed" msg)}))))
+            :reason :falsy-value :message (if (nil? msg) "assertion failed" msg)}))))

--- a/stdlib.lisp
+++ b/stdlib.lisp
@@ -38,7 +38,7 @@
     ((or (pair? coll) (empty? coll))
      (if (empty? coll) ()
        (cons (f (first coll)) (map f (rest coll)))))
-    (true (error {:error :type-error :message "map: not a sequence"}))))
+    (true (error {:error :type-error :reason :not-a-sequence :message "not a sequence"}))))
 
 (defn filter [p coll]
   "Return elements of coll for which (p element) is truthy. Type-preserving."
@@ -63,7 +63,7 @@
        (if (p (first coll))
          (cons (first coll) (filter p (rest coll)))
          (filter p (rest coll)))))
-    (true (error {:error :type-error :message "filter: not a sequence"}))))
+    (true (error {:error :type-error :reason :not-a-sequence :message "not a sequence"}))))
 
 (defn fold [f init lst]
   "Reduce lst by applying (f accumulator element) left to right, starting from init. Alias: reduce."
@@ -117,7 +117,7 @@
                           (loop (+ i 1))
                           false)))))
        (loop 0)))
-    (true (error {:error :type-error :message "all?: not a sequence"}))))
+    (true (error {:error :type-error :reason :not-a-sequence :message "not a sequence"}))))
 
 (defn any? [pred coll]
   (cond
@@ -135,7 +135,7 @@
                           true
                           (loop (+ i 1)))))))
        (loop 0)))
-    (true (error {:error :type-error :message "any?: not a sequence"}))))
+    (true (error {:error :type-error :reason :not-a-sequence :message "not a sequence"}))))
 
 (defn find [pred coll]
   (cond
@@ -153,7 +153,7 @@
                           (get coll i)
                           (loop (+ i 1)))))))
        (loop 0)))
-    (true (error {:error :type-error :message "find: not a sequence"}))))
+    (true (error {:error :type-error :reason :not-a-sequence :message "not a sequence"}))))
 
 (defn find-index [pred coll]
   (cond
@@ -173,7 +173,7 @@
                           i
                           (loop (+ i 1)))))))
        (loop 0)))
-    (true (error {:error :type-error :message "find-index: not a sequence"}))))
+    (true (error {:error :type-error :reason :not-a-sequence :message "not a sequence"}))))
 
 (defn count [pred coll]
   (cond
@@ -185,7 +185,7 @@
                         n
                         (loop (+ i 1) (if (pred (get coll i)) (+ n 1) n))))))
        (loop 0 0)))
-    (true (error {:error :type-error :message "count: not a sequence"}))))
+    (true (error {:error :type-error :reason :not-a-sequence :message "not a sequence"}))))
 
 (defn nth [n coll]
   (get coll n))
@@ -204,7 +204,7 @@
                              (reverse acc)
                              (loop (+ i 1) (cons (get c i) acc))))))
             (loop 0 ())))
-         (true (error {:error :type-error :message "zip: not a sequence"})))))
+         (true (error {:error :type-error :reason :not-a-sequence :message "not a sequence"})))))
      (from-list (fn (lst orig)
        (cond
          ((or (pair? orig) (empty? orig)) lst)
@@ -251,7 +251,7 @@
          result))
       ((array? coll)
        (apply array (flat (to-list coll))))
-      (true (error {:error :type-error :message "flatten: not a sequence"})))))
+      (true (error {:error :type-error :reason :not-a-sequence :message "not a sequence"})))))
 
 (defn take-while [pred coll]
   (letrec
@@ -280,7 +280,7 @@
                                               (loop (+ i 1) (cons (get coll i) acc))))))
                              (loop 0 ())))]]
          (apply array lst)))
-      (true (error {:error :type-error :message "take-while: not a sequence"})))))
+      (true (error {:error :type-error :reason :not-a-sequence :message "not a sequence"})))))
 
 (defn drop-while [pred coll]
   (letrec
@@ -314,7 +314,7 @@
                                               (loop (+ i 1) (cons (get coll i) acc))))))
                              (loop 0 ())))]]
          (apply array lst)))
-      (true (error {:error :type-error :message "drop-while: not a sequence"})))))
+      (true (error {:error :type-error :reason :not-a-sequence :message "not a sequence"})))))
 
 (defn distinct [coll]
   (let [[seen @{}]]
@@ -342,7 +342,7 @@
                                                  (loop (+ i 1) (cons (get coll i) acc))))))
                                 (loop 0 ())))]]
            (apply array lst)))
-        (true (error {:error :type-error :message "distinct: not a sequence"}))))))
+        (true (error {:error :type-error :reason :not-a-sequence :message "not a sequence"}))))))
 
 (defn frequencies [coll]
   (let [[counts @{}]]
@@ -366,7 +366,7 @@
                                            (reverse acc)
                                            (loop (+ i 1) (cons (get coll i) acc))))))
                           (loop 0 ())))))
-    (true (error {:error :type-error :message "mapcat: not a sequence"}))))
+    (true (error {:error :type-error :reason :not-a-sequence :message "not a sequence"}))))
 
 (defn group-by [f coll]
   (let [[groups @{}]]
@@ -400,7 +400,7 @@
                         ()
                         (cons (f i (get coll i)) (go (+ i 1)))))))
          (go 0))))
-    (true (error {:error :type-error :message "map-indexed: not a sequence"}))))
+    (true (error {:error :type-error :reason :not-a-sequence :message "not a sequence"}))))
 
 (defn partition [n coll]
   (cond
@@ -436,7 +436,7 @@
                         (cons (apply array (take n lst))
                               (part (drop n lst)))))))
        (apply array (part (to-list coll)))))
-    (true (error {:error :type-error :message "partition: not a sequence"}))))
+    (true (error {:error :type-error :reason :not-a-sequence :message "not a sequence"}))))
 
 (defn interpose [sep coll]
   (letrec
@@ -465,7 +465,7 @@
                                              (loop (+ i 1) (cons (get coll i) acc))))))
                              (loop 0 ())))]]
          (apply array lst)))
-      (true (error {:error :type-error :message "interpose: not a sequence"})))))
+      (true (error {:error :type-error :reason :not-a-sequence :message "not a sequence"})))))
 
 (defn min-key [f & args]
   (fold (fn (best x) (if (< (f x) (f best)) x best))
@@ -498,7 +498,7 @@
                              (reverse acc)
                              (loop (+ i 1) (cons (get c i) acc))))))
             (loop 0 ())))
-         (true (error {:error :type-error :message "sort-by: not a sequence"})))))
+         (true (error {:error :type-error :reason :not-a-sequence :message "not a sequence"})))))
      (from-list (fn (lst orig)
        (cond
          ((or (pair? orig) (empty? orig)) lst)
@@ -541,7 +541,7 @@
                              (reverse acc)
                              (loop (+ i 1) (cons (get c i) acc))))))
             (loop 0 ())))
-         (true (error {:error :type-error :message "sort-with: not a sequence"})))))
+         (true (error {:error :type-error :reason :not-a-sequence :message "not a sequence"})))))
      (from-list (fn (lst orig)
        (cond
          ((or (pair? orig) (empty? orig)) lst)
@@ -610,17 +610,15 @@
   (let* [[fmt (if (empty? opts)
                 :mermaid
                 (if (> (length opts) 1)
-                  (error {:error :arity-error :message "fn/cfg: expected at most 1 format keyword"})
+                  (error {:error :arity-error :reason :too-many-args :maximum 1 :message "expected at most 1 format keyword"})
                   (first opts)))]
          [cfg (fn/flow target)]]
     (when (nil? cfg)
-      (error {:error :type-error :message "fn/cfg: target has no LIR"}))
+      (error {:error :type-error :reason :no-lir :message "target has no LIR"}))
     (cond
       ((= fmt :mermaid) (fn/cfg-mermaid cfg))
       ((= fmt :dot)     (fn/cfg-dot cfg))
-      (true (error {:error :type-error :message (-> "fn/cfg: unknown format "
-                                   (append (string fmt))
-                                   (append ", expected :mermaid or :dot"))})))))
+      (true (error {:error :type-error :reason :unknown-format :format fmt :expected |:mermaid :dot| :message (string "unknown format: " fmt)})))))
 
 (defn fn/cfg-label (cfg)
   "Build the label string from a CFG struct's metadata."
@@ -774,11 +772,11 @@
    Keys in b override keys in a. Returns the same mutability as the inputs.
    Signals :type-error if either argument is not a struct or mutabilities differ."
   (if (not (struct? a))
-    (error {:error :type-error :message "merge: first argument must be a struct"})
+    (error {:error :type-error :reason :not-a-struct :position :first :message "first argument must be a struct"})
     (if (not (struct? b))
-      (error {:error :type-error :message "merge: second argument must be a struct"})
+      (error {:error :type-error :reason :not-a-struct :position :second :message "second argument must be a struct"})
       (if (not (= (mutable? a) (mutable? b)))
-        (error {:error :type-error :message "merge: mutability mismatch — both arguments must be the same mutability"})
+        (error {:error :type-error :reason :mutability-mismatch :message "both arguments must be the same mutability"})
         (let [[result (@struct)]]
           (each k in (keys a) (put result k (get a k)))
           (each k in (keys b) (put result k (get b k)))
@@ -1148,7 +1146,7 @@
         :park   (handle-park caller request)
         :notify (handle-notify caller request)
         (error {:error :protocol-error
-                :message (string "unknown :wait op: " (request :op))})))
+                :reason :unknown-op :op (request :op) :message (string "unknown op: " (request :op))})))
 
     (defn handle-fiber-after-resume [fiber]
       "Route a fiber to the right place after resume."
@@ -1282,7 +1280,7 @@
   (let [[timeout-ms (or (get args 0) 0)]
         [shutdown-fn (*shutdown*)]]
     (when (nil? shutdown-fn)
-      (error {:error :state-error :message "ev/shutdown: not inside an event loop"}))
+      (error {:error :state-error :reason :no-event-loop :message "not inside an event loop"}))
     (shutdown-fn timeout-ms)))
 
 (defn ev/with-scheduler [sched & thunks]
@@ -1335,7 +1333,7 @@
   "Emit a :wait signal. Guards against use outside async scheduler."
   (when (nil? (*spawn*))
     (error {:error :state-error
-            :message (string "ev/" (get request :op) " requires an async scheduler")}))
+            :reason :no-scheduler :op (get request :op) :message (string (get request :op) " requires an async scheduler")}))
   (emit :wait request))
 
 (defn ev/futex-wait [key cell expected]
@@ -1414,7 +1412,7 @@
       (each f in remaining (ev/abort f))
       (if (= done work)
         (ev/join work)
-        (error {:error :timeout :message "operation timed out"})))))
+        (error {:error :timeout :reason :deadline-exceeded :message "operation timed out"})))))
 
 (defn ev/scope [body-fn]
   "Structured concurrency nursery. body-fn receives a spawn function.
@@ -1604,10 +1602,10 @@
   (if (or (array? coll) (bytes? coll) (string? coll))
     (when (or (< key 0) (>= key (length coll)))
       (error {:error :key-error
-              :message (string "update: index out of bounds: " key)}))
+              :reason :index-out-of-bounds :key key :message (string "index out of bounds: " key)}))
     (unless (has? coll key)
       (error {:error :key-error
-              :message (string "update: key not found: " key)})))
+              :reason :key-not-found :key key :message (string "key not found: " key)})))
   (put coll key (f (get coll key))))
 
 (defn sum [xs]

--- a/tests/elle/irc.lisp
+++ b/tests/elle/irc.lisp
@@ -1,0 +1,68 @@
+## tests/elle/irc.lisp — IRC module tests
+##
+## Pure parsing and formatting tests. No network required.
+
+(def irc ((import-file "lib/irc.lisp")))
+
+## ── Verify exports ──────────────────────────────────────────────────
+
+(assert (fn? irc:connect) "export: connect is a function")
+(assert (fn? irc:parse-message) "export: parse-message is a function")
+(assert (fn? irc:format-message) "export: format-message is a function")
+(assert (fn? irc:parse-tags) "export: parse-tags is a function")
+(assert (fn? irc:parse-source) "export: parse-source is a function")
+(assert (fn? irc:parse-ctcp) "export: parse-ctcp is a function")
+(assert (fn? irc:test) "export: test is a function")
+
+## ── Run internal tests ──────────────────────────────────────────────
+
+(assert (irc:test) "internal tests pass")
+
+## ── Additional edge cases ───────────────────────────────────────────
+
+# Parse a CAP LS line
+(let [[msg (irc:parse-message ":server CAP * LS :multi-prefix sasl server-time")]]
+  (assert (= msg:command "CAP") "CAP LS: command")
+  (assert (= (get msg:params 0) "*") "CAP LS: target")
+  (assert (= (get msg:params 1) "LS") "CAP LS: subcommand")
+  (assert (= (get msg:params 2) "multi-prefix sasl server-time") "CAP LS: caps"))
+
+# Parse 001 welcome
+(let [[msg (irc:parse-message ":irc.libera.chat 001 ellebot :Welcome to Libera.Chat")]]
+  (assert (= msg:command "001") "001: command")
+  (assert (= msg:source:server "irc.libera.chat") "001: server source")
+  (assert (= (get msg:params 0) "ellebot") "001: nick")
+  (assert (string/starts-with? (get msg:params 1) "Welcome") "001: welcome text"))
+
+# Parse NICK change
+(let [[msg (irc:parse-message ":old!user@host NICK :new")]]
+  (assert (= msg:command "NICK") "NICK: command")
+  (assert (= msg:source:nick "old") "NICK: old nick")
+  (assert (= (get msg:params 0) "new") "NICK: new nick"))
+
+# Parse numeric with many params
+(let [[msg (irc:parse-message ":server 004 bot irc.server ircd-2.0 iowRs biklmnopst")]]
+  (assert (= msg:command "004") "004: command")
+  (assert (= (get msg:params 0) "bot") "004: nick")
+  (assert (= (get msg:params 1) "irc.server") "004: server name")
+  (assert (= (get msg:params 2) "ircd-2.0") "004: version")
+  (assert (= (get msg:params 3) "iowRs") "004: user modes")
+  (assert (= (get msg:params 4) "biklmnopst") "004: channel modes"))
+
+# Tags with escaped values
+(let [[msg (irc:parse-message "@time=2024-01-15T16:40:51.620Z;msgid=abc123 :nick!u@h PRIVMSG #ch :hello")]]
+  (assert (= msg:tags:time "2024-01-15T16:40:51.620Z") "tagged msg: time")
+  (assert (= msg:tags:msgid "abc123") "tagged msg: msgid")
+  (assert (= (get msg:params 1) "hello") "tagged msg: text"))
+
+# Format roundtrip with tags
+(let* [[msg {:tags {:time "2024-01-01"} :source {:nick "n" :user "u" :host "h"}
+             :command "PRIVMSG" :params ["#ch" "hi there"]}]
+       [line (irc:format-message msg)]
+       [reparsed (irc:parse-message line)]]
+  (assert (= reparsed:command "PRIVMSG") "tag roundtrip: command")
+  (assert (= reparsed:tags:time "2024-01-01") "tag roundtrip: time tag")
+  (assert (= reparsed:source:nick "n") "tag roundtrip: nick")
+  (assert (= (get reparsed:params 1) "hi there") "tag roundtrip: text"))
+
+(println "irc: all tests passed")


### PR DESCRIPTION
New lib/irc.lisp: IRCv3 client with coroutine read stream, CAP negotiation, SASL PLAIN, message tags, auto-PONG. Connection struct exposes :messages (coroutine), :send (function), :close (function).

Structured errors: every error across all 11 Elle files (9 libs + stdlib + prelude) now carries :error (module category), :reason (specific condition keyword), and promoted data fields. The :message string contains no information not already in a struct field. Convention documented in docs/errors.md.

Style: section headers modernized (# ==== -> ## ──) in http, dns, redis. Hyphenated string predicates -> slash-prefixed in http. cond dispatch -> case for constant dispatch in dns. cond -> match with extracted handlers in irc registration loop.