### PR TITLE
http: chunked transfer, https/tls, query, redirects, compress, SSE

### DIFF
--- a/docs/control.md
+++ b/docs/control.md
@@ -168,8 +168,8 @@ count                      # => 5
 
 ## each
 
-Iteration macro. `in` is optional sugar. Works on lists, arrays, and
-other sequences.
+Iteration macro. `in` is optional sugar. Works on lists, arrays,
+strings, bytes, sets, structs, and coroutines.
 
 ```lisp
 (var total 0)
@@ -183,6 +183,10 @@ total                      # => 60
     (when (> x 10)
       (break :found x)))
   nil)                     # => 16
+
+# coroutines: drives coro/resume until a nil yield terminates the loop
+(def co (coro/new (fn [] (yield 1) (yield 2) (yield 3))))
+(each n in co (println n))   # prints 1 2 3
 ```
 
 ---

--- a/lib/AGENTS.md
+++ b/lib/AGENTS.md
@@ -33,6 +33,28 @@ Agent guide for `lib/http.lisp` — Pure Elle HTTP/1.1 client and server.
 HTTP/1.1 over TCP using Elle's existing stream and scheduler primitives.
 Single file. No Rust changes (other than `port/path`, added in Chunk 0).
 
+HTTPS and compression are opt-in via `&named` args on the module init:
+
+```lisp
+(def http ((import "std/http")))                     # http only
+
+# HTTPS:
+(def tls-plug ((import "plugin/tls")))
+(def http ((import "std/http") :tls tls-plug))
+
+# Compress helpers (gzip/zlib/deflate/zstd):
+(def z ((import "std/compress")))
+(def http ((import "std/http") :compress z))
+#   — or have http import it for you:
+(def http ((import "std/http") :compress true))
+
+# Combined:
+(def http ((import "std/http") :tls tls-plug :compress true))
+```
+
+Future plugins (DNS overrides, proxies, etc.) will be added as more
+`&named` args on the same initializer.
+
 ## Data flow
 
 Client:
@@ -52,13 +74,96 @@ http-serve port handler → tcp/listen → forever:
 
 | Function | Signature | Effect | Returns |
 |----------|-----------|--------|---------|
-| `http-get` | `(fn [url &named headers])` | Yields | response struct |
-| `http-post` | `(fn [url body &named headers])` | Yields | response struct |
-| `http-request` | `(fn [method url &named body headers])` | Yields | response struct |
-| `http-serve` | `(fn [listener handler &named on-error])` | Yields | nil (runs forever) |
-| `http-send` | `(fn [session method path &named body headers])` | Yields | response struct |
-| `http-respond` | `(fn [status body &named headers])` | Silent | response struct |
+| `get` | `(fn [url &named headers query follow-redirects])` | Yields | response struct |
+| `post` | `(fn [url body &named headers query follow-redirects])` | Yields | response struct |
+| `request` | `(fn [method url &named body headers query follow-redirects])` | Yields | response struct |
+| `serve` | `(fn [listener handler &named on-error])` | Yields | nil (runs forever) |
+| `send` | `(fn [session method path &named body headers])` | Yields | response struct |
+| `respond` | `(fn [status body &named headers])` | Silent | response struct |
 | `parse-url` | `(fn [url])` | Errors | url struct |
+| `query-encode` | `(fn [params])` | Silent | string |
+| `header->kw` / `kw->header` | `(fn [name])` | Silent | keyword / string |
+| `chunked?` | `(fn [headers])` | Silent | boolean |
+| `write-chunk` / `write-last-chunk` | `(fn [t [data]])` | Yields | nil |
+| `tcp-transport` / `tls-transport` | `(fn [port-or-conn])` | Silent | transport struct |
+| `gzip` / `gunzip` / `zlib` / `unzlib` / `deflate` / `inflate` / `zstd` / `unzstd` | `(fn [data & opts])` | FFI | bytes |
+| `sse-get` | `(fn [url &named headers last-event-id reconnect])` | Yields | coroutine yielding events |
+| `sse-response` | `(fn [body-fn &named headers])` | Silent | response struct |
+| `format-sse-event` | `(fn [event])` | Silent | string |
+
+### `:query` named arg
+
+Accepts either a pre-encoded string or a struct. Struct values are
+percent-encoded with `query-encode`:
+
+- scalars (strings, integers, floats, keywords, booleans) → `key=value`
+- arrays/lists → repeated `key=v1&key=v2`
+- `nil` → dropped (useful for conditional parameters)
+
+If the URL already carries a query (`?foo=bar`), `:query` is appended
+with `&`. Keys iterate in struct order (sorted by key name).
+
+### `:follow-redirects` named arg
+
+Controls HTTP 3xx handling on the client:
+
+| Value | Behavior |
+|-------|----------|
+| `nil` / `false` | Return the 3xx response as-is (default) |
+| `true`           | Follow up to 10 hops |
+| `<integer>`      | Follow up to N hops |
+
+Per RFC 9110, `301` / `302` / `303` are followed with `GET` and an
+empty body; `307` / `308` preserve the original method and body.
+`Location` values may be absolute URLs, scheme-relative (`//host/path`),
+or absolute paths (`/path`). On hop exhaustion the last redirect
+response is returned to the caller.
+
+### `:compress` — raw helpers
+
+No auto-negotiation: supplying `:compress` merely exposes
+gzip/gunzip/zlib/unzlib/deflate/inflate/zstd/unzstd as `http:<name>`.
+Callers apply them explicitly to bodies or individual chunks. Calls
+signal `:http-error :compress-not-configured` if `:compress` was not
+passed at module init.
+
+## Server-Sent Events
+
+| Function | Signature | Returns |
+|----------|-----------|---------|
+| `sse-get` | `(fn [url &named headers last-event-id reconnect])` | coroutine |
+| `sse-response` | `(fn [body-fn &named headers])` | response struct |
+| `format-sse-event` | `(fn [event])` | string (SSE wire frame) |
+
+**Client**: `sse-get` returns a coroutine yielding event structs
+`{:event :data :id :retry}`. Iterate with `each`:
+
+```lisp
+(each evt in (http:sse-get "http://server/stream")
+  (println evt:event ": " evt:data))
+```
+
+`:reconnect` defaults to `true` — the client follows EventSource
+semantics: on disconnect/error it waits `retry-ms` (last server-sent
+`:retry`, default 3000) and reopens with `Last-Event-ID`. Stops on HTTP
+204 No Content. Set `:reconnect false` to make the coroutine end on
+the first disconnect.
+
+**Server**: return an `http:sse-response` from a handler. The body
+closure receives a `send-event` function:
+
+```lisp
+(defn handler [req]
+  (http:sse-response
+    (fn [send-event]
+      (send-event {:data "first"})
+      (send-event {:event "tick" :data "1" :id "a"})
+      (send-event {:retry 5000}))))
+```
+
+Under the hood `sse-response` sets `Content-Type: text/event-stream`
+plus `Transfer-Encoding: chunked` and reuses the existing chunked-body
+streaming path; each `send-event` call becomes one chunk on the wire.
 
 ## Struct shapes
 
@@ -80,7 +185,8 @@ http-serve port handler → tcp/listen → forever:
 
 **URL** (produced by parse-url):
 ```lisp
-{:scheme "http" :host "example.com" :port 80 :path "/foo" :query "page=1"}
+{:scheme "http"  :host "example.com" :port 80  :path "/foo" :query "page=1"}
+{:scheme "https" :host "example.com" :port 443 :path "/foo" :query nil}
 ```
 
 ## parse-url function
@@ -93,26 +199,26 @@ http-serve port handler → tcp/listen → forever:
 
 ### Parameters
 
-- `url` (string): HTTP URL to parse. Must start with `"http://"`.
+- `url` (string): URL to parse. Must start with `"http://"` or `"https://"`.
 
 ### Returns
 
 Immutable struct with keys:
-- `:scheme` (string): Always `"http"` (only scheme supported)
+- `:scheme` (string): `"http"` or `"https"`
 - `:host` (string): Hostname or IP address
-- `:port` (integer): Port number, default 80 if absent
+- `:port` (integer): Port number, defaults to 80 (http) or 443 (https) if absent
 - `:path` (string): Request path, default `"/"` if absent
 - `:query` (string or nil): Query string after `?`, or nil if absent
 
 ### Error cases
 
 Signals `:http-error` (via `error` form) for:
-1. **Unsupported scheme**: URL does not start with `"http://"` (e.g., `"ftp://"`, `"https://"`)
+1. **Unsupported scheme**: URL does not start with `"http://"` or `"https://"` (e.g., `"ftp://"`, `"wss://"`)
 2. **Missing host**: URL is `"http://"` with nothing after
 3. **Empty host**: Authority part is empty (e.g., `"http://:8080/"`)
 4. **Malformed port**: Port part is not a valid integer (e.g., `"http://example.com:abc/"`)
 
-Error value is a struct: `{:error :http-error :message "..."}`
+Error value is a struct: `{:error :http-error :reason ... :url ... :message "..."}`
 
 ### Examples
 
@@ -123,25 +229,50 @@ Error value is a struct: `{:error :http-error :message "..."}`
 (parse-url "http://example.com/index.html")
 # → {:scheme "http" :host "example.com" :port 80 :path "/index.html" :query nil}
 
-(parse-url "http://example.com")
-# → {:scheme "http" :host "example.com" :port 80 :path "/" :query nil}
+(parse-url "https://example.com")
+# → {:scheme "https" :host "example.com" :port 443 :path "/" :query nil}
 
-(parse-url "http://localhost:3000/?q=hello")
-# → {:scheme "http" :host "localhost" :port 3000 :path "/" :query "q=hello"}
+(parse-url "https://api.example.com:8443/v1/items?limit=10")
+# → {:scheme "https" :host "api.example.com" :port 8443 :path "/v1/items" :query "limit=10"}
 
 (parse-url "ftp://example.com/")
-# → error {:error :http-error :message "parse-url: unsupported scheme in: ftp://example.com/"}
+# → error {:error :http-error :reason :unsupported-scheme ...}
 ```
+
+Note: `parse-url` supports the `https` scheme unconditionally. `http:get`
+/ `http:post` / `http:request` only speak HTTPS when a TLS plugin was
+supplied via `((import "std/http") :tls tls-plug)` at module init;
+otherwise an `https://` URL signals `:http-error :tls-not-configured`.
+
+## Transport abstraction
+
+All wire-format helpers operate on a **transport**: a struct of closures
+`{:read :read-line :write :flush :close}`. Transports are produced by
+`tcp-transport` (plain TCP port) or `tls-transport` (TLS connection from
+the configured TLS plugin). `open-transport` picks the right one based
+on the parsed URL's scheme. This means the chunked reader, body reader,
+headers code, etc. are shared across http and https with no duplication.
+
+Session structs returned by `http:connect` now carry `:transport` rather
+than `:conn`; the underlying port or TLS conn is reachable via
+`session:transport`'s closures.
 
 ## Invariants
 
 1. Header keys are always lowercase keywords after parsing.
-2. Content-Length is always set in responses produced by `http-respond`.
+2. Content-Length is always set in responses produced by `http:respond`.
 3. Connections are always closed via `defer` — never leaked on error.
-4. `http-serve` absorbs handler errors (500 response); server keeps running.
-5. Only `http://` scheme is supported. No HTTPS, no HTTP/2.
-6. Content-Length body only. No chunked transfer encoding.
-7. No connection pooling. Each request opens and closes a TCP connection.
+4. `http:serve` absorbs handler errors (500 response); server keeps running.
+5. `http://` always uses plain TCP. `https://` requires `:tls` to have
+   been passed to the module initializer; otherwise client calls
+   signal `:http-error :tls-not-configured`.
+6. `http:serve` serves plain HTTP only. HTTPS serving is not first-class
+   yet; users can wrap accepted TCP connections with `tls:accept` and
+   feed the result into `connection-loop` via `tls-transport`.
+7. Chunked transfer encoding is supported on both read and write.
+   `Transfer-Encoding: chunked` takes precedence over `Content-Length`.
+8. No connection pooling. Each `http:get`/`http:post` opens and closes
+   a transport.
 
 ## Running tests
 

--- a/lib/http.lisp
+++ b/lib/http.lisp
@@ -730,6 +730,44 @@
                 ((not reconnect)            (break :session)))
               (ev/sleep (/ retry-ms 1000.0))))))))
 
