### PR TITLE
MCP server: async startup via yield-based population fiber

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -143,6 +143,27 @@ ELLE_MCP_STORE=/path/to/store elle tools/mcp-server.lisp
 The store is persistent — graph data survives across server restarts.
 The `.elle-mcp/` directory is gitignored by default.
 
+## Startup behavior
+
+The server responds to `initialize` immediately. Graph population (Elle
+primitives, Rust function triples) runs in a background fiber so the
+server can handle requests while the graph loads. This keeps MCP client
+connection timeouts from firing on large codebases.
+
+When population completes, the server emits a JSON-RPC notification:
+
+```json
+{"jsonrpc":"2.0","method":"notifications/model/populated","params":{"primitives":true,"rust":406}}
+```
+
+Tools that query the graph (`sparql_query`, `trace`, etc.) return
+whatever data is available — results may be incomplete until the
+notification arrives. Tools that don't depend on the graph
+(`initialize`, `ping`, `tools/list`, `analyze_file`, `portrait`, etc.)
+work immediately.
+
+The Rust file scan excludes `target/` to avoid parsing build artifacts.
+
 ## Populating the graph
 
 The server populates the graph incrementally via `analyze_file`. For

--- a/tools/mcp-server.lisp
+++ b/tools/mcp-server.lisp
@@ -79,16 +79,25 @@
   (ox:load store (rdf:primitives) :ntriples)
   (flush-store))
 
+(def rust-source-globs
+  ["src/**/*.rs" "plugins/**/*.rs" "tests/**/*.rs"
+   "benches/**/*.rs" "patches/**/*.rs"])
+
 (defn populate-rust []
-  "Parse all .rs files, load Rust triples and primitive cross-links."
-  (var files (glob:glob "**/*.rs"))
+  "Parse source .rs files, load Rust triples and primitive cross-links.
+   Yields between files so the main loop can process requests.
+   Scans only source directories to avoid the deep target/ tree."
+  (var files @[])
+  (each pattern in rust-source-globs
+    (each f in (glob:glob pattern)
+      (push files f)))
   (var count 0)
   (each file in files
-    (let [[[ok? _err] (protect
-            (begin
-              (ox:load store (rust-rdf:file file) :ntriples)
-              (ox:load store (rust-rdf:primitive-links file) :ntriples)))]]
-      (when ok? (assign count (inc count)))))
+    (when-ok [_ (begin
+                  (ox:load store (rust-rdf:file file) :ntriples)
+                  (ox:load store (rust-rdf:primitive-links file) :ntriples))]
+      (assign count (inc count)))
+    (yield nil))
   (flush-store)
   count)
 
@@ -103,9 +112,6 @@
   (clear-file-triples path)
   (ox:load store (rdf:file analysis path) :ntriples)
   (flush-store))
-
-(populate-primitives)
-(def rust-file-count (populate-rust))
 
 # ── Analysis cache ───────────────────────────────────────────────────────
 
