### PR TITLE
Add image, SVG, and color libraries for working with image data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,6 +57,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "aligned"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee4508988c62edf04abd8d92897fca0c2995d907ce1dfeaf369dac3716a40685"
+dependencies = [
+ "as-slice",
+]
+
+[[package]]
+name = "aligned-vec"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b"
+dependencies = [
+ "equator",
+]
+
+[[package]]
 name = "alloc-no-stdlib"
 version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -130,6 +148,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "ar_archive_writer"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -162,6 +189,17 @@ dependencies = [
  "percent-encoding",
  "windows-sys 0.60.2",
  "x11rb",
+]
+
+[[package]]
+name = "arg_enum_proc_macro"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -407,6 +445,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175571dd1d178ced59193a6fc02dde1b972eb0bc56c892cde9beeceac5bf0f6b"
 
 [[package]]
+name = "as-slice"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "516b6b4f0e40d50dcda9365d53964ec74560ad4284da2e7fc97122cd83174516"
+dependencies = [
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -470,6 +517,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "av-scenechange"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f321d77c20e19b92c39e7471cf986812cbb46659d2af674adc4331ef3f18394"
+dependencies = [
+ "aligned",
+ "anyhow",
+ "arg_enum_proc_macro",
+ "arrayvec",
+ "log",
+ "num-rational",
+ "num-traits",
+ "pastey",
+ "rayon",
+ "thiserror 2.0.18",
+ "v_frame",
+ "y4m",
+]
+
+[[package]]
+name = "av1-grain"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cfddb07216410377231960af4fcab838eaa12e013417781b78bd95ee22077f8"
+dependencies = [
+ "anyhow",
+ "arrayvec",
+ "log",
+ "nom 8.0.0",
+ "num-rational",
+ "v_frame",
+]
+
+[[package]]
+name = "avif-serialize"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "375082f007bd67184fb9c0374614b29f9aaa604ec301635f72338bb65386a53d"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -511,6 +601,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
+name = "bit_field"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -529,6 +625,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2"
 dependencies = [
  "typenum",
+]
+
+[[package]]
+name = "bitstream-io"
+version = "4.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60d4bd9d1db2c6bdf285e223a7fa369d5ce98ec767dec949c6ca62863ce61757"
+dependencies = [
+ "core2",
 ]
 
 [[package]]
@@ -592,6 +697,12 @@ dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
 ]
+
+[[package]]
+name = "built"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4ad8f11f288f48ca24471bbd51ac257aaeaaa07adae295591266b792902ae64"
 
 [[package]]
 name = "bumpalo"
@@ -733,7 +844,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
- "nom",
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -869,6 +980,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -987,6 +1104,24 @@ dependencies = [
  "bitflags 1.3.2",
  "core-foundation 0.9.4",
  "libc",
+]
+
+[[package]]
+name = "core2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "core_maths"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77745e017f5edba1a9c1d854f6f3a52dac8a12dd5af5d2f54aecf61e43d80d30"
+dependencies = [
+ "libm",
 ]
 
 [[package]]
@@ -1453,6 +1588,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-url"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
+
+[[package]]
 name = "debug_unsafe"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1731,6 +1872,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "elle-image"