+  (defn sse-post [url body &named headers]
+    "POST to url with body, expecting a text/event-stream response.
+     Returns a coroutine that yields events until the server closes.
+     Unlike sse-get this does NOT auto-reconnect — POST is typically
+     non-idempotent (think LLM streaming: you don't want to silently
+     re-submit a prompt).
+
+     Use case: OpenAI-compatible /v1/chat/completions with
+     {\"stream\": true} — the body is an SSE stream of token deltas
+     terminated by a `data: [DONE]` sentinel the caller can recognize."
+    (coro/new
+      (fn []
+        (let* [[url-parsed   (parse-url url)]
+               [base-headers {:accept       "text/event-stream"
+                              :cache-control "no-cache"
+                              :content-type "application/json"}]
+               [user-headers (freeze (or headers {}))]
+               [final-headers (merge base-headers user-headers)]
+               [t (open-transport url-parsed)]]
+          (defer (protect (t-close t))
+            (write-request-line t "POST" url-parsed:path)
+            (write-headers t (build-request-headers
+                               url-parsed:host final-headers body false))
+            (t-write t "\r\n")
+            (unless (nil? body) (t-write t body))
+            (t-flush t)
+            (let* [[status-line  (read-status-line t)]
+                   [resp-headers (read-headers t)]]
+              (cond
+                ((and (>= status-line:status 200) (< status-line:status 300))
+                 (sse-for-each-event t resp-headers
+                   (fn [evt] (yield evt))))
+                (true
+                 (error {:error :http-error :reason :sse-bad-status
+                         :status status-line:status
+                         :body   (read-body t resp-headers)
+                         :message "SSE POST: non-2xx response"})))))))))
+
   (defn sse-format-field [field value]
     "Serialize one field of an SSE event. Data values with embedded
      newlines are emitted as repeated 'field: line' entries per spec."
@@ -1295,6 +1333,7 @@
 
    # Server-Sent Events
    :sse-get           sse-get
+   :sse-post          sse-post
    :sse-response      sse-response
    :format-sse-event  format-sse-event
 

--- a/lib/http.lisp
+++ b/lib/http.lisp
@@ -1,429 +1,1302 @@
 ## lib/http.lisp — Pure Elle HTTP/1.1 client and server
 ##
-## Loaded via: (def http ((import-file "./lib/http.lisp")))
-## Usage:      (http:get "http://example.com/")
+## Plain HTTP only:
+##   (def http ((import "std/http")))
+##
+## HTTPS client support requires a TLS plugin passed as :tls:
+##   (def tls-plug ((import "plugin/tls")))
+##   (def http ((import "std/http") :tls tls-plug))
+##
+## Usage: (http:get "http://example.com/")   (http:get "https://...")
+##
+## Future plugins (DNS overrides, proxies, etc.) can be added as more
+## &named args on the constructor without breaking existing callers.
 
-## ── URL parsing ──────────────────────────────────────────────────────
+(fn [&named tls compress]
 
-(defn parse-url [url]
-  "Parse an HTTP URL string into {:scheme :host :port :path :query}.
-   Only 'http' scheme is supported. Default port is 80. Default path is '/'.
-   Query is nil if absent, otherwise the string after '?' without the '?'."
-  (unless (string/starts-with? url "http://")
-    (error {:error :http-error :reason :unsupported-scheme :url url :message "unsupported scheme"}))
-  (let* [[tail (slice url (length "http://"))]
-         [slash (string/find tail "/")]
-         [auth (if (nil? slash) tail (slice tail 0 slash))]
-         [path+query (if (nil? slash) "/" (slice tail slash))]
-         [colon (string/find auth ":")]
-         [host (if (nil? colon) auth (slice auth 0 colon))]
-         [port (if (nil? colon) 80 (integer (slice auth (inc colon))))]]
-    (when (empty? tail)
-      (error {:error :http-error :reason :missing-host :url url :message "missing host"}))
-    (when (empty? host)
-      (error {:error :http-error :reason :empty-host :url url :message "empty host"}))
-    (let* [[q-pos (string/find path+query "?")]
-           [path (if (nil? q-pos) path+query (slice path+query 0 q-pos))]
-           [query (if (nil? q-pos) nil (slice path+query (inc q-pos)))]]
-      {:scheme "http" :host host :port port :path path :query query})))
+  ## ── Optional compress plugin ─────────────────────────────────────────
+  ## Accept either a pre-imported compress struct (from (import "std/compress"))
+  ## or literal `true` to have this module import it for us. Exposes the
+  ## standard compress helpers (gzip/gunzip/zlib/unzlib/deflate/inflate/
+  ## zstd/unzstd) as http:<name>. No automatic Accept-Encoding negotiation —
+  ## callers apply these explicitly to bodies or chunks.
 
-## ── Header parsing and serialization ─────────────────────────────────
+  (def compress-mod
+    (cond
+      ((nil? compress)       nil)
+      ((= compress true)     ((import "std/compress")))
+      ((struct? compress)    compress)
+      (true (error {:error :http-error :reason :bad-compress :value compress
+                    :message ":compress must be nil, true, or a compress module struct"}))))
 
-(defn header->kw [name]
-  "Convert HTTP header name string to lowercase keyword.
-   'Content-Type' -> :content-type"
-  (keyword (string/lowercase name)))
+  (defn require-compress []
+    "Return the configured compress module, or signal a clear error if
+     :compress was not supplied at module init."
+    (when (nil? compress-mod)
+      (error {:error :http-error :reason :compress-not-configured
+              :message ":compress option was not supplied to (import \"std/http\")"}))
+    compress-mod)
 
-(defn capitalize-segment [part]
-  "Capitalize first letter of a string segment."
-  (if (empty? part)
-      part
-      (concat (string/uppercase (first part)) (rest part))))
+  (defn compress-gzip    [data & opts] (let [[c (require-compress)]] (apply c:gzip    data opts)))
+  (defn compress-gunzip  [data]        (let [[c (require-compress)]] (c:gunzip  data)))
+  (defn compress-zlib    [data & opts] (let [[c (require-compress)]] (apply c:zlib    data opts)))
+  (defn compress-unzlib  [data]        (let [[c (require-compress)]] (c:unzlib  data)))
+  (defn compress-deflate [data & opts] (let [[c (require-compress)]] (apply c:deflate data opts)))
+  (defn compress-inflate [data]        (let [[c (require-compress)]] (c:inflate data)))
+  (defn compress-zstd    [data & opts] (let [[c (require-compress)]] (apply c:zstd    data opts)))
+  (defn compress-unzstd  [data]        (let [[c (require-compress)]] (c:unzstd  data)))
 
-(defn kw->header [kw]
-  "Convert keyword to HTTP header name with capitalized segments.
-   :content-type -> 'Content-Type'"
-  (let* [[parts (string/split (string kw) "-")]
-         [capitalized (map capitalize-segment parts)]]
-    (string/join capitalized "-")))
 
-(defn read-headers [port]
-  "Read HTTP headers from port until blank line. Returns immutable struct.
-   Header keys are lowercase keywords (:content-type, :host, etc.).
-   Stops when it reads an empty line (CRLF-only or LF-only).
-   Signals :http-error on malformed header lines."
-  (def headers @{})
-  (forever
-    (let [[line (port/read-line port)]]
-      (when (or (nil? line) (empty? line))
-        (break (freeze headers)))
-      (let [[colon-pos (string/find line ":")]]
-        (when (nil? colon-pos)
-          (error {:error :http-error :reason :malformed-header :line line
-                  :message "malformed header"}))
-        (let* [[name (slice line 0 colon-pos)]
-               [value (string/trim (slice line (inc colon-pos)))]]
-          (put headers (header->kw name) value))))))
+  ## ── URL parsing ──────────────────────────────────────────────────────
 
-(defn write-headers [port headers]
-  "Write HTTP headers struct to port. Each header is written as 'Name: value\\r\\n'.
-   Keys are keywords converted back to HTTP header name casing."
-  (each [key value] in (pairs headers)
-    (port/write port (string/format "{}: {}\r\n" (kw->header key) value))))
+  (def url-schemes
+    {"http"  {:prefix-len 7 :default-port 80}
+     "https" {:prefix-len 8 :default-port 443}})
 
-## ── Request and response wire format ─────────────────────────────────
+  (defn pick-scheme [url]
+    "Return [scheme info] for url, or nil if no supported prefix matches."
+    (cond
+      ((string/starts-with? url "https://") ["https" (get url-schemes "https")])
+      ((string/starts-with? url "http://")  ["http"  (get url-schemes "http")])
+      (true nil)))
 
-(defn read-request-line [port]
-  "Read and parse HTTP request line: 'GET /path HTTP/1.1'.
-   Returns {:method :path :version} or nil on EOF."
-  (let [[line (port/read-line port)]]
-    (if (nil? line)
-      nil
-      (let [[parts (string/split line " ")]]
-        (when (< (length parts) 3)
-          (error {:error :http-error :reason :malformed-request-line :line line
-                  :message "malformed request line"}))
-        (let [[[method path version] parts]]
-          (unless (string/starts-with? version "HTTP/")
-            (error {:error :http-error :reason :invalid-http-version :version version
-                    :message "invalid HTTP version"}))
-          {:method method :path path :version version})))))
+  (defn parse-url [url]
+    "Parse an HTTP or HTTPS URL string into {:scheme :host :port :path :query}.
+     Supports 'http' (default port 80) and 'https' (default port 443).
+     Default path is '/'. Query is nil if absent, otherwise the string after '?'
+     without the '?'."
+    (let [[picked (pick-scheme url)]]
+      (when (nil? picked)
+        (error {:error :http-error :reason :unsupported-scheme :url url
+                :message "unsupported scheme"}))
+      (let* [[[scheme info] picked]
+             [tail (slice url info:prefix-len)]
+             [slash (string/find tail "/")]
+             [auth (if (nil? slash) tail (slice tail 0 slash))]
+             [path+query (if (nil? slash) "/" (slice tail slash))]
+             [colon (string/find auth ":")]
+             [host (if (nil? colon) auth (slice auth 0 colon))]
+             [port (if (nil? colon) info:default-port (integer (slice auth (inc colon))))]]
+        (when (empty? tail)
+          (error {:error :http-error :reason :missing-host :url url :message "missing host"}))
+        (when (empty? host)
+          (error {:error :http-error :reason :empty-host :url url :message "empty host"}))
+        (let* [[q-pos (string/find path+query "?")]
+               [path (if (nil? q-pos) path+query (slice path+query 0 q-pos))]
+               [query (if (nil? q-pos) nil (slice path+query (inc q-pos)))]]
+          {:scheme scheme :host host :port port :path path :query query}))))
 
-(defn write-request-line [port method path]
-  "Write HTTP request line: 'METHOD path HTTP/1.1\\r\\n'."
-  (port/write port (string/format "{} {} HTTP/1.1\r\n" method path)))
+  ## ── Query-string encoding ────────────────────────────────────────────
 
-(defn read-status-line [port]
-  "Read and parse HTTP status line: 'HTTP/1.1 200 OK'.
-   Returns {:version :status :reason} where :status is an integer.
-   Signals :http-error on malformed input."
-  (let* [[line (port/read-line port)]
-         [parts (string/split line " ")]]
-    (when (< (length parts) 2)
-      (error {:error :http-error :reason :malformed-status-line :line line
-              :message "malformed status line"}))
-    (let* [[[version status-str & reason-parts] parts]
-           [status (integer status-str)]
-           [reason (if (empty? reason-parts) "" (string/join reason-parts " "))]]
-      {:version version :status status :reason reason})))
+  (defn query-scalar->string [v]
+    "Render a scalar value into its query-string form. Booleans go to
+     'true'/'false'; everything else goes through (string v)."
+    (cond
+      ((boolean? v) (if v "true" "false"))
+      (true         (string v))))
 
-(defn write-status-line [port status reason]
-  "Write HTTP status line: 'HTTP/1.1 status reason\\r\\n'."
-  (port/write port (string/format "HTTP/1.1 {} {}\r\n" status reason)))
+  (defn query-encode-pair [ekey v parts]
+    "Push 'key=value' into parts (uri-encoded). Skip nil, recurse into
+     arrays/lists to produce repeated 'key=v1&key=v2' pairs."
+    (cond
+      ((nil? v) nil)
+      ((or (array? v) (list? v))
+       (each elt in v
+         (unless (nil? elt)
+           (push parts
+             (string/format "{}={}" ekey (uri-encode (query-scalar->string elt)))))))
+      (true
+       (push parts
+         (string/format "{}={}" ekey (uri-encode (query-scalar->string v)))))))
 
-(defn read-body [port headers]
-  "Read request/response body based on Content-Length header.
-   Returns body string, or nil if Content-Length is absent.
-   Loops on short reads to handle large responses over TCP."
-  (when headers:content-length
-    (var n (integer headers:content-length))
+  (defn query-encode [params]
+    "Encode a struct/map of query parameters as an
+     application/x-www-form-urlencoded string: 'k1=v1&k2=v2'. Keys and
+     values are percent-encoded per RFC 3986. Array/list values produce
+     repeated 'key=v1&key=v2' pairs. nil values are omitted."
+    (let [[parts @[]]]
+      (each [k v] in (pairs params)
+        (let [[ekey (uri-encode (string k))]]
+          (query-encode-pair ekey v parts)))
+      (string/join (freeze parts) "&")))
+
+  (defn merge-query [url-query extra]
+    "Combine a URL's existing query string with caller-supplied extra.
+     extra is nil, a string (used as-is), or a struct (query-encoded).
+     Returns the merged query string, or nil if both are absent."
+    (let [[encoded (cond
+                     ((nil? extra)    nil)
+                     ((string? extra) extra)
+                     (true            (query-encode extra)))]]
+      (cond
+        ((and url-query encoded) (string url-query "&" encoded))
+        (true                    (or url-query encoded)))))
+
+  ## ── Header parsing and serialization ─────────────────────────────────
+
+  (defn header->kw [name]
+    "Convert HTTP header name string to lowercase keyword.
+     'Content-Type' -> :content-type"
+    (keyword (string/lowercase name)))
+
+  (defn capitalize-segment [part]
+    "Capitalize first letter of a string segment."
+    (if (empty? part)
+        part
+        (concat (string/uppercase (first part)) (rest part))))
+
+  (defn kw->header [kw]
+    "Convert keyword to HTTP header name with capitalized segments.
+     :content-type -> 'Content-Type'"
+    (let* [[parts (string/split (string kw) "-")]
+           [capitalized (map capitalize-segment parts)]]
+      (string/join capitalized "-")))
+
+  ## ── Transport abstraction ────────────────────────────────────────────
+  ##
+  ## A transport is a struct of closures exposing the subset of port-like
+  ## operations HTTP needs: {:read :read-line :write :flush :close}. All
+  ## wire-format helpers take a transport, so the same code path handles
+  ## plain TCP ports and TLS connections.
+
+  (defn tcp-transport [port]
+    "Wrap a plain TCP (or file) port as a transport."
+    {:read      (fn [n] (port/read port n))
+     :read-line (fn [] (port/read-line port))
+     :write     (fn [data] (port/write port data))
+     :flush     (fn [] (port/flush port))
+     :close     (fn [] (port/close port))})
+
+  (defn strip-line-terminator [s]
+    "Strip a trailing CRLF, LF, or CR from a line. CRLF is a single
+     grapheme in Elle, so all three cases drop one grapheme."
+    (if (and s (or (string/ends-with? s "\r\n")
+                   (string/ends-with? s "\n")
+                   (string/ends-with? s "\r")))
+        (slice s 0 (dec (length s)))
+        s))
+
+  (defn tls-transport [conn]
+    "Wrap a TLS connection (from the configured tls plugin) as a transport.
+     Only available when :tls was passed to the module initializer.
+
+     Note: port/read-line strips trailing newlines; tls:read-line does
+     not. We normalize here so the wire-format helpers see the same
+     semantics regardless of transport."
+    {:read      (fn [n] (tls:read conn n))
+     :read-line (fn [] (let [[line (tls:read-line conn)]]
+                         (when line (strip-line-terminator line))))
+     :write     (fn [data] (tls:write conn data))
+     :flush     (fn [] nil)
+     :close     (fn [] (tls:close conn))})
+
+  (defn open-transport [url-parsed]
+    "Open a transport to the URL's host:port. Uses TLS when the scheme is
+     https and a tls plugin was supplied to the module initializer.
+     Signals :http-error :tls-not-configured if an https URL is used
+     without a tls plugin."
+    (cond
+      ((= url-parsed:scheme "https")
+       (when (nil? tls)
+         (error {:error :http-error :reason :tls-not-configured
+                 :url url-parsed
+                 :message "https URL requires the tls plugin; pass :tls to (import \"std/http\")"}))
+       (tls-transport (tls:connect url-parsed:host url-parsed:port)))
+      (true
+       (tcp-transport (tcp/connect url-parsed:host url-parsed:port)))))
+
+  (defn t-read       [t n]    ((get t :read) n))
+  (defn t-read-line  [t]      ((get t :read-line)))
+  (defn t-write      [t data] ((get t :write) data))
+  (defn t-flush      [t]      ((get t :flush)))
+  (defn t-close      [t]      ((get t :close)))
+
+  ## ── Wire format: headers ─────────────────────────────────────────────
+
+  (defn read-headers [t]
+    "Read HTTP headers from a transport until blank line. Returns an
+     immutable struct with lowercase-keyword keys (:content-type, :host).
+     Signals :http-error on malformed header lines."
+    (def headers @{})
+    (forever
+      (let [[line (t-read-line t)]]
+        (when (or (nil? line) (empty? line))
+          (break (freeze headers)))
+        (let [[colon-pos (string/find line ":")]]
+          (when (nil? colon-pos)
+            (error {:error :http-error :reason :malformed-header :line line
+                    :message "malformed header"}))
+          (let* [[name (slice line 0 colon-pos)]
+                 [value (string/trim (slice line (inc colon-pos)))]]
+            (put headers (header->kw name) value))))))
+
+  (defn write-headers [t headers]
+    "Write HTTP headers struct to a transport as 'Name: value\\r\\n' lines.
+     Keys are keywords converted back to HTTP header-name casing."
+    (each [key value] in (pairs headers)
+      (t-write t (string/format "{}: {}\r\n" (kw->header key) value))))
+
+  ## ── Wire format: request / status lines ──────────────────────────────
+
+  (defn read-request-line [t]
+    "Read and parse HTTP request line: 'GET /path HTTP/1.1'.
+     Returns {:method :path :version} or nil on EOF."
+    (let [[line (t-read-line t)]]
+      (if (nil? line)
+        nil
+        (let [[parts (string/split line " ")]]
+          (when (< (length parts) 3)
+            (error {:error :http-error :reason :malformed-request-line :line line
+                    :message "malformed request line"}))
+          (let [[[method path version] parts]]
+            (unless (string/starts-with? version "HTTP/")
+              (error {:error :http-error :reason :invalid-http-version :version version
+                      :message "invalid HTTP version"}))
+            {:method method :path path :version version})))))
+
+  (defn write-request-line [t method path]
+    "Write HTTP request line: 'METHOD path HTTP/1.1\\r\\n'."
+    (t-write t (string/format "{} {} HTTP/1.1\r\n" method path)))
+
+  (defn read-status-line [t]
+    "Read and parse HTTP status line: 'HTTP/1.1 200 OK'.
+     Returns {:version :status :reason} where :status is an integer."
+    (let* [[line (t-read-line t)]
+           [parts (string/split line " ")]]
+      (when (< (length parts) 2)
+        (error {:error :http-error :reason :malformed-status-line :line line
+                :message "malformed status line"}))
+      (let* [[[version status-str & reason-parts] parts]
+             [status (integer status-str)]
+             [reason (if (empty? reason-parts) "" (string/join reason-parts " "))]]
+        {:version version :status status :reason reason})))
+
+  (defn write-status-line [t status reason]
+    "Write HTTP status line: 'HTTP/1.1 status reason\\r\\n'."
+    (t-write t (string/format "HTTP/1.1 {} {}\r\n" status reason)))
+
+  ## ── Wire format: body (fixed-length + chunked) ───────────────────────
+
+  (defn read-fixed-body [t n]
+    "Read exactly n bytes from transport and return as a string.
+     Loops on short reads."
     (if (= n 0)
       ""
       (begin
+        (var remaining n)
         (var buf (@bytes))
-        (while (pos? n)
-          (let [[chunk (port/read port n)]]
+        (while (pos? remaining)
+          (let [[chunk (t-read t remaining)]]
             (when (nil? chunk)
-              (error {:error :http-error :reason :unexpected-eof :phase :body :message "unexpected EOF reading body"}))
+              (error {:error :http-error :reason :unexpected-eof :phase :body
+                      :message "unexpected EOF reading body"}))
             (let [[b (if (bytes? chunk) chunk (bytes chunk))]]
               (append buf b)
-              (assign n (- n (length b))))))
-        (string (freeze buf))))))
+              (assign remaining (- remaining (length b))))))
+        (string (freeze buf)))))
 
