### PR TITLE
Rewrite microgpt demo: idiomatic modules, Gaussian init, JIT-safe

### DIFF
--- a/demos/microgpt/autograd.lisp
+++ b/demos/microgpt/autograd.lisp
@@ -67,6 +67,37 @@
     "Add scalar s to Value v."
     (v+ v (make-value s)))
 
+  # ── Fused operations (reduce node count) ───────────────────────
+
+  (defn vdot [avec bvec n &named offset-a offset-b]
+    "Fused dot product: sum(avec[i]*bvec[i]) for i in 0..n-1.
+     Single Value node instead of 2n nodes.
+     Optional offset-a/offset-b for sliced access."
+    (default offset-a 0)
+    (default offset-b 0)
+    (var sum 0.0)
+    (let* ([children @[]] [grads @[]])
+      (var i 0)
+      (while (< i n)
+        (let* ([a (avec (+ offset-a i))]
+               [b (bvec (+ offset-b i))])
+          (assign sum (+ sum (* a:data b:data)))
+          (push children a)
+          (push children b)
+          (push grads b:data)
+          (push grads a:data))
+        (assign i (inc i)))
+      (make-op sum children grads)))
+
+  (defn vsum [vec]
+    "Fused sum: single Value node with all inputs as children."
+    (var sum 0.0)
+    (let ([grads @[]])
+      (each v in vec
+        (assign sum (+ sum v:data))
+        (push grads 1.0))
+      (make-op sum (if (array? vec) vec (thaw (->array vec))) grads)))
+
   # ── Backward pass ──────────────────────────────────────────────
 
   (defn topo-sort [root]
@@ -103,4 +134,5 @@
    :v-data v-data :v-grad v-grad
    :v+ v+ :v* v* :vneg vneg :vpow vpow :vexp vexp :vlog vlog :vrelu vrelu
    :v- v- :v/ v/ :v*s v*s :v+s v+s
+   :vdot vdot :vsum vsum
    :backward backward})

--- a/demos/microgpt/autograd.lisp
+++ b/demos/microgpt/autograd.lisp
@@ -1,104 +1,106 @@
-# ── Scalar autograd engine ────────────────────────────────────────
-#
-# Each Value node is a mutable @struct with:
-#   :id          unique integer (for visited-set keying)
-#   :data        float (forward value)
-#   :grad        float (accumulated gradient, mutated during backward)
-#   :children    array of Value nodes this was computed from
-#   :local-grads array of floats, d(this)/d(child_i)
+## autograd.lisp — Scalar autograd engine
+##
+## Each Value node is a mutable @struct with:
+##   :id          unique integer (for visited-set keying)
+##   :data        float (forward value)
+##   :grad        float (accumulated gradient, mutated during backward)
+##   :children    array of Value nodes this was computed from
+##   :local-grads array of floats, d(this)/d(child_i)
 
-# ── Value construction ───────────────────────────────────────────
+(fn []
 
-(var *next-id* 0)
+  # ── Value construction ─────────────────────────────────────────
 
-(defn make-value [data]
-  "Create a leaf Value node (no children)."
-  (let* ([id *next-id*])
-    (assign *next-id* (+ *next-id* 1))
-    @{:id id :data data :grad 0.0 :children @[] :local-grads @[]}))
+  (var *next-id* 0)
 
-(defn make-op [data children local-grads]
-  "Create a Value node that is the result of an operation."
-  (let* ([id *next-id*])
-    (assign *next-id* (+ *next-id* 1))
-    @{:id id :data data :grad 0.0
-      :children children :local-grads local-grads}))
+  (defn make-value [data]
+    "Create a leaf Value node (no children)."
+    (let* ([id *next-id*])
+      (assign *next-id* (inc *next-id*))
+      @{:id id :data data :grad 0.0 :children @[] :local-grads @[]}))
 
-# ── Accessors ────────────────────────────────────────────────────
+  (defn make-op [data children local-grads]
+    "Create a Value node that is the result of an operation."
+    (let* ([id *next-id*])
+      (assign *next-id* (inc *next-id*))
+      @{:id id :data data :grad 0.0
+        :children children :local-grads local-grads}))
 
-(defn v-data [v] v:data)
-(defn v-grad [v] v:grad)
-(defn v-id   [v] v:id)
+  # ── Accessors ──────────────────────────────────────────────────
 
-# ── Arithmetic operations ────────────────────────────────────────
+  (defn v-data [v] v:data)
+  (defn v-grad [v] v:grad)
 
-(defn v+ [a b]
-  (make-op (+ (v-data a) (v-data b)) @[a b] @[1.0 1.0]))
+  # ── Arithmetic operations ──────────────────────────────────────
 
-(defn v* [a b]
-  (make-op (* (v-data a) (v-data b)) @[a b] @[(v-data b) (v-data a)]))
+  (defn v+ [a b]
+    (make-op (+ (v-data a) (v-data b)) @[a b] @[1.0 1.0]))
 
-(defn vneg [a]
-  (make-op (- (v-data a)) @[a] @[-1.0]))
+  (defn v* [a b]
+    (make-op (* (v-data a) (v-data b)) @[a b] @[(v-data b) (v-data a)]))
 
-(defn vpow [a n]
-  (make-op (pow (v-data a) n) @[a] @[(* n (pow (v-data a) (- n 1.0)))]))
+  (defn vneg [a]
+    (make-op (- (v-data a)) @[a] @[-1.0]))
 
-(defn vexp [a]
-  (let* ([ea (exp (v-data a))])
-    (make-op ea @[a] @[ea])))
+  (defn vpow [a n]
+    (make-op (pow (v-data a) n) @[a] @[(* n (pow (v-data a) (- n 1.0)))]))
 
-(defn vlog [a]
-  (make-op (log (v-data a)) @[a] @[(/ 1.0 (v-data a))]))
+  (defn vexp [a]
+    (let* ([ea (exp (v-data a))])
+      (make-op ea @[a] @[ea])))
 
-(defn vrelu [a]
-  (let* ([d (v-data a)])
-    (make-op (if (> d 0.0) d 0.0) @[a] @[(if (> d 0.0) 1.0 0.0)])))
+  (defn vlog [a]
+    (make-op (log (v-data a)) @[a] @[(/ 1.0 (v-data a))]))
 
-(defn v- [a b] (v+ a (vneg b)))
-(defn v/ [a b] (v* a (vpow b -1.0)))
+  (defn vrelu [a]
+    (let* ([d (v-data a)])
+      (make-op (if (> d 0.0) d 0.0) @[a] @[(if (> d 0.0) 1.0 0.0)])))
 
-# ── Scalar-Value mixed ops ───────────────────────────────────────
+  (defn v- [a b] (v+ a (vneg b)))
+  (defn v/ [a b] (v* a (vpow b -1.0)))
 
-(defn v*s [v s]
-  "Multiply Value v by scalar s."
-  (v* v (make-value s)))
+  (defn v*s [v s]
+    "Multiply Value v by scalar s."
+    (v* v (make-value s)))
 
-(defn v+s [v s]
-  "Add scalar s to Value v."
-  (v+ v (make-value s)))
+  (defn v+s [v s]
+    "Add scalar s to Value v."
+    (v+ v (make-value s)))
 
-# ── Backward pass ────────────────────────────────────────────────
+  # ── Backward pass ──────────────────────────────────────────────
 
-(defn topo-sort [root]
-  "Topological sort (DFS, post-order) from root."
-  (let* ([topo @[]]
-         [visited @{}])
-    (letrec ([walk (fn [node]
-      (when (not (has? visited (v-id node)))
-        (put visited (v-id node) true)
-        (each child in node:children
-          (walk child))
-        (push topo node)))])
-      (walk root))
-    topo))
+  (defn topo-sort [root]
+    "Topological sort (DFS, post-order) from root."
+    (let* ([topo @[]]
+           [visited @||])
+      (letrec ([walk (fn [node]
+        (when (not (contains? visited node:id))
+          (add visited node:id)
+          (each child in node:children
+            (walk child))
+          (push topo node)))])
+        (walk root))
+      topo))
 
-(defn backward! [root]
-  "Run backpropagation from root. Assumes all grads already zeroed."
-  (let* ([topo (topo-sort root)])
-    # Zero all grads
-    (each node in topo
-      (put node :grad 0.0))
-    # Seed root gradient
-    (put root :grad 1.0)
-    # Reverse accumulation
-    (each node in (reverse topo)
-      (let* ([children   node:children]
-             [local-grads node:local-grads]
-             [node-grad  (v-grad node)])
-        (var j 0)
-        (while (< j (length children))
-          (let* ([child (children j)]
-                 [lg    (local-grads j)])
-            (put child :grad (+ (v-grad child) (* node-grad lg))))
-          (assign j (+ j 1)))))))
+  (defn backward [root]
+    "Run backpropagation from root."
+    (let* ([topo (topo-sort root)])
+      (each node in topo
+        (put node :grad 0.0))
+      (put root :grad 1.0)
+      (each node in (reverse topo)
+        (let* ([children   node:children]
+               [local-grads node:local-grads]
+               [node-grad  node:grad])
+          (var j 0)
+          (while (< j (length children))
+            (let* ([child (children j)]
+                   [lg    (local-grads j)])
+              (put child :grad (+ child:grad (* node-grad lg))))
+            (assign j (inc j)))))))
+
+  {:make-value make-value :make-op make-op
+   :v-data v-data :v-grad v-grad
+   :v+ v+ :v* v* :vneg vneg :vpow vpow :vexp vexp :vlog vlog :vrelu vrelu
+   :v- v- :v/ v/ :v*s v*s :v+s v+s
+   :backward backward})