+version = "1.0.0"
+dependencies = [
+ "elle",
+ "image",
+ "imageproc",
+]
+
+[[package]]
 name = "elle-jiff"
 version = "1.0.0"
 dependencies = [
@@ -1807,6 +1957,14 @@ version = "1.0.0"
 dependencies = [
  "elle",
  "selkie-rs",
+]
+
+[[package]]
+name = "elle-svg"
+version = "1.0.0"
+dependencies = [
+ "elle",
+ "resvg",
 ]
 
 [[package]]
@@ -1942,6 +2100,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7e7a64c02cf7a5b51e745a9e45f60660a286f151c238b9d397b3e923f5082f"
 
 [[package]]
+name = "equator"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4711b213838dfee0117e3be6ac926007d7f433d7bbe33595975d4190cb07e6fc"
+dependencies = [
+ "equator-macro",
+]
+
+[[package]]
+name = "equator-macro"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1968,6 +2146,30 @@ name = "ethnum"
 version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
+
+[[package]]
+name = "euclid"
+version = "0.22.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "exr"
+version = "1.74.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4300e043a56aa2cb633c01af81ca8f699a321879a7854d3896a0ba89056363be"
+dependencies = [
+ "bit_field",
+ "half",
+ "lebe",
+ "miniz_oxide",
+ "rayon-core",
+ "smallvec",
+ "zune-inflate",
+]
 
 [[package]]
 name = "fallible-iterator"
@@ -2068,6 +2270,12 @@ dependencies = [
 
 [[package]]
 name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+
+[[package]]
+name = "float-cmp"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
@@ -2092,6 +2300,29 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "fontconfig-parser"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbc773e24e02d4ddd8395fd30dc147524273a83e54e0f312d986ea30de5f5646"
+dependencies = [
+ "roxmltree",
+]
+
+[[package]]
+name = "fontdb"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "457e789b3d1202543297a350643cf459f836cade38934e7a4cf6a39e7cde2905"
+dependencies = [
+ "fontconfig-parser",
+ "log",
+ "memmap2",
+ "slotmap",
+ "tinyvec",
+ "ttf-parser 0.25.1",
+]
 
 [[package]]
 name = "fontdue"
@@ -2297,6 +2528,26 @@ dependencies = [
  "r-efi 6.0.0",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "gif"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ae047235e33e2829703574b54fdec96bfbad892062d97fed2f76022287de61b"
+dependencies = [
+ "color_quant",
+ "weezl",
+]
+
+[[package]]
+name = "gif"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
+dependencies = [
+ "color_quant",
+ "weezl",
 ]
 
 [[package]]
@@ -2665,11 +2916,61 @@ checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
 dependencies = [
  "bytemuck",
  "byteorder-lite",
+ "color_quant",
+ "exr",
+ "gif 0.14.2",
+ "image-webp",
  "moxcms",
  "num-traits",
- "png",
+ "png 0.18.1",
+ "qoi",
+ "ravif",
+ "rayon",
+ "rgb",
  "tiff",
+ "zune-core 0.5.1",
+ "zune-jpeg 0.5.15",
 ]
+
+[[package]]
+name = "image-webp"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
+dependencies = [
+ "byteorder-lite",
+ "quick-error 2.0.1",
+]
+
+[[package]]
+name = "imageproc"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2393fb7808960751a52e8a154f67e7dd3f8a2ef9bd80d1553078a7b4e8ed3f0d"
+dependencies = [
+ "ab_glyph",
+ "approx",
+ "getrandom 0.2.17",
+ "image",
+ "itertools 0.12.1",
+ "nalgebra",
+ "num",
+ "rand 0.8.5",
+ "rand_distr",
+ "rayon",
+]
+
+[[package]]
+name = "imagesize"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edcd27d72f2f071c64249075f42e205ff93c9a4c5f6c6da53e79ed9f9832c285"
+
+[[package]]
+name = "imgref"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c5cedc30da3a610cac6b4ba17597bdf7152cf974e8aab3afb3d54455e371c8"
 
 [[package]]
 name = "indexmap"
@@ -2688,6 +2989,17 @@ name = "integer-encoding"
 version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
+
+[[package]]
+name = "interpolate_name"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "io-uring"
@@ -2716,6 +3028,15 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]
@@ -2916,6 +3237,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
+name = "kurbo"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c62026ae44756f8a599ba21140f350303d4f08dcdcc71b5ad9c9bb8128c13c62"
+dependencies = [
+ "arrayvec",
+ "euclid",
+ "smallvec",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2926,6 +3258,12 @@ name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "lebe"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
 
 [[package]]
 name = "lexical-core"
@@ -3010,6 +3348,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libfuzzer-sys"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f12a681b7dd8ce12bff52488013ba614b869148d54dd79836ab85aafdd53f08d"
+dependencies = [
+ "arbitrary",
+ "cc",
+]
+
+[[package]]
 name = "libloading"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3087,6 +3435,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "loop9"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062"
+dependencies = [
+ "imgref",
+]
+
+[[package]]
 name = "lz4"
 version = "1.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3121,6 +3478,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "matrixmultiply"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
+dependencies = [
+ "autocfg",
+ "rawpointer",
+]
+
+[[package]]
+name = "maybe-rayon"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
+dependencies = [
+ "cfg-if",
+ "rayon",
 ]
 
 [[package]]
@@ -3222,6 +3599,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "nalgebra"
+version = "0.32.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5c17de023a86f59ed79891b2e5d5a94c705dbe904a5b5c9c952ea6221b03e4"
+dependencies = [
+ "approx",
+ "matrixmultiply",
+ "num-complex",
+ "num-rational",
+ "num-traits",
+ "simba",
+ "typenum",
+]
+
+[[package]]
 name = "ndk"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3250,6 +3642,12 @@ checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
 dependencies = [
  "jni-sys 0.3.1",
 ]
+
+[[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nibble_vec"
@@ -3287,6 +3685,21 @@ dependencies = [
  "memchr",
  "minimal-lexical",
 ]
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "noop_proc_macro"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
 
 [[package]]
 name = "now"
@@ -3344,6 +3757,17 @@ name = "num-conv"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "num-integer"
@@ -3931,6 +4355,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pastey"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
+
+[[package]]
 name = "path-clean"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4060,6 +4490,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pico-args"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
+
+[[package]]
 name = "pin-project"
 version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4132,6 +4568,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
+]
+
+[[package]]
+name = "png"
+version = "0.17.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
+dependencies = [
+ "bitflags 1.3.2",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -4768,6 +5217,19 @@ name = "profiling"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eb8486b569e12e2c32ad3e204dbaba5e4b5b216e9367044f25f1dba42341773"
+dependencies = [
+ "profiling-procmacros",
+]
+
+[[package]]
+name = "profiling-procmacros"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52717f9a02b6965224f95ca2a81e2e0c5c43baacd28ca057577988930b6c3d5b"
+dependencies = [
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "proptest"
@@ -4905,6 +5367,15 @@ name = "pxfm"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
+
+[[package]]
+name = "qoi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "quick-error"
@@ -5055,6 +5526,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "rav1e"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43b6dd56e85d9483277cde964fd1bdb0428de4fec5ebba7540995639a21cb32b"
+dependencies = [
+ "aligned-vec",
+ "arbitrary",
+ "arg_enum_proc_macro",
+ "arrayvec",
+ "av-scenechange",
+ "av1-grain",
+ "bitstream-io",
+ "built",
+ "cfg-if",
+ "interpolate_name",
+ "itertools 0.14.0",
+ "libc",
+ "libfuzzer-sys",
+ "log",
+ "maybe-rayon",
+ "new_debug_unreachable",
+ "noop_proc_macro",
+ "num-derive",
+ "num-traits",
+ "paste",
+ "profiling",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
+ "simd_helpers",
+ "thiserror 2.0.18",
+ "v_frame",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "ravif"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e52310197d971b0f5be7fe6b57530dcd27beb35c1b013f29d66c1ad73fbbcc45"
+dependencies = [
+ "avif-serialize",
+ "imgref",
+ "loop9",
+ "quick-error 2.0.1",
+ "rav1e",
+ "rayon",
+ "rgb",
+]
+
+[[package]]
 name = "raw-cpuid"
 version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5068,6 +5589,12 @@ name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
+
+[[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
@@ -5251,6 +5778,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "resvg"
+version = "0.45.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8928798c0a55e03c9ca6c4c6846f76377427d2c1e1f7e6de3c06ae57942df43"
+dependencies = [
+ "gif 0.13.3",
+ "image-webp",
+ "log",
+ "pico-args",
+ "rgb",
+ "svgtypes",
+ "tiny-skia",
+ "usvg",
+ "zune-jpeg 0.4.21",
+]
+
+[[package]]
+name = "rgb"
+version = "0.8.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5392,6 +5945,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustybuzz"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd3c7c96f8a08ee34eff8857b11b49b07d71d1c3f4e88f8a88d4c9e9f90b1702"
+dependencies = [
+ "bitflags 2.11.0",
+ "bytemuck",
+ "core_maths",
+ "log",
+ "smallvec",
+ "ttf-parser 0.25.1",
+ "unicode-bidi-mirroring",
+ "unicode-ccc",
+ "unicode-properties",
+ "unicode-script",
+]
+
+[[package]]
 name = "rustyline"
 version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5418,6 +5989,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "safe_arch"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "same-file"
@@ -5647,6 +6227,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "simba"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "061507c94fc6ab4ba1c9a0305018408e312e17c041eb63bef8aa726fa33aceae"
+dependencies = [
+ "approx",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "wide",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5680,10 +6273,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd_helpers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
+dependencies = [
+ "quote",
+]
+
+[[package]]
 name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "simplecss"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9c6883ca9c3c7c90e888de77b7a5c849c779d25d74a1269b0218b14e8b136c"
+dependencies = [
+ "log",
+]
 
 [[package]]
 name = "siphasher"
@@ -5940,6 +6551,9 @@ name = "strict-num"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
+dependencies = [
+ "float-cmp 0.9.0",
+]
 
 [[package]]
 name = "strum_macros"
@@ -5959,6 +6573,16 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "svgtypes"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68c7541fff44b35860c1a7a47a7cadf3e4a304c457b58f9870d9706ece028afc"
+dependencies = [
+ "kurbo",
+ "siphasher",
+]
 
 [[package]]
 name = "syn"
@@ -6085,7 +6709,7 @@ dependencies = [
  "half",
  "quick-error 2.0.1",
  "weezl",
- "zune-jpeg",
+ "zune-jpeg 0.5.15",
 ]
 
 [[package]]
@@ -6127,6 +6751,7 @@ dependencies = [
  "bytemuck",
  "cfg-if",
  "log",
+ "png 0.17.16",
  "tiny-skia-path",
 ]
 
@@ -6364,6 +6989,9 @@ name = "ttf-parser"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
+dependencies = [
+ "core_maths",
+]
 
 [[package]]
 name = "twox-hash"
@@ -6400,6 +7028,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
+name = "unicode-bidi-mirroring"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfa6e8c60bb66d49db113e0125ee8711b7647b5579dc7f5f19c42357ed039fe"
+
+[[package]]
+name = "unicode-ccc"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce61d488bcdc9bc8b5d1772c404828b17fc481c0a582b5581e95fb233aef503e"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6415,6 +7061,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
+
+[[package]]
 name = "unicode-reverse"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6424,10 +7076,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-script"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "383ad40bb927465ec0ce7720e033cb4ca06912855fc35db31b5755d0de75b1ee"
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-vo"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1d386ff53b415b7fe27b50bb44679e2cc4660272694b7b6f3326d8480823a94"
 
 [[package]]
 name = "unicode-width"
@@ -6472,6 +7136,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "usvg"
+version = "0.45.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80be9b06fbae3b8b303400ab20778c80bbaf338f563afe567cf3c9eea17b47ef"
+dependencies = [
+ "base64",
+ "data-url",
+ "flate2",
+ "fontdb",
+ "imagesize",
+ "kurbo",
+ "log",
+ "pico-args",
+ "roxmltree",
+ "rustybuzz",
+ "simplecss",
+ "siphasher",
+ "strict-num",
+ "svgtypes",
+ "tiny-skia-path",
+ "unicode-bidi",
+ "unicode-script",
+ "unicode-vo",
+ "xmlwriter",
+]
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6495,12 +7186,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "v_frame"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "666b7727c8875d6ab5db9533418d7c764233ac9c0cff1d469aec8fa127597be2"
+dependencies = [
+ "aligned-vec",
+ "num-traits",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "value-trait"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9170e001f458781e92711d2ad666110f153e4e50bfd5cbd02db6547625714187"
 dependencies = [
- "float-cmp",
+ "float-cmp 0.10.0",
  "halfbrown",
  "itoa",
  "ryu",
@@ -7200,6 +7902,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "wide"
+version = "0.7.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce5da8ecb62bcd8ec8b7ea19f69a51275e91299be594ea5cc6ef7819e16cd03"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7779,10 +8491,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
 
 [[package]]
+name = "xmlwriter"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9"
+
+[[package]]
 name = "xxhash-rust"
 version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
+
+[[package]]
+name = "y4m"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
 
 [[package]]
 name = "yasna"
@@ -7938,9 +8662,33 @@ dependencies = [
 
 [[package]]
 name = "zune-core"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f423a2c17029964870cfaabb1f13dfab7d092a62a29a89264f4d36990ca414a"
+
+[[package]]
+name = "zune-core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-inflate"
+version = "0.2.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
+name = "zune-jpeg"
+version = "0.4.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29ce2c8a9384ad323cf564b67da86e21d3cfdff87908bc1223ed5c99bc792713"
+dependencies = [
+ "zune-core 0.4.12",
+]
 
 [[package]]
 name = "zune-jpeg"
@@ -7948,5 +8696,5 @@ version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
 dependencies = [
- "zune-core",
+ "zune-core 0.5.1",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,6 @@
 members = [
     ".",
     "plugins/arrow",
-
     "plugins/crypto",
     "plugins/csv",
     "plugins/hash",
@@ -14,8 +13,9 @@ members = [
     "plugins/protobuf",
     "plugins/random",
     "plugins/regex",
+    "plugins/image",
     "plugins/selkie",
-
+    "plugins/svg",
     "plugins/syn",
     "plugins/tls",
     "plugins/toml",

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ PLUGINS := \
     csv \
     egui \
     hash \
+    image \
     jiff \
     mqtt \
     msgpack \
@@ -30,6 +31,7 @@ PLUGINS := \
     random \
     regex \
     selkie \
+    svg \
     syn \
     tls \
     toml \

--- a/lib/color.lisp
+++ b/lib/color.lisp
@@ -1,0 +1,332 @@
+## lib/color.lisp — Color science library (pure Elle)
+##
+## Color space conversions, mixing, gradients, and perceptual distance.
+## All colors are structs with :space and component fields.
+##
+## Usage:
+##   (def color ((import "std/color")))
+##   (color:rgb 0.5 0.3 0.8)                              => {:space :srgb :r 0.5 ...}
+##   (color:convert (color:rgb 1.0 0.0 0.0) :lab)         => {:space :lab :l 53.2 ...}
+##   (color:mix (color:rgb 1 0 0) (color:rgb 0 0 1) 0.5)  => blended color
+##   (color:gradient (color:hsl 0 0.8 0.5) (color:hsl 240 0.8 0.5) 5)
+##   (color:lighten (color:rgb 0.5 0 0) 0.2)
+##   (color:distance c1 c2)                                => CIEDE2000 float
+
+(fn []
+
+  # ── Construction ───────────────────────────────────────────────────
+
+  (defn rgb [r g b]
+    {:space :srgb :r (float r) :g (float g) :b (float b)})
+
+  (defn rgba [r g b a]
+    {:space :srgb :r (float r) :g (float g) :b (float b) :a (float a)})
+
+  (defn hsl [h s l]
+    {:space :hsl :h (float h) :s (float s) :l (float l)})
+
+  (defn lab [l a b]
+    {:space :lab :l (float l) :a (float a) :b (float b)})
+
+  (defn oklch [l c h]
+    {:space :oklch :l (float l) :c (float c) :h (float h)})
+
+  # ── sRGB ↔ Linear ─────────────────────────────────────────────────
+
+  (defn srgb-to-linear [x]
+    (if (<= x 0.04045)
+      (/ x 12.92)
+      (math/pow (/ (+ x 0.055) 1.055) 2.4)))
+
+  (defn linear-to-srgb [x]
+    (if (<= x 0.0031308)
+      (* x 12.92)
+      (- (* 1.055 (math/pow x (/ 1.0 2.4))) 0.055)))
+
+  # ── sRGB ↔ HSL ────────────────────────────────────────────────────
+
+  (defn rgb->hsl [c]
+    (let* [[r (get c :r)] [g (get c :g)] [b (get c :b)]
+           [mx (max r (max g b))]
+           [mn (min r (min g b))]
+           [d  (- mx mn)]
+           [l  (/ (+ mx mn) 2.0)]
+           [s  (if (= d 0.0) 0.0
+                 (/ d (- 1.0 (abs (- (* 2.0 l) 1.0)))))]
+           [h  (if (= d 0.0) 0.0
+                 (cond
+                   ((= mx r) (* 60.0 (fmod (/ (- g b) d) 6.0)))
+                   ((= mx g) (* 60.0 (+ (/ (- b r) d) 2.0)))
+                   (true     (* 60.0 (+ (/ (- r g) d) 4.0)))))]]
+      {:space :hsl
+       :h (if (< h 0.0) (+ h 360.0) h)
+       :s (max 0.0 (min 1.0 s))
+       :l (max 0.0 (min 1.0 l))}))
+
+  (defn hsl->rgb [c]
+    (let* [[h (get c :h)] [s (get c :s)] [l (get c :l)]
+           [ch  (* (- 1.0 (abs (- (* 2.0 l) 1.0))) s)]
+           [hp  (/ (fmod h 360.0) 60.0)]
+           [x   (* ch (- 1.0 (abs (- (fmod hp 2.0) 1.0))))]
+           [[r1 g1 b1]
+            (cond
+              ((< hp 1.0) [ch x  0.0])
+              ((< hp 2.0) [x  ch 0.0])
+              ((< hp 3.0) [0.0 ch x])
+              ((< hp 4.0) [0.0 x  ch])
+              ((< hp 5.0) [x  0.0 ch])
+              (true       [ch 0.0 x]))]
+           [m (- l (/ ch 2.0))]]
+      {:space :srgb :r (+ r1 m) :g (+ g1 m) :b (+ b1 m)}))
+
+  # ── sRGB ↔ XYZ (D65) ──────────────────────────────────────────────
+
+  (defn rgb->xyz [c]
+    (let* [[rl (srgb-to-linear (get c :r))]
+           [gl (srgb-to-linear (get c :g))]
+           [bl (srgb-to-linear (get c :b))]]
+      {:space :xyz
+       :x (+ (* 0.4124564 rl) (* 0.3575761 gl) (* 0.1804375 bl))
+       :y (+ (* 0.2126729 rl) (* 0.7151522 gl) (* 0.0721750 bl))
+       :z (+ (* 0.0193339 rl) (* 0.1191920 gl) (* 0.9503041 bl))}))
+
+  (defn xyz->rgb [c]
+    (let* [[x (get c :x)] [y (get c :y)] [z (get c :z)]
+           [rl (+ (* 3.2404542  x) (* -1.5371385 y) (* -0.4985314 z))]
+           [gl (+ (* -0.9692660 x) (* 1.8760108  y) (* 0.0415560  z))]
+           [bl (+ (* 0.0556434  x) (* -0.2040259 y) (* 1.0572252  z))]]
+      {:space :srgb
+       :r (max 0.0 (min 1.0 (linear-to-srgb rl)))
+       :g (max 0.0 (min 1.0 (linear-to-srgb gl)))
+       :b (max 0.0 (min 1.0 (linear-to-srgb bl)))}))
+
+  # ── XYZ ↔ Lab (D65) ───────────────────────────────────────────────
+
+  (def D65-X 0.95047)
+  (def D65-Y 1.00000)
+  (def D65-Z 1.08883)
+  (def LAB-E (/ 216.0 24389.0))
+  (def LAB-K (/ 24389.0 27.0))
+
+  (defn lab-f [t]
+    (if (> t LAB-E)
+      (math/cbrt t)
+      (/ (+ (* LAB-K t) 16.0) 116.0)))
+
+  (defn lab-f-inv [t]
+    (let [[t3 (* t t t)]]
+      (if (> t3 LAB-E) t3
+        (/ (- (* 116.0 t) 16.0) LAB-K))))
+
+  (defn xyz->lab [c]
+    (let* [[fx (lab-f (/ (get c :x) D65-X))]
+           [fy (lab-f (/ (get c :y) D65-Y))]
+           [fz (lab-f (/ (get c :z) D65-Z))]]
+      {:space :lab
+       :l (- (* 116.0 fy) 16.0)
+       :a (* 500.0 (- fx fy))
+       :b (* 200.0 (- fy fz))}))
+
+  (defn lab->xyz [c]
+    (let* [[l (get c :l)] [a (get c :a)] [b (get c :b)]
+           [fy (/ (+ l 16.0) 116.0)]
+           [fx (+ (/ a 500.0) fy)]
+           [fz (- fy (/ b 200.0))]]
+      {:space :xyz
+       :x (* D65-X (lab-f-inv fx))
+       :y (* D65-Y (lab-f-inv fy))
+       :z (* D65-Z (lab-f-inv fz))}))
+
+  # ── sRGB ↔ Lab shortcut ───────────────────────────────────────────
+
+  (defn rgb->lab [c] (xyz->lab (rgb->xyz c)))
+  (defn lab->rgb [c] (xyz->rgb (lab->xyz c)))
+
+  # ── Lab ↔ Oklch ────────────────────────────────────────────────────
+  ## Oklch uses the Oklab perceptual space with cylindrical coordinates.
+  ## sRGB → Linear → Oklab → Oklch
+
+  (defn rgb->oklab [c]
+    (let* [[rl (srgb-to-linear (get c :r))]
+           [gl (srgb-to-linear (get c :g))]
+           [bl (srgb-to-linear (get c :b))]
+           [l_ (+ (* 0.4122214708 rl) (* 0.5363325363 gl) (* 0.0514459929 bl))]
+           [m_ (+ (* 0.2119034982 rl) (* 0.6806995451 gl) (* 0.1073969566 bl))]
+           [s_ (+ (* 0.0883024619 rl) (* 0.2817188376 gl) (* 0.6299787005 bl))]
+           [l (math/cbrt l_)] [m (math/cbrt m_)] [s (math/cbrt s_)]]
+      {:space :oklab
+       :l (+ (* 0.2104542553 l) (* 0.7936177850 m) (* -0.0040720468 s))
+       :a (+ (* 1.9779984951 l) (* -2.4285922050 m) (* 0.4505937099 s))
+       :b (+ (* 0.0259040371 l) (* 0.7827717662 m) (* -0.8086757660 s))}))
+
+  (defn oklab->rgb [c]
+    (let* [[L (get c :l)] [A (get c :a)] [B (get c :b)]
+           [l_ (+ L (* 0.3963377774 A) (* 0.2158037573 B))]
+           [m_ (+ L (* -0.1055613458 A) (* -0.0638541728 B))]
+           [s_ (+ L (* -0.0894841775 A) (* -1.2914855480 B))]
+           [l (* l_ l_ l_)] [m (* m_ m_ m_)] [s (* s_ s_ s_)]
+           [rl (+ (* 4.0767416621 l) (* -3.3077115913 m) (* 0.2309699292 s))]
+           [gl (+ (* -1.2684380046 l) (* 2.6097574011 m) (* -0.3413193965 s))]
+           [bl (+ (* -0.0041960863 l) (* -0.7034186147 m) (* 1.7076147010 s))]]
+      {:space :srgb
+       :r (max 0.0 (min 1.0 (linear-to-srgb rl)))
+       :g (max 0.0 (min 1.0 (linear-to-srgb gl)))
+       :b (max 0.0 (min 1.0 (linear-to-srgb bl)))}))
+
+  (def DEG (/ 180.0 (math/pi)))
+  (def RAD (/ (math/pi) 180.0))
+
+  (defn oklab->oklch [c]
+    (let* [[a (get c :a)] [b (get c :b)]
+           [ch (math/sqrt (+ (* a a) (* b b)))]
+           [h  (* (math/atan2 b a) DEG)]]
+      {:space :oklch
+       :l (get c :l)
+       :c ch
+       :h (if (< h 0.0) (+ h 360.0) h)}))
+
+  (defn oklch->oklab [c]
+    (let* [[ch (get c :c)] [h (* (get c :h) RAD)]]
+      {:space :oklab
+       :l (get c :l)
+       :a (* ch (math/cos h))
+       :b (* ch (math/sin h))}))
+
+  (defn rgb->oklch [c] (oklab->oklch (rgb->oklab c)))
+  (defn oklch->rgb [c] (oklab->rgb (oklch->oklab c)))
+
+  # ── Conversion dispatch ───────────────────────────────────────────
+
+  (defn to-srgb [c]
+    (match (get c :space)
+      (:srgb  c)
+      (:hsl   (hsl->rgb c))
+      (:lab   (lab->rgb c))
+      (:xyz   (xyz->rgb c))
+      (:oklab (oklab->rgb c))
+      (:oklch (oklch->rgb c))
+      (_      (error {:error :color-error :message (string "unknown space " (get c :space))}))))
+
+  (defn convert [c space]
+    (let [[s (to-srgb c)]]
+      (match space
+        (:srgb  s)
+        (:hsl   (rgb->hsl s))
+        (:lab   (rgb->lab s))
+        (:xyz   (rgb->xyz s))
+        (:oklab (rgb->oklab s))
+        (:oklch (rgb->oklch s))
+        (_      (error {:error :color-error :message (string "unknown target space " space)})))))
+
+  # ── Operations ─────────────────────────────────────────────────────
+
+  (defn mix [c1 c2 t]
+    (let* [[a (to-srgb c1)] [b (to-srgb c2)]
+           [t (float t)] [inv (- 1.0 t)]]
+      {:space :srgb
+       :r (+ (* (get a :r) inv) (* (get b :r) t))
+       :g (+ (* (get a :g) inv) (* (get b :g) t))
+       :b (+ (* (get a :b) inv) (* (get b :b) t))}))
+
+  (defn gradient [c1 c2 n]
+    (let [[steps (max 2 n)]]
+      (map (fn [i] (mix c1 c2 (/ (float i) (float (dec steps)))))
+           (range steps))))
+
+  (defn lighten [c amount]
+    (let [[h (convert c :hsl)]]
+      (hsl->rgb (put h :l (max 0.0 (min 1.0 (+ (get h :l) (float amount))))))))
+
+  (defn darken [c amount]
+    (lighten c (- (float amount))))
+
+  (defn saturate [c amount]
+    (let [[h (convert c :hsl)]]
+      (hsl->rgb (put h :s (max 0.0 (min 1.0 (+ (get h :s) (float amount))))))))
+
+  (defn desaturate [c amount]
+    (saturate c (- (float amount))))
+
+  (defn complement [c]
+    (let [[h (convert c :hsl)]]
+      (hsl->rgb (put h :h (fmod (+ (get h :h) 180.0) 360.0)))))
+
+  # ── CIEDE2000 color distance ───────────────────────────────────────
+
+  (defn distance [c1 c2]
+    (let* [[a (convert c1 :lab)] [b (convert c2 :lab)]
+           [l1 (get a :l)] [a1 (get a :a)] [b1 (get a :b)]
+           [l2 (get b :l)] [a2 (get b :a)] [b2 (get b :b)]
+           [dl (- l2 l1)]
+           [lb (/ (+ l1 l2) 2.0)]
+           [c1s (math/sqrt (+ (* a1 a1) (* b1 b1)))]
+           [c2s (math/sqrt (+ (* a2 a2) (* b2 b2)))]
+           [cb  (/ (+ c1s c2s) 2.0)]
+           [cb7 (math/pow cb 7.0)]
+           [g   (* 0.5 (- 1.0 (math/sqrt (/ cb7 (+ cb7 (math/pow 25.0 7.0))))))]
+           [a1p (* a1 (+ 1.0 g))]
+           [a2p (* a2 (+ 1.0 g))]
+           [c1p (math/sqrt (+ (* a1p a1p) (* b1 b1)))]
+           [c2p (math/sqrt (+ (* a2p a2p) (* b2 b2)))]
+           [dcp (- c2p c1p)]
+           [cbp (/ (+ c1p c2p) 2.0)]
+           [h1p (let [[h (* (math/atan2 b1 a1p) DEG)]]
+                  (if (< h 0.0) (+ h 360.0) h))]
+           [h2p (let [[h (* (math/atan2 b2 a2p) DEG)]]
+                  (if (< h 0.0) (+ h 360.0) h))]
+           [dhp (cond
+                  ((or (= c1p 0.0) (= c2p 0.0)) 0.0)
+                  ((<= (abs (- h2p h1p)) 180.0) (- h2p h1p))
+                  ((> (- h2p h1p) 180.0) (- (- h2p h1p) 360.0))
+                  (true (+ (- h2p h1p) 360.0)))]
+           [dHp (* 2.0 (math/sqrt (* c1p c2p)) (math/sin (* (/ dhp 2.0) RAD)))]
+           [Hbp (cond
+                  ((or (= c1p 0.0) (= c2p 0.0)) (+ h1p h2p))
+                  ((<= (abs (- h1p h2p)) 180.0) (/ (+ h1p h2p) 2.0))
+                  ((< (+ h1p h2p) 360.0) (/ (+ h1p h2p 360.0) 2.0))
+                  (true (/ (+ h1p h2p -360.0) 2.0)))]
+           [T (+ 1.0
+                 (* -0.17 (math/cos (* (- Hbp 30.0) RAD)))
+                 (* 0.24  (math/cos (* (* 2.0 Hbp) RAD)))
+                 (* 0.32  (math/cos (* (+ (* 3.0 Hbp) 6.0) RAD)))
+                 (* -0.20 (math/cos (* (- (* 4.0 Hbp) 63.0) RAD))))]
+           [lbm50sq (* (- lb 50.0) (- lb 50.0))]
+           [sl (+ 1.0 (/ (* 0.015 lbm50sq) (math/sqrt (+ 20.0 lbm50sq))))]
+           [sc (+ 1.0 (* 0.045 cbp))]
+           [sh (+ 1.0 (* 0.015 cbp T))]
+           [cbp7 (math/pow cbp 7.0)]
+           [rt (* -2.0 (math/sqrt (/ cbp7 (+ cbp7 (math/pow 25.0 7.0))))
+                 (math/sin (* 60.0 (math/pow 2.718281828
+                                     (* -1.0 (* (/ (- Hbp 275.0) 25.0) (/ (- Hbp 275.0) 25.0))))))
+                 RAD)]]
+      (math/sqrt (+ (* (/ dl sl) (/ dl sl))
+                    (* (/ dcp sc) (/ dcp sc))
+                    (* (/ dHp sh) (/ dHp sh))
+                    (* rt (/ dcp sc) (/ dHp sh))))))
+
+  # ── Pixel interop ──────────────────────────────────────────────────
+
+  (defn to-rgba8 [c]
+    (let [[s (to-srgb c)]]
+      [(integer (* (max 0.0 (min 1.0 (get s :r))) 255.0))
+       (integer (* (max 0.0 (min 1.0 (get s :g))) 255.0))
+       (integer (* (max 0.0 (min 1.0 (get s :b))) 255.0))
+       (integer (* (max 0.0 (min 1.0 (or (get s :a) 1.0))) 255.0))]))
+
+  (defn from-rgba8 [r g b a]
+    {:space :srgb
+     :r (/ (float r) 255.0)
+     :g (/ (float g) 255.0)
+     :b (/ (float b) 255.0)
+     :a (/ (float a) 255.0)})
+
+  # ── Export ─────────────────────────────────────────────────────────
+
+  {:rgb rgb :rgba rgba :hsl hsl :lab lab :oklch oklch
+   :convert convert :to-srgb to-srgb
+   :mix mix :gradient gradient
+   :lighten lighten :darken darken
+   :saturate saturate :desaturate desaturate
+   :complement complement
+   :distance distance
+   :to-rgba8 to-rgba8 :from-rgba8 from-rgba8})

--- a/lib/svg.lisp
+++ b/lib/svg.lisp
@@ -1,0 +1,240 @@
+## lib/svg.lisp — SVG construction and emission (pure Elle)
+##
+## Build SVG documents as struct trees, emit as XML strings.
+## Optionally pass the svg plugin for rasterization.
+##
+## Usage:
+##   (def svg ((import "std/svg")))
+##   (def doc (svg:svg 400 300
+##              (svg:rect 10 20 100 50 {:fill "blue"})
+##              (svg:circle 50 50 30 {:fill "red"})))
+##   (println (svg:emit doc))
+##
+## With rendering:
+##   (def svgr (import "plugin/svg"))
+##   (def svg ((import "std/svg") svgr))
+##   (spit "out.png" (svg:render doc))
+
+(fn [& opts]
+
+  (def renderer (if (empty? opts) nil (first opts)))
+
+  # ── Element constructor ────────────────────────────────────────────
+
+  (defn element [tag attrs children]
+    {:tag tag :attrs attrs :children (->array children)})
+
+  # ── Attribute merge ────────────────────────────────────────────────
+
+  (defn opt-attrs [opts]
+    (if (empty? opts) nil (first opts)))
+
+  (defn merge-attrs [base user]
+    (if (nil? user) base (merge base user)))
+
+  # ── Document root ──────────────────────────────────────────────────
+
+  (defn svg [w h & children]
+    (element :svg
+      {:xmlns "http://www.w3.org/2000/svg"
+       :width (float w) :height (float h)
+       :viewBox (string "0 0 " w " " h)}
+      children))
+
+  # ── Shape elements ─────────────────────────────────────────────────
+
+  (defn rect [x y w h & opts]
+    (element :rect
+      (merge-attrs {:x (float x) :y (float y)
+                    :width (float w) :height (float h)}
+                   (opt-attrs opts))
+      []))
+
+  (defn circle [cx cy r & opts]
+    (element :circle
+      (merge-attrs {:cx (float cx) :cy (float cy) :r (float r)}
+                   (opt-attrs opts))
+      []))
+
+  (defn ellipse [cx cy rx ry & opts]
+    (element :ellipse
+      (merge-attrs {:cx (float cx) :cy (float cy)
+                    :rx (float rx) :ry (float ry)}
+                   (opt-attrs opts))
+      []))
+
+  (defn line [x1 y1 x2 y2 & opts]
+    (element :line
+      (merge-attrs {:x1 (float x1) :y1 (float y1)
+                    :x2 (float x2) :y2 (float y2)}
+                   (opt-attrs opts))
+      []))
+
+  (defn path [d & opts]
+    (element :path
+      (merge-attrs {:d d} (opt-attrs opts))
+      []))
+
+  # ── Points helpers ─────────────────────────────────────────────────
+
+  (defn points->string [pts]
+    (string/join (map (fn [p] (string (p 0) "," (p 1))) pts) " "))
+
+  (defn polyline [pts & opts]
+    (element :polyline
+      (merge-attrs {:points (points->string pts)} (opt-attrs opts))
+      []))
+
+  (defn polygon [pts & opts]
+    (element :polygon
+      (merge-attrs {:points (points->string pts)} (opt-attrs opts))
+      []))
+
+  # ── Text ───────────────────────────────────────────────────────────
+
+  (defn text [x y & rest]
+    (let [[attrs {:x (float x) :y (float y)}]
+          [children @[]]]
+      (each item in rest
+        (cond
+          ## Attrs struct (not an SVG element)
+          ((and (struct? item) (nil? (get item :tag)))
+            (assign attrs (merge attrs item)))
+          ## String content
+          ((string? item) (push children item))
+          ## SVG element child (tspan etc.)
+          (true (push children item))))
+      (element :text attrs (freeze children))))
+
+  (defn tspan [content & opts]
+    (element :tspan
+      (or (first opts) {})
+      [content]))
+
+  # ── Grouping and transforms ───────────────────────────────────────
+
+  (defn group [& args]
+    (if (and (not (empty? args)) (struct? (first args)) (nil? (get (first args) :tag)))
+      (element :g (first args) (slice args 1))
+      (element :g {} args)))
+
+  (defn translate [dx dy & children]
+    (element :g {:transform (string "translate(" dx "," dy ")")} children))
+
+  (defn rotate [deg & children]
+    (element :g {:transform (string "rotate(" deg ")")} children))
+
+  (defn scale [sx & rest]
+    (if (and (not (empty? rest)) (number? (first rest)))
+      (let [[sy (first rest)]]
+        (element :g {:transform (string "scale(" sx "," sy ")")} (slice rest 1)))
+      (element :g {:transform (string "scale(" sx "," sx ")")} rest)))
+
+  # ── Definitions ────────────────────────────────────────────────────
+
+  (defn defs [& children]
+    (element :defs {} children))
+
+  (defn linear-gradient [id attrs & stops]
+    (element :linearGradient (merge {:id id} attrs) stops))
+
+  (defn radial-gradient [id attrs & stops]
+    (element :radialGradient (merge {:id id} attrs) stops))
+
+  (defn stop [offset color & opts]
+    (element :stop
+      (merge-attrs {:offset (string (* offset 100.0) "%")
+                    :stop-color color}
+                   (opt-attrs opts))
+      []))
+
+  (defn clip-path [id & children]
+    (element :clipPath {:id id} children))
+
+  (defn mask [id & children]
+    (element :mask {:id id} children))
+
+  # ── Element manipulation ──────────────────────────────────────────
+
+  (defn set-attr [elem key value]
+    (put elem :attrs (put (get elem :attrs) key value)))
+
+  (defn add-child [elem child]
+    (let [[kids (thaw (get elem :children))]]
+      (push kids child)
+      (put elem :children (freeze kids))))
+
+  (defn wrap [elem tag & opts]
+    (element tag (or (first opts) {}) [elem]))
+
+  # ── XML emission ──────────────────────────────────────────────────
+
+  (defn xml-escape [s]
+    (-> s
+        (string/replace "&" "&amp;")
+        (string/replace "<" "&lt;")
+        (string/replace ">" "&gt;")))
+
+  (defn xml-escape-attr [s]
+    (-> s
+        (string/replace "&" "&amp;")
+        (string/replace "<" "&lt;")
+        (string/replace ">" "&gt;")
+        (string/replace "\"" "&quot;")))
+
+  (defn emit-attr-value [v]
+    (cond
+      ((string? v) (xml-escape-attr v))
+      ((int? v) (string v))
+      ((float? v) (string v))
+      ((keyword? v) (string v))
+      (true nil)))
+
+  (defn emit-element [elem]
+    (cond
+      ((string? elem) (xml-escape elem))
+      ((struct? elem)
+        (let* [[tag (get elem :tag)]
+               [attrs (get elem :attrs)]
+               [children (get elem :children)]
+               [out @""]]
+          (append out (string "<" tag))
+          (when attrs
+            (each [k v] in attrs
+              (let [[val-str (emit-attr-value v)]]
+                (when val-str
+                  (append out (string " " k "=\"" val-str "\""))))))
+          (if (or (nil? children) (empty? children))
+            (append out "/>")
+            (begin
+              (append out ">")
+              (each child in children
+                (append out (emit-element child)))
+              (append out (string "</" tag ">"))))
+          (freeze out)))
+      (true "")))
+
+  (defn emit [doc]
+    (string "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" (emit-element doc)))
+
+  # ── Export ─────────────────────────────────────────────────────────
+
+  (def exports
+    {:svg svg :rect rect :circle circle :ellipse ellipse
+     :line line :path path :polyline polyline :polygon polygon
+     :text text :tspan tspan
+     :group group :translate translate :rotate rotate :scale scale
+     :defs defs :linear-gradient linear-gradient
+     :radial-gradient radial-gradient :stop stop
+     :clip-path clip-path :mask mask
+     :set-attr set-attr :add-child add-child :wrap wrap
+     :emit emit :element element})
+
+  ## If renderer plugin provided, add rendering functions
+  (if renderer
+    (merge exports
+      {:render      (get renderer :render)
+       :render-raw  (get renderer :render-raw)
+       :render-to-file (get renderer :render-to-file)
+       :dimensions  (get renderer :dimensions)})
+    exports))

--- a/plugins/image/Cargo.toml
+++ b/plugins/image/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "elle-image"
+version = "1.0.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+elle = { path = "../.." }
+image = { version = "0.25", default-features = false, features = [
+    "png", "jpeg", "gif", "webp", "tiff", "bmp", "ico", "qoi",
+] }
+imageproc = "0.25"

--- a/plugins/image/src/analysis.rs
+++ b/plugins/image/src/analysis.rs
@@ -1,0 +1,201 @@
+//! Image analysis: histogram, edge detection, threshold, morphology.
+
+use std::collections::BTreeMap;
+
+use image::DynamicImage;
+use imageproc::contrast;
+use imageproc::edges;
+use imageproc::morphology;
+
+use elle::primitives::def::PrimitiveDef;
+use elle::signals::Signal;
+use elle::value::fiber::{SignalBits, SIG_ERROR, SIG_OK};
+use elle::value::types::{Arity, TableKey};
+use elle::value::{error_val, Value};
+
+use crate::{get_image, require_int, wrap_image};
+
+// ── image/histogram ─────────────────────────────────────────────────
+
+fn prim_histogram(args: &[Value]) -> (SignalBits, Value) {
+    let img = match get_image(&args[0], "image/histogram") {
+        Ok(i) => i,
+        Err(e) => return e,
+    };
+    let rgba = img.to_rgba8();
+    let mut r_hist = vec![0i64; 256];
+    let mut g_hist = vec![0i64; 256];
+    let mut b_hist = vec![0i64; 256];
+    let mut a_hist = vec![0i64; 256];
+
+    for px in rgba.pixels() {
+        r_hist[px[0] as usize] += 1;
+        g_hist[px[1] as usize] += 1;
+        b_hist[px[2] as usize] += 1;
+        a_hist[px[3] as usize] += 1;
+    }
+
+    let to_array = |h: Vec<i64>| Value::array(h.into_iter().map(Value::int).collect());
+
+    let mut fields = BTreeMap::new();
+    fields.insert(TableKey::Keyword("r".into()), to_array(r_hist));
+    fields.insert(TableKey::Keyword("g".into()), to_array(g_hist));
+    fields.insert(TableKey::Keyword("b".into()), to_array(b_hist));
+    fields.insert(TableKey::Keyword("a".into()), to_array(a_hist));
+
+    (SIG_OK, Value::struct_from(fields))
+}
+
+pub static HISTOGRAM: PrimitiveDef = PrimitiveDef {
+    name: "image/histogram",
+    func: prim_histogram,
+    signal: Signal::errors(),
+    arity: Arity::Exact(1),
+    doc: "Compute per-channel histograms. Returns {:r :g :b :a} with 256-element arrays.",
+    params: &["img"],
+    category: "image",
+    example: "(image/histogram img)",
+    aliases: &[],
+};
+
+// ── image/edges ─────────────────────────────────────────────────────
+
+fn prim_edges(args: &[Value]) -> (SignalBits, Value) {
+    let img = match get_image(&args[0], "image/edges") {
+        Ok(i) => i,
+        Err(e) => return e,
+    };
+    let algo = if args.len() > 1 {
+        args[1]
+            .as_keyword_name()
+            .unwrap_or_else(|| "canny".to_string())
+    } else {
+        "canny".to_string()
+    };
+    let gray = img.to_luma8();
+    let result = match algo.as_str() {
+        "canny" => edges::canny(&gray, 50.0, 100.0),
+        "sobel" => {
+            // Sobel via horizontal + vertical gradient magnitude
+            let h = imageproc::gradients::horizontal_sobel(&gray);
+            let v = imageproc::gradients::vertical_sobel(&gray);
+            let mut out = image::GrayImage::new(gray.width(), gray.height());
+            for (x, y, px) in out.enumerate_pixels_mut() {
+                let hv = h.get_pixel(x, y)[0] as f64;
+                let vv = v.get_pixel(x, y)[0] as f64;
+                let mag = (hv * hv + vv * vv).sqrt().min(255.0) as u8;
+                *px = image::Luma([mag]);
+            }
+            out
+        }
+        _ => {
+            return (
+                SIG_ERROR,
+                error_val(
+                    "value-error",
+                    format!(
+                        "image/edges: unknown algorithm :{}, expected :canny or :sobel",
+                        algo
+                    ),
+                ),
+            )
+        }
+    };
+    (SIG_OK, wrap_image(DynamicImage::ImageLuma8(result)))
+}
+
+pub static EDGES: PrimitiveDef = PrimitiveDef {
+    name: "image/edges",
+    func: prim_edges,
+    signal: Signal::errors(),
+    arity: Arity::Range(1, 2),
+    doc: "Detect edges. Optional algorithm: :canny (default) or :sobel. Returns grayscale image.",
+    params: &["img", "algo"],
+    category: "image",
+    example: "(image/edges img :canny)",
+    aliases: &[],
+};
+
+// ── image/threshold ─────────────────────────────────────────────────
+
+fn prim_threshold(args: &[Value]) -> (SignalBits, Value) {
+    let img = match get_image(&args[0], "image/threshold") {
+        Ok(i) => i,
+        Err(e) => return e,
+    };
+    let t = match require_int(&args[1], "image/threshold", "threshold") {
+        Ok(v) => v.clamp(0, 255) as u8,
+        Err(e) => return e,
+    };
+    let gray = img.to_luma8();
+    let result = contrast::threshold(&gray, t, imageproc::contrast::ThresholdType::Binary);
+    (SIG_OK, wrap_image(DynamicImage::ImageLuma8(result)))
+}
+
+pub static THRESHOLD: PrimitiveDef = PrimitiveDef {
+    name: "image/threshold",
+    func: prim_threshold,
+    signal: Signal::errors(),
+    arity: Arity::Exact(2),
+    doc: "Binary threshold: pixels above t become 255, below become 0. Returns grayscale.",
+    params: &["img", "threshold"],
+    category: "image",
+    example: "(image/threshold img 128)",
+    aliases: &[],
+};
+
+// ── image/erode ─────────────────────────────────────────────────────
+
+fn prim_erode(args: &[Value]) -> (SignalBits, Value) {
+    let img = match get_image(&args[0], "image/erode") {
+        Ok(i) => i,
+        Err(e) => return e,
+    };
+    let radius = match require_int(&args[1], "image/erode", "radius") {
+        Ok(v) => v.max(0) as u8,
+        Err(e) => return e,
+    };
+    let gray = img.to_luma8();
+    let result = morphology::erode(&gray, imageproc::distance_transform::Norm::LInf, radius);
+    (SIG_OK, wrap_image(DynamicImage::ImageLuma8(result)))
+}
+
+pub static ERODE: PrimitiveDef = PrimitiveDef {
+    name: "image/erode",
+    func: prim_erode,
+    signal: Signal::errors(),
+    arity: Arity::Exact(2),
+    doc: "Morphological erosion with given radius. Operates on grayscale.",
+    params: &["img", "radius"],
+    category: "image",
+    example: "(image/erode img 2)",
+    aliases: &[],
+};
+
+// ── image/dilate ────────────────────────────────────────────────────
+
+fn prim_dilate(args: &[Value]) -> (SignalBits, Value) {
+    let img = match get_image(&args[0], "image/dilate") {
+        Ok(i) => i,
+        Err(e) => return e,
+    };
+    let radius = match require_int(&args[1], "image/dilate", "radius") {
+        Ok(v) => v.max(0) as u8,
+        Err(e) => return e,
+    };
+    let gray = img.to_luma8();
+    let result = morphology::dilate(&gray, imageproc::distance_transform::Norm::LInf, radius);
+    (SIG_OK, wrap_image(DynamicImage::ImageLuma8(result)))
+}
+
+pub static DILATE: PrimitiveDef = PrimitiveDef {
+    name: "image/dilate",
+    func: prim_dilate,
+    signal: Signal::errors(),
+    arity: Arity::Exact(2),
+    doc: "Morphological dilation with given radius. Operates on grayscale.",
+    params: &["img", "radius"],
+    category: "image",
+    example: "(image/dilate img 2)",
+    aliases: &[],
+};

--- a/plugins/image/src/composite.rs
+++ b/plugins/image/src/composite.rs
@@ -1,0 +1,104 @@
+//! Image compositing: overlay and blend.
+
+use image::DynamicImage;
+
+use elle::primitives::def::PrimitiveDef;
+use elle::signals::Signal;
+use elle::value::fiber::{SignalBits, SIG_ERROR, SIG_OK};
+use elle::value::types::Arity;
+use elle::value::{error_val, Value};
+
+use crate::{get_image, require_float, require_int, wrap_image};
+
+// ── image/overlay ───────────────────────────────────────────────────
+
+fn prim_overlay(args: &[Value]) -> (SignalBits, Value) {
+    let mut base = match get_image(&args[0], "image/overlay") {
+        Ok(i) => i.to_rgba8(),
+        Err(e) => return e,
+    };
+    let overlay = match get_image(&args[1], "image/overlay") {
+        Ok(i) => i.to_rgba8(),
+        Err(e) => return e,
+    };
+    let x = match require_int(&args[2], "image/overlay", "x") {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+    let y = match require_int(&args[3], "image/overlay", "y") {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+    image::imageops::overlay(&mut base, &overlay, x, y);
+    (SIG_OK, wrap_image(DynamicImage::ImageRgba8(base)))
+}
+
+pub static OVERLAY: PrimitiveDef = PrimitiveDef {
+    name: "image/overlay",
+    func: prim_overlay,
+    signal: Signal::errors(),
+    arity: Arity::Exact(4),
+    doc: "Composite overlay image onto base at position (x, y). Alpha-blended.",
+    params: &["base", "overlay", "x", "y"],
+    category: "image",
+    example: "(image/overlay base-img overlay-img 10 20)",
+    aliases: &[],
+};
+
+// ── image/blend ─────────────────────────────────────────────────────
+
+fn prim_blend(args: &[Value]) -> (SignalBits, Value) {
+    let img1 = match get_image(&args[0], "image/blend") {
+        Ok(i) => i.to_rgba8(),
+        Err(e) => return e,
+    };
+    let img2 = match get_image(&args[1], "image/blend") {
+        Ok(i) => i.to_rgba8(),
+        Err(e) => return e,
+    };
+    let alpha = match require_float(&args[2], "image/blend", "alpha") {
+        Ok(v) => v as f32,
+        Err(e) => return e,
+    };
+    if img1.dimensions() != img2.dimensions() {
+        return (
+            SIG_ERROR,
+            error_val(
+                "value-error",
+                format!(
+                    "image/blend: images must have same dimensions, got {}x{} and {}x{}",
+                    img1.width(),
+                    img1.height(),
+                    img2.width(),
+                    img2.height()
+                ),
+            ),
+        );
+    }
+    let alpha = alpha.clamp(0.0, 1.0);
+    let inv = 1.0 - alpha;
+    let mut out = image::RgbaImage::new(img1.width(), img1.height());
+    for (x, y, px1) in img1.enumerate_pixels() {
+        let px2 = img2.get_pixel(x, y);
+        let blended = image::Rgba([
+            (px1[0] as f32 * inv + px2[0] as f32 * alpha) as u8,
+            (px1[1] as f32 * inv + px2[1] as f32 * alpha) as u8,
+            (px1[2] as f32 * inv + px2[2] as f32 * alpha) as u8,
+            (px1[3] as f32 * inv + px2[3] as f32 * alpha) as u8,
+        ]);
+        out.put_pixel(x, y, blended);
+    }
+    (SIG_OK, wrap_image(DynamicImage::ImageRgba8(out)))
+}
+
+pub static BLEND: PrimitiveDef = PrimitiveDef {
+    name: "image/blend",
+    func: prim_blend,
+    signal: Signal::errors(),
+    arity: Arity::Exact(3),
+    doc: "Alpha-blend two same-size images. alpha=0 is all img1, alpha=1 is all img2.",
+    params: &["img1", "img2", "alpha"],
+    category: "image",
+    example: "(image/blend img1 img2 0.5)",
+    aliases: &[],
+};

--- a/plugins/image/src/draw.rs
+++ b/plugins/image/src/draw.rs
@@ -1,0 +1,230 @@
+//! Drawing primitives for mutable @image.
+
+use imageproc::drawing;
+
+use elle::primitives::def::PrimitiveDef;
+use elle::signals::Signal;
+use elle::value::fiber::{SignalBits, SIG_OK};
+use elle::value::types::Arity;
+use elle::value::Value;
+
+use crate::{extract_color, get_image_mut, require_int};
+
+// ── image/draw-line ─────────────────────────────────────────────────
+
+fn prim_draw_line(args: &[Value]) -> (SignalBits, Value) {
+    let m = match get_image_mut(&args[0], "image/draw-line") {
+        Ok(m) => m,
+        Err(e) => return e,
+    };
+    let x1 = match require_int(&args[1], "image/draw-line", "x1") {
+        Ok(v) => v as i32,
+        Err(e) => return e,
+    };
+    let y1 = match require_int(&args[2], "image/draw-line", "y1") {
+        Ok(v) => v as i32,
+        Err(e) => return e,
+    };
+    let x2 = match require_int(&args[3], "image/draw-line", "x2") {
+        Ok(v) => v as i32,
+        Err(e) => return e,
+    };
+    let y2 = match require_int(&args[4], "image/draw-line", "y2") {
+        Ok(v) => v as i32,
+        Err(e) => return e,
+    };
+    let color = match extract_color(&args[5], "image/draw-line") {
+        Ok(c) => c,
+        Err(e) => return e,
+    };
+    let mut img = m.0.borrow_mut();
+    let rgba = img.as_mut_rgba8().expect("draw requires rgba8 @image");
+    drawing::draw_line_segment_mut(rgba, (x1 as f32, y1 as f32), (x2 as f32, y2 as f32), color);
+    (SIG_OK, Value::NIL)
+}
+
+pub static DRAW_LINE: PrimitiveDef = PrimitiveDef {
+    name: "image/draw-line",
+    func: prim_draw_line,
+    signal: Signal::errors(),
+    arity: Arity::Exact(6),
+    doc: "Draw a line on @image from (x1,y1) to (x2,y2) with color [r g b a].",
+    params: &["img", "x1", "y1", "x2", "y2", "color"],
+    category: "image",
+    example: "(image/draw-line @img 0 0 100 100 [255 0 0 255])",
+    aliases: &[],
+};
+
+// ── image/draw-rect ─────────────────────────────────────────────────
+
+fn prim_draw_rect(args: &[Value]) -> (SignalBits, Value) {
+    let m = match get_image_mut(&args[0], "image/draw-rect") {
+        Ok(m) => m,
+        Err(e) => return e,
+    };
+    let x = match require_int(&args[1], "image/draw-rect", "x") {
+        Ok(v) => v as i32,
+        Err(e) => return e,
+    };
+    let y = match require_int(&args[2], "image/draw-rect", "y") {
+        Ok(v) => v as i32,
+        Err(e) => return e,
+    };
+    let w = match require_int(&args[3], "image/draw-rect", "width") {
+        Ok(v) => v as u32,
+        Err(e) => return e,
+    };
+    let h = match require_int(&args[4], "image/draw-rect", "height") {
+        Ok(v) => v as u32,
+        Err(e) => return e,
+    };
+    let color = match extract_color(&args[5], "image/draw-rect") {
+        Ok(c) => c,
+        Err(e) => return e,
+    };
+    let mut img = m.0.borrow_mut();
+    let rgba = img.as_mut_rgba8().expect("draw requires rgba8 @image");
+    let rect = imageproc::rect::Rect::at(x, y).of_size(w, h);
+    drawing::draw_hollow_rect_mut(rgba, rect, color);
+    (SIG_OK, Value::NIL)
+}
+
+pub static DRAW_RECT: PrimitiveDef = PrimitiveDef {
+    name: "image/draw-rect",
+    func: prim_draw_rect,
+    signal: Signal::errors(),
+    arity: Arity::Exact(6),
+    doc: "Draw a rectangle outline on @image.",
+    params: &["img", "x", "y", "width", "height", "color"],
+    category: "image",
+    example: "(image/draw-rect @img 10 10 80 60 [0 255 0 255])",
+    aliases: &[],
+};
+
+// ── image/draw-circle ───────────────────────────────────────────────
+
+fn prim_draw_circle(args: &[Value]) -> (SignalBits, Value) {
+    let m = match get_image_mut(&args[0], "image/draw-circle") {
+        Ok(m) => m,
+        Err(e) => return e,
+    };
+    let cx = match require_int(&args[1], "image/draw-circle", "cx") {
+        Ok(v) => v as i32,
+        Err(e) => return e,
+    };
+    let cy = match require_int(&args[2], "image/draw-circle", "cy") {
+        Ok(v) => v as i32,
+        Err(e) => return e,
+    };
+    let r = match require_int(&args[3], "image/draw-circle", "radius") {
+        Ok(v) => v as i32,
+        Err(e) => return e,
+    };
+    let color = match extract_color(&args[4], "image/draw-circle") {
+        Ok(c) => c,
+        Err(e) => return e,
+    };
+    let mut img = m.0.borrow_mut();
+    let rgba = img.as_mut_rgba8().expect("draw requires rgba8 @image");
+    drawing::draw_hollow_circle_mut(rgba, (cx, cy), r, color);
+    (SIG_OK, Value::NIL)
+}
+
+pub static DRAW_CIRCLE: PrimitiveDef = PrimitiveDef {
+    name: "image/draw-circle",
+    func: prim_draw_circle,
+    signal: Signal::errors(),
+    arity: Arity::Exact(5),
+    doc: "Draw a circle outline on @image.",
+    params: &["img", "cx", "cy", "radius", "color"],
+    category: "image",
+    example: "(image/draw-circle @img 50 50 30 [0 0 255 255])",
+    aliases: &[],
+};
+
+// ── image/fill-rect ─────────────────────────────────────────────────
+
+fn prim_fill_rect(args: &[Value]) -> (SignalBits, Value) {
+    let m = match get_image_mut(&args[0], "image/fill-rect") {
+        Ok(m) => m,
+        Err(e) => return e,
+    };
+    let x = match require_int(&args[1], "image/fill-rect", "x") {
+        Ok(v) => v as i32,
+        Err(e) => return e,
+    };
+    let y = match require_int(&args[2], "image/fill-rect", "y") {
+        Ok(v) => v as i32,
+        Err(e) => return e,
+    };
+    let w = match require_int(&args[3], "image/fill-rect", "width") {
+        Ok(v) => v as u32,
+        Err(e) => return e,
+    };
+    let h = match require_int(&args[4], "image/fill-rect", "height") {
+        Ok(v) => v as u32,
+        Err(e) => return e,
+    };
+    let color = match extract_color(&args[5], "image/fill-rect") {
+        Ok(c) => c,
+        Err(e) => return e,
+    };
+    let mut img = m.0.borrow_mut();
+    let rgba = img.as_mut_rgba8().expect("draw requires rgba8 @image");
+    let rect = imageproc::rect::Rect::at(x, y).of_size(w, h);
+    drawing::draw_filled_rect_mut(rgba, rect, color);
+    (SIG_OK, Value::NIL)
+}
+
+pub static FILL_RECT: PrimitiveDef = PrimitiveDef {
+    name: "image/fill-rect",
+    func: prim_fill_rect,
+    signal: Signal::errors(),
+    arity: Arity::Exact(6),
+    doc: "Draw a filled rectangle on @image.",
+    params: &["img", "x", "y", "width", "height", "color"],
+    category: "image",
+    example: "(image/fill-rect @img 10 10 80 60 [255 255 0 255])",
+    aliases: &[],
+};
+
+// ── image/fill-circle ───────────────────────────────────────────────
+
+fn prim_fill_circle(args: &[Value]) -> (SignalBits, Value) {
+    let m = match get_image_mut(&args[0], "image/fill-circle") {
+        Ok(m) => m,
+        Err(e) => return e,
+    };
+    let cx = match require_int(&args[1], "image/fill-circle", "cx") {
+        Ok(v) => v as i32,
+        Err(e) => return e,
+    };
+    let cy = match require_int(&args[2], "image/fill-circle", "cy") {
+        Ok(v) => v as i32,
+        Err(e) => return e,
+    };
+    let r = match require_int(&args[3], "image/fill-circle", "radius") {
+        Ok(v) => v as i32,
+        Err(e) => return e,
+    };
+    let color = match extract_color(&args[4], "image/fill-circle") {
+        Ok(c) => c,
+        Err(e) => return e,
+    };
+    let mut img = m.0.borrow_mut();
+    let rgba = img.as_mut_rgba8().expect("draw requires rgba8 @image");
+    drawing::draw_filled_circle_mut(rgba, (cx, cy), r, color);
+    (SIG_OK, Value::NIL)
+}
+
+pub static FILL_CIRCLE: PrimitiveDef = PrimitiveDef {
+    name: "image/fill-circle",
+    func: prim_fill_circle,
+    signal: Signal::errors(),
+    arity: Arity::Exact(5),
+    doc: "Draw a filled circle on @image.",
+    params: &["img", "cx", "cy", "radius", "color"],
+    category: "image",
+    example: "(image/fill-circle @img 50 50 30 [255 0 255 255])",
+    aliases: &[],
+};

--- a/plugins/image/src/inspect.rs
+++ b/plugins/image/src/inspect.rs
@@ -1,0 +1,449 @@
+//! Image introspection, pixel access, and mutability conversion.
+
+use image::{DynamicImage, GenericImage, GenericImageView};
+
+use elle::primitives::def::PrimitiveDef;
+use elle::signals::Signal;
+use elle::value::fiber::{SignalBits, SIG_ERROR, SIG_OK};
+use elle::value::types::Arity;
+use elle::value::{error_val, Value};
+
+use crate::{
+    color_type_keyword, extract_color, get_image, get_image_mut, get_image_ref, parse_color_type,
+    require_int, wrap_image, wrap_image_mut,
+};
+
+// ── image/width ─────────────────────────────────────────────────────
+
+fn prim_width(args: &[Value]) -> (SignalBits, Value) {
+    let r = match get_image_ref(&args[0], "image/width") {
+        Ok(r) => r,
+        Err(e) => return e,
+    };
+    (SIG_OK, Value::int(r.with(|img| img.width() as i64)))
+}
+
+pub static WIDTH: PrimitiveDef = PrimitiveDef {
+    name: "image/width",
+    func: prim_width,
+    signal: Signal::silent(),
+    arity: Arity::Exact(1),
+    doc: "Return the width of an image in pixels.",
+    params: &["img"],
+    category: "image",
+    example: "(image/width img)",
+    aliases: &[],
+};
+
+// ── image/height ────────────────────────────────────────────────────
+
+fn prim_height(args: &[Value]) -> (SignalBits, Value) {
+    let r = match get_image_ref(&args[0], "image/height") {
+        Ok(r) => r,
+        Err(e) => return e,
+    };
+    (SIG_OK, Value::int(r.with(|img| img.height() as i64)))
+}
+
+pub static HEIGHT: PrimitiveDef = PrimitiveDef {
+    name: "image/height",
+    func: prim_height,
+    signal: Signal::silent(),
+    arity: Arity::Exact(1),
+    doc: "Return the height of an image in pixels.",
+    params: &["img"],
+    category: "image",
+    example: "(image/height img)",
+    aliases: &[],
+};
+
+// ── image/dimensions ────────────────────────────────────────────────
+
+fn prim_dimensions(args: &[Value]) -> (SignalBits, Value) {
+    let r = match get_image_ref(&args[0], "image/dimensions") {
+        Ok(r) => r,
+        Err(e) => return e,
+    };
+    let (w, h) = r.with(|img| img.dimensions());
+    (
+        SIG_OK,
+        Value::array(vec![Value::int(w as i64), Value::int(h as i64)]),
+    )
+}
+
+pub static DIMENSIONS: PrimitiveDef = PrimitiveDef {
+    name: "image/dimensions",
+    func: prim_dimensions,
+    signal: Signal::silent(),
+    arity: Arity::Exact(1),
+    doc: "Return [width height] of an image.",
+    params: &["img"],
+    category: "image",
+    example: "(image/dimensions img)",
+    aliases: &[],
+};
+
+// ── image/color-type ────────────────────────────────────────────────
+
+fn prim_color_type(args: &[Value]) -> (SignalBits, Value) {
+    let r = match get_image_ref(&args[0], "image/color-type") {
+        Ok(r) => r,
+        Err(e) => return e,
+    };
+    (SIG_OK, Value::keyword(r.with(color_type_keyword)))
+}
+
+pub static COLOR_TYPE: PrimitiveDef = PrimitiveDef {
+    name: "image/color-type",
+    func: prim_color_type,
+    signal: Signal::silent(),
+    arity: Arity::Exact(1),
+    doc: "Return the color type keyword of an image (:rgba8 :rgb8 :luma8 etc.).",
+    params: &["img"],
+    category: "image",
+    example: "(image/color-type img)",
+    aliases: &[],
+};
+
+// ── image/pixels ────────────────────────────────────────────────────
+
+fn prim_pixels(args: &[Value]) -> (SignalBits, Value) {
+    let r = match get_image_ref(&args[0], "image/pixels") {
+        Ok(r) => r,
+        Err(e) => return e,
+    };
+    (SIG_OK, Value::bytes(r.with(|img| img.as_bytes().to_vec())))
+}
+
+pub static PIXELS: PrimitiveDef = PrimitiveDef {
+    name: "image/pixels",
+    func: prim_pixels,
+    signal: Signal::silent(),
+    arity: Arity::Exact(1),
+    doc: "Return the raw pixel data as bytes.",
+    params: &["img"],
+    category: "image",
+    example: "(image/pixels img)",
+    aliases: &[],
+};
+
+// ── image/from-pixels ───────────────────────────────────────────────
+
+fn prim_from_pixels(args: &[Value]) -> (SignalBits, Value) {
+    let w = match require_int(&args[0], "image/from-pixels", "width") {
+        Ok(v) => v as u32,
+        Err(e) => return e,
+    };
+    let h = match require_int(&args[1], "image/from-pixels", "height") {
+        Ok(v) => v as u32,
+        Err(e) => return e,
+    };
+    let fmt_kw = match args[2].as_keyword_name() {
+        Some(s) => s,
+        None => {
+            return (
+                SIG_ERROR,
+                error_val(
+                    "type-error",
+                    format!(
+                        "image/from-pixels: format must be keyword, got {}",
+                        args[2].type_name()
+                    ),
+                ),
+            )
+        }
+    };
+    let data = if let Some(b) = args[3].as_bytes() {
+        b.to_vec()
+    } else if let Some(bm) = args[3].as_bytes_mut() {
+        bm.borrow().clone()
+    } else {
+        return (
+            SIG_ERROR,
+            error_val(
+                "type-error",
+                format!(
+                    "image/from-pixels: data must be bytes, got {}",
+                    args[3].type_name()
+                ),
+            ),
+        );
+    };
+    let result = match fmt_kw.as_str() {
+        "rgba8" => image::RgbaImage::from_raw(w, h, data).map(DynamicImage::ImageRgba8),
+        "rgb8" => image::RgbImage::from_raw(w, h, data).map(DynamicImage::ImageRgb8),
+        "luma8" => image::GrayImage::from_raw(w, h, data).map(DynamicImage::ImageLuma8),
+        _ => {
+            return (
+                SIG_ERROR,
+                error_val(
+                    "value-error",
+                    format!("image/from-pixels: unsupported format :{}", fmt_kw),
+                ),
+            )
+        }
+    };
+    match result {
+        Some(img) => (SIG_OK, wrap_image(img)),
+        None => (
+            SIG_ERROR,
+            error_val(
+                "value-error",
+                format!(
+                    "image/from-pixels: data length {} does not match {}x{} :{}",
+                    args[3].as_bytes().map(|b| b.len()).unwrap_or(0),
+                    w,
+                    h,
+                    fmt_kw
+                ),
+            ),
+        ),
+    }
+}
+
+pub static FROM_PIXELS: PrimitiveDef = PrimitiveDef {
+    name: "image/from-pixels",
+    func: prim_from_pixels,
+    signal: Signal::errors(),
+    arity: Arity::Exact(4),
+    doc: "Construct an immutable image from raw pixel data. Format: :rgba8 :rgb8 :luma8.",
+    params: &["width", "height", "format", "bytes"],
+    category: "image",
+    example: "(image/from-pixels 2 2 :rgba8 pixel-bytes)",
+    aliases: &[],
+};
+
+// ── image/get-pixel ─────────────────────────────────────────────────
+
+fn prim_get_pixel(args: &[Value]) -> (SignalBits, Value) {
+    let r = match get_image_ref(&args[0], "image/get-pixel") {
+        Ok(r) => r,
+        Err(e) => return e,
+    };
+    let x = match require_int(&args[1], "image/get-pixel", "x") {
+        Ok(v) => v as u32,
+        Err(e) => return e,
+    };
+    let y = match require_int(&args[2], "image/get-pixel", "y") {
+        Ok(v) => v as u32,
+        Err(e) => return e,
+    };
+    r.with(|img| {
+        if x >= img.width() || y >= img.height() {
+            (
+                SIG_ERROR,
+                error_val(
+                    "range-error",
+                    format!(
+                        "image/get-pixel: ({}, {}) out of bounds for {}x{} image",
+                        x,
+                        y,
+                        img.width(),
+                        img.height()
+                    ),
+                ),
+            )
+        } else {
+            let px = img.to_rgba8().get_pixel(x, y).0;
+            (
+                SIG_OK,
+                Value::array(vec![
+                    Value::int(px[0] as i64),
+                    Value::int(px[1] as i64),
+                    Value::int(px[2] as i64),
+                    Value::int(px[3] as i64),
+                ]),
+            )
+        }
+    })
+}
+
+pub static GET_PIXEL: PrimitiveDef = PrimitiveDef {
+    name: "image/get-pixel",
+    func: prim_get_pixel,
+    signal: Signal::errors(),
+    arity: Arity::Exact(3),
+    doc: "Get pixel at (x, y) as [r g b a] array (0-255).",
+    params: &["img", "x", "y"],
+    category: "image",
+    example: "(image/get-pixel img 0 0)",
+    aliases: &[],
+};
+
+// ── image/put-pixel ─────────────────────────────────────────────────
+
+fn prim_put_pixel(args: &[Value]) -> (SignalBits, Value) {
+    let x = match require_int(&args[1], "image/put-pixel", "x") {
+        Ok(v) => v as u32,
+        Err(e) => return e,
+    };
+    let y = match require_int(&args[2], "image/put-pixel", "y") {
+        Ok(v) => v as u32,
+        Err(e) => return e,
+    };
+    let color = match extract_color(&args[3], "image/put-pixel") {
+        Ok(c) => c,
+        Err(e) => return e,
+    };
+
+    // Mutable path: mutate in place
+    if let Some(m) = args[0].as_external::<crate::ImageMut>() {
+        let mut img = m.0.borrow_mut();
+        if x >= img.width() || y >= img.height() {
+            return (
+                SIG_ERROR,
+                error_val(
+                    "range-error",
+                    format!(
+                        "image/put-pixel: ({}, {}) out of bounds for {}x{} image",
+                        x,
+                        y,
+                        img.width(),
+                        img.height()
+                    ),
+                ),
+            );
+        }
+        img.as_mut_rgba8()
+            .map(|buf| buf.put_pixel(x, y, color))
+            .or_else(|| {
+                img.as_mut_rgb8().map(|buf| {
+                    buf.put_pixel(x, y, image::Rgb([color.0[0], color.0[1], color.0[2]]))
+                })
+            })
+            .or_else(|| {
+                img.as_mut_luma8()
+                    .map(|buf| buf.put_pixel(x, y, image::Luma([color.0[0]])))
+            });
+        return (SIG_OK, Value::NIL);
+    }
+
+    // Immutable path: clone and modify
+    let mut img = match get_image(&args[0], "image/put-pixel") {
+        Ok(i) => i,
+        Err(e) => return e,
+    };
+    if x >= img.width() || y >= img.height() {
+        return (
+            SIG_ERROR,
+            error_val(
+                "range-error",
+                format!(
+                    "image/put-pixel: ({}, {}) out of bounds for {}x{} image",
+                    x,
+                    y,
+                    img.width(),
+                    img.height()
+                ),
+            ),
+        );
+    }
+    img.put_pixel(x, y, color);
+    (SIG_OK, wrap_image(img))
+}
+
+pub static PUT_PIXEL: PrimitiveDef = PrimitiveDef {
+    name: "image/put-pixel",
+    func: prim_put_pixel,
+    signal: Signal::errors(),
+    arity: Arity::Exact(4),
+    doc: "Set pixel at (x, y) to [r g b a]. On immutable image returns new image; on @image mutates in place.",
+    params: &["img", "x", "y", "color"],
+    category: "image",
+    example: "(image/put-pixel img 0 0 [255 0 0 255])",
+    aliases: &[],
+};
+
+// ── image/thaw ──────────────────────────────────────────────────────
+
+fn prim_thaw(args: &[Value]) -> (SignalBits, Value) {
+    let img = match get_image(&args[0], "image/thaw") {
+        Ok(i) => i,
+        Err(e) => return e,
+    };
+    (SIG_OK, wrap_image_mut(img))
+}
+
+pub static THAW: PrimitiveDef = PrimitiveDef {
+    name: "image/thaw",
+    func: prim_thaw,
+    signal: Signal::errors(),
+    arity: Arity::Exact(1),
+    doc: "Convert an immutable image to a mutable @image (copy).",
+    params: &["img"],
+    category: "image",
+    example: "(image/thaw img)",
+    aliases: &[],
+};
+
+// ── image/freeze ────────────────────────────────────────────────────
+
+fn prim_freeze(args: &[Value]) -> (SignalBits, Value) {
+    let m = match get_image_mut(&args[0], "image/freeze") {
+        Ok(m) => m,
+        Err(e) => return e,
+    };
+    (SIG_OK, wrap_image(m.0.borrow().clone()))
+}
+
+pub static FREEZE: PrimitiveDef = PrimitiveDef {
+    name: "image/freeze",
+    func: prim_freeze,
+    signal: Signal::errors(),
+    arity: Arity::Exact(1),
+    doc: "Convert a mutable @image to an immutable image (snapshot).",
+    params: &["img"],
+    category: "image",
+    example: "(image/freeze @img)",
+    aliases: &[],
+};
+
+// ── image/new ───────────────────────────────────────────────────────
+
+fn prim_new(args: &[Value]) -> (SignalBits, Value) {
+    let w = match require_int(&args[0], "image/new", "width") {
+        Ok(v) => v as u32,
+        Err(e) => return e,
+    };
+    let h = match require_int(&args[1], "image/new", "height") {
+        Ok(v) => v as u32,
+        Err(e) => return e,
+    };
+    let fmt_kw = match args[2].as_keyword_name() {
+        Some(s) => s,
+        None => {
+            return (
+                SIG_ERROR,
+                error_val(
+                    "type-error",
+                    format!(
+                        "image/new: format must be keyword, got {}",
+                        args[2].type_name()
+                    ),
+                ),
+            )
+        }
+    };
+    match parse_color_type(&fmt_kw) {
+        Some(ctor) => (SIG_OK, wrap_image_mut(ctor(w, h))),
+        None => (
+            SIG_ERROR,
+            error_val(
+                "value-error",
+                format!("image/new: unsupported format :{}", fmt_kw),
+            ),
+        ),
+    }
+}
+
+pub static NEW: PrimitiveDef = PrimitiveDef {
+    name: "image/new",
+    func: prim_new,
+    signal: Signal::errors(),
+    arity: Arity::Exact(3),
+    doc: "Create a blank mutable @image. Format: :rgba8 :rgb8 :luma8 :lumaa8.",
+    params: &["width", "height", "format"],
+    category: "image",
+    example: "(image/new 100 100 :rgba8)",
+    aliases: &[],
+};

--- a/plugins/image/src/io.rs
+++ b/plugins/image/src/io.rs
@@ -1,0 +1,146 @@
+//! Image I/O primitives: read, write, decode, encode.
+
+use std::io::Cursor;
+
+use elle::primitives::def::PrimitiveDef;
+use elle::signals::Signal;
+use elle::value::fiber::{SignalBits, SIG_ERROR, SIG_OK};
+use elle::value::types::Arity;
+use elle::value::{error_val, Value};
+
+use crate::{get_image, parse_format, require_string, wrap_image};
+
+// ── image/read ──────────────────────────────────────────────────────
+
+fn prim_read(args: &[Value]) -> (SignalBits, Value) {
+    let path = match require_string(&args[0], "image/read", "path") {
+        Ok(s) => s,
+        Err(e) => return e,
+    };
+    match image::open(&path) {
+        Ok(img) => (SIG_OK, wrap_image(img)),
+        Err(e) => (
+            SIG_ERROR,
+            error_val("image-error", format!("image/read: {}", e)),
+        ),
+    }
+}
+
+pub static READ: PrimitiveDef = PrimitiveDef {
+    name: "image/read",
+    func: prim_read,
+    signal: Signal::errors(),
+    arity: Arity::Exact(1),
+    doc: "Read an image from a file path. Returns an immutable image.",
+    params: &["path"],
+    category: "image",
+    example: "(image/read \"photo.jpg\")",
+    aliases: &[],
+};
+
+// ── image/write ─────────────────────────────────────────────────────
+
+fn prim_write(args: &[Value]) -> (SignalBits, Value) {
+    let img = match get_image(&args[0], "image/write") {
+        Ok(i) => i,
+        Err(e) => return e,
+    };
+    let path = match require_string(&args[1], "image/write", "path") {
+        Ok(s) => s,
+        Err(e) => return e,
+    };
+    match img.save(&path) {
+        Ok(()) => (SIG_OK, Value::NIL),
+        Err(e) => (
+            SIG_ERROR,
+            error_val("image-error", format!("image/write: {}", e)),
+        ),
+    }
+}
+
+pub static WRITE: PrimitiveDef = PrimitiveDef {
+    name: "image/write",
+    func: prim_write,
+    signal: Signal::errors(),
+    arity: Arity::Exact(2),
+    doc: "Write an image to a file. Format is inferred from extension.",
+    params: &["img", "path"],
+    category: "image",
+    example: "(image/write img \"out.png\")",
+    aliases: &[],
+};
+
+// ── image/decode ────────────────────────────────────────────────────
+
+fn prim_decode(args: &[Value]) -> (SignalBits, Value) {
+    let data = if let Some(b) = args[0].as_bytes() {
+        b.to_vec()
+    } else if let Some(bm) = args[0].as_bytes_mut() {
+        bm.borrow().clone()
+    } else {
+        return (
+            SIG_ERROR,
+            error_val(
+                "type-error",
+                format!("image/decode: expected bytes, got {}", args[0].type_name()),
+            ),
+        );
+    };
+    let fmt = match parse_format(&args[1], "image/decode") {
+        Ok(f) => f,
+        Err(e) => return e,
+    };
+    let reader = Cursor::new(data);
+    match image::load(reader, fmt) {
+        Ok(img) => (SIG_OK, wrap_image(img)),
+        Err(e) => (
+            SIG_ERROR,
+            error_val("image-error", format!("image/decode: {}", e)),
+        ),
+    }
+}
+
+pub static DECODE: PrimitiveDef = PrimitiveDef {
+    name: "image/decode",
+    func: prim_decode,
+    signal: Signal::errors(),
+    arity: Arity::Exact(2),
+    doc: "Decode an image from bytes with a specified format keyword (:png :jpeg :gif :webp :tiff :bmp :ico :qoi).",
+    params: &["bytes", "format"],
+    category: "image",
+    example: "(image/decode raw-bytes :png)",
+    aliases: &[],
+};
+
+// ── image/encode ────────────────────────────────────────────────────
+
+fn prim_encode(args: &[Value]) -> (SignalBits, Value) {
+    let img = match get_image(&args[0], "image/encode") {
+        Ok(i) => i,
+        Err(e) => return e,
+    };
+    let fmt = match parse_format(&args[1], "image/encode") {
+        Ok(f) => f,
+        Err(e) => return e,
+    };
+    let mut buf = Cursor::new(Vec::new());
+    match img.write_to(&mut buf, fmt) {
+        Ok(()) => (SIG_OK, Value::bytes(buf.into_inner())),
+        Err(e) => (
+            SIG_ERROR,
+            error_val("image-error", format!("image/encode: {}", e)),
+        ),
+    }
+}
+
+pub static ENCODE: PrimitiveDef = PrimitiveDef {
+    name: "image/encode",
+    func: prim_encode,
+    signal: Signal::errors(),
+    arity: Arity::Exact(2),
+    doc: "Encode an image to bytes in the specified format. Returns bytes.",
+    params: &["img", "format"],
+    category: "image",
+    example: "(image/encode img :png)",
+    aliases: &[],
+};

--- a/plugins/image/src/lib.rs
+++ b/plugins/image/src/lib.rs
@@ -1,0 +1,332 @@
+//! Elle image plugin — raster image I/O, transforms, drawing, and analysis
+//! via the `image` and `imageproc` crates.
+
+mod analysis;
+mod composite;
+mod draw;
+mod inspect;
+mod io;
+mod transform;
+
+use std::cell::RefCell;
+
+use image::DynamicImage;
+
+use elle::primitives::def::PrimitiveDef;
+use elle::value::fiber::{SignalBits, SIG_ERROR};
+use elle::value::{error_val, Value};
+
+// ── Type wrappers ───────────────────────────────────────────────────
+
+/// Immutable image stored as an external value.
+pub struct ImageWrap(pub DynamicImage);
+
+/// Mutable image stored as an external value with interior mutability.
+pub struct ImageMut(pub RefCell<DynamicImage>);
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+/// Extract a DynamicImage reference from either an immutable or mutable image.
+/// For mutable images, clones the inner value (needed for transforms that
+/// consume or borrow the image).
+pub fn get_image(val: &Value, name: &str) -> Result<DynamicImage, (SignalBits, Value)> {
+    if let Some(w) = val.as_external::<ImageWrap>() {
+        Ok(w.0.clone())
+    } else if let Some(m) = val.as_external::<ImageMut>() {
+        Ok(m.0.borrow().clone())
+    } else {
+        Err((
+            SIG_ERROR,
+            error_val(
+                "type-error",
+                format!(
+                    "{}: expected image or @image, got {}",
+                    name,
+                    val.type_name()
+                ),
+            ),
+        ))
+    }
+}
+
+/// Extract a read-only reference to an immutable image without cloning.
+pub fn get_image_ref<'a>(val: &'a Value, name: &str) -> Result<ImageRef<'a>, (SignalBits, Value)> {
+    if let Some(w) = val.as_external::<ImageWrap>() {
+        Ok(ImageRef::Immutable(&w.0))
+    } else if let Some(m) = val.as_external::<ImageMut>() {
+        Ok(ImageRef::Mutable(m))
+    } else {
+        Err((
+            SIG_ERROR,
+            error_val(
+                "type-error",
+                format!(
+                    "{}: expected image or @image, got {}",
+                    name,
+                    val.type_name()
+                ),
+            ),
+        ))
+    }
+}
+
+/// Reference to either image type for read-only operations.
+pub enum ImageRef<'a> {
+    Immutable(&'a DynamicImage),
+    Mutable(&'a ImageMut),
+}
+
+impl ImageRef<'_> {
+    pub fn with<F, R>(&self, f: F) -> R
+    where
+        F: FnOnce(&DynamicImage) -> R,
+    {
+        match self {
+            ImageRef::Immutable(img) => f(img),
+            ImageRef::Mutable(m) => f(&m.0.borrow()),
+        }
+    }
+}
+
+/// Require a mutable image; error if immutable.
+pub fn get_image_mut<'a>(val: &'a Value, name: &str) -> Result<&'a ImageMut, (SignalBits, Value)> {
+    val.as_external::<ImageMut>().ok_or_else(|| {
+        (
+            SIG_ERROR,
+            error_val(
+                "type-error",
+                format!("{}: expected @image, got {}", name, val.type_name()),
+            ),
+        )
+    })
+}
+
+pub fn wrap_image(img: DynamicImage) -> Value {
+    Value::external("image", ImageWrap(img))
+}
+
+pub fn wrap_image_mut(img: DynamicImage) -> Value {
+    Value::external("@image", ImageMut(RefCell::new(img)))
+}
+
+fn require_int(val: &Value, name: &str, param: &str) -> Result<i64, (SignalBits, Value)> {
+    val.as_int().ok_or_else(|| {
+        (
+            SIG_ERROR,
+            error_val(
+                "type-error",
+                format!("{}: {} must be int, got {}", name, param, val.type_name()),
+            ),
+        )
+    })
+}
+
+fn require_float(val: &Value, name: &str, param: &str) -> Result<f64, (SignalBits, Value)> {
+    val.as_float()
+        .or_else(|| val.as_int().map(|i| i as f64))
+        .ok_or_else(|| {
+            (
+                SIG_ERROR,
+                error_val(
+                    "type-error",
+                    format!(
+                        "{}: {} must be number, got {}",
+                        name,
+                        param,
+                        val.type_name()
+                    ),
+                ),
+            )
+        })
+}
+
+fn require_string(val: &Value, name: &str, param: &str) -> Result<String, (SignalBits, Value)> {
+    val.with_string(|s| s.to_owned()).ok_or_else(|| {
+        (
+            SIG_ERROR,
+            error_val(
+                "type-error",
+                format!(
+                    "{}: {} must be string, got {}",
+                    name,
+                    param,
+                    val.type_name()
+                ),
+            ),
+        )
+    })
+}
+
+/// Extract an RGBA color from a [r g b a] array.
+pub fn extract_color(val: &Value, name: &str) -> Result<image::Rgba<u8>, (SignalBits, Value)> {
+    let arr = val.as_array().ok_or_else(|| {
+        (
+            SIG_ERROR,
+            error_val(
+                "type-error",
+                format!(
+                    "{}: color must be [r g b a] array, got {}",
+                    name,
+                    val.type_name()
+                ),
+            ),
+        )
+    })?;
+    if arr.len() != 4 {
+        return Err((
+            SIG_ERROR,
+            error_val(
+                "value-error",
+                format!(
+                    "{}: color array must have 4 elements, got {}",
+                    name,
+                    arr.len()
+                ),
+            ),
+        ));
+    }
+    let mut rgba = [0u8; 4];
+    for (i, v) in arr.iter().enumerate() {
+        let n = v.as_int().ok_or_else(|| {
+            (
+                SIG_ERROR,
+                error_val(
+                    "type-error",
+                    format!(
+                        "{}: color component must be int, got {}",
+                        name,
+                        v.type_name()
+                    ),
+                ),
+            )
+        })?;
+        rgba[i] = n.clamp(0, 255) as u8;
+    }
+    Ok(image::Rgba(rgba))
+}
+
+/// Map an image format keyword to an ImageFormat.
+pub fn parse_format(val: &Value, name: &str) -> Result<image::ImageFormat, (SignalBits, Value)> {
+    let kw = val.as_keyword_name().ok_or_else(|| {
+        (
+            SIG_ERROR,
+            error_val(
+                "type-error",
+                format!(
+                    "{}: format must be a keyword, got {}",
+                    name,
+                    val.type_name()
+                ),
+            ),
+        )
+    })?;
+    match kw.as_str() {
+        "png" => Ok(image::ImageFormat::Png),
+        "jpeg" | "jpg" => Ok(image::ImageFormat::Jpeg),
+        "gif" => Ok(image::ImageFormat::Gif),
+        "webp" => Ok(image::ImageFormat::WebP),
+        "tiff" | "tif" => Ok(image::ImageFormat::Tiff),
+        "bmp" => Ok(image::ImageFormat::Bmp),
+        "ico" => Ok(image::ImageFormat::Ico),
+        "qoi" => Ok(image::ImageFormat::Qoi),
+        _ => Err((
+            SIG_ERROR,
+            error_val(
+                "value-error",
+                format!("{}: unsupported format :{}", name, kw),
+            ),
+        )),
+    }
+}
+
+/// Map a DynamicImage color type to a keyword name.
+pub fn color_type_keyword(img: &DynamicImage) -> &'static str {
+    match img {
+        DynamicImage::ImageLuma8(_) => "luma8",
+        DynamicImage::ImageLumaA8(_) => "lumaa8",
+        DynamicImage::ImageRgb8(_) => "rgb8",
+        DynamicImage::ImageRgba8(_) => "rgba8",
+        DynamicImage::ImageLuma16(_) => "luma16",
+        DynamicImage::ImageLumaA16(_) => "lumaa16",
+        DynamicImage::ImageRgb16(_) => "rgb16",
+        DynamicImage::ImageRgba16(_) => "rgba16",
+        DynamicImage::ImageRgb32F(_) => "rgb32f",
+        DynamicImage::ImageRgba32F(_) => "rgba32f",
+        _ => "unknown",
+    }
+}
+
+/// Parse a color type keyword into a constructor for blank images.
+pub fn parse_color_type(kw: &str) -> Option<fn(u32, u32) -> DynamicImage> {
+    match kw {
+        "rgba8" => Some(DynamicImage::new_rgba8 as fn(u32, u32) -> DynamicImage),
+        "rgb8" => Some(DynamicImage::new_rgb8 as fn(u32, u32) -> DynamicImage),
+        "luma8" => Some(DynamicImage::new_luma8 as fn(u32, u32) -> DynamicImage),
+        "lumaa8" => Some(DynamicImage::new_luma_a8 as fn(u32, u32) -> DynamicImage),
+        _ => None,
+    }
+}
+
+// ── Plugin init ─────────────────────────────────────────────────────
+
+fn all_primitives() -> Vec<&'static PrimitiveDef> {
+    vec![
+        // I/O
+        &io::READ,
+        &io::WRITE,
+        &io::DECODE,
+        &io::ENCODE,
+        // Introspection
+        &inspect::WIDTH,
+        &inspect::HEIGHT,
+        &inspect::DIMENSIONS,
+        &inspect::COLOR_TYPE,
+        &inspect::PIXELS,
+        &inspect::FROM_PIXELS,
+        &inspect::GET_PIXEL,
+        &inspect::PUT_PIXEL,
+        // Mutability
+        &inspect::THAW,
+        &inspect::FREEZE,
+        &inspect::NEW,
+        // Transforms
+        &transform::RESIZE,
+        &transform::CROP,
+        &transform::ROTATE,
+        &transform::FLIP,
+        // Adjustments
+        &transform::BLUR,
+        &transform::CONTRAST,
+        &transform::BRIGHTEN,
+        &transform::GRAYSCALE,
+        &transform::INVERT,
+        &transform::HUE_ROTATE,
+        &transform::TO_RGBA8,
+        &transform::TO_RGB8,
+        &transform::TO_LUMA8,
+        // Drawing
+        &draw::DRAW_LINE,
+        &draw::DRAW_RECT,
+        &draw::DRAW_CIRCLE,
+        &draw::FILL_RECT,
+        &draw::FILL_CIRCLE,
+        // Compositing
+        &composite::OVERLAY,
+        &composite::BLEND,
+        // Analysis
+        &analysis::HISTOGRAM,
+        &analysis::EDGES,
+        &analysis::THRESHOLD,
+        &analysis::ERODE,
+        &analysis::DILATE,
+    ]
+}
+
+#[no_mangle]
+/// # Safety
+///
+/// Called by Elle's plugin loader via `dlsym`.
+pub unsafe extern "C" fn elle_plugin_init(ctx: &mut elle::plugin::PluginContext) -> Value {
+    let prims = all_primitives();
+    elle::plugin::register_and_build_refs(ctx, &prims, "image/")
+}

--- a/plugins/image/src/transform.rs
+++ b/plugins/image/src/transform.rs
@@ -1,0 +1,401 @@
+//! Image transforms and adjustments.
+
+use image::imageops::FilterType;
+use image::DynamicImage;
+
+use elle::primitives::def::PrimitiveDef;
+use elle::signals::Signal;
+use elle::value::fiber::{SignalBits, SIG_ERROR, SIG_OK};
+use elle::value::types::Arity;
+use elle::value::{error_val, Value};
+
+use crate::{get_image, require_float, require_int, wrap_image};
+
+// ── image/resize ────────────────────────────────────────────────────
+
+fn parse_filter(val: &Value) -> FilterType {
+    val.as_keyword_name()
+        .as_deref()
+        .map(|s| match s {
+            "nearest" => FilterType::Nearest,
+            "bilinear" | "triangle" => FilterType::Triangle,
+            "catmull-rom" | "cubic" => FilterType::CatmullRom,
+            "gaussian" => FilterType::Gaussian,
+            "lanczos3" | "lanczos" => FilterType::Lanczos3,
+            _ => FilterType::Lanczos3,
+        })
+        .unwrap_or(FilterType::Lanczos3)
+}
+
+fn prim_resize(args: &[Value]) -> (SignalBits, Value) {
+    let img = match get_image(&args[0], "image/resize") {
+        Ok(i) => i,
+        Err(e) => return e,
+    };
+    let w = match require_int(&args[1], "image/resize", "width") {
+        Ok(v) => v as u32,
+        Err(e) => return e,
+    };
+    let h = match require_int(&args[2], "image/resize", "height") {
+        Ok(v) => v as u32,
+        Err(e) => return e,
+    };
+    let filter = if args.len() > 3 {
+        parse_filter(&args[3])
+    } else {
+        FilterType::Lanczos3
+    };
+    (SIG_OK, wrap_image(img.resize_exact(w, h, filter)))
+}
+
+pub static RESIZE: PrimitiveDef = PrimitiveDef {
+    name: "image/resize",
+    func: prim_resize,
+    signal: Signal::errors(),
+    arity: Arity::Range(3, 4),
+    doc: "Resize image to width x height. Optional filter: :nearest :bilinear :catmull-rom :lanczos3 (default).",
+    params: &["img", "width", "height", "filter"],
+    category: "image",
+    example: "(image/resize img 200 150)",
+    aliases: &[],
+};
+
+// ── image/crop ──────────────────────────────────────────────────────
+
+fn prim_crop(args: &[Value]) -> (SignalBits, Value) {
+    let mut img = match get_image(&args[0], "image/crop") {
+        Ok(i) => i,
+        Err(e) => return e,
+    };
+    let x = match require_int(&args[1], "image/crop", "x") {
+        Ok(v) => v as u32,
+        Err(e) => return e,
+    };
+    let y = match require_int(&args[2], "image/crop", "y") {
+        Ok(v) => v as u32,
+        Err(e) => return e,
+    };
+    let w = match require_int(&args[3], "image/crop", "width") {
+        Ok(v) => v as u32,
+        Err(e) => return e,
+    };
+    let h = match require_int(&args[4], "image/crop", "height") {
+        Ok(v) => v as u32,
+        Err(e) => return e,
+    };
+    (SIG_OK, wrap_image(img.crop(x, y, w, h)))
+}
+
+pub static CROP: PrimitiveDef = PrimitiveDef {
+    name: "image/crop",
+    func: prim_crop,
+    signal: Signal::errors(),
+    arity: Arity::Exact(5),
+    doc: "Crop a region from an image. Returns new image.",
+    params: &["img", "x", "y", "width", "height"],
+    category: "image",
+    example: "(image/crop img 10 10 100 100)",
+    aliases: &[],
+};
+
+// ── image/rotate ────────────────────────────────────────────────────
+
+fn prim_rotate(args: &[Value]) -> (SignalBits, Value) {
+    let img = match get_image(&args[0], "image/rotate") {
+        Ok(i) => i,
+        Err(e) => return e,
+    };
+    let angle = match args[1].as_keyword_name() {
+        Some(s) => s,
+        None => {
+            return (
+                SIG_ERROR,
+                error_val(
+                    "type-error",
+                    format!(
+                        "image/rotate: angle must be :r90 :r180 :r270, got {}",
+                        args[1].type_name()
+                    ),
+                ),
+            )
+        }
+    };
+    let result = match angle.as_str() {
+        "r90" | "90" => img.rotate90(),
+        "r180" | "180" => img.rotate180(),
+        "r270" | "270" => img.rotate270(),
+        _ => {
+            return (
+                SIG_ERROR,
+                error_val(
+                    "value-error",
+                    format!("image/rotate: expected :r90 :r180 :r270, got :{}", angle),
+                ),
+            )
+        }
+    };
+    (SIG_OK, wrap_image(result))
+}
+
+pub static ROTATE: PrimitiveDef = PrimitiveDef {
+    name: "image/rotate",
+    func: prim_rotate,
+    signal: Signal::errors(),
+    arity: Arity::Exact(2),
+    doc: "Rotate image by :r90, :r180, or :r270.",
+    params: &["img", "angle"],
+    category: "image",
+    example: "(image/rotate img :r90)",
+    aliases: &[],
+};
+
+// ── image/flip ──────────────────────────────────────────────────────
+
+fn prim_flip(args: &[Value]) -> (SignalBits, Value) {
+    let img = match get_image(&args[0], "image/flip") {
+        Ok(i) => i,
+        Err(e) => return e,
+    };
+    let dir = match args[1].as_keyword_name() {
+        Some(s) => s,
+        None => {
+            return (
+                SIG_ERROR,
+                error_val(
+                    "type-error",
+                    format!(
+                        "image/flip: direction must be :h or :v, got {}",
+                        args[1].type_name()
+                    ),
+                ),
+            )
+        }
+    };
+    let result = match dir.as_str() {
+        "h" | "horizontal" => img.fliph(),
+        "v" | "vertical" => img.flipv(),
+        _ => {
+            return (
+                SIG_ERROR,
+                error_val(
+                    "value-error",
+                    format!("image/flip: expected :h or :v, got :{}", dir),
+                ),
+            )
+        }
+    };
+    (SIG_OK, wrap_image(result))
+}
+
+pub static FLIP: PrimitiveDef = PrimitiveDef {
+    name: "image/flip",
+    func: prim_flip,
+    signal: Signal::errors(),
+    arity: Arity::Exact(2),
+    doc: "Flip image :h (horizontal) or :v (vertical).",
+    params: &["img", "direction"],
+    category: "image",
+    example: "(image/flip img :h)",
+    aliases: &[],
+};
+
+// ── Adjustments ─────────────────────────────────────────────────────
+
+fn prim_blur(args: &[Value]) -> (SignalBits, Value) {
+    let img = match get_image(&args[0], "image/blur") {
+        Ok(i) => i,
+        Err(e) => return e,
+    };
+    let sigma = match require_float(&args[1], "image/blur", "sigma") {
+        Ok(v) => v as f32,
+        Err(e) => return e,
+    };
+    (SIG_OK, wrap_image(img.blur(sigma)))
+}
+
+pub static BLUR: PrimitiveDef = PrimitiveDef {
+    name: "image/blur",
+    func: prim_blur,
+    signal: Signal::errors(),
+    arity: Arity::Exact(2),
+    doc: "Apply Gaussian blur with given sigma.",
+    params: &["img", "sigma"],
+    category: "image",
+    example: "(image/blur img 2.0)",
+    aliases: &[],
+};
+
+fn prim_contrast(args: &[Value]) -> (SignalBits, Value) {
+    let img = match get_image(&args[0], "image/contrast") {
+        Ok(i) => i,
+        Err(e) => return e,
+    };
+    let c = match require_float(&args[1], "image/contrast", "contrast") {
+        Ok(v) => v as f32,
+        Err(e) => return e,
+    };
+    (SIG_OK, wrap_image(img.adjust_contrast(c)))
+}
+
+pub static CONTRAST: PrimitiveDef = PrimitiveDef {
+    name: "image/contrast",
+    func: prim_contrast,
+    signal: Signal::errors(),
+    arity: Arity::Exact(2),
+    doc: "Adjust contrast. Positive values increase, negative decrease.",
+    params: &["img", "contrast"],
+    category: "image",
+    example: "(image/contrast img 20.0)",
+    aliases: &[],
+};
+
+fn prim_brighten(args: &[Value]) -> (SignalBits, Value) {
+    let img = match get_image(&args[0], "image/brighten") {
+        Ok(i) => i,
+        Err(e) => return e,
+    };
+    let b = match require_int(&args[1], "image/brighten", "brightness") {
+        Ok(v) => v as i32,
+        Err(e) => return e,
+    };
+    (SIG_OK, wrap_image(img.brighten(b)))
+}
+
+pub static BRIGHTEN: PrimitiveDef = PrimitiveDef {
+    name: "image/brighten",
+    func: prim_brighten,
+    signal: Signal::errors(),
+    arity: Arity::Exact(2),
+    doc: "Adjust brightness. Positive brightens, negative darkens.",
+    params: &["img", "amount"],
+    category: "image",
+    example: "(image/brighten img 30)",
+    aliases: &[],
+};
+
+fn prim_grayscale(args: &[Value]) -> (SignalBits, Value) {
+    let img = match get_image(&args[0], "image/grayscale") {
+        Ok(i) => i,
+        Err(e) => return e,
+    };
+    (SIG_OK, wrap_image(img.grayscale()))
+}
+
+pub static GRAYSCALE: PrimitiveDef = PrimitiveDef {
+    name: "image/grayscale",
+    func: prim_grayscale,
+    signal: Signal::errors(),
+    arity: Arity::Exact(1),
+    doc: "Convert image to grayscale.",
+    params: &["img"],
+    category: "image",
+    example: "(image/grayscale img)",
+    aliases: &[],
+};
+
+fn prim_invert(args: &[Value]) -> (SignalBits, Value) {
+    let mut img = match get_image(&args[0], "image/invert") {
+        Ok(i) => i,
+        Err(e) => return e,
+    };
+    img.invert();
+    (SIG_OK, wrap_image(img))
+}
+
+pub static INVERT: PrimitiveDef = PrimitiveDef {
+    name: "image/invert",
+    func: prim_invert,
+    signal: Signal::errors(),
+    arity: Arity::Exact(1),
+    doc: "Invert all pixel colors.",
+    params: &["img"],
+    category: "image",
+    example: "(image/invert img)",
+    aliases: &[],
+};
+
+fn prim_hue_rotate(args: &[Value]) -> (SignalBits, Value) {
+    let img = match get_image(&args[0], "image/hue-rotate") {
+        Ok(i) => i,
+        Err(e) => return e,
+    };
+    let deg = match require_int(&args[1], "image/hue-rotate", "degrees") {
+        Ok(v) => v as i32,
+        Err(e) => return e,
+    };
+    (SIG_OK, wrap_image(img.huerotate(deg)))
+}
+
+pub static HUE_ROTATE: PrimitiveDef = PrimitiveDef {
+    name: "image/hue-rotate",
+    func: prim_hue_rotate,
+    signal: Signal::errors(),
+    arity: Arity::Exact(2),
+    doc: "Rotate hue by given degrees.",
+    params: &["img", "degrees"],
+    category: "image",
+    example: "(image/hue-rotate img 90)",
+    aliases: &[],
+};
+
+// ── Color format conversion ─────────────────────────────────────────
+
+fn prim_to_rgba8(args: &[Value]) -> (SignalBits, Value) {
+    let img = match get_image(&args[0], "image/to-rgba8") {
+        Ok(i) => i,
+        Err(e) => return e,
+    };
+    (SIG_OK, wrap_image(DynamicImage::ImageRgba8(img.to_rgba8())))
+}
+
+pub static TO_RGBA8: PrimitiveDef = PrimitiveDef {
+    name: "image/to-rgba8",
+    func: prim_to_rgba8,
+    signal: Signal::errors(),
+    arity: Arity::Exact(1),
+    doc: "Convert image to RGBA8 color type.",
+    params: &["img"],
+    category: "image",
+    example: "(image/to-rgba8 img)",
+    aliases: &[],
+};
+
+fn prim_to_rgb8(args: &[Value]) -> (SignalBits, Value) {
+    let img = match get_image(&args[0], "image/to-rgb8") {
+        Ok(i) => i,
+        Err(e) => return e,
+    };
+    (SIG_OK, wrap_image(DynamicImage::ImageRgb8(img.to_rgb8())))
+}
+
+pub static TO_RGB8: PrimitiveDef = PrimitiveDef {
+    name: "image/to-rgb8",
+    func: prim_to_rgb8,
+    signal: Signal::errors(),
+    arity: Arity::Exact(1),
+    doc: "Convert image to RGB8 color type.",
+    params: &["img"],
+    category: "image",
+    example: "(image/to-rgb8 img)",
+    aliases: &[],
+};
+
+fn prim_to_luma8(args: &[Value]) -> (SignalBits, Value) {
+    let img = match get_image(&args[0], "image/to-luma8") {
+        Ok(i) => i,
+        Err(e) => return e,
+    };
+    (SIG_OK, wrap_image(DynamicImage::ImageLuma8(img.to_luma8())))
+}
+
+pub static TO_LUMA8: PrimitiveDef = PrimitiveDef {
+    name: "image/to-luma8",
+    func: prim_to_luma8,
+    signal: Signal::errors(),
+    arity: Arity::Exact(1),
+    doc: "Convert image to 8-bit grayscale.",
+    params: &["img"],
+    category: "image",
+    example: "(image/to-luma8 img)",
+    aliases: &[],
+};

--- a/plugins/svg/Cargo.toml
+++ b/plugins/svg/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "elle-svg"
+version = "1.0.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+elle = { path = "../.." }
+resvg = "0.45"

--- a/plugins/svg/src/lib.rs
+++ b/plugins/svg/src/lib.rs
@@ -1,0 +1,326 @@
+//! Elle SVG plugin — SVG rasterization via resvg.
+//!
+//! Renders SVG strings (or struct trees emitted to XML) to PNG or raw pixels.
+//! Construction and emission live in lib/svg.lisp (pure Elle).
+
+use std::collections::BTreeMap;
+
+use elle::primitives::def::PrimitiveDef;
+use elle::value::fiber::{SignalBits, SIG_ERROR, SIG_OK};
+use elle::value::types::{Arity, TableKey};
+use elle::value::{error_val, Value};
+
+use elle::signals::Signal;
+
+elle::elle_plugin_init!(PRIMITIVES, "svg/");
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+/// Emit an element struct tree to an SVG XML string.
+fn emit_element(val: &Value, out: &mut String) {
+    if let Some(s) = val.with_string(|s| s.to_owned()) {
+        xml_escape(&s, out);
+        return;
+    }
+    let s = match val.as_struct() {
+        Some(s) => s,
+        None => return,
+    };
+    let tag = match s.get(&TableKey::Keyword("tag".into())) {
+        Some(v) => match v.as_keyword_name() {
+            Some(name) => name,
+            None => return,
+        },
+        None => return,
+    };
+    out.push('<');
+    out.push_str(&tag);
+    if let Some(attrs_val) = s.get(&TableKey::Keyword("attrs".into())) {
+        if let Some(attrs) = attrs_val.as_struct() {
+            for (k, v) in attrs {
+                let key = match k {
+                    TableKey::Keyword(name) => name.clone(),
+                    TableKey::String(name) => name.clone(),
+                    _ => continue,
+                };
+                out.push(' ');
+                out.push_str(&key);
+                out.push_str("=\"");
+                let val_str = if let Some(s) = v.with_string(|s| s.to_owned()) {
+                    s
+                } else if let Some(i) = v.as_int() {
+                    i.to_string()
+                } else if let Some(f) = v.as_float() {
+                    format!("{}", f)
+                } else if let Some(kw) = v.as_keyword_name() {
+                    kw
+                } else {
+                    continue;
+                };
+                xml_escape_attr(&val_str, out);
+                out.push('"');
+            }
+        }
+    }
+    let children = s
+        .get(&TableKey::Keyword("children".into()))
+        .and_then(|v| v.as_array());
+    match children {
+        Some([]) => out.push_str("/>"),
+        Some(kids) => {
+            out.push('>');
+            for child in kids {
+                emit_element(child, out);
+            }
+            out.push_str("</");
+            out.push_str(&tag);
+            out.push('>');
+        }
+        None => out.push_str("/>"),
+    }
+}
+
+fn xml_escape(s: &str, out: &mut String) {
+    for c in s.chars() {
+        match c {
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '&' => out.push_str("&amp;"),
+            _ => out.push(c),
+        }
+    }
+}
+
+fn xml_escape_attr(s: &str, out: &mut String) {
+    for c in s.chars() {
+        match c {
+            '"' => out.push_str("&quot;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '&' => out.push_str("&amp;"),
+            _ => out.push(c),
+        }
+    }
+}
+
+/// Get SVG XML string from either a struct tree or a raw string.
+fn get_svg_string(val: &Value, name: &str) -> Result<String, (SignalBits, Value)> {
+    if let Some(s) = val.with_string(|s| s.to_owned()) {
+        Ok(s)
+    } else if val.as_struct().is_some() {
+        let mut out = String::new();
+        out.push_str("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
+        emit_element(val, &mut out);
+        Ok(out)
+    } else {
+        Err((
+            SIG_ERROR,
+            error_val(
+                "type-error",
+                format!(
+                    "{}: expected SVG string or struct tree, got {}",
+                    name,
+                    val.type_name()
+                ),
+            ),
+        ))
+    }
+}
+
+fn require_string(val: &Value, name: &str, param: &str) -> Result<String, (SignalBits, Value)> {
+    val.with_string(|s| s.to_owned()).ok_or_else(|| {
+        (
+            SIG_ERROR,
+            error_val(
+                "type-error",
+                format!(
+                    "{}: {} must be string, got {}",
+                    name,
+                    param,
+                    val.type_name()
+                ),
+            ),
+        )
+    })
+}
+
+// ── Render helpers ──────────────────────────────────────────────────
+
+struct RenderOpts {
+    width: Option<u32>,
+    height: Option<u32>,
+}
+
+fn parse_render_opts(args: &[Value], idx: usize) -> RenderOpts {
+    let mut opts = RenderOpts {
+        width: None,
+        height: None,
+    };
+    if args.len() > idx {
+        if let Some(s) = args[idx].as_struct() {
+            if let Some(w) = s
+                .get(&TableKey::Keyword("width".into()))
+                .and_then(|v| v.as_int())
+            {
+                opts.width = Some(w as u32);
+            }
+            if let Some(h) = s
+                .get(&TableKey::Keyword("height".into()))
+                .and_then(|v| v.as_int())
+            {
+                opts.height = Some(h as u32);
+            }
+        }
+    }
+    opts
+}
+
+fn render_svg_to_pixmap(
+    svg_str: &str,
+    opts: &RenderOpts,
+) -> Result<resvg::tiny_skia::Pixmap, String> {
+    let tree = resvg::usvg::Tree::from_str(svg_str, &resvg::usvg::Options::default())
+        .map_err(|e| format!("SVG parse error: {}", e))?;
+    let size = tree.size();
+    let w = opts.width.unwrap_or(size.width() as u32);
+    let h = opts.height.unwrap_or(size.height() as u32);
+    let mut pixmap = resvg::tiny_skia::Pixmap::new(w, h)
+        .ok_or_else(|| format!("failed to create {}x{} pixmap", w, h))?;
+    let sx = w as f32 / size.width();
+    let sy = h as f32 / size.height();
+    let transform = resvg::tiny_skia::Transform::from_scale(sx, sy);
+    resvg::render(&tree, transform, &mut pixmap.as_mut());
+    Ok(pixmap)
+}
+
+// ── Primitives ──────────────────────────────────────────────────────
+
+fn prim_render(args: &[Value]) -> (SignalBits, Value) {
+    let svg_str = match get_svg_string(&args[0], "svg/render") {
+        Ok(s) => s,
+        Err(e) => return e,
+    };
+    let opts = parse_render_opts(args, 1);
+    match render_svg_to_pixmap(&svg_str, &opts) {
+        Ok(pixmap) => match pixmap.encode_png() {
+            Ok(png_data) => (SIG_OK, Value::bytes(png_data)),
+            Err(e) => (
+                SIG_ERROR,
+                error_val("svg-error", format!("svg/render: PNG encode: {}", e)),
+            ),
+        },
+        Err(e) => (
+            SIG_ERROR,
+            error_val("svg-error", format!("svg/render: {}", e)),
+        ),
+    }
+}
+
+fn prim_render_raw(args: &[Value]) -> (SignalBits, Value) {
+    let svg_str = match get_svg_string(&args[0], "svg/render-raw") {
+        Ok(s) => s,
+        Err(e) => return e,
+    };
+    let opts = parse_render_opts(args, 1);
+    match render_svg_to_pixmap(&svg_str, &opts) {
+        Ok(pixmap) => {
+            let w = pixmap.width();
+            let h = pixmap.height();
+            let data = pixmap.take();
+            let mut fields = BTreeMap::new();
+            fields.insert(TableKey::Keyword("width".into()), Value::int(w as i64));
+            fields.insert(TableKey::Keyword("height".into()), Value::int(h as i64));
+            fields.insert(TableKey::Keyword("data".into()), Value::bytes(data));
+            (SIG_OK, Value::struct_from(fields))
+        }
+        Err(e) => (
+            SIG_ERROR,
+            error_val("svg-error", format!("svg/render-raw: {}", e)),
+        ),
+    }
+}
+
+fn prim_render_to_file(args: &[Value]) -> (SignalBits, Value) {
+    let svg_str = match get_svg_string(&args[0], "svg/render-to-file") {
+        Ok(s) => s,
+        Err(e) => return e,
+    };
+    let path = match require_string(&args[1], "svg/render-to-file", "path") {
+        Ok(s) => s,
+        Err(e) => return e,
+    };
+    let opts = parse_render_opts(args, 2);
+    match render_svg_to_pixmap(&svg_str, &opts) {
+        Ok(pixmap) => match pixmap.save_png(&path) {
+            Ok(()) => (SIG_OK, Value::NIL),
+            Err(e) => (
+                SIG_ERROR,
+                error_val("svg-error", format!("svg/render-to-file: {}", e)),
+            ),
+        },
+        Err(e) => (
+            SIG_ERROR,
+            error_val("svg-error", format!("svg/render-to-file: {}", e)),
+        ),
+    }
+}
+
+fn prim_dimensions(args: &[Value]) -> (SignalBits, Value) {
+    let svg_str = match get_svg_string(&args[0], "svg/dimensions") {
+        Ok(s) => s,
+        Err(e) => return e,
+    };
+    match resvg::usvg::Tree::from_str(&svg_str, &resvg::usvg::Options::default()) {
+        Ok(tree) => {
+            let size = tree.size();
+            (
+                SIG_OK,
+                Value::array(vec![
+                    Value::float(size.width() as f64),
+                    Value::float(size.height() as f64),
+                ]),
+            )
+        }
+        Err(e) => (
+            SIG_ERROR,
+            error_val("svg-error", format!("svg/dimensions: {}", e)),
+        ),
+    }
+}
+
+// ── Registration ────────────────────────────────────────────────────
+
+static PRIMITIVES: &[PrimitiveDef] = &[
+    PrimitiveDef {
+        name: "svg/render", func: prim_render, signal: Signal::errors(),
+        arity: Arity::Range(1, 2),
+        doc: "Render SVG (string or struct tree) to PNG bytes. Optional opts: {:width N :height N}.",
+        params: &["source", "opts"], category: "svg",
+        example: "(svg/render \"<svg width='100' height='100'><circle cx='50' cy='50' r='40' fill='red'/></svg>\")",
+        aliases: &[],
+    },
+    PrimitiveDef {
+        name: "svg/render-raw", func: prim_render_raw, signal: Signal::errors(),
+        arity: Arity::Range(1, 2),
+        doc: "Render SVG to raw RGBA8 pixels. Returns {:width :height :data bytes}.",
+        params: &["source", "opts"], category: "svg",
+        example: "(svg/render-raw svg-string)",
+        aliases: &[],
+    },
+    PrimitiveDef {
+        name: "svg/render-to-file", func: prim_render_to_file, signal: Signal::errors(),
+        arity: Arity::Range(2, 3),
+        doc: "Render SVG to a PNG file.",
+        params: &["source", "path", "opts"], category: "svg",
+        example: "(svg/render-to-file svg-string \"output.png\")",
+        aliases: &[],
+    },
+    PrimitiveDef {
+        name: "svg/dimensions", func: prim_dimensions, signal: Signal::errors(),
+        arity: Arity::Exact(1),
+        doc: "Return [width height] of an SVG's intrinsic dimensions.",
+        params: &["source"], category: "svg",
+        example: "(svg/dimensions \"<svg width='100' height='200'></svg>\")",
+        aliases: &[],
+    },
+];

--- a/prelude.lisp
+++ b/prelude.lisp
@@ -233,6 +233,13 @@
             (while (< idx len)
               (let ((,var (get items idx))) ,;body)
               (assign idx (+ idx 1)))))
+         ((or :struct :@struct)
+          (let ((pairs (pairs seq)))
+            (var idx 0)
+            (var len (length pairs))
+            (while (< idx len)
+              (let ((,var (get pairs idx))) ,;body)
+              (assign idx (+ idx 1)))))
          (_ (error {:error :type-error :reason :not-a-sequence :message "not a sequence"}))))))
 
 ## case - equality dispatch (flat pairs)

--- a/src/hir/analyze/binding.rs
+++ b/src/hir/analyze/binding.rs
@@ -450,7 +450,8 @@ impl<'a> Analyzer<'a> {
             // the binding is captured by a lambda in the same begin block.
             // Without this, an immutable captured local would be captured
             // by value (nil) before its initializer runs.
-            let binding = self.bind(name, &[], BindingScope::Local);
+            let name_scopes = items[1].scopes.as_slice();
+            let binding = self.bind(name, name_scopes, BindingScope::Local);
             self.arena.get_mut(binding).is_prebound = true;
 
             if immutable {

--- a/src/pipeline/compile.rs
+++ b/src/pipeline/compile.rs
@@ -282,7 +282,18 @@ fn compile_file_inner(
     // Phase 2: Macro expansion (cached VM held only for this phase)
     let (expanded_forms, expander, meta) =
         cache::with_compilation_cache(|macro_vm, mut expander, meta| {
-            let mut pending: std::collections::VecDeque<Syntax> = syntaxes.into();
+            // Stamp a file scope on user code so user bindings are
+            // distinguishable from primitives (Flatt 2016 §3). Skip for
+            // internal sources (<stdlib>, <internal>).
+            let mut pending: std::collections::VecDeque<Syntax> = if source_name.starts_with('<') {
+                syntaxes.into()
+            } else {
+                let file_scope = expander.fresh_scope();
+                syntaxes
+                    .into_iter()
+                    .map(|s| expander.stamp_scope(s, file_scope))
+                    .collect()
+            };
             let mut expanded_forms = Vec::new();
             let mut included: HashSet<String> = HashSet::from([source_name.to_string()]);
             while let Some(syntax) = pending.pop_front() {

--- a/src/pipeline/eval.rs
+++ b/src/pipeline/eval.rs
@@ -75,7 +75,12 @@ pub fn eval(
     // Get cached expander and meta (uses throwaway cache VM only for init)
     let (mut expander, meta) = cache::get_cached_expander_and_meta();
 
-    let expanded = expander.expand(syntax, symbols, vm)?;
+    let scoped = if source_name.starts_with('<') {
+        syntax
+    } else {
+        expander.stamp_file_scope(syntax)
+    };
+    let expanded = expander.expand(scoped, symbols, vm)?;
 
     let mut arena = BindingArena::new();
     let mut analyzer = Analyzer::new_with_primitives(

--- a/src/primitives/math.rs
+++ b/src/primitives/math.rs
@@ -161,6 +161,24 @@ fn prim_pow(args: &[Value]) -> (SignalBits, Value) {
     }
 }
 
+fn prim_fmod(args: &[Value]) -> (SignalBits, Value) {
+    let a = match require_number("fmod", &args[0]) {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+    let b = match require_number("fmod", &args[1]) {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+    if b == 0.0 {
+        return (
+            SIG_ERROR,
+            error_val("division-by-zero", "fmod: division by zero"),
+        );
+    }
+    (SIG_OK, Value::float(a % b))
+}
+
 fn prim_atan2(args: &[Value]) -> (SignalBits, Value) {
     let y = match require_number("atan2", &args[0]) {
         Ok(v) => v,
@@ -290,6 +308,13 @@ pub(crate) const PRIMITIVES: &[PrimitiveDef] = &[
         arity: Arity::Exact(1), doc: "Returns the arctangent of a number (in radians).",
         params: &["x"], category: "math", example: "(math/atan 1)",
         aliases: &["atan"],
+    },
+    PrimitiveDef {
+        name: "math/fmod", func: prim_fmod, signal: Signal::errors(),
+        arity: Arity::Exact(2),
+        doc: "Floating-point remainder. Returns a - floor(a/b) * b.",
+        params: &["a", "b"], category: "math", example: "(math/fmod 5.5 2.0) #=> 1.5",
+        aliases: &["fmod"],
     },
     PrimitiveDef {
         name: "math/atan2", func: prim_atan2, signal: Signal::errors(),

--- a/src/syntax/convert.rs
+++ b/src/syntax/convert.rs
@@ -154,10 +154,18 @@ impl Syntax {
     /// this case; the syntax object carries its own (more accurate) span.
     pub fn from_value(value: &Value, symbols: &SymbolTable, span: Span) -> Result<Syntax, String> {
         // Syntax objects pass through directly, preserving scopes.
-        // Mark as scope_exempt so the intro scope isn't stamped on
-        // call-site identifiers that survived the Value round-trip.
+        // The intro scope WILL be added by add_scope_recursive, which
+        // is correct: it distinguishes this expansion's symbols from
+        // other scopes. Both template symbols (from quasiquote) and
+        // argument symbols (from unquote) get the intro scope on top
+        // of their existing scopes, enabling proper hygiene resolution.
         if let Some(syntax_rc) = value.as_syntax() {
             let mut s = syntax_rc.as_ref().clone();
+            // Mark scope_exempt so the intro scope isn't added to
+            // call-site identifiers that survived the Value round-trip.
+            // Template symbols from quasiquote also come through here
+            // (via SyntaxLiteral) and are exempt — their definition-site
+            // scopes are sufficient for correct resolution.
             s.scope_exempt = true;
             // Safety check: the cloned Syntax must not contain SyntaxLiteral
             // children. SyntaxLiteral holds a heap-pointer Value that may be

--- a/src/syntax/expand/mod.rs
+++ b/src/syntax/expand/mod.rs
@@ -101,8 +101,16 @@ impl Expander {
     pub fn load_prelude(&mut self, symbols: &mut SymbolTable, vm: &mut VM) -> Result<(), String> {
         const PRELUDE: &str = include_str!("../../../prelude.lisp");
         let syntaxes = crate::reader::read_syntax_all(PRELUDE, "<internal>")?;
+        // Use ScopeId(0) — the reserved primitive scope — so that
+        // prelude symbols match primitive bindings (which are also
+        // bound with ScopeId(0)). This is critical for macro hygiene:
+        // template symbols in quasiquotes carry ScopeId(0), allowing
+        // them to resolve to primitives even when the call site has
+        // shadowing bindings with the same name.
+        let prelude_scope = ScopeId(0);
         for syntax in syntaxes {
-            self.expand(syntax, symbols, vm)?;
+            let scoped = self.add_scope_recursive(syntax, prelude_scope);
+            self.expand(scoped, symbols, vm)?;
         }
         Ok(())
     }
@@ -122,6 +130,21 @@ impl Expander {
     /// Create a list syntax node
     fn make_list(&self, items: Vec<Syntax>, span: Span) -> Syntax {
         Syntax::new(SyntaxKind::List(items), span)
+    }
+
+    /// Stamp a fresh file scope onto a syntax tree. This distinguishes
+    /// user bindings from primitives (which have empty scopes), enabling
+    /// macro hygiene: template symbols from the prelude carry
+    /// `ScopeId(0)` and won't match user bindings that carry the file
+    /// scope instead.
+    pub fn stamp_file_scope(&mut self, syntax: Syntax) -> Syntax {
+        let scope = self.fresh_scope();
+        self.add_scope_recursive(syntax, scope)
+    }
+
+    /// Public wrapper for adding a scope to a syntax tree.
+    pub(crate) fn stamp_scope(&self, syntax: Syntax, scope: ScopeId) -> Syntax {
+        self.add_scope_recursive(syntax, scope)
     }
 
     /// Expand all macros in a syntax tree

--- a/src/syntax/expand/quasiquote.rs
+++ b/src/syntax/expand/quasiquote.rs
@@ -4,6 +4,7 @@ use super::Expander;
 use crate::symbol::SymbolTable;
 use crate::syntax::{Span, Syntax, SyntaxKind};
 use crate::vm::VM;
+use crate::Value;
 
 impl Expander {
     /// Convert quasiquote to code that constructs the value at runtime
@@ -78,7 +79,18 @@ impl Expander {
                 span.clone(),
             )),
 
-            // Everything else gets quoted
+            // Symbols: wrap as SyntaxLiteral to preserve definition-site
+            // scopes through the Value round-trip (Flatt 2016 §3). Without
+            // this, template symbols become bare Values and lose their scopes.
+            // The intro scope is added later by add_scope_recursive, which
+            // together with the definition-site scopes ensures correct
+            // resolution even when the call site shadows the same name.
+            SyntaxKind::Symbol(_) => Ok(Syntax::new(
+                SyntaxKind::SyntaxLiteral(Value::syntax(syntax.clone())),
+                span.clone(),
+            )),
+
+            // Everything else gets quoted (atoms don't participate in binding)
             _ => Ok(self.make_list(
                 vec![self.make_symbol("quote", span.clone()), syntax.clone()],
                 span.clone(),

--- a/tests/elle/hygiene.lisp
+++ b/tests/elle/hygiene.lisp
@@ -1,0 +1,61 @@
+#!/usr/bin/env elle
+
+## Macro hygiene tests — counter-factual tests that verify template symbols
+## resolve to their definition-site bindings, not call-site shadows.
+
+# ── each macro: template `rest` must resolve to the builtin ──────────
+
+## Counter-factual: without hygiene, `rest` in the `each` template would
+## resolve to the user's `& rest` parameter, causing "Cannot call" error.
+(defn iterate-rest [& rest]
+  (let [[out @[]]]
+    (each item in rest
+      (push out item))
+    (freeze out)))
+
+(assert (= (iterate-rest 1 2 3) [1 2 3]) "each: template rest not captured by user rest")
+
+## Same with `cur` — another name used internally by `each`
+(defn iterate-cur [& cur]
+  (let [[out @[]]]
+    (each item in cur
+      (push out item))
+    (freeze out)))
+
+(assert (= (iterate-cur "a" "b") ["a" "b"]) "each: template cur not captured by user cur")
+
+## Same with `seq`
+(defn iterate-seq [& seq]
+  (let [[out @[]]]
+    (each item in seq
+      (push out item))
+    (freeze out)))
+
+(assert (= (iterate-seq :x :y) [:x :y]) "each: template seq not captured by user seq")
+
+# ── when/unless: template symbols not captured ───────────────────────
+
+(let [[empty? (fn [x] true)]]
+  (var reached false)
+  (when true (assign reached true))
+  (assert reached "when: template not captured by shadowed empty?"))
+
+# ── Nested macro expansion ───────────────────────────────────────────
+
+(defn collect-rest [& rest]
+  (let [[result @[]]]
+    (each x in rest
+      (when (> x 0)
+        (push result x)))
+    (freeze result)))
+
+(assert (= (collect-rest -1 2 -3 4) [2 4]) "nested macros: each+when with shadowed rest")
+
+# ── Struct iteration ─────────────────────────────────────────────────
+
+(let [[out @[]]]
+  (each [k v] in {:a 1 :b 2}
+    (push out [k v]))
+  (assert (= (length out) 2) "each: struct iteration"))
+
+(println "hygiene: all tests passed")

--- a/tests/elle/lib/color.lisp
+++ b/tests/elle/lib/color.lisp
@@ -1,0 +1,118 @@
+#!/usr/bin/env elle
+
+## Test suite for lib/color — color science library
+
+(def color ((import "std/color")))
+
+# ── Construction ─────────────────────────────────────────────────────
+
+(def red (color:rgb 1.0 0.0 0.0))
+(assert (= (get red :space) :srgb) "rgb constructs srgb")
+(assert (= (get red :r) 1.0) "rgb red component")
+
+(def blue-a (color:rgba 0.0 0.0 1.0 0.5))
+(assert (= (get blue-a :a) 0.5) "rgba alpha")
+
+(def hsl-blue (color:hsl 240.0 1.0 0.5))
+(assert (= (get hsl-blue :space) :hsl) "hsl constructs hsl")
+
+# ── sRGB ↔ HSL roundtrip ────────────────────────────────────────────
+
+(defn approx [a b tol]
+  (< (abs (- a b)) tol))
+
+(def red-hsl (color:convert red :hsl))
+(assert (approx (get red-hsl :h) 0.0 1.0) "red hue ~0")
+(assert (approx (get red-hsl :s) 1.0 0.01) "red saturation ~1")
+(assert (approx (get red-hsl :l) 0.5 0.01) "red lightness ~0.5")
+
+(def red-back (color:convert red-hsl :srgb))
+(assert (approx (get red-back :r) 1.0 0.01) "HSL→sRGB roundtrip r")
+(assert (approx (get red-back :g) 0.0 0.01) "HSL→sRGB roundtrip g")
+(assert (approx (get red-back :b) 0.0 0.01) "HSL→sRGB roundtrip b")
+
+# ── sRGB ↔ Lab roundtrip ────────────────────────────────────────────
+
+(def red-lab (color:convert red :lab))
+(assert (approx (get red-lab :l) 53.23 1.0) "red Lab L ~53")
+(assert (> (get red-lab :a) 60.0) "red Lab a is positive (toward red)")
+
+(def red-from-lab (color:convert red-lab :srgb))
+(assert (approx (get red-from-lab :r) 1.0 0.02) "Lab→sRGB roundtrip r")
+(assert (approx (get red-from-lab :g) 0.0 0.02) "Lab→sRGB roundtrip g")
+
+# ── sRGB ↔ Oklch roundtrip ──────────────────────────────────────────
+
+(def red-oklch (color:convert red :oklch))
+(assert (> (get red-oklch :l) 0.0) "oklch L > 0")
+(assert (> (get red-oklch :c) 0.0) "oklch chroma > 0")
+
+(def red-from-oklch (color:convert red-oklch :srgb))
+(assert (approx (get red-from-oklch :r) 1.0 0.02) "Oklch→sRGB roundtrip r")
+(assert (approx (get red-from-oklch :g) 0.0 0.05) "Oklch→sRGB roundtrip g")
+
+# ── Mixing ───────────────────────────────────────────────────────────
+
+(def blue (color:rgb 0.0 0.0 1.0))
+(def purple (color:mix red blue 0.5))
+(assert (approx (get purple :r) 0.5 0.01) "mix r")
+(assert (approx (get purple :b) 0.5 0.01) "mix b")
+
+(def all-red (color:mix red blue 0.0))
+(assert (approx (get all-red :r) 1.0 0.01) "mix t=0 is c1")
+
+# ── Gradient ─────────────────────────────────────────────────────────
+
+(def grad (color:gradient red blue 5))
+(assert (= (length grad) 5) "gradient length")
+(assert (approx (get (grad 0) :r) 1.0 0.01) "gradient start is c1")
+(assert (approx (get (grad 4) :b) 1.0 0.01) "gradient end is c2")
+
+# ── Lighten / Darken ─────────────────────────────────────────────────
+
+(def dark-red (color:rgb 0.5 0.0 0.0))
+(def lighter (color:lighten dark-red 0.2))
+(assert (> (get (color:convert lighter :hsl) :l)
+           (get (color:convert dark-red :hsl) :l))
+  "lighten increases lightness")
+
+(def darker (color:darken dark-red 0.1))
+(assert (< (get (color:convert darker :hsl) :l)
+           (get (color:convert dark-red :hsl) :l))
+  "darken decreases lightness")
+
+# ── Saturate / Desaturate ────────────────────────────────────────────
+
+(def muted (color:rgb 0.5 0.3 0.3))
+(def more-sat (color:saturate muted 0.2))
+(assert (> (get (color:convert more-sat :hsl) :s)
+           (get (color:convert muted :hsl) :s))
+  "saturate increases saturation")
+
+# ── Complement ───────────────────────────────────────────────────────
+
+(def comp (color:complement red))
+(def comp-hsl (color:convert comp :hsl))
+(assert (approx (get comp-hsl :h) 180.0 2.0) "complement of red is cyan")
+
+# ── Distance ─────────────────────────────────────────────────────────
+
+(def d-same (color:distance red red))
+(assert (approx d-same 0.0 0.01) "distance to self is 0")
+
+(def green (color:rgb 0.0 1.0 0.0))
+(def d-diff (color:distance red green))
+(assert (> d-diff 50.0) "red-green distance is large")
+
+# ── Pixel interop ───────────────────────────────────────────────────
+
+(def px (color:to-rgba8 red))
+(assert (= (px 0) 255) "to-rgba8 r=255")
+(assert (= (px 1) 0) "to-rgba8 g=0")
+(assert (= (px 3) 255) "to-rgba8 a=255 default")
+
+(def from-px (color:from-rgba8 255 128 0 255))
+(assert (approx (get from-px :r) 1.0 0.01) "from-rgba8 r")
+(assert (approx (get from-px :g) 0.502 0.01) "from-rgba8 g")
+
+(println "color: all tests passed")

--- a/tests/elle/plugins/image.lisp
+++ b/tests/elle/plugins/image.lisp
@@ -1,0 +1,130 @@
+#!/usr/bin/env elle
+
+## Test suite for image plugin
+
+(def [ok? img] (protect (import "plugin/image")))
+(when (not ok?)
+  (println "SKIP: image plugin not built")
+  (exit 0))
+
+# ── Create image from pixels ─────────────────────────────────────────
+
+## 2x2 red RGBA8 image
+(def red-pixel [255 0 0 255])
+(def red-bytes b[255 0 0 255  255 0 0 255  255 0 0 255  255 0 0 255])
+(def red-img (img:from-pixels 2 2 :rgba8 red-bytes))
+
+(assert (= (img:width red-img) 2) "width")
+(assert (= (img:height red-img) 2) "height")
+(assert (= (img:dimensions red-img) [2 2]) "dimensions")
+(assert (= (img:color-type red-img) :rgba8) "color-type")
+
+# ── Pixel access ─────────────────────────────────────────────────────
+
+(def px (img:get-pixel red-img 0 0))
+(assert (= px [255 0 0 255]) "get-pixel red")
+
+(def blue-img (img:put-pixel red-img 1 1 [0 0 255 255]))
+(assert (= (img:get-pixel blue-img 1 1) [0 0 255 255]) "put-pixel immutable")
+
+# ── Mutable image ────────────────────────────────────────────────────
+
+(def mimg (img:new 4 4 :rgba8))
+(assert (= (img:width mimg) 4) "@image width")
+(img:put-pixel mimg 0 0 [128 64 32 255])
+(assert (= (img:get-pixel mimg 0 0) [128 64 32 255]) "put-pixel mutable")
+
+# ── Thaw / Freeze ────────────────────────────────────────────────────
+
+(def thawed (img:thaw red-img))
+(img:put-pixel thawed 0 0 [0 255 0 255])
+(assert (= (img:get-pixel thawed 0 0) [0 255 0 255]) "thaw then mutate")
+
+## Original unchanged
+(assert (= (img:get-pixel red-img 0 0) [255 0 0 255]) "original unchanged after thaw")
+
+(def frozen (img:freeze thawed))
+(assert (= (img:get-pixel frozen 0 0) [0 255 0 255]) "freeze snapshot")
+
+# ── Transforms ───────────────────────────────────────────────────────
+
+(def resized (img:resize red-img 4 4 :nearest))
+(assert (= (img:dimensions resized) [4 4]) "resize")
+
+(def cropped (img:crop resized 1 1 2 2))
+(assert (= (img:dimensions cropped) [2 2]) "crop")
+
+(def rotated (img:rotate red-img :r90))
+(assert (= (img:dimensions rotated) [2 2]) "rotate r90")
+
+(def flipped (img:flip red-img :h))
+(assert (= (img:dimensions flipped) [2 2]) "flip h")
+
+# ── Adjustments ──────────────────────────────────────────────────────
+
+(def gray (img:grayscale red-img))
+(assert (or (= (img:color-type gray) :luma8) (= (img:color-type gray) :lumaa8)) "grayscale → luma")
+
+(def inv (img:invert red-img))
+(assert (not (nil? inv)) "invert runs")
+
+(def blurred (img:blur red-img 1.0))
+(assert (not (nil? blurred)) "blur runs")
+
+# ── Color conversion ─────────────────────────────────────────────────
+
+(def as-rgb (img:to-rgb8 red-img))
+(assert (= (img:color-type as-rgb) :rgb8) "to-rgb8")
+
+(def as-rgba (img:to-rgba8 as-rgb))
+(assert (= (img:color-type as-rgba) :rgba8) "to-rgba8")
+
+# ── Encode / Decode roundtrip ────────────────────────────────────────
+
+(def png-bytes (img:encode red-img :png))
+(assert (> (length png-bytes) 0) "encode produces bytes")
+
+(def decoded (img:decode png-bytes :png))
+(assert (= (img:dimensions decoded) [2 2]) "decode roundtrip dimensions")
+(assert (= (img:get-pixel decoded 0 0) [255 0 0 255]) "decode roundtrip pixel")
+
+# ── Drawing ──────────────────────────────────────────────────────────
+
+(def canvas (img:new 100 100 :rgba8))
+(img:fill-rect canvas 10 10 20 20 [255 0 0 255])
+(assert (= (img:get-pixel canvas 15 15) [255 0 0 255]) "fill-rect")
+(assert (= (img:get-pixel canvas 0 0) [0 0 0 0]) "outside fill-rect")
+
+(img:draw-line canvas 0 0 99 99 [0 255 0 255])
+(img:draw-rect canvas 5 5 90 90 [0 0 255 255])
+(img:draw-circle canvas 50 50 20 [255 255 0 255])
+(img:fill-circle canvas 50 50 5 [255 0 255 255])
+
+# ── Compositing ──────────────────────────────────────────────────────
+
+(def base (img:new 10 10 :rgba8))
+(img:fill-rect base 0 0 10 10 [100 100 100 255])
+(def base-frozen (img:freeze base))
+
+(def overlay (img:new 5 5 :rgba8))
+(img:fill-rect overlay 0 0 5 5 [200 200 200 255])
+(def overlay-frozen (img:freeze overlay))
+
+(def composited (img:overlay base-frozen overlay-frozen 2 2))
+(assert (= (img:dimensions composited) [10 10]) "overlay dimensions")
+
+(def blended (img:blend base-frozen base-frozen 0.5))
+(assert (= (img:dimensions blended) [10 10]) "blend dimensions")
+
+# ── Analysis ─────────────────────────────────────────────────────────
+
+(def hist (img:histogram red-img))
+(assert (= (length (get hist :r)) 256) "histogram 256 bins")
+
+(def edges (img:edges red-img))
+(assert (not (nil? edges)) "edges runs")
+
+(def thresh (img:threshold red-img 128))
+(assert (= (img:color-type thresh) :luma8) "threshold → luma8")
+
+(println "image: all tests passed")

--- a/tests/elle/plugins/svg.lisp
+++ b/tests/elle/plugins/svg.lisp
@@ -1,0 +1,102 @@
+#!/usr/bin/env elle
+
+## Test suite for lib/svg + plugin/svg
+
+(def [ok? svgr] (protect (import "plugin/svg")))
+(when (not ok?)
+  (println "SKIP: svg plugin not built")
+  (exit 0))
+
+## Load library with renderer
+(def svg ((import "std/svg") svgr))
+
+# ── Construction ─────────────────────────────────────────────────────
+
+(def r (svg:rect 10 20 100 50 {:fill "blue"}))
+(assert (= (get r :tag) :rect) "rect tag")
+(assert (= (get (get r :attrs) :x) 10.0) "rect x attr")
+(assert (= (get (get r :attrs) :fill) "blue") "rect fill attr")
+
+(def c (svg:circle 50 50 30 {:fill "red"}))
+(assert (= (get c :tag) :circle) "circle tag")
+
+(def l (svg:line 0 0 100 100 {:stroke "black"}))
+(assert (= (get l :tag) :line) "line tag")
+
+(def p (svg:path "M 0 0 L 100 50"))
+(assert (= (get p :tag) :path) "path tag")
+(assert (= (get (get p :attrs) :d) "M 0 0 L 100 50") "path d attr")
+
+(def t (svg:text 10 80 "Hello" {:font-size 14}))
+(assert (= (get t :tag) :text) "text tag")
+
+# ── Grouping and transforms ─────────────────────────────────────────
+
+(def g (svg:group {:opacity 0.5} r c))
+(assert (= (get g :tag) :g) "group tag")
+(assert (= (length (get g :children)) 2) "group has 2 children")
+
+(def tr (svg:translate 100 50 r))
+(assert (= (get (get tr :attrs) :transform) "translate(100,50)") "translate")
+
+(def rot (svg:rotate 45 r))
+(assert (= (get (get rot :attrs) :transform) "rotate(45)") "rotate")
+
+# ── Document ─────────────────────────────────────────────────────────
+
+(def doc (svg:svg 400 300 r c l))
+(assert (= (get doc :tag) :svg) "svg tag")
+(assert (= (length (get doc :children)) 3) "svg has 3 children")
+
+# ── Gradients ────────────────────────────────────────────────────────
+
+(def grad (svg:linear-gradient "g1" {}
+            (svg:stop 0 "red")
+            (svg:stop 1 "blue")))
+(assert (= (get grad :tag) :linearGradient) "linearGradient tag")
+(assert (= (length (get grad :children)) 2) "gradient has 2 stops")
+
+# ── Element manipulation ─────────────────────────────────────────────
+
+(def r2 (svg:set-attr r :stroke "black"))
+(assert (= (get (get r2 :attrs) :stroke) "black") "set-attr adds attr")
+(assert (= (get (get r2 :attrs) :fill) "blue") "set-attr preserves existing")
+
+(def g2 (svg:add-child g p))
+(assert (= (length (get g2 :children)) 3) "add-child appends")
+
+(def wrapped (svg:wrap r :g {:opacity 0.8}))
+(assert (= (get wrapped :tag) :g) "wrap tag")
+(assert (= (length (get wrapped :children)) 1) "wrap has 1 child")
+
+# ── Emission ─────────────────────────────────────────────────────────
+
+(def xml (svg:emit doc))
+(assert (not (nil? (string/find xml "<svg"))) "emit contains <svg")
+(assert (not (nil? (string/find xml "<rect"))) "emit contains <rect")
+(assert (not (nil? (string/find xml "</svg>"))) "emit contains </svg>")
+(assert (not (nil? (string/find xml "xmlns"))) "emit contains xmlns")
+
+# ── Rendering (via plugin) ───────────────────────────────────────────
+
+(def simple-doc (svg:svg 100 100
+                  (svg:rect 0 0 100 100 {:fill "white"})
+                  (svg:circle 50 50 40 {:fill "red"})))
+
+(def png-bytes (svg:render simple-doc))
+(assert (> (length png-bytes) 0) "render produces bytes")
+
+## PNG magic bytes
+(assert (= (png-bytes 0) 137) "PNG magic byte 0")
+(assert (= (png-bytes 1) 80) "PNG magic byte 1 (P)")
+
+(def raw (svg:render-raw simple-doc))
+(assert (= (get raw :width) 100) "render-raw width")
+(assert (= (get raw :height) 100) "render-raw height")
+(assert (> (length (get raw :data)) 0) "render-raw has data")
+
+(def dims (svg:dimensions simple-doc))
+(assert (= (dims 0) 100.0) "dimensions width")
+(assert (= (dims 1) 100.0) "dimensions height")
+
+(println "svg: all tests passed")


### PR DESCRIPTION

- plugins/image: Rust plugin (35 primitives) — I/O, transforms,
  drawing, compositing, analysis via image + imageproc crates
- plugins/svg: Rust plugin (4 primitives) — SVG rasterization via resvg
- lib/svg.lisp: Elle library — declarative SVG construction and XML
  emission as struct trees; optionally wraps the svg plugin for rendering
- lib/color.lisp: Elle library — color science: sRGB/HSL/Lab/Oklch
  conversions, mixing, gradients, CIEDE2000 distance