-## ── Reason phrases ───────────────────────────────────────────────────
+  (defn chunk-size [line]
+    "Parse a chunk-size line per RFC 7230: hex digits with optional
+     ';ext=...' extensions. Signals :http-error on malformed input."
+    (when (nil? line)
+      (error {:error :http-error :reason :unexpected-eof :phase :chunk-size
+              :message "unexpected EOF reading chunk size"}))
+    (let* [[semi (string/find line ";")]
+           [hex (string/trim (if (nil? semi) line (slice line 0 semi)))]]
+      (when (empty? hex)
+        (error {:error :http-error :reason :malformed-chunk-size :line line
+                :message "malformed chunk size"}))
+      (integer hex 16)))
 
-(def reason-phrases
-  {200 "OK"
-   201 "Created"
-   204 "No Content"
-   301 "Moved Permanently"
-   302 "Found"
-   304 "Not Modified"
-   400 "Bad Request"
-   401 "Unauthorized"
-   403 "Forbidden"
-   404 "Not Found"
-   405 "Method Not Allowed"
-   413 "Payload Too Large"
-   409 "Conflict"
-   500 "Internal Server Error"
-   502 "Bad Gateway"
-   503 "Service Unavailable"})
+  (defn read-chunked-body [t]
+    "Read an HTTP/1.1 Transfer-Encoding: chunked body from transport.
+     Reads chunks until the terminating 0-chunk, discards chunk extensions
+     and trailers, returns the reassembled body as a string."
+    (var buf (@bytes))
+    (block :chunks
+      (forever
+        (let [[size (chunk-size (t-read-line t))]]
+          (when (= size 0)
+            # Consume optional trailers until the blank line.
+            (forever
+              (let [[line (t-read-line t)]]
+                (when (or (nil? line) (empty? line)) (break))))
+            (break :chunks nil))
+          (var remaining size)
+          (while (pos? remaining)
+            (let [[chunk (t-read t remaining)]]
+              (when (nil? chunk)
+                (error {:error :http-error :reason :unexpected-eof :phase :chunk-data
+                        :message "unexpected EOF reading chunk data"}))
+              (let [[b (if (bytes? chunk) chunk (bytes chunk))]]
+                (append buf b)
+                (assign remaining (- remaining (length b))))))
+          # Consume the CRLF that terminates the chunk data.
+          (t-read-line t))))
+    (string (freeze buf)))
 
-## ── Response construction ────────────────────────────────────────────
+  (defn chunked? [headers]
+    "True when headers indicate Transfer-Encoding: chunked."
+    (let [[te headers:transfer-encoding]]
+      (and te (string/contains? (string/lowercase te) "chunked"))))
 
-(defn http-respond [status body &named headers]
-  "Build a response struct with Content-Type and Content-Length set.
-   Caller can override headers via :headers."
-  (let* [[base-headers {:content-type "text/plain"
-                        :content-length (string (string/size-of body))}]
-         [merged (if (nil? headers)
-                   base-headers
-                   (merge base-headers (freeze headers)))]]
-    {:status status :headers merged :body body}))
+  (defn read-body [t headers]
+    "Read request/response body from transport.
+     If Transfer-Encoding: chunked is set, reads chunks and reassembles
+     (taking precedence over Content-Length per RFC 7230 §3.3.3).
+     Otherwise falls back to Content-Length. Returns body string, or nil
+     if neither framing header is present."
+    (cond
+      ((chunked? headers) (read-chunked-body t))
+      (headers:content-length (read-fixed-body t (integer headers:content-length)))
+      (true nil)))
 
-## ── Client API ───────────────────────────────────────────────────────
+  (defn write-chunk [t data]
+    "Write a single chunk to transport in HTTP/1.1 chunked encoding.
+     data may be a string or bytes. Writing an empty chunk is a no-op
+     (callers must still invoke write-last-chunk to terminate the body)."
+    (let* [[b (if (bytes? data) data (bytes data))]
+           [n (length b)]]
+      (when (pos? n)
+        (t-write t (string/format "{}\r\n" (number->string n 16)))
+        (t-write t b)
+        (t-write t "\r\n"))))
 
-(defn wants-close? [headers]
-  "True if headers indicate the connection should close."
-  (let [[conn headers:connection]]
-    (and conn (= (string/lowercase conn) "close"))))
+  (defn write-last-chunk [t]
+    "Write the terminating zero-length chunk and trailer CRLF.
+     Every chunked body must end with this."
+    (t-write t "0\r\n\r\n"))
 
-(defn build-request-headers [host extra-headers body keep-alive]
-  "Build request headers. Sets connection: keep-alive or close."
-  (let [[headers (merge {:host host
-                         :connection (if keep-alive "keep-alive" "close")}
-                        (freeze (or extra-headers {})))]]
-    (if (nil? body)
-        headers
-        (merge headers {:content-length (string (string/size-of body))}))))
+  ## ── Reason phrases ───────────────────────────────────────────────────
 
-(defn send-request [conn method path host extra-headers body keep-alive]
-  "Send an HTTP request on an open connection. Returns response struct.
-   Does NOT close the connection."
-  (write-request-line conn method path)
-  (let [[headers (build-request-headers host extra-headers body keep-alive)]]
-    (write-headers conn headers)
-    (port/write conn "\r\n")
-    (unless (nil? body) (port/write conn body))
-    (port/flush conn)
-    (let* [[status-line (read-status-line conn)]
-           [resp-headers (read-headers conn)]
-           [resp-body (read-body conn resp-headers)]]
-      {:status status-line:status :headers resp-headers :body resp-body})))
+  (def reason-phrases
+    {200 "OK"
+     201 "Created"
+     204 "No Content"
+     301 "Moved Permanently"
+     302 "Found"
+     304 "Not Modified"
+     400 "Bad Request"
+     401 "Unauthorized"
+     403 "Forbidden"
+     404 "Not Found"
+     405 "Method Not Allowed"
+     413 "Payload Too Large"
+     409 "Conflict"
+     500 "Internal Server Error"
+     502 "Bad Gateway"
+     503 "Service Unavailable"})
 
-(defn http-request [method url &named body headers]
-  "Make an HTTP/1.1 request. Opens a new connection, sends request, closes.
-   Returns {:status :headers :body}."
-  (let* [[url-parsed (parse-url url)]
-         [request-path (if (nil? url-parsed:query)
-                           url-parsed:path
-                           (string/format "{}?{}" url-parsed:path url-parsed:query))]
-         [conn (tcp/connect url-parsed:host url-parsed:port)]]
-    (defer (port/close conn)
-      (send-request conn method request-path
-                    url-parsed:host headers body false))))
+  ## ── Response construction ────────────────────────────────────────────
 
-(defn http-get [url &named headers]
-  "Make a GET request. Returns {:status :headers :body}."
-  (http-request "GET" url :headers headers))
+  (defn http-respond [status body &named headers]
+    "Build a response struct with Content-Type and Content-Length set.
+     Caller can override headers via :headers."
+    (let* [[base-headers {:content-type "text/plain"
+                          :content-length (string (string/size-of body))}]
+           [merged (if (nil? headers)
+                     base-headers
+                     (merge base-headers (freeze headers)))]]
+      {:status status :headers merged :body body}))
 
-(defn http-post [url body &named headers]
-  "Make a POST request with body. Returns {:status :headers :body}."
-  (http-request "POST" url :body body :headers headers))
+  ## ── Redirect handling ────────────────────────────────────────────────
 
-(defn http-connect [url]
-  "Open a keep-alive connection to a URL's host:port.
-   Returns {:conn :host :path-prefix} for use with http:send."
-  (let* [[url-parsed (parse-url url)]
-         [conn (tcp/connect url-parsed:host url-parsed:port)]]
-    {:conn conn :host url-parsed:host}))
+  (def redirect-statuses |301 302 303 307 308|)
+  (def get-rewrite-statuses |301 302 303|)
 
-(defn http-send [session method path &named body headers]
-  "Send a request on an existing keep-alive connection.
-   session: struct from http:connect. Returns {:status :headers :body}.
-   Connection remains open unless server sends connection: close."
-  (send-request session:conn method path
-                session:host headers body true))
+  (defn default-redirect-limit [] 10)
 
-(defn http-close [session]
-  "Close a keep-alive session."
-  (port/close session:conn))
+  (defn resolve-location [base location]
+    "Resolve a redirect Location header value against the base URL
+     struct. Handles absolute URLs, scheme-relative ('//host/path'),
+     and absolute paths ('/foo'). Other forms are treated as absolute
+     paths rooted at '/'."
+    (cond
+      ((or (string/starts-with? location "http://")
+           (string/starts-with? location "https://"))
+       location)
+      ((string/starts-with? location "//")
+       (string base:scheme ":" location))
+      (true
+       (let [[path (if (string/starts-with? location "/")
+                       location
+                       (string "/" location))]]
+         (string base:scheme "://" base:host ":" base:port path)))))
 
-## ── Server API ───────────────────────────────────────────────────────
+  (defn redirect-limit [follow]
+    "Normalize the :follow-redirects option: nil/false → 0, true →
+     default, integer → itself."
+    (cond
+      ((nil? follow)           0)
+      ((= follow false)        0)
+      ((= follow true)         (default-redirect-limit))
+      ((integer? follow)       follow)
+      (true (error {:error :http-error :reason :bad-follow-redirects
+                    :value follow
+                    :message ":follow-redirects must be nil, true, or a non-negative integer"}))))
 
-(defn read-request [conn]
-  "Read a complete HTTP request from a connection port.
-   Returns {:method :path :version :headers :body}, or nil on EOF."
-  (when-let [[req-line (read-request-line conn)]]
-    (let* [[headers (read-headers conn)]
-           [body (read-body conn headers)]]
-      {:method req-line:method
-       :path req-line:path
-       :version req-line:version
-       :headers headers
-       :body body})))
+  ## ── Client API ───────────────────────────────────────────────────────
 