--- a/demos/microgpt/helpers.lisp
+++ b/demos/microgpt/helpers.lisp
@@ -1,38 +1,23 @@
-# ── Utility functions for microgpt ────────────────────────────────
+## helpers.lisp — Utility functions for microgpt
 
-(import "plugin/random")
+(fn []
 
-# ── Array shuffling ──────────────────────────────────────────────
+  (defn make-2d [rows cols init-fn]
+    "Create a rows x cols mutable 2D array, calling (init-fn r c) for each cell."
+    (let* ([result @[]])
+      (each r in (range rows)
+        (let* ([row @[]])
+          (each c in (range cols)
+            (push row (init-fn r c)))
+          (push result row)))
+      result))
 
-(defn shuffle! [arr]
-  "Shuffle array in place using Fisher-Yates."
-  (var i (- (length arr) 1))
-  (while (> i 0)
-    (let* ([j (floor (* (random/float) (+ i 1)))]
-           [tmp (arr i)])
-      (put arr i (arr j))
-      (put arr j tmp))
-    (assign i (- i 1)))
-  arr)
+  (defn make-kv-caches [n-layer]
+    "Create fresh per-layer KV caches. Returns [keys-cache values-cache]."
+    (let* ([ks @[]] [vs @[]])
+      (each _ in (range n-layer)
+        (push ks @[])
+        (push vs @[]))
+      [ks vs]))
 
-# ── 2D array construction ───────────────────────────────────────
-
-(defn make-2d [rows cols init-fn]
-  "Create a rows x cols mutable 2D array, calling (init-fn r c) for each cell."
-  (let* ([result @[]])
-    (each r in (range rows)
-      (let* ([row @[]])
-        (each c in (range cols)
-          (push row (init-fn r c)))
-        (push result row)))
-    result))
-
-# ── KV cache construction ───────────────────────────────────────
-
-(defn make-kv-caches [n-layer]
-  "Create fresh per-layer KV caches. Returns [keys-cache values-cache]."
-  (let* ([ks @[]] [vs @[]])
-    (each _ in (range n-layer)
-      (push ks @[])
-      (push vs @[]))
-    [ks vs]))
+  {:make-2d make-2d :make-kv-caches make-kv-caches})

--- a/demos/microgpt/microgpt.lisp
+++ b/demos/microgpt/microgpt.lisp
@@ -12,21 +12,13 @@
 (def helpers ((import "demos/microgpt/helpers.lisp")))
 (def gpt     ((import "demos/microgpt/model.lisp") ag helpers rng))
 