@@ -134,8 +140,8 @@
   (each sym in (compile/symbols analysis)
     (when (= (get sym :kind) :function)
       (var name (get sym :name))
-      (let [[[ok? sig] (protect (compile/signal analysis (keyword name)))]]
-        (when ok? (put result name sig)))))
+      (when-ok [sig (compile/signal analysis (keyword name))]
+        (put result name sig))))
   result)
 
 (defn diff-signals [old-sigs new-sigs]
@@ -386,10 +392,7 @@
 
   (each sym in fn-syms
     (var name (get sym :name))
-    (var sig nil)
-    (let [[[ok? val] (protect (compile/signal analysis (keyword name)))]]
-      (when ok? (assign sig val)))
-    (when sig
+    (when-ok [sig (compile/signal analysis (keyword name))]
       (cond
         ((get sig :silent)                         (push silent-names name))
         ((not (empty? (get sig :propagates)))      (push delegating-names name))
@@ -397,14 +400,8 @@
         ((get sig :yields)                         (push yielding-names name))
         (true                                      (push io-names name)))
 
-      (var caps nil)
-      (let [[[ok? val] (protect (compile/captures analysis (keyword name)))]]
-        (when ok? (assign caps val)))
-      (when caps
-        (var callees nil)
-        (let [[[ok? val] (protect (compile/callees analysis (keyword name)))]]
-          (when ok? (assign callees val)))
-        (when callees
+      (when-ok [caps (compile/captures analysis (keyword name))]
+        (when-ok [callees (compile/callees analysis (keyword name))]
           (each o in (portrait-lib:observations analysis name sig caps callees)
             (push observations
               (string/format "{}: [{}] {}" name (get o :kind) (get o :message))))))))
@@ -488,12 +485,9 @@
   (push out (string/format "Called by ({} callers):\n" (length callers)))
   (each c in callers
     (var caller-name (get c :name))
-    (var caller-sig nil)
-    (let [[[ok? val] (protect (compile/signal analysis (keyword caller-name)))]]
-      (when ok? (assign caller-sig val)))
     (push out (string/format "  {} (line {}, tail={})"
       caller-name (or (get c :line) "?") (or (get c :tail) false)))
-    (when caller-sig
+    (when-ok [caller-sig (compile/signal analysis (keyword caller-name))]
       (when (get caller-sig :silent)
         (push out " ! caller is silent — adding effects here will propagate"))
       (when (get caller-sig :jit-eligible)
@@ -653,11 +647,10 @@
 
     (if (empty? impl-rows)
       # Not a primitive — it's an Elle-defined function, show its signal
-      (let [[[ok? sig] (protect (compile/signal analysis (keyword callee-name)))]]
-        (when ok?
-          (push out (string/format "         signal: {}\n"
-            (if (get sig :silent) "silent"
-              (string/join (map string (->list (get sig :bits))) ", "))))))
+      (when-ok [sig (compile/signal analysis (keyword callee-name))]
+        (push out (string/format "         signal: {}\n"
+          (if (get sig :silent) "silent"
+            (string/join (map string (->list (get sig :bits))) ", ")))))
 
       # Primitive — trace into Rust
       (each impl-row in impl-rows
@@ -747,7 +740,27 @@
 
 (eprintln "elle-mcp server starting (v0.5.0)")
 (eprintln "  store: " store-path)
-(eprintln "  rust: " rust-file-count " files loaded")
+
+# Population fiber — yields between work units so the main loop
+# can process requests between FFI calls.
+(def populator (fiber/new (fn []
+  (populate-primitives)
+  (yield nil)
+  (eprintln "  primitives: loaded")
+  (var count (populate-rust))
+  (eprintln "  rust: " count " files loaded")
+  (send-response {:jsonrpc "2.0"
+                  :method "notifications/model/populated"
+                  :params {:primitives true :rust count}}))
+  |:yield|))
+
+# Kick off population — runs populate-primitives, then yields
+(fiber/resume populator nil)
+
+(defn tick-populator []
+  "Resume the population fiber one step if it's still alive."
+  (when (= (fiber/status populator) :paused)
+    (fiber/resume populator nil)))
 
 # Watcher fiber
 (eprintln "  watch: enabled")
@@ -780,6 +793,7 @@
     (when (nil? line)
       (eprintln "stdin closed, shutting down")
       (break))
+    (tick-populator)
     (unless (empty? line)
       (let [[[ok? msg] (protect (json/parse line))]]
         (if (not ok?)

--- a/tools/test-mcp.lisp
+++ b/tools/test-mcp.lisp
@@ -6,6 +6,11 @@
 ## of Elle primitives and Rust function triples, then populates, queries,
 ## and resets user-loaded RDF data through the public tool surface.
 ##
+## The server populates the graph in a background fiber. This test
+## verifies that initialize responds within 10 seconds (not blocked
+## by population) and that the notifications/model/populated notification
+## arrives before graph-dependent tests run.
+##
 ## Usage:
 ##   elle tools/test-mcp.lisp                   # uses "elle" in PATH
 ##   elle tools/test-mcp.lisp ./target/debug/elle
@@ -14,10 +19,6 @@
 (elle/epoch 5)
 
 ## ── Configuration ────────────────────────────────────────────────────────
-##
-## Argument resolution: the first positional arg is the elle binary to test
-## against (the test spawns mcp-server.lisp as a subprocess using this
-## binary). Fall back to $ELLE_BIN, then to "elle" in PATH.
 
 (def test-args (sys/args))
 
@@ -46,6 +47,8 @@
 
 ## ── JSON-RPC I/O helpers ────────────────────────────────────────────────
 
+(var notification-buffer @[])
+
 (defn send [pin msg]
   "Send a single JSON-RPC message to the server."
   (port/write pin (json/serialize msg))
@@ -53,19 +56,42 @@
   (port/flush pin))
 
 (defn recv-response [pout want-id]
-  "Read JSON-RPC messages until one with id=want-id arrives. Notifications
-   (messages without an id) are skipped — they come from the watcher fiber
-   and aren't responses to our requests."
+  "Read JSON-RPC messages until one with id=want-id arrives.
+   Notifications (messages without an id) are saved in the buffer."
   (var result nil)
   (while (nil? result)
     (let [[line (port/read-line pout)]]
       (when (nil? line)
         (error {:error :eof :message "server closed stdout"}))
       (let [[msg (json/parse line)]]
-        (var msg-id (get msg "id"))
-        (when (and (not (nil? msg-id)) (= msg-id want-id))
-          (assign result msg)))))
+        (if (and (not (nil? (get msg "id"))) (= (get msg "id") want-id))
+          (assign result msg)
+          (when (not (nil? (get msg "method")))
+            (push notification-buffer msg))))))
   result)
+
+(defn recv-notification [pout want-method]
+  "Wait for a notification with the given method. Checks buffer first,
+   then reads from the port until found."
+  (var found nil)
+  (var keep @[])
+  (each msg in notification-buffer
+    (if (and (nil? found) (= (get msg "method") want-method))
+      (assign found msg)
+      (push keep msg)))
+  (assign notification-buffer keep)
+  (if (not (nil? found))
+    found
+    (begin
+      (while (nil? found)
+        (let [[line (port/read-line pout)]]
+          (when (nil? line)
+            (error {:error :eof :message "server closed stdout"}))
+          (let [[msg (json/parse line)]]
+            (if (= (get msg "method") want-method)
+              (assign found msg)
+              (push notification-buffer msg)))))
+      found)))
 
 (defn call-tool [pin pout id name args]
   "Send a tools/call request and wait for the matching response."
@@ -92,17 +118,22 @@
 
 (defer (begin (subprocess/kill proc) (rm-rf test-store))
 
-  ## ── 1. initialize ─────────────────────────────────────────────────────
-  (send pin {:jsonrpc "2.0" :id 1 :method "initialize"
-             :params {:protocolVersion "2025-03-26"
-                      :capabilities {}
-                      :clientInfo {:name "test-mcp" :version "0.1"}}})
-  (let [[r (recv-response pout 1)]]
-    (test "initialize: has result"
-      (not (nil? (get r "result"))) "missing result")
-    (test "initialize: server name is elle-mcp"
-      (= (get (get (get r "result") "serverInfo") "name") "elle-mcp")
-      (string "got " (get (get (get r "result") "serverInfo") "name"))))
+  ## ── 1. initialize (must respond within 10s — not blocked by population)
+  (let [[[ok? r] (protect
+      (ev/timeout 10 (fn []
+        (send pin {:jsonrpc "2.0" :id 1 :method "initialize"
+                   :params {:protocolVersion "2025-03-26"
+                            :capabilities {}
+                            :clientInfo {:name "test-mcp" :version "0.1"}}})
+        (recv-response pout 1))))]]
+    (test "initialize: responds within 10 seconds" ok?
+      "server took too long — population is blocking startup")
+    (when ok?
+      (test "initialize: has result"
+        (not (nil? (get r "result"))) "missing result")
+      (test "initialize: server name is elle-mcp"
+        (= (get (get (get r "result") "serverInfo") "name") "elle-mcp")
+        (string "got " (get (get (get r "result") "serverInfo") "name")))))
 
   ## initialized notification — no response expected
   (send pin {:jsonrpc "2.0" :method "notifications/initialized"})
@@ -121,12 +152,31 @@
     (test "ping: has result"
       (not (nil? (get r "result"))) "missing result"))
 
-  ## ── 4. startup populated Elle primitives ──────────────────────────────
-  ## populate-primitives runs at server startup and loads one
-  ## urn:elle:Primitive triple per built-in. If the import of std/rdf or
-  ## the oxigraph plugin regresses, this COUNT query returns 0 and the
-  ## test fails loudly.
-  (let [[r (call-tool pin pout 4 "sparql_query"
+  ## ── 4. drive population to completion ───────────────────────────────────
+  ## The server populates the graph one file per request. Send pings to
+  ## drive the populator forward until the notification arrives.
+  (var ping-id 100)
+  (var populated false)
+  (while (not populated)
+    (send pin {:jsonrpc "2.0" :id ping-id :method "ping" :params {}})
+    (var result nil)
+    (while (nil? result)
+      (let [[line (port/read-line pout)]]
+        (when (nil? line)
+          (error {:error :eof :message "server closed stdout"}))
+        (let [[msg (json/parse line)]]
+          (if (= (get msg "method") "notifications/model/populated")
+            (begin
+              (assign populated true)
+              (assign result msg))
+            (when (and (not (nil? (get msg "id"))) (= (get msg "id") ping-id))
+              (assign result msg))))))
+    (assign ping-id (inc ping-id)))
+
+  (test "population: completed" populated "population notification never arrived")
+
+  ## ── 5. startup populated Elle primitives ──────────────────────────────
+  (let [[r (call-tool pin pout 5 "sparql_query"
              {:query (string "SELECT (COUNT(?p) AS ?n) WHERE { "
                              "?p <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> "
                              "<urn:elle:Primitive> }")})]]
@@ -137,10 +187,8 @@
              (not (string/contains? text "SPARQL error")))
         (string "got: " text))))
 
-  ## ── 5. startup populated Rust fn triples ──────────────────────────────
-  ## populate-rust iterates all .rs files via std/glob. If either the
-  ## glob or syn plugin regresses, rust triples never make it in.
-  (let [[r (call-tool pin pout 5 "sparql_query"
+  ## ── 6. startup populated Rust fn triples ──────────────────────────────
+  (let [[r (call-tool pin pout 6 "sparql_query"
              {:query (string "SELECT (COUNT(?f) AS ?n) WHERE { "
                              "?f <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> "
                              "<urn:rust:Fn> }")})]]
@@ -151,8 +199,8 @@
              (not (string/contains? text "SPARQL error")))
         (string "got: " text))))
 
-  ## ── 6. populate: load_rdf with user-owned test triples ────────────────
-  (let [[r (call-tool pin pout 6 "load_rdf"
+  ## ── 7. populate: load_rdf with user-owned test triples ────────────────
+  (let [[r (call-tool pin pout 7 "load_rdf"
              {:data (string "<http://test/alice> <http://test/name> \"Alice\" .\n"
                             "<http://test/bob> <http://test/name> \"Bob\" .\n")
               :format "ntriples"})]]
@@ -160,8 +208,8 @@
       (string/contains? (tool-text r) "successfully")
       (tool-text r)))
 
-  ## ── 7. query: the just-loaded data is visible ────────────────────────
-  (let [[r (call-tool pin pout 7 "sparql_query"
+  ## ── 8. query: the just-loaded data is visible ────────────────────────
+  (let [[r (call-tool pin pout 8 "sparql_query"
              {:query "SELECT ?name WHERE { ?p <http://test/name> ?name } ORDER BY ?name"})]]
     (let [[text (tool-text r)]]
       (test "query: Alice is present"
@@ -169,15 +217,15 @@
       (test "query: Bob is present"
         (string/contains? text "Bob") text)))
 
-  ## ── 8. reset: sparql_update DELETE clears the user triples ────────────
-  (let [[r (call-tool pin pout 8 "sparql_update"
+  ## ── 9. reset: sparql_update DELETE clears the user triples ────────────
+  (let [[r (call-tool pin pout 9 "sparql_update"
              {:update "DELETE WHERE { ?s <http://test/name> ?o }"})]]
     (test "reset: sparql_update delete succeeded"
       (string/contains? (tool-text r) "successfully")
       (tool-text r)))
 
-  ## ── 9. query: user triples are gone after reset ──────────────────────
-  (let [[r (call-tool pin pout 9 "sparql_query"
+  ## ── 10. query: user triples are gone after reset ──────────────────────
+  (let [[r (call-tool pin pout 10 "sparql_query"
              {:query "SELECT ?name WHERE { ?p <http://test/name> ?name }"})]]
     (let [[text (tool-text r)]]
       (test "reset: user triples are cleared"
@@ -185,10 +233,8 @@
              (not (string/contains? text "Bob")))
         (string "store still has data: " text))))
 
-  ## ── 10. startup-loaded data survives the reset ───────────────────────
-  ## The DELETE above was scoped to http://test/name triples, so elle
-  ## primitives must still be present.
-  (let [[r (call-tool pin pout 10 "sparql_query"
+  ## ── 11. startup-loaded data survives the reset ─────────────────────────
+  (let [[r (call-tool pin pout 11 "sparql_query"
              {:query (string "SELECT (COUNT(?p) AS ?n) WHERE { "
                              "?p <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> "
                              "<urn:elle:Primitive> }")})]]
@@ -198,9 +244,9 @@
              (not (string/contains? text "No results")))
         (string "got: " text))))
 
-  ## ── 11. unknown method returns a JSON-RPC error ──────────────────────
-  (send pin {:jsonrpc "2.0" :id 11 :method "bogus/method" :params {}})
-  (let [[r (recv-response pout 11)]]
+  ## ── 12. unknown method returns a JSON-RPC error ──────────────────────
+  (send pin {:jsonrpc "2.0" :id 12 :method "bogus/method" :params {}})
+  (let [[r (recv-response pout 12)]]
     (test "unknown method: returns error object"
       (not (nil? (get r "error"))) "expected error response"))
 


### PR DESCRIPTION
The server was blocking for >60s before responding to initialize because populate-primitives and populate-rust ran synchronously.

- Population runs in a fiber/new coroutine with |:yield| mask; yields between files so the main loop can interleave requests
- Targeted globs (src/, plugins/, tests/, benches/, patches/) skip the deep target/ tree
- notifications/model/populated emitted when population completes
- Test verifies initialize responds within 10 seconds
- when-ok cleanup throughout tool handlers