-(defn write-response [conn response]
-  "Write a complete HTTP response to a connection port and flush.
-   response is {:status :headers :body}."
-  (write-status-line conn response:status
-                     (or (get reason-phrases response:status) "Unknown"))
-  (write-headers conn response:headers)
-  (port/write conn "\r\n")
-  (unless (nil? response:body)
-    (port/write conn response:body))
-  (port/flush conn))
+  (defn wants-close? [headers]
+    "True if headers indicate the connection should close."
+    (let [[conn headers:connection]]
+      (and conn (= (string/lowercase conn) "close"))))
 
-(defn connection-loop [conn handler on-error]
-  "Handle HTTP requests on a connection until it closes or either side
-   sends connection: close. Each request is read, passed to handler,
-   and the response is written. Errors in handler produce a 500 response.
-   on-error is called with (request error) when the handler fails."
-  (defer (protect (port/close conn))
+  (defn build-request-headers [host extra-headers body keep-alive]
+    "Build request headers. Sets Connection: keep-alive or close."
+    (let [[headers (merge {:host host
+                           :connection (if keep-alive "keep-alive" "close")}
+                          (freeze (or extra-headers {})))]]
+      (if (nil? body)
+          headers
+          (merge headers {:content-length (string (string/size-of body))}))))
+
+  (defn send-request [t method path host extra-headers body keep-alive]
+    "Send an HTTP request on an open transport. Returns response struct.
+     Does NOT close the transport."
+    (write-request-line t method path)
+    (let [[headers (build-request-headers host extra-headers body keep-alive)]]
+      (write-headers t headers)
+      (t-write t "\r\n")
+      (unless (nil? body) (t-write t body))
+      (t-flush t)
+      (let* [[status-line (read-status-line t)]
+             [resp-headers (read-headers t)]
+             [resp-body (read-body t resp-headers)]]
+        {:status status-line:status :headers resp-headers :body resp-body})))
+
+  (defn do-request [method url-parsed headers body query]
+    "Issue a single HTTP request against a parsed URL, applying any
+     :query struct/string to the request path, and return the response
+     struct. Opens and closes a fresh transport."
+    (let* [[full-query (merge-query url-parsed:query query)]
+           [request-path (if (nil? full-query)
+                             url-parsed:path
+                             (string/format "{}?{}" url-parsed:path full-query))]
+           [t (open-transport url-parsed)]]
+      (defer (protect (t-close t))
+        (send-request t method request-path
+                      url-parsed:host headers body false))))
+
+  (defn http-request [method url &named body headers query follow-redirects]
+    "Make an HTTP/1.1 request. Opens a new transport, sends request, closes.
+     Returns {:status :headers :body}. Uses TLS for https URLs if :tls was
+     supplied to the module initializer.
+
+     :query is an optional struct or pre-encoded string appended to the
+     URL's existing query. Values may be strings, numbers, booleans,
+     keywords, or arrays/lists (repeated 'key=v1&key=v2'). nil entries
+     are omitted.
+
+     :follow-redirects controls automatic handling of 301/302/303/307/308:
+       nil / false (default) — return the redirect response untouched.
+       true                  — follow up to 10 hops.
+       <integer>             — follow up to N hops.
+     Per RFC 9110, 301/302/303 are followed with GET and an empty body;
+     307/308 preserve the original method and body. The Location header
+     may be absolute, scheme-relative, or an absolute path."
+    (var current-method method)
+    (var current-body   body)
+    (var current-query  query)
+    (var current-parsed (parse-url url))
+    (var remaining      (redirect-limit follow-redirects))
+    (var last-response  nil)
+    (block :redirects
+      (forever
+        (let [[resp (do-request current-method current-parsed headers
+                                current-body current-query)]]
+          (assign last-response resp)
+          (when (or (zero? remaining)
+                    (not (redirect-statuses resp:status)))
+            (break :redirects nil))
+          (let [[loc (get resp:headers :location)]]
+            (when (nil? loc)
+              (break :redirects nil))
+            (let [[next-url (resolve-location current-parsed loc)]]
+              (assign current-parsed (parse-url next-url)))
+            # Drop :query on redirect — Location already carries the
+            # redirected query; caller's :query was for the *initial*
+            # request only.
+            (assign current-query nil)
+            (when (get-rewrite-statuses resp:status)
+              (assign current-method "GET")
+              (assign current-body nil))
+            (assign remaining (dec remaining))))))
+    last-response)
+
+  (defn http-get [url &named headers query follow-redirects]
+    "Make a GET request. Returns {:status :headers :body}."
+    (http-request "GET" url :headers headers :query query
+                  :follow-redirects follow-redirects))
+
+  (defn http-post [url body &named headers query follow-redirects]
+    "Make a POST request with body. Returns {:status :headers :body}."
+    (http-request "POST" url :body body :headers headers :query query
+                  :follow-redirects follow-redirects))
+
+  (defn http-connect [url]
+    "Open a keep-alive transport to a URL's host:port.
+     Returns {:transport :host} for use with http:send."
+    (let* [[url-parsed (parse-url url)]
+           [t (open-transport url-parsed)]]
+      {:transport t :host url-parsed:host}))
+
+  (defn http-send [session method path &named body headers]
+    "Send a request on an existing keep-alive session.
+     session: struct from http:connect. Returns {:status :headers :body}.
+     Transport remains open unless server sends Connection: close."
+    (send-request session:transport method path
+                  session:host headers body true))
+
+  (defn http-close [session]
+    "Close a keep-alive session."
+    (t-close session:transport))
+
+  ## ── Server-Sent Events (SSE) ─────────────────────────────────────────
+
+  (def sse-default-retry-ms 3000)
+
+  (defn sse-strip-leading-space [s]
+    "Per the SSE spec, a single leading space on a field value is
+     eaten (so 'data: hello' yields data='hello')."
+    (if (string/starts-with? s " ") (slice s 1) s))
+
+  (defn sse-parse-field [line]
+    "Parse one SSE field line per the HTML spec. Returns {:field :value},
+     or nil for comments and unparseable input."
+    (cond
+      ((empty? line) nil)
+      ((string/starts-with? line ":") nil)  # comment
+      (true
+       (let [[colon (string/find line ":")]]
+         (cond
+           ((nil? colon)
+            {:field line :value ""})
+           (true
+            {:field (slice line 0 colon)
+             :value (sse-strip-leading-space (slice line (inc colon)))}))))))
+
+  (defn sse-for-each-body-line [t headers on-line]
+    "Call (on-line line) for every body line. Handles both
+     Transfer-Encoding: chunked and plain bodies. on-line receives lines
+     with trailing CRLF/LF already stripped."
+    (if (chunked? headers)
+      (sse-for-each-body-line-chunked t on-line)
+      (sse-for-each-body-line-plain t on-line)))
+
+  (defn sse-for-each-body-line-plain [t on-line]
     (forever
-      (let [[[ok? req] (protect (read-request conn))]]
+      (let [[line (t-read-line t)]]
+        (when (nil? line) (break))
+        (on-line line))))
+
+  (defn sse-drain-buffered-lines [buf on-line]
+    "Yield all complete lines already present in buf. Returns the new
+     buf value with the last (incomplete) line left behind."
+    (var remaining buf)
+    (block :drain
+      (forever
+        (let [[nl (string/find remaining "\n")]]
+          (when (nil? nl) (break :drain remaining))
+          (let* [[raw (slice remaining 0 nl)]
+                 [line (if (string/ends-with? raw "\r")
+                           (slice raw 0 (dec (length raw)))
+                           raw)]]
+            (on-line line)
+            (assign remaining (slice remaining (inc nl))))))))
+
+  (defn sse-for-each-body-line-chunked [t on-line]
+    (var buf "")
+    (block :chunks
+      (forever
+        (let [[size (chunk-size (t-read-line t))]]
+          (when (= size 0)
+            (forever
+              (let [[line (t-read-line t)]]
+                (when (or (nil? line) (empty? line)) (break))))
+            (unless (empty? buf) (on-line buf))
+            (break :chunks))
+          (var remaining size)
+          (while (pos? remaining)
+            (let [[data (t-read t remaining)]]
+              (when (nil? data)
+                (error {:error :http-error :reason :unexpected-eof :phase :chunk-data
+                        :message "unexpected EOF reading chunk data"}))
+              (let* [[b (if (bytes? data) data (bytes data))]
+                     [s (string b)]]
+                (assign buf (string buf s))
+                (assign remaining (- remaining (length b))))))
+          (t-read-line t)  # consume trailing CRLF after chunk data
+          (assign buf (sse-drain-buffered-lines buf on-line))))))
+
+  (defn sse-dispatch-event [state on-event]
+    "If state has accumulated :data, emit an event via on-event and
+     reset the per-event accumulators. :id and :retry persist across
+     events per the SSE spec."
+    (when (pos? (length state:data-lines))
+      (on-event {:event (or state:event-type "message")
+                 :data  (string/join (freeze state:data-lines) "\n")
+                 :id    state:last-id
+                 :retry state:retry}))
+    (put state :event-type nil)
+    (put state :data-lines @[]))
+
+  (defn sse-handle-line [state line on-event]
+    "Apply one line of an SSE stream to state. Empty line flushes the
+     event; comments and unknown fields are ignored."
+    (if (empty? line)
+      (sse-dispatch-event state on-event)
+      (let [[parsed (sse-parse-field line)]]
+        (when parsed
+          (case parsed:field
+            "event" (put state :event-type parsed:value)
+            "data"  (push state:data-lines parsed:value)
+            "id"    (unless (string/contains? parsed:value "\0")
+                      (put state :last-id parsed:value))
+            "retry" (let [[[ok? n] (protect (integer parsed:value))]]
+                      (when (and ok? n (pos? n))
+                        (put state :retry n))))))))
+
+  (defn sse-for-each-event [t headers on-event]
+    "Parse the SSE body on transport t, calling on-event for each
+     complete event. Returns when the stream closes."
+    (let [[state @{:event-type nil
+                   :data-lines @[]
+                   :last-id    nil
+                   :retry      nil}]]
+      (sse-for-each-body-line t headers
+        (fn [line] (sse-handle-line state line on-event)))))
+
+  (defn sse-open [url headers last-event-id]
+    "Open an SSE request. Returns {:transport :status :headers}.
+     Body is NOT consumed — caller parses it via sse-for-each-event."
+    (let* [[url-parsed (parse-url url)]
+           [base-headers {:accept        "text/event-stream"
+                          :cache-control "no-cache"}]
+           [with-id (if last-event-id
+                      (merge base-headers {:last-event-id last-event-id})
+                      base-headers)]
+           [user-headers (freeze (or headers {}))]
+           [final-headers (merge with-id user-headers)]
+           [t (open-transport url-parsed)]]
+      (write-request-line t "GET" url-parsed:path)
+      (write-headers t (build-request-headers
+                         url-parsed:host final-headers nil false))
+      (t-write t "\r\n")
+      (t-flush t)
+      (let* [[status-line (read-status-line t)]
+             [resp-headers (read-headers t)]]
+        {:transport t
+         :status    status-line:status
+         :headers   resp-headers})))
+
+  (defn sse-get [url &named headers last-event-id reconnect]
+    "Open an SSE connection to url and return a coroutine that yields
+     events until the stream terminates. Each event is a struct:
+       {:event \"message\" :data \"...\" :id \"...\" :retry 3000}
+
+     :reconnect — true (default) or nil/false.
+       When true, follows EventSource semantics: on disconnect or
+       failure, waits retry-ms (last server-sent :retry, default 3000)
+       and reopens with Last-Event-ID. Stops on HTTP 204 No Content.
+     :last-event-id — initial Last-Event-ID header.
+     :headers — extra request headers merged into the SSE defaults."
+    (default reconnect true)
+    (coro/new
+      (fn []
+        (var current-id last-event-id)
+        (var retry-ms   sse-default-retry-ms)
+        (block :session
+          (forever
+            (let* [[[ok? result]
+                    (protect
+                      (let [[conn (sse-open url headers current-id)]]
+                        (defer (protect (t-close conn:transport))
+                          (cond
+                            ((= conn:status 204) :done)
+                            ((and (>= conn:status 200) (< conn:status 300))
+                             (sse-for-each-event conn:transport conn:headers
+                               (fn [evt]
+                                 (when evt:id    (assign current-id evt:id))
+                                 (when evt:retry (assign retry-ms evt:retry))
+                                 (yield evt)))
+                             :eof)
+                            (true
+                             (error {:error :http-error :reason :sse-bad-status
+                                     :status conn:status
+                                     :message "SSE: non-2xx response"}))))))]]
+              (cond
+                ((and ok? (= result :done)) (break :session))
+                ((not reconnect)            (break :session)))
+              (ev/sleep (/ retry-ms 1000.0))))))))
+
+  (defn sse-format-field [field value]
+    "Serialize one field of an SSE event. Data values with embedded
+     newlines are emitted as repeated 'field: line' entries per spec."
+    (let [[s (string value)]]
+      (if (and (= field "data") (string/contains? s "\n"))
+        (string/join (map (fn [line] (string/format "data: {}\n" line))
+                          (string/split s "\n"))
+                     "")
+        (string/format "{}: {}\n" field s))))
+
+  (defn format-sse-event [evt]
+    "Serialize an event struct to SSE wire format. Recognizes :event,
+     :data, :id, :retry; unknown fields are omitted. Returns the
+     complete frame, terminator included."
+    (let [[parts @[]]]
+      (when (and evt:event (not (= evt:event "message")))
+        (push parts (sse-format-field "event" evt:event)))
+      (when evt:id
+        (push parts (sse-format-field "id" evt:id)))
+      (when evt:retry
+        (push parts (sse-format-field "retry" evt:retry)))
+      (when evt:data
+        (push parts (sse-format-field "data" evt:data)))
+      (string (string/join (freeze parts) "") "\n")))
+
+  (defn sse-response [body-fn &named headers]
+    "Build a streaming SSE response. body-fn is a closure (fn [send-event])
+     where send-event takes an event struct and emits it to the client.
+     Returns a response that uses chunked transfer; suitable for use
+     with http:serve."
+    (let* [[base-headers {:content-type      "text/event-stream"
+                          :cache-control     "no-cache"
+                          :connection        "keep-alive"
+                          :transfer-encoding "chunked"}]
+           [merged (if (nil? headers)
+                     base-headers
+                     (merge base-headers (freeze headers)))]]
+      {:status 200
+       :headers merged
+       :body (fn [write-chunk]
+               (body-fn (fn [evt] (write-chunk (format-sse-event evt)))))}))
+
+  ## ── Server API ───────────────────────────────────────────────────────
+
+  (defn read-request [t]
+    "Read a complete HTTP request from a transport.
+     Returns {:method :path :version :headers :body}, or nil on EOF."
+    (when-let [[req-line (read-request-line t)]]
+      (let* [[headers (read-headers t)]
+             [body (read-body t headers)]]
+        {:method req-line:method
+         :path req-line:path
+         :version req-line:version
+         :headers headers
+         :body body})))
+
+  (defn write-response [t response]
+    "Write a complete HTTP response to a transport and flush.
+     response is {:status :headers :body}.
+     If the headers declare Transfer-Encoding: chunked, the body is framed
+     as chunks. A body that is a function (fn [write-chunk]) is invoked
+     with a chunk writer so handlers can stream arbitrary data; otherwise
+     the body is written as a single chunk."
+    (write-status-line t response:status
+                       (or (get reason-phrases response:status) "Unknown"))
+    (write-headers t response:headers)
+    (t-write t "\r\n")
+    (cond
+      ((chunked? response:headers)
+       (let [[body response:body]]
+         (cond
+           ((nil? body)  nil)
+           ((fn? body)   (body (fn [data] (write-chunk t data))))
+           (true         (write-chunk t body)))
+         (write-last-chunk t)))
+      ((not (nil? response:body))
+       (t-write t response:body)))
+    (t-flush t))
+
+  (defn connection-loop [t handler on-error]
+    "Handle HTTP requests on a transport until it closes or either side
+     sends Connection: close. Errors in handler produce a 500 response.
+     on-error is called with (request error) when the handler fails."
+    (defer (protect (t-close t))
+      (forever
+        (let [[[ok? req] (protect (read-request t))]]
+          (unless ok? (break))
+          (when (nil? req) (break))
+          (let* [[[ok? val] (protect (handler req))]
+                 [response (if ok?
+                             val
+                             (begin
+                               (when on-error (on-error req val))
+                               (http-respond 500 "Internal Server Error")))]]
+            (write-response t response)
+            (when (or (wants-close? req:headers)
+                      (wants-close? response:headers))
+              (break)))))))
+
+  (defn default-on-error [request err]
+    "Default error handler: print to stderr."
+    (port/write (port/stderr)
+      (string/format "http: handler error on {} {}: {}\n"
+                     request:method request:path err)))
+
+  (defn http-serve [listener handler &named on-error]
+    "Accept connections on listener and handle them with keep-alive.
+     Each connection runs in its own fiber via ev/spawn.
+     Exits cleanly when the listener is closed.
+     handler: (fn [request]) -> response
+     :on-error: (fn [request error]) -> nil (default: print to stderr)
+     Serves plain HTTP; for HTTPS, the caller can wrap accepted TCP
+     connections with tls:accept and pass the resulting tls-conn into
+     their own transport (future: first-class https-serve)."
+    (default on-error default-on-error)
+    (forever
+      (let [[[ok? conn] (protect (tcp/accept listener))]]
         (unless ok? (break))
-        (when (nil? req) (break))
-        (let* [[[ok? val] (protect (handler req))]
-               [response (if ok?
-                           val
-                           (begin
-                             (when on-error (on-error req val))
-                             (http-respond 500 "Internal Server Error")))]]
-          (write-response conn response)
-          (when (or (wants-close? req:headers)
-                    (wants-close? response:headers))
-            (break)))))))
+        (ev/spawn
+          (fn [] (connection-loop (tcp-transport conn) handler on-error))))))
 