-(def {:make-value make-value :v-data v-data :v-grad v-grad
-      :v+ v+ :v* v* :vpow vpow :backward backward} ag)
-(def {:make-kv-caches make-kv-caches} helpers)
-(def {:init-model init-model :collect-params collect-params
-      :gpt-forward-token gpt-forward-token
-      :cross-entropy-loss-incremental cross-entropy-loss-incremental
-      :*block-size* *block-size* :*n-layer* *n-layer*} gpt)
-
 # ── Data loading and tokenizer ──────────────────────────────────
 
 (defn load-data [path]
   "Load names from file, return mutable array of non-empty trimmed strings."
   (let* ([result @[]])
     (each line in (read-lines path)
-      (let* ([trimmed (string/trim line)])
+      (let ([trimmed (string/trim line)])
         (when (> (length trimmed) 0)
           (push result trimmed))))
     result))
@@ -34,29 +26,27 @@
 (defn build-tokenizer [names]
   "Build char-level tokenizer. Returns struct with :char->id, :id->char, :vocab-size.
    BOS token is at the last index (also serves as EOS)."
-  (let* ([chars @{}])
+  (let* ([chars @{}]
+         [char->id @{}]
+         [id->char @{}])
     (each name in names
       (each ch in name
         (put chars ch true)))
-    (let* ([sorted-chars (->array (sort (keys chars)))]
-           [char->id @{}]
-           [id->char @{}])
-      (var idx 0)
-      (each ch in sorted-chars
-        (put char->id ch idx)
-        (put id->char idx ch)
-        (assign idx (inc idx)))
-      (put id->char idx "<BOS>")
-      @{:char->id char->id :id->char id->char
-        :vocab-size (inc idx) :bos idx})))
+    (var idx 0)
+    (each ch in (sort (keys chars))
+      (put char->id ch idx)
+      (put id->char idx ch)
+      (assign idx (inc idx)))
+    (put id->char idx "<BOS>")
+    @{:char->id char->id :id->char id->char
+      :vocab-size (inc idx) :bos idx}))
 
 (defn tokenize [name tokenizer]
   "Tokenize a name into array of integer IDs. Prepends and appends BOS."
-  (let* ([char->id tokenizer:char->id]
-         [bos tokenizer:bos]
+  (let* ([bos tokenizer:bos]
          [ids @[bos]])
     (each ch in name
-      (push ids (char->id ch)))
+      (push ids (tokenizer:char->id ch)))
     (push ids bos)
     ids))
 
@@ -64,115 +54,97 @@
 
 (defn make-adam [params lr beta1 beta2 eps]
   "Create Adam optimizer state."
-  (let* ([n (length params)])
-    @{:params params :lr lr :beta1 beta1 :beta2 beta2 :eps eps
-      :m (array/new n 0.0) :v (array/new n 0.0) :step 0}))
+  @{:params params :lr lr :beta1 beta1 :beta2 beta2 :eps eps
+    :m (array/new (length params) 0.0)
+    :v (array/new (length params) 0.0)
+    :step 0})
 
 (defn adam-step [opt lr-current]
   "One Adam update step."
-  (let* ([params opt:params]
-         [beta1 opt:beta1] [beta2 opt:beta2] [eps opt:eps]
-         [m-arr opt:m] [v-arr opt:v]
-         [step (inc opt:step)])
+  (let ([step (inc opt:step)])
     (put opt :step step)
     (var i 0)
-    (while (< i (length params))
-      (let* ([p (params i)]
-             [g (v-grad p)]
-             [m-new (+ (* beta1 (m-arr i)) (* (- 1.0 beta1) g))]
-             [v-new (+ (* beta2 (v-arr i)) (* (- 1.0 beta2) (* g g)))]
-             [m-hat (/ m-new (- 1.0 (pow beta1 (float step))))]
-             [v-hat (/ v-new (- 1.0 (pow beta2 (float step))))])
-        (put m-arr i m-new)
-        (put v-arr i v-new)
-        (put p :data (- (v-data p) (* lr-current (/ m-hat (+ (sqrt v-hat) eps))))))
+    (while (< i (length opt:params))
+      (let* ([p (opt:params i)]
+             [g (ag:v-grad p)]
+             [m-new (+ (* opt:beta1 (opt:m i)) (* (- 1.0 opt:beta1) g))]
+             [v-new (+ (* opt:beta2 (opt:v i)) (* (- 1.0 opt:beta2) (* g g)))]
+             [m-hat (/ m-new (- 1.0 (pow opt:beta1 (float step))))]
+             [v-hat (/ v-new (- 1.0 (pow opt:beta2 (float step))))])
+        (put opt:m i m-new)
+        (put opt:v i v-new)
+        (put p :data (- (ag:v-data p) (* lr-current (/ m-hat (+ (sqrt v-hat) opt:eps))))))
       (assign i (inc i)))))
 
 # ── Training ────────────────────────────────────────────────────
 
-(defn zero-grads [params]
-  "Zero all gradients."
-  (each p in params
-    (put p :grad 0.0)))
-
 (defn train [model tokenizer names num-steps lr]
   "Train the model."
-  (let* ([params (collect-params model)]
+  (let* ([params (gpt:collect-params model)]
          [opt (make-adam params lr 0.85 0.99 0.00000001)]
-         [n-names (length names)]
-         [max-len (inc *block-size*)])
+         [n-names (length names)])
     (println "Parameters: " (length params))
     (var step 0)
     (while (< step num-steps)
-      (let* ([name (names (mod step n-names))]
-             [tokens (tokenize name tokenizer)]
-             [tokens (if (> (length tokens) max-len)
-                       (slice tokens 0 max-len)
+      (let* ([tokens (tokenize (names (mod step n-names)) tokenizer)]
+             [tokens (if (> (length tokens) (inc gpt:*block-size*))
+                       (slice tokens 0 (inc gpt:*block-size*))
                        tokens)]
-             [loss (cross-entropy-loss-incremental model tokens)]
+             [loss (gpt:cross-entropy-loss-incremental model tokens)]
              [lr-current (* lr (- 1.0 (/ (float step) (float num-steps))))])
-        (backward loss)
+        (ag:backward loss)
         (adam-step opt lr-current)
-        (zero-grads params)
+        (each p in params (put p :grad 0.0))
         (when (= (mod step 100) 0)
           (println (string/format "step {:>4d} / {} | loss {:.4f}"
-                                  step num-steps (v-data loss)))))
+                                  step num-steps (ag:v-data loss)))))
       (assign step (inc step)))))
 
 # ── Inference ───────────────────────────────────────────────────
 
 (defn softmax-floats [scores]
-  "Numerically stable softmax over an array of floats. Returns unnormalized exps."
+  "Numerically stable softmax over an array of floats."
   (var max-val (scores 0))
   (each s in scores
     (when (> s max-val) (assign max-val s)))
-  (let* ([exps @[]])
-    (each s in scores
-      (push exps (exp (- s max-val))))
-    exps))
+  (map (fn [s] (exp (- s max-val))) scores))
 
 (defn sample-token [logits temperature]
   "Sample next token from logits using temperature-scaled softmax."
-  (let* ([scaled @[]])
-    (each l in logits
-      (push scaled (/ (v-data l) temperature)))
-    (let* ([exps (softmax-floats scaled)]
-           [indices (->array (range (length exps)))])
-      (rng:weighted indices exps))))
+  (let* ([scaled (map (fn [l] (/ (ag:v-data l) temperature)) logits)]
+         [exps (softmax-floats scaled)])
+    (rng:weighted (->array (range (length exps))) (->array exps))))
 
 (defn generate [model tokenizer n-samples temperature max-len]
   "Generate n-samples names using incremental forward pass."
-  (let* ([id->char tokenizer:id->char]
-         [bos tokenizer:bos])
-    (repeat n-samples
-      (let* ([chars @[]]
-             [[kv-keys kv-values] (make-kv-caches *n-layer*)])
-        (var token-id bos)
-        (var pos 0)
-        (block :gen
-          (while (< pos max-len)
-            (let* ([logits (gpt-forward-token token-id pos kv-keys kv-values model)]
-                   [next-tok (sample-token logits temperature)])
-              (when (= next-tok bos) (break :gen))
-              (assign token-id next-tok)
-              (push chars (id->char next-tok))
-              (assign pos (inc pos)))))
-        (println " " (string/join chars ""))))))
+  (repeat n-samples
+    (let* ([chars @[]]
+           [[kv-keys kv-values] (helpers:make-kv-caches gpt:*n-layer*)])
+      (var token-id tokenizer:bos)
+      (var pos 0)
+      (block :gen
+        (while (< pos max-len)
+          (let* ([logits (gpt:gpt-forward-token token-id pos kv-keys kv-values model)]
+                 [next-tok (sample-token logits temperature)])
+            (when (= next-tok tokenizer:bos) (break :gen))
+            (assign token-id next-tok)
+            (push chars (tokenizer:id->char next-tok))
+            (assign pos (inc pos)))))
+      (println " " (string/join chars "")))))
 
 # ── Gradient check ──────────────────────────────────────────────
 
 (defn check-grads []
   "Quick gradient correctness check."
-  (let* ([a (make-value 3.0)]
-         [b (make-value 4.0)]
-         [c (v+ (v* a b) (vpow a 2.0))])
-    (backward c)
-    # dc/da = b + 2a = 4 + 6 = 10
-    # dc/db = a = 3
-    (when (> (abs (- (v-grad a) 10.0)) 0.000001)
-      (error (string/format "grad check failed: da = {} (expected 10.0)" (v-grad a))))
-    (when (> (abs (- (v-grad b) 3.0)) 0.000001)
-      (error (string/format "grad check failed: db = {} (expected 3.0)" (v-grad b))))
+  (let* ([a (ag:make-value 3.0)]
+         [b (ag:make-value 4.0)]
+         [c (ag:v+ (ag:v* a b) (ag:vpow a 2.0))])
+    (ag:backward c)
+    # dc/da = b + 2a = 4 + 6 = 10, dc/db = a = 3
+    (when (> (abs (- (ag:v-grad a) 10.0)) 0.000001)
+      (error (string/format "grad check failed: da = {} (expected 10.0)" (ag:v-grad a))))
+    (when (> (abs (- (ag:v-grad b) 3.0)) 0.000001)
+      (error (string/format "grad check failed: db = {} (expected 3.0)" (ag:v-grad b))))
     (println "Gradient check passed.")))
 
 # ── Main ────────────────────────────────────────────────────────
@@ -182,17 +154,17 @@
   (check-grads)
 
   (println "Loading data...")
-  (let* ([names (rng:shuffle (load-data "demos/microgpt/input.txt"))])
+  (let ([names (rng:shuffle (load-data "demos/microgpt/input.txt"))])
     (println "Loaded " (length names) " names")
 
-    (let* ([tokenizer (build-tokenizer names)])
+    (let ([tokenizer (build-tokenizer names)])
       (println "Vocab size: " tokenizer:vocab-size)
 
       (println "Initializing model...")
-      (let* ([model (init-model tokenizer:vocab-size)])
+      (let ([model (gpt:init-model tokenizer:vocab-size)])
 
         (println "Training...")
-        (let* ([start (clock/monotonic)])
+        (let ([start (clock/monotonic)])
           (train model tokenizer names 1000 0.01)
           (println (string/format "Training took {:.1f}s"
                                   (- (clock/monotonic) start))))

--- a/demos/microgpt/microgpt.lisp
+++ b/demos/microgpt/microgpt.lisp
@@ -7,78 +7,56 @@
 #
 # Usage: cargo run --release -- demos/microgpt/microgpt.lisp
 
-(import "plugin/random")
-(import "demos/microgpt/helpers.lisp")
-(import "demos/microgpt/autograd.lisp")
-(import "demos/microgpt/model.lisp")
+(def rng (import "plugin/random"))
+(def ag      ((import "demos/microgpt/autograd.lisp")))
+(def helpers ((import "demos/microgpt/helpers.lisp")))
+(def gpt     ((import "demos/microgpt/model.lisp") ag helpers rng))
+
+(def {:make-value make-value :v-data v-data :v-grad v-grad
+      :v+ v+ :v* v* :vpow vpow :backward backward} ag)
+(def {:make-kv-caches make-kv-caches} helpers)
+(def {:init-model init-model :collect-params collect-params
+      :gpt-forward-token gpt-forward-token
+      :cross-entropy-loss-incremental cross-entropy-loss-incremental
+      :*block-size* *block-size* :*n-layer* *n-layer*} gpt)
 
 # ── Data loading and tokenizer ──────────────────────────────────
 
 (defn load-data [path]
-  "Load names from file, return mutable array of trimmed strings.
-   Preserves original case to match Python reference (uppercase initials
-   are distinct tokens from their lowercase counterparts)."
-  (let* ([lines (read-lines path)]
-         [result @[]])
-    (each line in lines
+  "Load names from file, return mutable array of non-empty trimmed strings."
+  (let* ([result @[]])
+    (each line in (read-lines path)
       (let* ([trimmed (string/trim line)])
         (when (> (length trimmed) 0)
           (push result trimmed))))
     result))
 
-(defn sort-strings [arr]
-  "Insertion sort for an array of strings. Returns a new sorted array.
-   Used to produce a deterministic char->id mapping matching the Python reference."
-  (let* ([result @[]])
-    (each s in arr
-      (push result s))
-    (var i 1)
-    (while (< i (length result))
-      (let* ([key (result i)])
-        (var j (- i 1))
-        (while (and (>= j 0) (> (result j) key))
-          (put result (+ j 1) (result j))
-          (assign j (- j 1)))
-        (put result (+ j 1) key))
-      (assign i (+ i 1)))
-    result))
-
 (defn build-tokenizer [names]
-  "Build char-level tokenizer. Returns @struct with :char->id, :id->char, :vocab-size.
-   BOS token is at the last index (also serves as EOS).
-   Characters are sorted to produce a deterministic mapping matching Python."
+  "Build char-level tokenizer. Returns struct with :char->id, :id->char, :vocab-size.
+   BOS token is at the last index (also serves as EOS)."
   (let* ([chars @{}])
-    # Collect unique chars from all names
     (each name in names
-      (var i 0)
-      (while (< i (length name))
-        (put chars (name i) true)
-        (assign i (+ i 1))))
-    (let* ([sorted-chars (sort-strings (keys chars))]
+      (each ch in name
+        (put chars ch true)))
+    (let* ([sorted-chars (->array (sort (keys chars)))]
            [char->id @{}]
            [id->char @{}])
       (var idx 0)
       (each ch in sorted-chars
         (put char->id ch idx)
         (put id->char idx ch)
-        (assign idx (+ idx 1)))
-      # BOS/EOS is the last index
-      (let* ([bos idx])
-        (put id->char bos "<BOS>")
-        @{:char->id char->id
-          :id->char id->char
-          :vocab-size (+ idx 1)
-          :bos bos}))))
+        (assign idx (inc idx)))
+      (put id->char idx "<BOS>")
+      @{:char->id char->id :id->char id->char
+        :vocab-size (inc idx) :bos idx})))
 
 (defn tokenize [name tokenizer]
   "Tokenize a name into array of integer IDs. Prepends and appends BOS."
   (let* ([char->id tokenizer:char->id]
          [bos tokenizer:bos]
          [ids @[bos]])
-    (var i 0)
-    (while (< i (length name))
-      (push ids (char->id (name i)))
-      (assign i (+ i 1)))
+    (each ch in name
+      (push ids (char->id ch)))
     (push ids bos)
     ids))
 
@@ -86,36 +64,29 @@
 
 (defn make-adam [params lr beta1 beta2 eps]
   "Create Adam optimizer state."
-  (let* ([n (length params)]
-         [m (@array/new n 0.0)]
-         [v (@array/new n 0.0)])
+  (let* ([n (length params)])
     @{:params params :lr lr :beta1 beta1 :beta2 beta2 :eps eps
-      :m m :v v :step 0}))
+      :m (array/new n 0.0) :v (array/new n 0.0) :step 0}))
 
 (defn adam-step [opt lr-current]
   "One Adam update step."
   (let* ([params opt:params]
-         [beta1 opt:beta1]
-         [beta2 opt:beta2]
-         [eps opt:eps]
-         [m-arr opt:m]
-         [v-arr opt:v]
-         [step (+ opt:step 1)])
+         [beta1 opt:beta1] [beta2 opt:beta2] [eps opt:eps]
+         [m-arr opt:m] [v-arr opt:v]
+         [step (inc opt:step)])
     (put opt :step step)
     (var i 0)
     (while (< i (length params))
       (let* ([p (params i)]
              [g (v-grad p)]
-             [m-old (m-arr i)]
-             [v-old (v-arr i)]
-             [m-new (+ (* beta1 m-old) (* (- 1.0 beta1) g))]
-             [v-new (+ (* beta2 v-old) (* (- 1.0 beta2) (* g g)))]
+             [m-new (+ (* beta1 (m-arr i)) (* (- 1.0 beta1) g))]
+             [v-new (+ (* beta2 (v-arr i)) (* (- 1.0 beta2) (* g g)))]
              [m-hat (/ m-new (- 1.0 (pow beta1 (float step))))]
              [v-hat (/ v-new (- 1.0 (pow beta2 (float step))))])
         (put m-arr i m-new)
         (put v-arr i v-new)
         (put p :data (- (v-data p) (* lr-current (/ m-hat (+ (sqrt v-hat) eps))))))
-      (assign i (+ i 1)))))
+      (assign i (inc i)))))
 
 # ── Training ────────────────────────────────────────────────────
 
@@ -129,85 +100,64 @@
   (let* ([params (collect-params model)]
          [opt (make-adam params lr 0.85 0.99 0.00000001)]
          [n-names (length names)]
-         [max-len (+ *block-size* 1)])
+         [max-len (inc *block-size*)])
     (println "Parameters: " (length params))
     (var step 0)
     (while (< step num-steps)
-      # Pick a random name
-      (let* ([idx (floor (* (random/float) n-names))]
-             [name (names idx)]
+      (let* ([name (names (mod step n-names))]
              [tokens (tokenize name tokenizer)]
              [tokens (if (> (length tokens) max-len)
                        (slice tokens 0 max-len)
-                       tokens)])
-        # Forward + loss (incremental per-token)
-        (let* ([loss (cross-entropy-loss-incremental model tokens)]
-               [lr-current (* lr (- 1.0 (/ (float step) (float num-steps))))])
-          # Backward
-          (backward! loss)
-          # Update
-          (adam-step opt lr-current)
-          # Zero grads
-          (zero-grads params)
-          # Log
-          (when (= (mod step 100) 0)
-            (println (string/format "step {:>4d} / {} | loss {:.4f}"
-                                    step num-steps (v-data loss))))))
-      (assign step (+ step 1)))))
+                       tokens)]
+             [loss (cross-entropy-loss-incremental model tokens)]
+             [lr-current (* lr (- 1.0 (/ (float step) (float num-steps))))])
+        (backward loss)
+        (adam-step opt lr-current)
+        (zero-grads params)
+        (when (= (mod step 100) 0)
+          (println (string/format "step {:>4d} / {} | loss {:.4f}"
+                                  step num-steps (v-data loss)))))
+      (assign step (inc step)))))
 
 # ── Inference ───────────────────────────────────────────────────
 
 (defn softmax-floats [scores]
-  "Numerically stable softmax over an array of floats. Returns [probs sum]."
+  "Numerically stable softmax over an array of floats. Returns unnormalized exps."
   (var max-val (scores 0))
   (each s in scores
     (when (> s max-val) (assign max-val s)))
-  (let* ([exps @[]]
-         [sum-exp 0.0])
+  (let* ([exps @[]])
     (each s in scores
-      (let* ([e (exp (- s max-val))])
-        (push exps e)
-        (assign sum-exp (+ sum-exp e))))
-    [exps sum-exp]))
+      (push exps (exp (- s max-val))))
+    exps))
 
 (defn sample-token [logits temperature]
   "Sample next token from logits using temperature-scaled softmax."
   (let* ([scaled @[]])
     (each l in logits
       (push scaled (/ (v-data l) temperature)))
-    (let* ([[exps sum-exp] (softmax-floats scaled)]
-           [r (random/float)])
-      (var cumulative 0.0)
-      (var idx 0)
-      (block :sample
-        (while (< idx (length exps))
-          (assign cumulative (+ cumulative (/ (exps idx) sum-exp)))
-          (when (>= cumulative r) (break :sample idx))
-          (assign idx (+ idx 1)))
-        (- (length exps) 1)))))
+    (let* ([exps (softmax-floats scaled)]
+           [indices (->array (range (length exps)))])
+      (rng:weighted indices exps))))
 
 (defn generate [model tokenizer n-samples temperature max-len]
   "Generate n-samples names using incremental forward pass."
   (let* ([id->char tokenizer:id->char]
          [bos tokenizer:bos])
-    (var sample 0)
-    (while (< sample n-samples)
-      (let* ([name ""]
+    (repeat n-samples
+      (let* ([chars @[]]
              [[kv-keys kv-values] (make-kv-caches *n-layer*)])
         (var token-id bos)
-        (var done false)
         (var pos 0)
-        (while (and (not done) (< pos max-len))
-          (let* ([logits (gpt-forward-token token-id pos kv-keys kv-values model)]
-                 [next-tok (sample-token logits temperature)])
-            (if (= next-tok bos)
-              (assign done true)
-              (begin
-                (assign token-id next-tok)
-                (assign name (string name (id->char next-tok)))
-                (assign pos (+ pos 1))))))
-        (println " " name))
-      (assign sample (+ sample 1)))))
+        (block :gen
+          (while (< pos max-len)
+            (let* ([logits (gpt-forward-token token-id pos kv-keys kv-values model)]
+                   [next-tok (sample-token logits temperature)])
+              (when (= next-tok bos) (break :gen))
+              (assign token-id next-tok)
+              (push chars (id->char next-tok))
+              (assign pos (inc pos)))))
+        (println " " (string/join chars ""))))))
 
 # ── Gradient check ──────────────────────────────────────────────
 