-(defn default-on-error [request err]
-  "Default error handler: print to stderr."
-  (port/write (port/stderr)
-    (string/format "http: handler error on {} {}: {}\n"
-                   request:method request:path err)))
+  ## ── Internal tests ──────────────────────────────────────────────────
 
-(defn http-serve [listener handler &named on-error]
-  "Accept connections on listener and handle them with keep-alive.
-   Each connection runs in its own fiber via ev/spawn.
-   Exits cleanly when the listener is closed.
-   handler: (fn [request]) -> response
-   :on-error: (fn [request error]) -> nil (default: print to stderr)"
-  (default on-error default-on-error)
-  (forever
-    (let [[[ok? conn] (protect (tcp/accept listener))]]
-      (unless ok? (break))
-      (ev/spawn (fn [] (connection-loop conn handler on-error))))))
+  (defn with-file-transport [path mode thunk]
+    "Helper: open file at path as a transport, run thunk, close."
+    (let [[p (port/open path mode)]]
+      (defer (protect (port/close p))
+        (thunk (tcp-transport p)))))
 
-## ── Exports ─────────────────────────────────────────────────────────
+  (defn run-internal-tests []
+    "Sanity checks on internal wire-format helpers. Called via (http:test)."
 
-(defn run-internal-tests []
-  "Sanity checks on internal wire-format helpers. Called via (http:test)."
+    # header->kw
+    (assert (= (header->kw "Content-Type") :content-type) "header->kw Content-Type")
+    (assert (= (header->kw "Host") :host)                 "header->kw Host")
+    (assert (= (header->kw "X-Custom-Header") :x-custom-header)
+      "header->kw X-Custom-Header")
+    (assert (= (header->kw "content-type") :content-type) "header->kw lowercase")
 
-  # header->kw
-  (assert (= (header->kw "Content-Type") :content-type) "header->kw Content-Type")
-  (assert (= (header->kw "Host") :host)                 "header->kw Host")
-  (assert (= (header->kw "X-Custom-Header") :x-custom-header)
-    "header->kw X-Custom-Header")
-  (assert (= (header->kw "content-type") :content-type) "header->kw lowercase")
+    # kw->header
+    (assert (= (kw->header :content-type) "Content-Type")     "kw->header content-type")
+    (assert (= (kw->header :host) "Host")                     "kw->header host")
+    (assert (= (kw->header :x-custom-header) "X-Custom-Header")
+      "kw->header x-custom-header")
+    (assert (= (kw->header :content-length) "Content-Length")  "kw->header content-length")
 
-  # kw->header
-  (assert (= (kw->header :content-type) "Content-Type")     "kw->header content-type")
-  (assert (= (kw->header :host) "Host")                     "kw->header host")
-  (assert (= (kw->header :x-custom-header) "X-Custom-Header")
-    "kw->header x-custom-header")
-  (assert (= (kw->header :content-length) "Content-Length")  "kw->header content-length")
+    # round-trip
+    (assert (= (kw->header (header->kw "Content-Type")) "Content-Type")
+      "header round-trip Content-Type")
+    (assert (= (kw->header (header->kw "Host")) "Host")
+      "header round-trip Host")
 
-  # round-trip
-  (assert (= (kw->header (header->kw "Content-Type")) "Content-Type")
-    "header round-trip Content-Type")
-  (assert (= (kw->header (header->kw "Host")) "Host")
-    "header round-trip Host")
+    # read-headers via file transport
+    (spit "/tmp/elle-http-test-headers"
+      "Content-Type: text/plain\r\nHost: example.com\r\nContent-Length: 42\r\n\r\n")
+    (with-file-transport "/tmp/elle-http-test-headers" :read
+      (fn [t]
+        (let [[h (read-headers t)]]
+          (assert (= h:content-type   "text/plain")  "read-headers content-type")
+          (assert (= h:host           "example.com") "read-headers host")
+          (assert (= h:content-length "42")           "read-headers content-length"))))
 
-  # read-headers via file port
-  (spit "/tmp/elle-http-test-headers"
-    "Content-Type: text/plain\r\nHost: example.com\r\nContent-Length: 42\r\n\r\n")
-  (let [[p (port/open "/tmp/elle-http-test-headers" :read)]]
-    (let [[h (read-headers p)]]
-      (port/close p)
-      (assert (= h:content-type   "text/plain")  "read-headers content-type")
-      (assert (= h:host           "example.com") "read-headers host")
-      (assert (= h:content-length "42")           "read-headers content-length")))
+    # read-headers trims whitespace
+    (spit "/tmp/elle-http-test-headers-ws" "X-Foo:   bar baz   \r\n\r\n")
+    (with-file-transport "/tmp/elle-http-test-headers-ws" :read
+      (fn [t]
+        (let [[h (read-headers t)]]
+          (assert (= h:x-foo "bar baz") "read-headers trims whitespace"))))
 
-  # read-headers trims whitespace
-  (spit "/tmp/elle-http-test-headers-ws" "X-Foo:   bar baz   \r\n\r\n")
-  (let [[p (port/open "/tmp/elle-http-test-headers-ws" :read)]]
-    (let [[h (read-headers p)]]
-      (port/close p)
-      (assert (= h:x-foo "bar baz") "read-headers trims whitespace")))
+    # read-headers malformed
+    (spit "/tmp/elle-http-test-headers-bad" "no-colon-here\r\n\r\n")
+    (with-file-transport "/tmp/elle-http-test-headers-bad" :read
+      (fn [t]
+        (let [[[ok? _] (protect (read-headers t))]]
+          (assert (not ok?) "read-headers malformed signals error"))))
 
-  # read-headers malformed
-  (spit "/tmp/elle-http-test-headers-bad" "no-colon-here\r\n\r\n")
-  (let [[p-bad (port/open "/tmp/elle-http-test-headers-bad" :read)]]
-    (let [[[ok? _] (protect (read-headers p-bad))]]
-      (assert (not ok?) "read-headers malformed signals error")))
+    # write-headers
+    (with-file-transport "/tmp/elle-http-test-write-headers" :write
+      (fn [t]
+        (write-headers t {:content-type "text/plain" :content-length "11"})
+        (t-write t "\r\n")
+        (t-flush t)))
+    (let [[content (slurp "/tmp/elle-http-test-write-headers")]]
+      (assert (string/contains? content "Content-Type: text/plain")
+        "write-headers content-type")
+      (assert (string/contains? content "Content-Length: 11")
+        "write-headers content-length"))
 
-  # write-headers
-  (let [[p (port/open "/tmp/elle-http-test-write-headers" :write)]]
-    (write-headers p {:content-type "text/plain" :content-length "11"})
-    (port/write p "\r\n")
-    (port/flush p)
-    (port/close p))
-  (let [[content (slurp "/tmp/elle-http-test-write-headers")]]
-    (assert (string/contains? content "Content-Type: text/plain")
-      "write-headers content-type")
-    (assert (string/contains? content "Content-Length: 11")
-      "write-headers content-length"))
+    # read-request-line
+    (spit "/tmp/elle-http-test-req-line" "GET /path HTTP/1.1\r\n")
+    (with-file-transport "/tmp/elle-http-test-req-line" :read
+      (fn [t]
+        (let [[rl (read-request-line t)]]
+          (assert (= rl:method  "GET")      "request-line method")
+          (assert (= rl:path    "/path")    "request-line path")
+          (assert (= rl:version "HTTP/1.1") "request-line version"))))
 
-  # read-request-line
-  (spit "/tmp/elle-http-test-req-line" "GET /path HTTP/1.1\r\n")
-  (let [[p (port/open "/tmp/elle-http-test-req-line" :read)]]
-    (let [[rl (read-request-line p)]]
-      (port/close p)
-      (assert (= rl:method  "GET")      "request-line method")
-      (assert (= rl:path    "/path")    "request-line path")
-      (assert (= rl:version "HTTP/1.1") "request-line version")))
+    # read-status-line
+    (spit "/tmp/elle-http-test-status-200" "HTTP/1.1 200 OK\r\n")
+    (with-file-transport "/tmp/elle-http-test-status-200" :read
+      (fn [t]
+        (let [[sl (read-status-line t)]]
+          (assert (= sl:version "HTTP/1.1") "status-line version")
+          (assert (= sl:status  200)         "status-line status")
+          (assert (= sl:reason  "OK")        "status-line reason"))))
 
-  # read-status-line
-  (spit "/tmp/elle-http-test-status-200" "HTTP/1.1 200 OK\r\n")
-  (let [[p (port/open "/tmp/elle-http-test-status-200" :read)]]
-    (let [[sl (read-status-line p)]]
-      (port/close p)
-      (assert (= sl:version "HTTP/1.1") "status-line version")
-      (assert (= sl:status  200)         "status-line status")
-      (assert (= sl:reason  "OK")        "status-line reason")))
+    # read-body with Content-Length
+    (spit "/tmp/elle-http-test-body" "hello world")
+    (with-file-transport "/tmp/elle-http-test-body" :read
+      (fn [t]
+        (let [[body (read-body t {:content-length "11"})]]
+          (assert (= body "hello world") "read-body with content-length"))))
 
-  # read-body with Content-Length
-  (spit "/tmp/elle-http-test-body" "hello world")
-  (let [[p (port/open "/tmp/elle-http-test-body" :read)]]
-    (let [[body (read-body p {:content-length "11"})]]
-      (port/close p)
-      (assert (= body "hello world") "read-body with content-length")))
+    # read-body without Content-Length
+    (spit "/tmp/elle-http-test-body-no-cl" "ignored")
+    (with-file-transport "/tmp/elle-http-test-body-no-cl" :read
+      (fn [t]
+        (let [[body (read-body t {})]]
+          (assert (nil? body) "read-body without content-length is nil"))))
 
-  # read-body without Content-Length
-  (spit "/tmp/elle-http-test-body-no-cl" "ignored")
-  (let [[p (port/open "/tmp/elle-http-test-body-no-cl" :read)]]
-    (let [[body (read-body p {})]]
-      (port/close p)
-      (assert (nil? body) "read-body without content-length is nil")))
+    # chunk-size: hex digits, with optional extension, error cases
+    (assert (= (chunk-size "0")              0)   "chunk-size 0")
+    (assert (= (chunk-size "a")              10)  "chunk-size a")
+    (assert (= (chunk-size "1a")             26)  "chunk-size 1a")
+    (assert (= (chunk-size "FF")             255) "chunk-size FF (uppercase)")
+    (assert (= (chunk-size "10;ext=value")   16)  "chunk-size with extension")
+    (assert (= (chunk-size "  20  ")         32)  "chunk-size trims whitespace")
+    (let [[[ok? _] (protect (chunk-size nil))]]
+      (assert (not ok?) "chunk-size nil signals error"))
+    (let [[[ok? _] (protect (chunk-size ""))]]
+      (assert (not ok?) "chunk-size empty signals error"))
+    (let [[[ok? _] (protect (chunk-size ";ext"))]]
+      (assert (not ok?) "chunk-size bare extension signals error"))
 
-  # full request parse
-  (spit "/tmp/elle-http-test-full-req"
-    "POST /submit HTTP/1.1\r\nHost: localhost\r\nContent-Length: 4\r\n\r\ndata")
-  (let [[out @[nil nil nil nil]]]
-    (let [[p (port/open "/tmp/elle-http-test-full-req" :read)]]
-      (let [[rl (read-request-line p)]]
-        (put out 0 rl:method)
-        (put out 1 rl:path)
-        (let [[h (read-headers p)]]
-          (put out 2 h:host)
-          (let [[body (read-body p h)]]
-            (put out 3 body))))
-      (port/close p))
-    (assert (= (get out 0) "POST")      "full req method")
-    (assert (= (get out 1) "/submit")   "full req path")
-    (assert (= (get out 2) "localhost") "full req host")
-    (assert (= (get out 3) "data")      "full req body"))
+    # chunked? predicate
+    (assert (chunked? {:transfer-encoding "chunked"})       "chunked? lowercase")
+    (assert (chunked? {:transfer-encoding "Chunked"})       "chunked? mixed-case")
+    (assert (chunked? {:transfer-encoding "gzip, chunked"}) "chunked? with gzip")
+    (assert (not (chunked? {}))                             "chunked? absent")
+    (assert (not (chunked? {:transfer-encoding "gzip"}))    "chunked? gzip-only")
 
-  true)
+    # read-chunked-body: happy path
+    (spit "/tmp/elle-http-test-chunked"
+      "5\r\nhello\r\n6\r\n world\r\n0\r\n\r\n")
+    (with-file-transport "/tmp/elle-http-test-chunked" :read
+      (fn [t]
+        (let [[body (read-chunked-body t)]]
+          (assert (= body "hello world") "read-chunked-body concatenates chunks"))))
 
-(fn []
-  {:parse-url  parse-url
+    # read-chunked-body: chunk extensions are ignored
+    (spit "/tmp/elle-http-test-chunked-ext"
+      "3;ext=foo\r\nabc\r\n0\r\n\r\n")
+    (with-file-transport "/tmp/elle-http-test-chunked-ext" :read
+      (fn [t]
+        (let [[body (read-chunked-body t)]]
+          (assert (= body "abc") "read-chunked-body ignores extensions"))))
+
+    # read-chunked-body: trailers are discarded
+    (spit "/tmp/elle-http-test-chunked-trail"
+      "4\r\ndata\r\n0\r\nX-Trailer: value\r\n\r\n")
+    (with-file-transport "/tmp/elle-http-test-chunked-trail" :read
+      (fn [t]
+        (let [[body (read-chunked-body t)]]
+          (assert (= body "data") "read-chunked-body discards trailers"))))
+
+    # read-chunked-body: hex sizes
+    (spit "/tmp/elle-http-test-chunked-hex"
+      "1a\r\nabcdefghijklmnopqrstuvwxyz\r\n0\r\n\r\n")
+    (with-file-transport "/tmp/elle-http-test-chunked-hex" :read
+      (fn [t]
+        (let [[body (read-chunked-body t)]]
+          (assert (= body "abcdefghijklmnopqrstuvwxyz")
+            "read-chunked-body hex-encoded size"))))
+
+    # read-chunked-body: empty body (just the 0-chunk)
+    (spit "/tmp/elle-http-test-chunked-empty" "0\r\n\r\n")
+    (with-file-transport "/tmp/elle-http-test-chunked-empty" :read
+      (fn [t]
+        (let [[body (read-chunked-body t)]]
+          (assert (= body "") "read-chunked-body empty body"))))
+
+    # read-body dispatches on Transfer-Encoding before Content-Length
+    (spit "/tmp/elle-http-test-body-chunked"
+      "5\r\nhello\r\n0\r\n\r\n")
+    (with-file-transport "/tmp/elle-http-test-body-chunked" :read
+      (fn [t]
+        (let [[body (read-body t {:transfer-encoding "chunked"
+                                  :content-length "999"})]]
+          (assert (= body "hello")
+            "read-body prefers chunked over content-length"))))
+
+    # write-chunk: produces hex-size + CRLF + data + CRLF
+    (with-file-transport "/tmp/elle-http-test-write-chunk" :write
+      (fn [t]
+        (write-chunk t "hi")
+        (write-chunk t "there")
+        (write-last-chunk t)
+        (t-flush t)))
+    (let [[content (slurp "/tmp/elle-http-test-write-chunk")]]
+      (assert (= content "2\r\nhi\r\n5\r\nthere\r\n0\r\n\r\n")
+        "write-chunk + write-last-chunk produce correct framing"))
+
+    # write-chunk: empty chunk is a no-op
+    (with-file-transport "/tmp/elle-http-test-write-chunk-empty" :write
+      (fn [t]
+        (write-chunk t "")
+        (write-last-chunk t)
+        (t-flush t)))
+    (let [[content (slurp "/tmp/elle-http-test-write-chunk-empty")]]
+      (assert (= content "0\r\n\r\n")
+        "write-chunk empty is a no-op"))
+
+    # round-trip: write chunks, read them back
+    (with-file-transport "/tmp/elle-http-test-chunk-roundtrip" :write
+      (fn [t]
+        (write-chunk t "one ")
+        (write-chunk t "two ")
+        (write-chunk t "three")
+        (write-last-chunk t)
+        (t-flush t)))
+    (with-file-transport "/tmp/elle-http-test-chunk-roundtrip" :read
+      (fn [t]
+        (let [[body (read-chunked-body t)]]
+          (assert (= body "one two three") "chunk round-trip"))))
+
+    # full request parse
+    (spit "/tmp/elle-http-test-full-req"
+      "POST /submit HTTP/1.1\r\nHost: localhost\r\nContent-Length: 4\r\n\r\ndata")
+    (let [[out @[nil nil nil nil]]]
+      (with-file-transport "/tmp/elle-http-test-full-req" :read
+        (fn [t]
+          (let [[rl (read-request-line t)]]
+            (put out 0 rl:method)
+            (put out 1 rl:path)
+            (let [[h (read-headers t)]]
+              (put out 2 h:host)
+              (let [[body (read-body t h)]]
+                (put out 3 body))))))
+      (assert (= (get out 0) "POST")      "full req method")
+      (assert (= (get out 1) "/submit")   "full req path")
+      (assert (= (get out 2) "localhost") "full req host")
+      (assert (= (get out 3) "data")      "full req body"))
+
+    # https URL without :tls plugin: clear error
+    (when (nil? tls)
+      (let [[[ok? err] (protect (http-get "https://example.com/"))]]
+        (assert (not ok?) "https without tls signals error")
+        (assert (= err:reason :tls-not-configured)
+          "https without tls reports :tls-not-configured")))
+
+    # query-encode: scalars
+    (assert (= (query-encode {}) "")
+      "query-encode empty → empty string")
+    (assert (= (query-encode {:page 2}) "page=2")
+      "query-encode integer value")
+    (assert (= (query-encode {:q "hello world"}) "q=hello%20world")
+      "query-encode percent-encodes spaces")
+    (assert (= (query-encode {:flag true}) "flag=true")
+      "query-encode boolean true")
+    (assert (= (query-encode {:flag false}) "flag=false")
+      "query-encode boolean false")
+
+    # query-encode: keyword values render as bare strings (no colon)
+    (assert (= (query-encode {:sort :asc}) "sort=asc")
+      "query-encode keyword strips colon")
+
+    # query-encode: nil values are dropped
+    (assert (= (query-encode {:a 1 :b nil :c 3})
+               "a=1&c=3")
+      "query-encode omits nil values")
+
+    # query-encode: arrays/lists produce repeated keys
+    (assert (= (query-encode {:tag ["a" "b" "c"]})
+               "tag=a&tag=b&tag=c")
+      "query-encode repeats array values")
+
+    # query-encode: reserved characters in keys and values are encoded
+    (assert (= (query-encode {"a b" "c&d=e"}) "a%20b=c%26d%3De")
+      "query-encode encodes reserved characters in both keys and values")
+
+    # merge-query: struct merges with existing URL query
+    (assert (= (merge-query "fmt=json" {:page 2}) "fmt=json&page=2")
+      "merge-query appends struct to url query")
+    (assert (= (merge-query nil {:page 2}) "page=2")
+      "merge-query with nil url query")
+    (assert (= (merge-query "fmt=json" nil) "fmt=json")
+      "merge-query with nil extra keeps url query")
+    (assert (= (merge-query "fmt=json" "page=2") "fmt=json&page=2")
+      "merge-query accepts pre-encoded string")
+    (assert (nil? (merge-query nil nil))
+      "merge-query nil+nil is nil")
+
+    # strip-line-terminator: parity between tcp and tls transports.
+    # port/read-line strips newlines; tls:read-line does not; tls-transport
+    # reconciles them so wire-format helpers see a single semantics.
+    (assert (= (strip-line-terminator "hi\r\n") "hi") "strip-line-terminator CRLF")
+    (assert (= (strip-line-terminator "hi\n")   "hi") "strip-line-terminator LF")
+    (assert (= (strip-line-terminator "hi\r")   "hi") "strip-line-terminator CR")
+    (assert (= (strip-line-terminator "hi")     "hi") "strip-line-terminator no terminator")
+    (assert (= (strip-line-terminator "")       "")   "strip-line-terminator empty")
+    (assert (nil? (strip-line-terminator nil))        "strip-line-terminator nil passthrough")
+
+    # redirect-limit normalization
+    (assert (= (redirect-limit nil)   0)  "redirect-limit nil → 0")
+    (assert (= (redirect-limit false) 0)  "redirect-limit false → 0")
+    (assert (= (redirect-limit true)  (default-redirect-limit))
+      "redirect-limit true → default")
+    (assert (= (redirect-limit 3)     3)  "redirect-limit integer passthrough")
+    (let [[[ok? _] (protect (redirect-limit "bogus"))]]
+      (assert (not ok?) "redirect-limit rejects non-integer/non-bool"))
+
+    # resolve-location
+    (let [[base (parse-url "http://example.com/foo")]]
+      (assert (= (resolve-location base "https://other.com/bar")
+                 "https://other.com/bar")
+        "resolve-location absolute URL passthrough")
+      (assert (= (resolve-location base "//other.com/bar")
+                 "http://other.com/bar")
+        "resolve-location scheme-relative")
+      (assert (= (resolve-location base "/new/path")
+                 "http://example.com:80/new/path")
+        "resolve-location absolute path"))
+
+    # redirect-statuses / get-rewrite-statuses
+    (each s [301 302 303 307 308]
+      (assert (redirect-statuses s)
+        (string/format "status {} is a redirect" s)))
+    (assert (not (redirect-statuses 200))  "200 is not a redirect")
+    (assert (not (redirect-statuses 500))  "500 is not a redirect")
+    (each s [301 302 303]
+      (assert (get-rewrite-statuses s)
+        (string/format "status {} rewrites to GET" s)))
+    (each s [307 308]
+      (assert (not (get-rewrite-statuses s))
+        (string/format "status {} preserves method" s)))
+
+    # SSE: field parsing
+    (let [[f (sse-parse-field "event: update")]]
+      (assert (= f:field "event") "sse-parse-field event name"))
+    (let [[f (sse-parse-field "data: hello")]]
+      (assert (= f:value "hello")
+        "sse-parse-field eats one leading space on value"))
+    (let [[f (sse-parse-field "data:hello")]]
+      (assert (= f:value "hello")
+        "sse-parse-field no space is fine too"))
+    (assert (nil? (sse-parse-field ": comment"))
+      "sse-parse-field treats : prefix as comment")
+    (assert (nil? (sse-parse-field ""))
+      "sse-parse-field skips empty line")
+    (let [[f (sse-parse-field "field-no-colon")]]
+      (assert (= f:field "field-no-colon")
+        "sse-parse-field colonless line is field")
+      (assert (= f:value "")
+        "sse-parse-field colonless value is empty"))
+
+    # SSE: sse-handle-line dispatches events on blank lines
+    (let [[events @[]]
+          [state  @{:event-type nil :data-lines @[] :last-id nil :retry nil}]]
+      (defn collect [e] (push events e))
+      (sse-handle-line state "event: ping"    collect)
+      (sse-handle-line state "data: one"      collect)
+      (sse-handle-line state "data: two"      collect)
+      (sse-handle-line state "id: 42"         collect)
+      (sse-handle-line state ""               collect)   # dispatch
+      (sse-handle-line state "data: alone"    collect)
+      (sse-handle-line state ""               collect)   # dispatch (no event, inherits id)
+      (assert (= (length events) 2)        "sse-handle-line: 2 events")
+      (let [[e0 (get events 0)]]
+        (assert (= e0:event "ping")         "SSE event name")
+        (assert (= e0:data  "one\ntwo")     "SSE multi-line data joined")
+        (assert (= e0:id    "42")           "SSE id captured"))
+      (let [[e1 (get events 1)]]
+        (assert (= e1:event "message")      "SSE default event type")
+        (assert (= e1:id    "42")           "SSE id persists across events")))
+
+    # SSE: format-sse-event round-trips basics
+    (assert (= (format-sse-event {:event "message" :data "hi"})
+               "data: hi\n\n")
+      "format-sse-event default event skips 'event:' line")
+    (assert (= (format-sse-event {:event "tick" :data "1" :id "a"})
+               "event: tick\nid: a\ndata: 1\n\n")
+      "format-sse-event full frame")
+    (assert (= (format-sse-event {:data "line1\nline2"})
+               "data: line1\ndata: line2\n\n")
+      "format-sse-event splits multi-line data")
+    (assert (= (format-sse-event {:retry 5000})
+               "retry: 5000\n\n")
+      "format-sse-event retry-only event")
+
+    # SSE: parse + format round-trip
+    (let [[events @[]]
+          [state  @{:event-type nil :data-lines @[] :last-id nil :retry nil}]
+          [wire   (format-sse-event {:event "tick" :data "hello" :id "7"})]]
+      (each line in (string/split wire "\n")
+        (sse-handle-line state line (fn [e] (push events e))))
+      (assert (= (length events) 1) "SSE round-trip: one event")
+      (let [[e (get events 0)]]
+        (assert (= e:event "tick")   "SSE round-trip: event")
+        (assert (= e:data  "hello")  "SSE round-trip: data")
+        (assert (= e:id    "7")      "SSE round-trip: id")))
+
+    # SSE: sse-response builds a chunked streaming response
+    (let [[resp (sse-response (fn [send]
+                                (send {:data "first"})
+                                (send {:event "tick" :data "1"})))]]
+      (assert (= resp:status 200)
+        "sse-response: status 200")
+      (assert (= (get resp:headers :content-type) "text/event-stream")
+        "sse-response: content-type")
+      (assert (string/contains?
+                (string/lowercase (get resp:headers :transfer-encoding))
+                "chunked")
+        "sse-response: transfer-encoding chunked")
+      (assert (fn? resp:body) "sse-response: body is a closure"))
+
+    true)
+
+  ## ── Exports ─────────────────────────────────────────────────────────
+
+  {:parse-url         parse-url
+
+   # Header helpers
+   :header->kw        header->kw
+   :kw->header        kw->header
 
    # Response construction
-   :respond    http-respond
+   :respond           http-respond
+
+   # Query-string encoding
+   :query-encode     query-encode
+
+   # Chunked transfer encoding
+   :chunked?          chunked?
+   :write-chunk       write-chunk
+   :write-last-chunk  write-last-chunk
+
+   # Compress helpers (require :compress at module init)
+   :gzip              compress-gzip
+   :gunzip            compress-gunzip
+   :zlib              compress-zlib
+   :unzlib            compress-unzlib
+   :deflate           compress-deflate
+   :inflate           compress-inflate
+   :zstd              compress-zstd
+   :unzstd            compress-unzstd
+
+   # Transport helpers (for advanced users)
+   :tcp-transport     tcp-transport
+   :tls-transport     tls-transport
 
    # Client — one-shot
-   :get        http-get
-   :post       http-post
-   :request    http-request
+   :get               http-get
+   :post              http-post
+   :request           http-request
 
    # Client — keep-alive
-   :connect    http-connect
-   :send       http-send
-   :close      http-close
+   :connect           http-connect
+   :send              http-send
+   :close             http-close
 
    # Server
-   :serve      http-serve
+   :serve             http-serve
+
+   # Server-Sent Events
+   :sse-get           sse-get
+   :sse-response      sse-response
+   :format-sse-event  format-sse-event
 
    # Internal tests
-   :test       run-internal-tests})
+   :test              run-internal-tests})

--- a/prelude.lisp
+++ b/prelude.lisp
@@ -240,6 +240,11 @@
             (while (< idx len)
               (let ((,var (get pairs idx))) ,;body)
               (assign idx (+ idx 1)))))
+         (:fiber
+          (var v (coro/resume seq))
+          (while v
+            (let ((,var v)) ,;body)
+            (assign v (coro/resume seq))))
          (_ (error {:error :type-error :reason :not-a-sequence :message "not a sequence"}))))))
 
 ## case - equality dispatch (flat pairs)

--- a/tests/elle/http.lisp
+++ b/tests/elle/http.lisp
@@ -3,7 +3,7 @@
 # Tests the public API of lib/http.lisp. Internal wire-format helpers
 # are tested via (http:test) which runs sanity checks inside the module.
 
-(def http ((import-file "lib/http.lisp")))
+(def http ((import "std/http")))
 
 # ============================================================================
 # Internal wire-format sanity checks
@@ -45,20 +45,38 @@
   (assert (= u:path "/")        "path /")
   (assert (nil? u:query)         "no query"))
 
-# Error: non-http scheme
-(let [[[ok? err] (protect (http:parse-url "ftp://example.com/"))]]
-  (assert (not ok?)                        "ftp scheme signals error")
-  (assert (= (get err :error) :http-error) "ftp scheme is :http-error"))
-
 # Error: malformed (no scheme)
 (let [[[ok? err] (protect (http:parse-url "example.com/foo"))]]
   (assert (not ok?)                        "bare hostname signals error")
   (assert (= (get err :error) :http-error) "bare hostname is :http-error"))
 