@@ -216,7 +166,7 @@
   (let* ([a (make-value 3.0)]
          [b (make-value 4.0)]
          [c (v+ (v* a b) (vpow a 2.0))])
-    (backward! c)
+    (backward c)
     # dc/da = b + 2a = 4 + 6 = 10
     # dc/db = a = 3
     (when (> (abs (- (v-grad a) 10.0)) 0.000001)
@@ -228,33 +178,25 @@
 # ── Main ────────────────────────────────────────────────────────
 
 (defn main []
-  (random/seed 42)
-
-  # Verify autograd
+  (rng:seed 42)
   (check-grads)
 
-  # Load data
   (println "Loading data...")
-  (let* ([names (load-data "demos/microgpt/input.txt")])
-    (shuffle! names)
+  (let* ([names (rng:shuffle (load-data "demos/microgpt/input.txt"))])
     (println "Loaded " (length names) " names")
 
-    # Build tokenizer
     (let* ([tokenizer (build-tokenizer names)])
       (println "Vocab size: " tokenizer:vocab-size)
 
-      # Initialize model
       (println "Initializing model...")
       (let* ([model (init-model tokenizer:vocab-size)])
 
-        # Train
         (println "Training...")
         (let* ([start (clock/monotonic)])
           (train model tokenizer names 1000 0.01)
-          (let* ([elapsed (- (clock/monotonic) start)])
-            (println (string/format "Training took {:.1f}s" elapsed))))
+          (println (string/format "Training took {:.1f}s"
+                                  (- (clock/monotonic) start))))
 
-        # Generate
         (println "\nGenerated names:")
         (generate model tokenizer 20 0.5 16)))))
 

--- a/demos/microgpt/model.lisp
+++ b/demos/microgpt/model.lisp
@@ -55,15 +55,11 @@
   # ── Forward pass building blocks ───────────────────────────────
 
   (defn mat-vec-mul [mat vec-in]
-    "Matrix-vector multiply: mat[rows x cols] * vec-in[cols] → result[rows]."
-    (let ([result @[]])
+    "Matrix-vector multiply: mat[rows x cols] * vec-in[cols] → result[rows].
+     Uses fused dot product — one Value node per output element."
+    (let ([n (length vec-in)] [result @[]])
       (each row in mat
-        (let ([acc (ag:make-value 0.0)])
-          (var c 0)
-          (while (< c (length row))
-            (assign acc (ag:v+ acc (ag:v* (row c) (vec-in c))))
-            (assign c (inc c)))
-          (push result acc)))
+        (push result (ag:vdot row vec-in n)))
       result))
 
   (defn vec-add [a b]
@@ -77,10 +73,9 @@
 
   (defn rms-norm [vec-in]
     "RMS normalization: x / sqrt(mean(x^2) + eps)."
-    (var sum-sq (ag:make-value 0.0))
-    (each v in vec-in
-      (assign sum-sq (ag:v+ sum-sq (ag:v* v v))))
-    (let ([rms (ag:vpow (ag:v+s (ag:v*s sum-sq (/ 1.0 (length vec-in))) *eps*) 0.5)])
+    (let* ([squares (map (fn [v] (ag:v* v v)) vec-in)]
+           [sum-sq (ag:vsum squares)]
+           [rms (ag:vpow (ag:v+s (ag:v*s sum-sq (/ 1.0 (length vec-in))) *eps*) 0.5)])
       (thaw (->array (map (fn [v] (ag:v/ v rms)) vec-in)))))
 
   (defn softmax-values [scores]
@@ -109,19 +104,15 @@
   (defn attn-head [h q layer-keys layer-vals n-t x-attn]
     "Compute one attention head and write results into x-attn."
     (let* ([hs (* h *head-dim*)]
-           [q-head (slice q hs (+ hs *head-dim*))]
            [sf (/ 1.0 (sqrt (float *head-dim*)))]
            [attn-logits @[]])
+      # Q·K dot products (fused — one node per past position)
       (var ti 0)
       (while (< ti n-t)
-        (let ([k-t (layer-keys ti)])
-          (var dot (ag:make-value 0.0))
-          (var d 0)
-          (while (< d *head-dim*)
-            (assign dot (ag:v+ dot (ag:v* (q-head d) (k-t (+ hs d)))))
-            (assign d (inc d)))
-          (push attn-logits (ag:v*s dot sf)))
+        (push attn-logits (ag:v*s (ag:vdot q (layer-keys ti) *head-dim*
+                                           :offset-a hs :offset-b hs) sf))
         (assign ti (inc ti)))
+      # Weighted sum of cached values
       (let ([aw (softmax-values attn-logits)])
         (each j in (range *head-dim*)
           (var acc (ag:make-value 0.0))

--- a/demos/microgpt/model.lisp
+++ b/demos/microgpt/model.lisp
@@ -6,11 +6,6 @@
 
 (fn [ag helpers rng]
 
-  (def {:make-value make-value :v-data v-data :v-grad v-grad
-        :v+ v+ :v* v* :vpow vpow :vexp vexp :vlog vlog :vrelu vrelu
-        :v/ v/ :v*s v*s :v+s v+s :vneg vneg} ag)
-  (def {:make-2d make-2d :make-kv-caches make-kv-caches} helpers)
-
   # ── Hyperparameters ────────────────────────────────────────────
 
   (def *n-embd* 16)
@@ -25,32 +20,32 @@
 
   (defn init-weight [rows cols scale]
     "Create a rows x cols 2D array of Value nodes with Gaussian random init."
-    (make-2d rows cols
-      (fn [r c] (make-value (rng:normal 0.0 scale)))))
+    (helpers:make-2d rows cols
+      (fn [r c] (ag:make-value (rng:normal 0.0 scale)))))
 
   (defn layer-key [i suffix]
     (string/format "layer{}.{}" i suffix))
 
   (defn init-model [vocab-size]
     "Initialize all model parameters. Returns an @struct of named weight matrices."
-    (let* ([scale (/ 1.0 (sqrt (float *n-embd*)))]
-           [model @{:wte (init-weight vocab-size *n-embd* scale)
-                    :wpe (init-weight *block-size* *n-embd* scale)
-                    :lm-head (init-weight vocab-size *n-embd* scale)}])
-      (each layer in (range *n-layer*)
-        (put model (layer-key layer "attn-wq") (init-weight *n-embd* *n-embd* scale))
-        (put model (layer-key layer "attn-wk") (init-weight *n-embd* *n-embd* scale))
-        (put model (layer-key layer "attn-wv") (init-weight *n-embd* *n-embd* scale))
-        (put model (layer-key layer "attn-wo") (init-weight *n-embd* *n-embd* scale))
-        (put model (layer-key layer "mlp-fc1") (init-weight *mlp-hidden* *n-embd* scale))
-        (put model (layer-key layer "mlp-fc2") (init-weight *n-embd* *mlp-hidden* scale)))
-      model))
+    (let ([scale (/ 1.0 (sqrt (float *n-embd*)))])
+      (let ([model @{:wte (init-weight vocab-size *n-embd* scale)
+                     :wpe (init-weight *block-size* *n-embd* scale)
+                     :lm-head (init-weight vocab-size *n-embd* scale)}])
+        (each layer in (range *n-layer*)
+          (put model (layer-key layer "attn-wq") (init-weight *n-embd* *n-embd* scale))
+          (put model (layer-key layer "attn-wk") (init-weight *n-embd* *n-embd* scale))
+          (put model (layer-key layer "attn-wv") (init-weight *n-embd* *n-embd* scale))
+          (put model (layer-key layer "attn-wo") (init-weight *n-embd* *n-embd* scale))
+          (put model (layer-key layer "mlp-fc1") (init-weight *mlp-hidden* *n-embd* scale))
+          (put model (layer-key layer "mlp-fc2") (init-weight *n-embd* *mlp-hidden* scale)))
+        model)))
 
   # ── Collect parameters ─────────────────────────────────────────
 
   (defn collect-params [model]
     "Collect all Value parameter nodes from the model into a flat array."
-    (let* ([params @[]])
+    (let ([params @[]])
       (each key in (keys model)
         (each row in (model key)
           (each val in row
@@ -60,49 +55,45 @@
   # ── Forward pass building blocks ───────────────────────────────
 
   (defn mat-vec-mul [mat vec-in]
-    "Matrix-vector multiply: mat (2D array of Values) x vec-in (1D array of Values)."
-    (let* ([result @[]])
+    "Matrix-vector multiply: mat[rows x cols] * vec-in[cols] → result[rows]."
+    (let ([result @[]])
       (each row in mat
-        (let* ([acc (make-value 0.0)])
+        (let ([acc (ag:make-value 0.0)])
           (var c 0)
           (while (< c (length row))
-            (assign acc (v+ acc (v* (row c) (vec-in c))))
+            (assign acc (ag:v+ acc (ag:v* (row c) (vec-in c))))
             (assign c (inc c)))
           (push result acc)))
       result))
 
   (defn vec-add [a b]
     "Element-wise autograd addition of two vectors."
-    (let* ([result @[]])
+    (let ([result @[]])
       (var i 0)
       (while (< i (length a))
-        (push result (v+ (a i) (b i)))
+        (push result (ag:v+ (a i) (b i)))
         (assign i (inc i)))
       result))
 
   (defn rms-norm [vec-in]
     "RMS normalization: x / sqrt(mean(x^2) + eps)."
-    (let* ([n (length vec-in)]
-           [sum-sq (make-value 0.0)])
-      (each v in vec-in
-        (assign sum-sq (v+ sum-sq (v* v v))))
-      (let* ([mean-sq (v*s sum-sq (/ 1.0 n))]
-             [rms (vpow (v+s mean-sq *eps*) 0.5)])
-        (thaw (->array (map (fn [v] (v/ v rms)) vec-in))))))
+    (var sum-sq (ag:make-value 0.0))
+    (each v in vec-in
+      (assign sum-sq (ag:v+ sum-sq (ag:v* v v))))
+    (let ([rms (ag:vpow (ag:v+s (ag:v*s sum-sq (/ 1.0 (length vec-in))) *eps*) 0.5)])
+      (thaw (->array (map (fn [v] (ag:v/ v rms)) vec-in)))))
 
   (defn softmax-values [scores]
-    "Softmax over an array of Value nodes. Returns array of Value nodes."
-    (var max-val (v-data (scores 0)))
+    "Softmax over an array of Value nodes."
+    (var max-val (ag:v-data (scores 0)))
     (each s in scores
-      (let* ([d (v-data s)])
-        (when (> d max-val) (assign max-val d))))
-    (let* ([exps @[]]
-           [sum-exp (make-value 0.0)])
-      (each s in scores
-        (let* ([e (vexp (v+s s (- 0.0 max-val)))])
-          (push exps e)
-          (assign sum-exp (v+ sum-exp e))))
-      (thaw (->array (map (fn [e] (v/ e sum-exp)) exps)))))
+      (when (> (ag:v-data s) max-val)
+        (assign max-val (ag:v-data s))))
+    (var sum-exp (ag:make-value 0.0))
+    (let ([exps (->array (map (fn [s] (ag:vexp (ag:v+s s (- 0.0 max-val)))) scores))])
+      (each e in exps
+        (assign sum-exp (ag:v+ sum-exp e)))
+      (thaw (->array (map (fn [e] (ag:v/ e sum-exp)) exps)))))
 
   (defn layer-weights [model i]
     "Get all weight matrices for transformer layer i."
@@ -123,23 +114,23 @@
            [attn-logits @[]])
       (var ti 0)
       (while (< ti n-t)
-        (let* ([k-t (layer-keys ti)]
-               [dot (make-value 0.0)])
+        (let ([k-t (layer-keys ti)])
+          (var dot (ag:make-value 0.0))
           (var d 0)
           (while (< d *head-dim*)
-            (assign dot (v+ dot (v* (q-head d) (k-t (+ hs d)))))
+            (assign dot (ag:v+ dot (ag:v* (q-head d) (k-t (+ hs d)))))
             (assign d (inc d)))
-          (push attn-logits (v*s dot sf)))
+          (push attn-logits (ag:v*s dot sf)))
         (assign ti (inc ti)))
-      (let* ([aw (softmax-values attn-logits)])
+      (let ([aw (softmax-values attn-logits)])
         (each j in (range *head-dim*)
-          (let* ([acc (make-value 0.0)])
-            (var t2 0)
-            (while (< t2 n-t)
-              (assign acc (v+ acc (v* (aw t2)
-                                      ((layer-vals t2) (+ hs j)))))
-              (assign t2 (inc t2)))
-            (put x-attn (+ hs j) acc))))))
+          (var acc (ag:make-value 0.0))
+          (var t2 0)
+          (while (< t2 n-t)
+            (assign acc (ag:v+ acc (ag:v* (aw t2)
+                                          ((layer-vals t2) (+ hs j)))))
+            (assign t2 (inc t2)))
+          (put x-attn (+ hs j) acc)))))
 
   (defn attn-block [x weights kv-keys kv-values li]
     "Multi-head attention with KV cache. Returns updated x with residual."
@@ -150,7 +141,7 @@
            [layer-keys (begin (push (kv-keys li) k) (kv-keys li))]
            [layer-vals (begin (push (kv-values li) v) (kv-values li))]
            [n-t (length layer-keys)]
-           [x-attn (array/new *n-embd* (make-value 0.0))])
+           [x-attn (array/new *n-embd* (ag:make-value 0.0))])
       (each h in (range *n-head*)
         (attn-head h q layer-keys layer-vals n-t x-attn))
       (vec-add (mat-vec-mul weights:wo x-attn) x)))
@@ -158,7 +149,7 @@
   (defn mlp-block [x weights]
     "MLP block with residual connection."
     (let* ([h (mat-vec-mul weights:fc1 (rms-norm x))]
-           [h (thaw (->array (map vrelu h)))]
+           [h (thaw (->array (map ag:vrelu h)))]
            [h (mat-vec-mul weights:fc2 h)])
       (vec-add h x)))
 
@@ -168,7 +159,7 @@
      Returns a 1D array of logit Value nodes."
     (var x (rms-norm (vec-add (model:wte token-id) (model:wpe pos-id))))
     (each li in (range *n-layer*)
-      (let* ([weights (layer-weights model li)])
+      (let ([weights (layer-weights model li)])
         (assign x (attn-block x weights kv-keys kv-values li))
         (assign x (mlp-block x weights))))
     (mat-vec-mul model:lm-head x))
@@ -179,18 +170,15 @@
     "Compute cross-entropy loss over a token sequence using incremental forward.
      Returns a single Value node (the mean loss)."
     (let* ([n (min *block-size* (dec (length tokens)))]
-           [[kv-keys kv-values] (make-kv-caches *n-layer*)]
-           [total-loss (make-value 0.0)])
+           [[kv-keys kv-values] (helpers:make-kv-caches *n-layer*)]
+           [total-loss (ag:make-value 0.0)])
       (var pos 0)
       (while (< pos n)
-        (let* ([token-id (tokens pos)]
-               [target-id (tokens (inc pos))]
-               [logits (gpt-forward-token token-id pos kv-keys kv-values model)]
-               [probs (softmax-values logits)]
-               [loss-t (vneg (vlog (probs target-id)))])
-          (assign total-loss (v+ total-loss loss-t)))
+        (let* ([logits (gpt-forward-token (tokens pos) pos kv-keys kv-values model)]
+               [probs (softmax-values logits)])
+          (assign total-loss (ag:v+ total-loss (ag:vneg (ag:vlog (probs (tokens (inc pos))))))))
         (assign pos (inc pos)))
-      (v*s total-loss (/ 1.0 (float n)))))
+      (ag:v*s total-loss (/ 1.0 (float n)))))
 
   {:init-model init-model :collect-params collect-params
    :gpt-forward-token gpt-forward-token

--- a/demos/microgpt/model.lisp
+++ b/demos/microgpt/model.lisp
@@ -1,214 +1,198 @@
-# ── GPT model: initialization, forward pass, loss ────────────────
-#
-# Architecture: GPT-2 style transformer (RMSNorm, no biases, ReLU
-# instead of GeLU). Single-layer, 4-head attention with KV cache
-# for incremental inference.
+## model.lisp — GPT model: initialization, forward pass, loss
+##
+## Architecture: GPT-2 style transformer (RMSNorm, no biases, ReLU
+## instead of GeLU). Single-layer, 4-head attention with KV cache
+## for incremental inference.
 
-# ── Hyperparameters ──────────────────────────────────────────────
+(fn [ag helpers rng]
 
-(def *n-embd* 16)       # embedding dimension (width of the network)
-(def *n-head* 4)        # number of attention heads
-(def *head-dim* 4)      # per-head dimension (n-embd / n-head)
-(def *n-layer* 1)       # number of transformer layers
-(def *block-size* 16)   # maximum context length
-(def *mlp-hidden* 64)   # MLP hidden dimension (4 * n-embd)
-(def *eps* 0.00000001)  # epsilon for RMS normalization
+  (def {:make-value make-value :v-data v-data :v-grad v-grad
+        :v+ v+ :v* v* :vpow vpow :vexp vexp :vlog vlog :vrelu vrelu
+        :v/ v/ :v*s v*s :v+s v+s :vneg vneg} ag)
+  (def {:make-2d make-2d :make-kv-caches make-kv-caches} helpers)
 
-# ── Parameter initialization ────────────────────────────────────
+  # ── Hyperparameters ────────────────────────────────────────────
 
-(defn init-weight [rows cols scale]
-  "Create a rows x cols 2D array of Value nodes with uniform random init."
-  (make-2d rows cols
-    (fn [r c] (make-value (- (* (random/float) 2.0 scale) scale)))))
+  (def *n-embd* 16)
+  (def *n-head* 4)
+  (def *head-dim* 4)
+  (def *n-layer* 1)
+  (def *block-size* 16)
+  (def *mlp-hidden* 64)
+  (def *eps* 0.00000001)
 
-(defn layer-key [i suffix]
-  (string/format "layer{}.{}" i suffix))
+  # ── Parameter initialization ───────────────────────────────────
 
-(defn init-model [vocab-size]
-  "Initialize all model parameters. Returns an @struct of named weight matrices."
-  (let* ([scale (/ 1.0 (sqrt (float *n-embd*)))]
-         [model @{:wte (init-weight vocab-size *n-embd* scale)
-                  :wpe (init-weight *block-size* *n-embd* scale)
-                  :lm-head (init-weight vocab-size *n-embd* scale)}])
-    (var layer 0)
-    (while (< layer *n-layer*)
-      (put model (layer-key layer "attn-wq") (init-weight *n-embd* *n-embd* scale))
-      (put model (layer-key layer "attn-wk") (init-weight *n-embd* *n-embd* scale))
-      (put model (layer-key layer "attn-wv") (init-weight *n-embd* *n-embd* scale))
-      (put model (layer-key layer "attn-wo") (init-weight *n-embd* *n-embd* scale))
-      (put model (layer-key layer "mlp-fc1") (init-weight *mlp-hidden* *n-embd* scale))
-      (put model (layer-key layer "mlp-fc2") (init-weight *n-embd* *mlp-hidden* scale))
-      (assign layer (+ layer 1)))
-    model))
+  (defn init-weight [rows cols scale]
+    "Create a rows x cols 2D array of Value nodes with Gaussian random init."
+    (make-2d rows cols
+      (fn [r c] (make-value (rng:normal 0.0 scale)))))
 
-# ── Collect parameters ──────────────────────────────────────────
+  (defn layer-key [i suffix]
+    (string/format "layer{}.{}" i suffix))
 
-(defn collect-params [model]
-  "Collect all Value parameter nodes from the model into a flat array."
-  (let* ([params @[]])
-    (each key in (keys model)
-      (each row in (model key)
-        (each val in row
-          (push params val))))
-    params))
+  (defn init-model [vocab-size]
+    "Initialize all model parameters. Returns an @struct of named weight matrices."
+    (let* ([scale (/ 1.0 (sqrt (float *n-embd*)))]
+           [model @{:wte (init-weight vocab-size *n-embd* scale)
+                    :wpe (init-weight *block-size* *n-embd* scale)
+                    :lm-head (init-weight vocab-size *n-embd* scale)}])
+      (each layer in (range *n-layer*)
+        (put model (layer-key layer "attn-wq") (init-weight *n-embd* *n-embd* scale))
+        (put model (layer-key layer "attn-wk") (init-weight *n-embd* *n-embd* scale))
+        (put model (layer-key layer "attn-wv") (init-weight *n-embd* *n-embd* scale))
+        (put model (layer-key layer "attn-wo") (init-weight *n-embd* *n-embd* scale))
+        (put model (layer-key layer "mlp-fc1") (init-weight *mlp-hidden* *n-embd* scale))
+        (put model (layer-key layer "mlp-fc2") (init-weight *n-embd* *mlp-hidden* scale)))
+      model))
 
-# ── Forward pass building blocks ────────────────────────────────
+  # ── Collect parameters ─────────────────────────────────────────
 
-(defn mat-vec-mul [mat vec-in]
-  "Matrix-vector multiply: mat (2D array of Values) x vec-in (1D array of Values)."
-  (let* ([result @[]])
-    (each row in mat
-      (let* ([acc (make-value 0.0)])
-        (var c 0)
-        (while (< c (length row))
-          (assign acc (v+ acc (v* (row c) (vec-in c))))
-          (assign c (+ c 1)))
-        (push result acc)))
-    result))
+  (defn collect-params [model]
+    "Collect all Value parameter nodes from the model into a flat array."
+    (let* ([params @[]])
+      (each key in (keys model)
+        (each row in (model key)
+          (each val in row
+            (push params val))))
+      params))
 
-(defn vec-add [a b]
-  "Element-wise autograd addition of two vectors."
-  @array ;(map v+ a b))
+  # ── Forward pass building blocks ───────────────────────────────
 
-(defn rms-norm [vec-in]
-  "RMS normalization: x / sqrt(mean(x^2) + eps)."
-  (let* ([n (length vec-in)]
-         [sum-sq (make-value 0.0)])
-    (each v in vec-in
-      (assign sum-sq (v+ sum-sq (v* v v))))
-    (let* ([mean-sq (v*s sum-sq (/ 1.0 n))]
-           [rms (vpow (v+s mean-sq *eps*) 0.5)])
-      @array ;(map (fn [v] (v/ v rms)) vec-in))))
+  (defn mat-vec-mul [mat vec-in]
+    "Matrix-vector multiply: mat (2D array of Values) x vec-in (1D array of Values)."
+    (let* ([result @[]])
+      (each row in mat
+        (let* ([acc (make-value 0.0)])
+          (var c 0)
+          (while (< c (length row))
+            (assign acc (v+ acc (v* (row c) (vec-in c))))
+            (assign c (inc c)))
+          (push result acc)))
+      result))
 
-(defn softmax-values [scores]
-  "Softmax over an array of Value nodes. Returns array of Value nodes."
-  (var max-val (v-data (scores 0)))
-  (var i 1)
-  (while (< i (length scores))
-    (let* ([d (v-data (scores i))])
-      (when (> d max-val) (assign max-val d)))
-    (assign i (+ i 1)))
-  (let* ([exps @[]]
-         [sum-exp (make-value 0.0)])
+  (defn vec-add [a b]
+    "Element-wise autograd addition of two vectors."
+    (let* ([result @[]])
+      (var i 0)
+      (while (< i (length a))
+        (push result (v+ (a i) (b i)))
+        (assign i (inc i)))
+      result))
+
+  (defn rms-norm [vec-in]
+    "RMS normalization: x / sqrt(mean(x^2) + eps)."
+    (let* ([n (length vec-in)]
+           [sum-sq (make-value 0.0)])
+      (each v in vec-in
+        (assign sum-sq (v+ sum-sq (v* v v))))
+      (let* ([mean-sq (v*s sum-sq (/ 1.0 n))]
+             [rms (vpow (v+s mean-sq *eps*) 0.5)])
+        (thaw (->array (map (fn [v] (v/ v rms)) vec-in))))))
+
+  (defn softmax-values [scores]
+    "Softmax over an array of Value nodes. Returns array of Value nodes."
+    (var max-val (v-data (scores 0)))
     (each s in scores
-      (let* ([e (vexp (v+s s (- 0.0 max-val)))])
-        (push exps e)
-        (assign sum-exp (v+ sum-exp e))))
-    @array ;(map (fn [e] (v/ e sum-exp)) exps)))
+      (let* ([d (v-data s)])
+        (when (> d max-val) (assign max-val d))))
+    (let* ([exps @[]]
+           [sum-exp (make-value 0.0)])
+      (each s in scores
+        (let* ([e (vexp (v+s s (- 0.0 max-val)))])
+          (push exps e)
+          (assign sum-exp (v+ sum-exp e))))
+      (thaw (->array (map (fn [e] (v/ e sum-exp)) exps)))))
 
-(defn layer-weights [model i]
-  "Get all weight matrices for transformer layer i."
-  @{:wq  (model (layer-key i "attn-wq"))
-    :wk  (model (layer-key i "attn-wk"))
-    :wv  (model (layer-key i "attn-wv"))
-    :wo  (model (layer-key i "attn-wo"))
-    :fc1 (model (layer-key i "mlp-fc1"))
-    :fc2 (model (layer-key i "mlp-fc2"))})
+  (defn layer-weights [model i]
+    "Get all weight matrices for transformer layer i."
+    {:wq  (model (layer-key i "attn-wq"))
+     :wk  (model (layer-key i "attn-wk"))
+     :wv  (model (layer-key i "attn-wv"))
+     :wo  (model (layer-key i "attn-wo"))
+     :fc1 (model (layer-key i "mlp-fc1"))
+     :fc2 (model (layer-key i "mlp-fc2"))})
 
-# ── Per-token forward pass ──────────────────────────────────────
-# Incremental with KV cache. Process one token at a time,
-# accumulating key/value vectors in per-layer caches.
+  # ── Per-token forward pass ─────────────────────────────────────
 
-(defn gpt-forward-token [token-id pos-id kv-keys kv-values model]
-  "Forward pass for a single token at position pos-id.
-   kv-keys and kv-values are arrays of length n-layer, each containing
-   an array of past key/value vectors (one per previous position).
-   Mutates kv-keys and kv-values by appending new k/v vectors.
-   Returns a 1D array of logit Value nodes."
-  (let* ([wte model:wte]
-         [wpe model:wpe]
-         [lm-head model:lm-head]
-         [tok-emb (wte token-id)]
-         [pos-emb (wpe pos-id)]
-         [x (vec-add tok-emb pos-emb)])
-    (assign x (rms-norm x))
-    # Transformer layers
-    (var li 0)
-    (while (< li *n-layer*)
-      (let* ([weights (layer-weights model li)]
-             [wq weights:wq]
-             [wk weights:wk]
-             [wv weights:wv]
-             [wo weights:wo]
-             [fc1 weights:fc1]
-             [fc2 weights:fc2]
-             [x-residual x])
-        # Pre-norm + Q/K/V projections
-        (assign x (rms-norm x))
-        (let* ([q (mat-vec-mul wq x)]
-               [k (mat-vec-mul wk x)]
-               [v (mat-vec-mul wv x)])
-          # Append k, v to caches
-          (push (kv-keys li) k)
-          (push (kv-values li) v)
-          (let* ([layer-keys (kv-keys li)]
-                 [layer-vals (kv-values li)]
-                 [n-t (length layer-keys)]
-                 [x-attn (@array/new *n-embd* (make-value 0.0))])
-            # Multi-head attention
-            (var h 0)
-            (while (< h *n-head*)
-              (let* ([hs (* h *head-dim*)]
-                     [q-head (slice q hs (+ hs *head-dim*))]
-                     [scale-factor (/ 1.0 (sqrt (float *head-dim*)))]
-                     [attn-logits @[]])
-                # Dot product of q with each past key
-                (var t-idx 0)
-                (while (< t-idx n-t)
-                  (let* ([k-t (layer-keys t-idx)]
-                         [dot (make-value 0.0)])
-                    (var d 0)
-                    (while (< d *head-dim*)
-                      (assign dot (v+ dot (v* (q-head d) (k-t (+ hs d)))))
-                      (assign d (+ d 1)))
-                    (push attn-logits (v*s dot scale-factor)))
-                  (assign t-idx (+ t-idx 1)))
-                # Softmax
-                (let* ([attn-weights (softmax-values attn-logits)])
-                  # Weighted sum of values
-                  (var j 0)
-                  (while (< j *head-dim*)
-                    (let* ([acc (v* (attn-weights 0)
-                                    ((layer-vals 0) (+ hs j)))])
-                      (var t-idx2 1)
-                      (while (< t-idx2 n-t)
-                        (assign acc (v+ acc (v* (attn-weights t-idx2)
-                                             ((layer-vals t-idx2) (+ hs j)))))
-                        (assign t-idx2 (+ t-idx2 1)))
-                      (put x-attn (+ hs j) acc))
-                    (assign j (+ j 1)))))
-              (assign h (+ h 1)))
-            # Project attention output
-            (assign x (mat-vec-mul wo x-attn))
-            # Residual
-            (assign x (vec-add x x-residual))))
-        # MLP block
-        (let* ([x-residual2 x])
-          (assign x (rms-norm x))
-          (assign x (mat-vec-mul fc1 x))
-          (assign x @array ;(map vrelu x))
-          (assign x (mat-vec-mul fc2 x))
-          (assign x (vec-add x x-residual2))))
-      (assign li (+ li 1)))
-    # Project to vocab
-    (mat-vec-mul lm-head x)))
+  (defn attn-head [h q layer-keys layer-vals n-t x-attn]
+    "Compute one attention head and write results into x-attn."
+    (let* ([hs (* h *head-dim*)]
+           [q-head (slice q hs (+ hs *head-dim*))]
+           [sf (/ 1.0 (sqrt (float *head-dim*)))]
+           [attn-logits @[]])
+      (var ti 0)
+      (while (< ti n-t)
+        (let* ([k-t (layer-keys ti)]
+               [dot (make-value 0.0)])
+          (var d 0)
+          (while (< d *head-dim*)
+            (assign dot (v+ dot (v* (q-head d) (k-t (+ hs d)))))
+            (assign d (inc d)))
+          (push attn-logits (v*s dot sf)))
+        (assign ti (inc ti)))
+      (let* ([aw (softmax-values attn-logits)])
+        (each j in (range *head-dim*)
+          (let* ([acc (make-value 0.0)])
+            (var t2 0)
+            (while (< t2 n-t)
+              (assign acc (v+ acc (v* (aw t2)
+                                      ((layer-vals t2) (+ hs j)))))
+              (assign t2 (inc t2)))
+            (put x-attn (+ hs j) acc))))))
 
-# ── Loss ─────────────────────────────────────────────────────────
+  (defn attn-block [x weights kv-keys kv-values li]
+    "Multi-head attention with KV cache. Returns updated x with residual."
+    (let* ([x-norm (rms-norm x)]
+           [q (mat-vec-mul weights:wq x-norm)]
+           [k (mat-vec-mul weights:wk x-norm)]
+           [v (mat-vec-mul weights:wv x-norm)]
+           [layer-keys (begin (push (kv-keys li) k) (kv-keys li))]
+           [layer-vals (begin (push (kv-values li) v) (kv-values li))]
+           [n-t (length layer-keys)]
+           [x-attn (array/new *n-embd* (make-value 0.0))])
+      (each h in (range *n-head*)
+        (attn-head h q layer-keys layer-vals n-t x-attn))
+      (vec-add (mat-vec-mul weights:wo x-attn) x)))
 
-(defn cross-entropy-loss-incremental [model tokens]
-  "Compute cross-entropy loss over a token sequence using incremental forward.
-   tokens includes BOS at start and end.
-   Returns a single Value node (the mean loss)."
-  (let* ([n (min *block-size* (- (length tokens) 1))]
-         [[kv-keys kv-values] (make-kv-caches *n-layer*)]
-         [total-loss (make-value 0.0)])
-    (var pos 0)
-    (while (< pos n)
-      (let* ([token-id (tokens pos)]
-             [target-id (tokens (+ pos 1))]
-             [logits (gpt-forward-token token-id pos kv-keys kv-values model)]
-             [probs (softmax-values logits)]
-             [loss-t (vneg (vlog (probs target-id)))])
-        (assign total-loss (v+ total-loss loss-t)))
-      (assign pos (+ pos 1)))
-    (v*s total-loss (/ 1.0 (float n)))))
+  (defn mlp-block [x weights]
+    "MLP block with residual connection."
+    (let* ([h (mat-vec-mul weights:fc1 (rms-norm x))]
+           [h (thaw (->array (map vrelu h)))]
+           [h (mat-vec-mul weights:fc2 h)])
+      (vec-add h x)))
+
+  (defn gpt-forward-token [token-id pos-id kv-keys kv-values model]
+    "Forward pass for a single token at position pos-id.
+     Mutates kv-keys and kv-values by appending new k/v vectors.
+     Returns a 1D array of logit Value nodes."
+    (var x (rms-norm (vec-add (model:wte token-id) (model:wpe pos-id))))
+    (each li in (range *n-layer*)
+      (let* ([weights (layer-weights model li)])
+        (assign x (attn-block x weights kv-keys kv-values li))
+        (assign x (mlp-block x weights))))
+    (mat-vec-mul model:lm-head x))
+
+  # ── Loss ───────────────────────────────────────────────────────
+
+  (defn cross-entropy-loss-incremental [model tokens]
+    "Compute cross-entropy loss over a token sequence using incremental forward.
+     Returns a single Value node (the mean loss)."
+    (let* ([n (min *block-size* (dec (length tokens)))]
+           [[kv-keys kv-values] (make-kv-caches *n-layer*)]
+           [total-loss (make-value 0.0)])
+      (var pos 0)
+      (while (< pos n)
+        (let* ([token-id (tokens pos)]
+               [target-id (tokens (inc pos))]
+               [logits (gpt-forward-token token-id pos kv-keys kv-values model)]
+               [probs (softmax-values logits)]
+               [loss-t (vneg (vlog (probs target-id)))])
+          (assign total-loss (v+ total-loss loss-t)))
+        (assign pos (inc pos)))
+      (v*s total-loss (/ 1.0 (float n)))))
+
+  {:init-model init-model :collect-params collect-params
+   :gpt-forward-token gpt-forward-token
+   :cross-entropy-loss-incremental cross-entropy-loss-incremental
+   :*block-size* *block-size* :*n-layer* *n-layer*})


### PR DESCRIPTION
- Closure-as-module pattern for all files (autograd, helpers, model)
- Plugin accessed via struct (rng:seed, rng:weighted) not globals
- Gaussian weight init via rng:normal (was uniform random)
- random/weighted for token sampling (was manual cumulative dist)
- Decompose gpt-forward-token into attn-head, attn-block, mlp-block to stay under JIT function size limit
- @set for topo-sort visited (was @struct keyed by id)
- Replace index-based char loops with each, while loops with each/range
- Delete manual sort-strings (use stdlib sort), shuffle (use rng:shuffle)
- Deterministic training order (mod step n-names) matching Python ref
- block/break for generation, repeat for sample loop, inc/dec
- Fix @array/new → array/new, backward! → backward (no ! convention)