-# Error: https not supported
-(let [[[ok? err] (protect (http:parse-url "https://example.com/"))]]
-  (assert (not ok?)                        "https signals error")
-  (assert (= (get err :error) :http-error) "https is :http-error"))
+# HTTPS: default port 443
+(let [[u (http:parse-url "https://example.com/")]]
+  (assert (= u:scheme "https")       "https scheme")
+  (assert (= u:host   "example.com") "https host")
+  (assert (= u:port   443)            "https default port 443")
+  (assert (= u:path   "/")            "https path"))
+
+# HTTPS: explicit port, path, query
+(let [[u (http:parse-url "https://api.example.com:8443/v1/items?limit=10")]]
+  (assert (= u:scheme "https")            "https scheme")
+  (assert (= u:host   "api.example.com")  "https host")
+  (assert (= u:port   8443)               "https explicit port")
+  (assert (= u:path   "/v1/items")        "https path")
+  (assert (= u:query  "limit=10")         "https query"))
+
+# HTTPS: no path defaults to /
+(let [[u (http:parse-url "https://example.com")]]
+  (assert (= u:port 443) "https no path: default port")
+  (assert (= u:path "/") "https no path: default /"))
+
+# Error: non-http/https scheme
+(let [[[ok? err] (protect (http:parse-url "ftp://example.com/"))]]
+  (assert (not ok?)                        "ftp scheme signals error")
+  (assert (= (get err :error) :http-error) "ftp scheme is :http-error"))
+(let [[[ok? err] (protect (http:parse-url "wss://example.com/"))]]
+  (assert (not ok?)                        "wss scheme signals error")
+  (assert (= (get err :error) :http-error) "wss scheme is :http-error"))
 
 # ============================================================================
 # Response construction (pure, no I/O)
@@ -82,6 +100,141 @@
 # Connection refused (nothing listening on port 1)
 (let [[[ok? _] (protect (http:get "http://127.0.0.1:1/"))]]
   (assert (not ok?) "http:get connection refused signals error"))
+
+# ============================================================================
+# TLS plugin integration — https requires :tls on module init
+# ============================================================================
+
+# Without :tls, https URLs must fail with a clear :tls-not-configured error.
+(let [[[ok? err] (protect (http:get "https://example.com/"))]]
+  (assert (not ok?)                           "https without :tls signals error")
+  (assert (= err:reason :tls-not-configured)
+    "https without :tls reports :tls-not-configured"))
+
+# With :tls, the module uses the supplied plugin. We use a fake plugin that
+# records calls so we can verify the wiring without pulling in real TLS.
+(def tls-log @[])
+(defn push-log [& args] (push tls-log args))
+
+(def fake-tls
+  {:connect   (fn [host port] (push-log :connect host port) :fake-conn)
+   :read      (fn [conn n]   (push-log :read conn n) nil)
+   :read-line (fn [conn]     (push-log :read-line conn) nil)
+   :write     (fn [conn data] (push-log :write conn data) (length data))
+   :close     (fn [conn]     (push-log :close conn))})
+
+(def https-http ((import "std/http") :tls fake-tls))
+
+# The fake TLS plugin returns nil from read-line, which the wire-format
+# code treats as EOF and surfaces as malformed input. That's fine — we
+# just want to confirm the TLS path is taken, not that the full handshake
+# succeeds.
+(let [[[ok? _] (protect (https-http:get "https://example.com/"))]]
+  (assert (not ok?) "https-http:get exits via TLS path"))
+
+(assert (= (first (first tls-log)) :connect)
+  "tls:connect was called via https URL")
+(assert (= (get (first tls-log) 1) "example.com")
+  "tls:connect received the https host")
+(assert (= (get (first tls-log) 2) 443)
+  "tls:connect received the default https port 443")
+
+# Parity: tls-transport's read-line must strip trailing newlines so the
+# wire-format helpers behave identically whether the underlying pipe is
+# TCP or TLS. We simulate a full HTTP/1.1 response from a TLS peer that
+# emits lines with CRLF intact (which is what the real tls:read-line
+# does), and verify the parser doesn't choke.
+
+(def canned-response
+  ["HTTP/1.1 200 OK\r\n"
+   "Content-Type: text/plain\r\n"
+   "Content-Length: 5\r\n"
+   "\r\n"])
+(def canned-cursor @[0])
+
+(defn canned-read-line [conn]
+  "Fake tls:read-line: returns the next response line with CRLF intact."
+  (let [[i (get canned-cursor 0)]]
+    (put canned-cursor 0 (inc i))
+    (when (< i (length canned-response))
+      (get canned-response i))))
+
+(def canned-body-cursor @[0])
+
+(defn canned-read [conn n]
+  "Fake tls:read: dribble out the body one chunk at a time."
+  (let [[i (get canned-body-cursor 0)]
+        [body "hello"]]
+    (when (< i (length body))
+      (let [[end (min (length body) (+ i n))]]
+        (put canned-body-cursor 0 end)
+        (bytes (slice body i end))))))
+
+(def line-strip-tls
+  {:connect   (fn [host port] :canned)
+   :read      canned-read
+   :read-line canned-read-line
+   :write     (fn [conn data] (length data))
+   :close     (fn [conn] nil)})
+
+(def line-strip-http ((import "std/http") :tls line-strip-tls))
+(let [[resp (line-strip-http:get "https://example.com/")]]
+  (assert (= resp:status 200)
+    "tls-transport: read-line stripping yields parseable status")
+  (assert (= resp:body "hello")
+    "tls-transport: full https response round-trips"))
+
+# ============================================================================
+# :compress — raw helpers exposed via http module
+# ============================================================================
+
+# Without :compress, http:gzip signals :compress-not-configured.
+(let [[[ok? err] (protect (http:gzip "hello"))]]
+  (assert (not ok?)                        "no :compress ⇒ http:gzip errors")
+  (assert (= err:reason :compress-not-configured)
+    "no :compress ⇒ :compress-not-configured reason"))
+
+# Fake compress plugin: just record calls and return a tagged value so
+# we don't depend on libz being present in the test environment.
+(def compress-log @[])
+(def fake-compress
+  {:gzip    (fn [data & opts] (push compress-log [:gzip data opts])    (bytes (string "GZ:" data)))
+   :gunzip  (fn [data]         (push compress-log [:gunzip data])       (bytes "ungz"))
+   :zlib    (fn [data & opts] (push compress-log [:zlib data opts])    (bytes (string "ZL:" data)))
+   :unzlib  (fn [data]         (push compress-log [:unzlib data])       (bytes "unzl"))
+   :deflate (fn [data & opts] (push compress-log [:deflate data opts]) (bytes (string "DF:" data)))
+   :inflate (fn [data]         (push compress-log [:inflate data])      (bytes "infl"))
+   :zstd    (fn [data & opts] (push compress-log [:zstd data opts])    (bytes (string "ZD:" data)))
+   :unzstd  (fn [data]         (push compress-log [:unzstd data])       (bytes "unzd"))})
+
+(def http-z ((import "std/http") :compress fake-compress))
+
+(assert (= (string (http-z:gzip "hi")) "GZ:hi")
+  ":compress struct ⇒ http:gzip dispatches to the plugin")
+(assert (= (string (http-z:gunzip (bytes "anything"))) "ungz")
+  ":compress struct ⇒ http:gunzip dispatches to the plugin")
+(assert (= (string (http-z:zstd "hi" 5)) "ZD:hi")
+  ":compress struct ⇒ http:zstd forwards level argument")
+(let [[gzip-call (first compress-log)]]
+  (assert (= (first gzip-call) :gzip)     "compress-log recorded :gzip call")
+  (assert (= (get gzip-call 1) "hi")      "compress-log recorded the data"))
+
+# :compress true ⇒ module imports std/compress itself. We can't easily
+# test libz presence, so just verify the path dispatches (not an error
+# from :compress-not-configured). Use protect so missing libz doesn't
+# break CI environments without zlib.
+(let [[http-auto ((import "std/http") :compress true)]]
+  (let [[[ok? err] (protect (http-auto:gunzip (bytes 0x1f 0x8b 0x08 0x00 0x00 0x00 0x00 0x00 0x00 0x03)))]]
+    # Either the call succeeded (libz available) or it errored — but NOT
+    # with :compress-not-configured.
+    (when (not ok?)
+      (assert (not (= err:reason :compress-not-configured))
+        ":compress true ⇒ module imported, not reporting compress-not-configured"))))
+
+# Invalid :compress value → clear error at module init
+(let [[[ok? err] (protect ((import "std/http") :compress 42))]]
+  (assert (not ok?)                    "invalid :compress signals error")
+  (assert (= err:reason :bad-compress) "invalid :compress reason"))
 
 # ============================================================================
 # Server + Client integration (local loopback)
@@ -117,7 +270,216 @@
               :headers {:x-test "custom-value"})]]
   (assert (= resp:status 200) "loopback custom header: status 200"))
 
+# Test 4: :query encodes a struct into the request path. Elle struct
+# iteration is key-sorted, so we assert on the sorted order the server
+# will actually receive.
+(let [[resp (http:get (string "http://127.0.0.1:" server-port "/search")
+              :query {:q "hello world" :page 2})]]
+  (assert (= resp:status 200) "query struct: status 200")
+  (assert (string/contains? resp:body "/search?page=2&q=hello%20world")
+    "query struct: encoded path echoed in body"))
+
+# Test 5: :query merges with existing URL query (URL first, struct after)
+(let [[resp (http:get (string "http://127.0.0.1:" server-port "/feed?fmt=json")
+              :query {:limit 10})]]
+  (assert (string/contains? resp:body "/feed?fmt=json&limit=10")
+    "query merge: url query retained, struct appended"))
+
 # Shut down: closing the listener cancels the pending accept, server exits
 (port/close listener)
+
+# ============================================================================
+# Chunked transfer integration: server streams response, client decodes
+# ============================================================================
+
+(def chunk-listener (tcp/listen "127.0.0.1" 0))
+(def chunk-port
+  (let [[parts (string/split (port/path chunk-listener) ":")]]
+    (int (get parts (- (length parts) 1)))))
+
+# Two handlers, dispatched on path:
+#  /string — body is a plain string, framed as a single chunk
+#  /stream — body is a closure that emits multiple chunks
+(defn chunked-handler [req]
+  (case req:path
+    "/string"
+    {:status 200
+     :headers {:content-type      "text/plain"
+               :transfer-encoding "chunked"}
+     :body "single-chunk body"}
+
+    "/stream"
+    {:status 200
+     :headers {:content-type      "text/plain"
+               :transfer-encoding "chunked"}
+     :body (fn [write]
+             (write "alpha ")
+             (write "beta ")
+             (write "gamma"))}
+
+    (http:respond 404 "not found")))
+
+(def chunk-fiber
+  (ev/spawn (fn [] (http:serve chunk-listener chunked-handler))))
+
+# Single-chunk body
+(let [[resp (http:get (string "http://127.0.0.1:" chunk-port "/string"))]]
+  (assert (= resp:status 200)               "chunked single: status 200")
+  (assert (= resp:body "single-chunk body") "chunked single: body reassembled")
+  (assert (= (string/lowercase (get resp:headers :transfer-encoding))
+             "chunked")
+    "chunked single: server sent Transfer-Encoding: chunked"))
+
+# Streamed multi-chunk body
+(let [[resp (http:get (string "http://127.0.0.1:" chunk-port "/stream"))]]
+  (assert (= resp:status 200)              "chunked stream: status 200")
+  (assert (= resp:body "alpha beta gamma") "chunked stream: chunks concatenated"))
+
+(port/close chunk-listener)
+
+# ============================================================================
+# Redirect following
+# ============================================================================
+
+(def redir-listener (tcp/listen "127.0.0.1" 0))
+(def redir-port
+  (let [[parts (string/split (port/path redir-listener) ":")]]
+    (int (get parts (- (length parts) 1)))))
+
+(def redir-count @[0])
+
+(defn redir-handler [req]
+  (put redir-count 0 (+ (get redir-count 0) 1))
+  (case req:path
+    # /hop1 → /hop2 (302, rewrites to GET)
+    "/hop1"
+    {:status 302
+     :headers {:location "/hop2" :content-length "0"}
+     :body ""}
+
+    # /hop2 → /hop3 (301, rewrites to GET)
+    "/hop2"
+    {:status 301
+     :headers {:location "/hop3" :content-length "0"}
+     :body ""}
+
+    # /hop3 → /end (307, preserves method/body)
+    "/hop3"
+    {:status 307
+     :headers {:location "/end" :content-length "0"}
+     :body ""}
+
+    # /end: terminal
+    "/end"
+    (http:respond 200 (string req:method " /end"))
+
+    # /loop → /loop (detect loop)
+    "/loop"
+    {:status 302
+     :headers {:location "/loop" :content-length "0"}
+     :body ""}
+
+    # /abs → absolute URL redirect to /end
+    "/abs"
+    {:status 302
+     :headers {:location (string "http://127.0.0.1:" redir-port "/end")
+               :content-length "0"}
+     :body ""}
+
+    (http:respond 404 "not found")))
+
+(def redir-fiber
+  (ev/spawn (fn [] (http:serve redir-listener redir-handler))))
+
+# No follow: redirect status is returned to caller
+(let [[resp (http:get (string "http://127.0.0.1:" redir-port "/hop1"))]]
+  (assert (= resp:status 302) "redirect: without :follow-redirects, returns 302"))
+
+# :follow-redirects true: follows all hops to 200
+(put redir-count 0 0)
+(let [[resp (http:get (string "http://127.0.0.1:" redir-port "/hop1")
+              :follow-redirects true)]]
+  (assert (= resp:status 200) "redirect: :follow-redirects true reaches 200")
+  (assert (= resp:body "GET /end") "redirect: method is GET after rewrite")
+  (assert (= (get redir-count 0) 4)
+    "redirect: server saw 4 requests (hop1, hop2, hop3, end)"))
+
+# :follow-redirects integer: limits hops
+(let [[resp (http:get (string "http://127.0.0.1:" redir-port "/hop1")
+              :follow-redirects 1)]]
+  (assert (= resp:status 301)
+    "redirect: hop limit 1 stops at the second redirect response"))
+
+# 307 preserves method on POST
+(let [[resp (http:post (string "http://127.0.0.1:" redir-port "/hop3")
+              "payload"
+              :follow-redirects true)]]
+  (assert (= resp:status 200) "redirect: 307 POST reaches end")
+  (assert (= resp:body "POST /end") "redirect: 307 preserves POST method"))
+
+# Loop detection: we bound hops, so a redirect loop terminates with
+# the last redirect response rather than hanging.
+(let [[resp (http:get (string "http://127.0.0.1:" redir-port "/loop")
+              :follow-redirects 3)]]
+  (assert (= resp:status 302) "redirect: loops stop at hop limit")
+  (assert (= (get resp:headers :location) "/loop")
+    "redirect: loop final response has the Location header"))
+
+# Absolute Location URL works
+(let [[resp (http:get (string "http://127.0.0.1:" redir-port "/abs")
+              :follow-redirects true)]]
+  (assert (= resp:status 200) "redirect: absolute Location URL followed")
+  (assert (= resp:body "GET /end") "redirect: absolute Location produced GET"))
+
+(port/close redir-listener)
+
+# ============================================================================
+# Server-Sent Events: server emits, client coroutine consumes
+# ============================================================================
+
+(def sse-listener (tcp/listen "127.0.0.1" 0))
+(def sse-server-port
+  (let [[parts (string/split (port/path sse-listener) ":")]]
+    (int (get parts (- (length parts) 1)))))
+
+(defn sse-test-handler [req]
+  (case req:path
+    "/stream"
+    (http:sse-response
+      (fn [send]
+        (send {:data "first"})
+        (send {:event "tick" :data "1" :id "a"})
+        (send {:event "tick" :data "2" :id "b"})
+        (send {:data "multi\nline"})))
+
+    "/retry-then-done"
+    (http:sse-response
+      (fn [send]
+        (send {:retry 50 :id "x"})
+        (send {:event "once" :data "hello" :id "x"})))
+
+    (http:respond 404 "not found")))
+
+(def sse-fiber
+  (ev/spawn (fn [] (http:serve sse-listener sse-test-handler))))
+
+# Basic stream: connect, consume all events, stop when stream ends.
+(let [[events @[]]
+      [source (http:sse-get
+                (string "http://127.0.0.1:" sse-server-port "/stream")
+                :reconnect false)]]
+  (each evt in source
+    (push events evt))
+  (assert (= (length events) 4) "sse: received all four events")
+  (let [[[e0 e1 e2 e3] events]]
+    (assert (= e0:event "message") "sse: first event defaults to 'message'")
+    (assert (= e0:data  "first")   "sse: first event data")
+    (assert (= e1:event "tick")    "sse: named event type")
+    (assert (= e1:id    "a")       "sse: id captured")
+    (assert (= e2:id    "b")       "sse: id advances")
+    (assert (= e3:data  "multi\nline")
+      "sse: multi-line data preserved as single payload")))
+
+(port/close sse-listener)
 
 (println "all http tests passed")

--- a/tests/elle/http.lisp
+++ b/tests/elle/http.lisp
@@ -458,6 +458,25 @@
         (send {:retry 50 :id "x"})
         (send {:event "once" :data "hello" :id "x"})))
 
+    # /echo-post: POST-only handler that streams back a synthetic
+    # chat-completion-style response, echoing the request body in the
+    # first event so the test can verify end-to-end delivery.
+    "/echo-post"
+    (if (= req:method "POST")
+      (http:sse-response
+        (fn [send]
+          (send {:event "meta" :data (string "ct=" (or (get req:headers :content-type) "none"))})
+          (send {:event "delta" :data (string "body=" (or req:body ""))})
+          (send {:event "delta" :data "token-1"})
+          (send {:event "delta" :data "token-2"})
+          (send {:event "done"  :data "[DONE]"})))
+      (http:respond 405 "method not allowed"))
+
+    # /bad-post: POST handler that rejects with 400 so we can verify
+    # sse-post's error surface.
+    "/bad-post"
+    (http:respond 400 "nope")
+
     (http:respond 404 "not found")))
 
 (def sse-fiber
@@ -479,6 +498,54 @@
     (assert (= e2:id    "b")       "sse: id advances")
     (assert (= e3:data  "multi\nline")
       "sse: multi-line data preserved as single payload")))
+
+# ============================================================================
+# sse-post: POST with body, consume streamed SSE response
+# ============================================================================
+
+# Happy path: POST a JSON body, expect events echoing the body.
+(let [[events @[]]
+      [source (http:sse-post
+                (string "http://127.0.0.1:" sse-server-port "/echo-post")
+                "{\"prompt\":\"hi\"}")]]
+  (each evt in source
+    (push events evt))
+  (assert (= (length events) 5) "sse-post: received all five events")
+  (let [[[meta body t1 t2 done] events]]
+    (assert (= meta:event "meta")               "sse-post: first event name")
+    (assert (string/contains? meta:data "json")
+      "sse-post: server saw Content-Type application/json by default")
+    (assert (= body:event "delta")              "sse-post: body echo event")
+    (assert (= body:data  "body={\"prompt\":\"hi\"}")
+      "sse-post: request body delivered to server intact")
+    (assert (= t1:data  "token-1")              "sse-post: token-1")
+    (assert (= t2:data  "token-2")              "sse-post: token-2")
+    (assert (= done:event "done")               "sse-post: terminal event")
+    (assert (= done:data  "[DONE]")
+      "sse-post: caller can detect OpenAI-style [DONE] sentinel")))
+
+# Custom headers on sse-post are merged into the request.
+(let [[events @[]]
+      [source (http:sse-post
+                (string "http://127.0.0.1:" sse-server-port "/echo-post")
+                "raw bytes"
+                :headers {:content-type "text/plain"})]]
+  (each evt in source
+    (push events evt))
+  (let [[meta (first events)]]
+    (assert (string/contains? meta:data "text/plain")
+      "sse-post: :headers override the default Content-Type")))
+
+# Error path: non-2xx response signals :sse-bad-status (coroutine body
+# errors during draining; the error surfaces to the each-loop driver).
+(let [[[ok? err] (protect
+                   (let [[source (http:sse-post
+                                   (string "http://127.0.0.1:" sse-server-port "/bad-post")
+                                   "ignored")]]
+                     (each _ in source nil)))]]
+  (assert (not ok?)                         "sse-post: non-2xx signals error")
+  (assert (= err:reason :sse-bad-status)    "sse-post: reason is :sse-bad-status")
+  (assert (= err:status 400)                "sse-post: reports server status"))
 
 (port/close sse-listener)
 

--- a/tests/elle/http.lisp
+++ b/tests/elle/http.lisp
@@ -219,17 +219,20 @@
   (assert (= (first gzip-call) :gzip)     "compress-log recorded :gzip call")
   (assert (= (get gzip-call 1) "hi")      "compress-log recorded the data"))
 
-# :compress true ⇒ module imports std/compress itself. We can't easily
-# test libz presence, so just verify the path dispatches (not an error
-# from :compress-not-configured). Use protect so missing libz doesn't
-# break CI environments without zlib.
-(let [[http-auto ((import "std/http") :compress true)]]
-  (let [[[ok? err] (protect (http-auto:gunzip (bytes 0x1f 0x8b 0x08 0x00 0x00 0x00 0x00 0x00 0x00 0x03)))]]
-    # Either the call succeeded (libz available) or it errored — but NOT
-    # with :compress-not-configured.
-    (when (not ok?)
-      (assert (not (= err:reason :compress-not-configured))
-        ":compress true ⇒ module imported, not reporting compress-not-configured"))))
+# :compress true ⇒ module imports std/compress itself. Only meaningful
+# when libz/libzstd are available — on macOS the FFI loader expects
+# libz.dylib, which lib/compress.lisp doesn't currently probe for.
+# Mirror the skip guard from tests/elle/compress.lisp.
+(let [[[libz-ok? _] (protect ((fn [] (ffi/native "libz.so"))))]
+      [[zstd-ok? _] (protect ((fn [] (ffi/native "libzstd.so"))))]]
+  (if (and libz-ok? zstd-ok?)
+    (let [[http-auto ((import "std/http") :compress true)]]
+      (let* [[data (bytes 0x1f 0x8b 0x08 0x00 0x00 0x00 0x00 0x00 0x00 0x03)]
+             [[ok? err] (protect (http-auto:gunzip data))]]
+        (when (not ok?)
+          (assert (not (= err:reason :compress-not-configured))
+            ":compress true ⇒ module imported, not reporting compress-not-configured"))))
+    (println "SKIP: :compress true test — libz/libzstd not available")))
 
 # Invalid :compress value → clear error at module init
 (let [[[ok? err] (protect ((import "std/http") :compress 42))]]

--- a/tests/elle/prelude.lisp
+++ b/tests/elle/prelude.lisp
@@ -205,3 +205,22 @@
       (assign n (+ n 1))
       (if (= n 3) (break :while :done))))])
   (assert (= result :done) "forever break value"))
+
+# ============================================================================
+# each — iterates coroutines (fibers)
+# ============================================================================
+
+# Drives a coroutine via coro/resume until it stops yielding.
+(let ([seen @[]])
+  (def co (coro/new (fn () (yield 10) (yield 20) (yield 30))))
+  (each x in co (push seen x))
+  (assert (= (length seen) 3) "each+fiber: yielded values consumed")
+  (assert (= (get seen 0) 10) "each+fiber: first value")
+  (assert (= (get seen 1) 20) "each+fiber: second value")
+  (assert (= (get seen 2) 30) "each+fiber: third value"))
+
+# Exhausted coroutine iterates zero times.
+(let ([calls @[0]])
+  (def co (coro/new (fn () nil)))  # body returns immediately, never yields
+  (each _ in co (put calls 0 (inc (get calls 0))))
+  (assert (= (get calls 0) 0) "each+fiber: empty coroutine invokes body zero times"))


### PR DESCRIPTION
- parse-url accepts https:// (default port 443) alongside http://
- Module is now parameterized: ((import "std/http") :tls plug :compress plug).
- Transport abstraction routes reads/writes through {:read :read-line :write :flush :close} closures, sharing the same wire-format helpers across TCP, TLS, and file ports. tls-transport strips trailing newlines to match port/read-line semantics.
- Chunked transfer: read-chunked-body reassembles; write-chunk / write-last-chunk emit. write-response streams when body is a closure.
- Client gains :query (struct or pre-encoded string, merged with URL's existing query) and :follow-redirects (nil/false, true → 10 hops, or an integer). 301/302/303 rewrite to GET, 307/308 preserve method and body.
- :compress exposes gzip/gunzip/zlib/unzlib/deflate/inflate/zstd/unzstd as raw helpers (no auto-negotiation). Accepts the compress module struct or literal true (http imports std/compress itself).
- Server-Sent Events: sse-get returns a coroutine yielding events with spec-compliant auto-reconnect (Last-Event-ID, :retry honored, 204 stops). sse-response wraps a body closure with text/event-stream + chunked. format-sse-event exposed for low-level composition.
- Exported kw->header for module consumers.
- each macro in prelude now iterates fibers (coroutines) via coro/resume until nil yield, plus a test.
- lib/AGENTS.md rewritten for the new module shape; docs/control.md notes the coroutine case of each.