### PR TITLE
Upgrade cranelift 0.116 → 0.130

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,7 +24,7 @@ version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59317f77929f0e679d39364702289274de2f0f0b22cbf50b2b8cff2169a0b27a"
 dependencies = [
- "gimli 0.33.0",
+ "gimli",
 ]
 
 [[package]]
@@ -1226,28 +1226,13 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.116.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e15d04a0ce86cb36ead88ad68cf693ffd6cda47052b9e0ac114bc47fd9cd23c4"
-dependencies = [
- "cranelift-entity 0.116.1",
-]
-
-[[package]]
-name = "cranelift-bforest"
 version = "0.130.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb6a4ab44c6b371e661846b97dab687387a60ac4e2f864e2d4257284aad9e889"
 dependencies = [
- "cranelift-entity 0.130.1",
+ "cranelift-entity",
  "wasmtime-internal-core",
 ]
-
-[[package]]
-name = "cranelift-bitset"
-version = "0.116.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c6e3969a7ce267259ce244b7867c5d3bc9e65b0a87e81039588dfdeaede9f34"
 
 [[package]]
 name = "cranelift-bitset"
@@ -1262,50 +1247,26 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.116.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c22032c4cb42558371cf516bb47f26cdad1819d3475c133e93c49f50ebf304e"
-dependencies = [
- "bumpalo",
- "cranelift-bforest 0.116.1",
- "cranelift-bitset 0.116.1",
- "cranelift-codegen-meta 0.116.1",
- "cranelift-codegen-shared 0.116.1",
- "cranelift-control 0.116.1",
- "cranelift-entity 0.116.1",
- "cranelift-isle 0.116.1",
- "gimli 0.31.1",
- "hashbrown 0.14.5",
- "log",
- "regalloc2 0.11.2",
- "rustc-hash",
- "serde",
- "smallvec",
- "target-lexicon",
-]
-
-[[package]]
-name = "cranelift-codegen"
 version = "0.130.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01b06598133b1dd76758b8b95f8d6747c124124aade50cea96a3d88b962da9fa"
 dependencies = [
  "bumpalo",
  "cranelift-assembler-x64",
- "cranelift-bforest 0.130.1",
- "cranelift-bitset 0.130.1",
- "cranelift-codegen-meta 0.130.1",
- "cranelift-codegen-shared 0.130.1",
- "cranelift-control 0.130.1",
- "cranelift-entity 0.130.1",
- "cranelift-isle 0.130.1",
- "gimli 0.33.0",
+ "cranelift-bforest",
+ "cranelift-bitset",
+ "cranelift-codegen-meta",
+ "cranelift-codegen-shared",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-isle",
+ "gimli",
  "hashbrown 0.16.1",
  "libm",
  "log",
  "postcard",
  "pulley-interpreter",
- "regalloc2 0.15.0",
+ "regalloc2",
  "rustc-hash",
  "serde",
  "serde_derive",
@@ -1317,21 +1278,12 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.116.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c904bc71c61b27fc57827f4a1379f29de64fe95653b620a3db77d59655eee0b8"
-dependencies = [
- "cranelift-codegen-shared 0.116.1",
-]
-
-[[package]]
-name = "cranelift-codegen-meta"
 version = "0.130.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6190e2e7bcf0a678da2f715363d34ed530fedf7a2f0ab75edaefef72a70465ff"
 dependencies = [
  "cranelift-assembler-x64-meta",
- "cranelift-codegen-shared 0.130.1",
+ "cranelift-codegen-shared",
  "cranelift-srcgen",
  "heck",
  "pulley-interpreter",
@@ -1339,24 +1291,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.116.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40180f5497572f644ce88c255480981ae2ec1d7bb4d8e0c0136a13b87a2f2ceb"
-
-[[package]]
-name = "cranelift-codegen-shared"
 version = "0.130.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f583cf203d1aa8b79560e3b01f929bdacf9070b015eec4ea9c46e22a3f83e4a0"
-
-[[package]]
-name = "cranelift-control"
-version = "0.116.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d132c6d0bd8a489563472afc171759da0707804a65ece7ceb15a8c6d7dd5ef"
-dependencies = [
- "arbitrary",
-]
 
 [[package]]
 name = "cranelift-control"
@@ -1369,35 +1306,14 @@ dependencies = [
 
 [[package]]
 name = "cranelift-entity"
-version = "0.116.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b2d0d9618275474fbf679dd018ac6e009acbd6ae6850f6a67be33fb3b00b323"
-dependencies = [
- "cranelift-bitset 0.116.1",
-]
-
-[[package]]
-name = "cranelift-entity"
 version = "0.130.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3109e417257082d88087f5bcce677525bdaa8322b88dd7f175ed1a1fd41d546c"
 dependencies = [
- "cranelift-bitset 0.130.1",
+ "cranelift-bitset",
  "serde",
  "serde_derive",
  "wasmtime-internal-core",
-]
-
-[[package]]
-name = "cranelift-frontend"
-version = "0.116.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fac41e16729107393174b0c9e3730fb072866100e1e64e80a1a963b2e484d57"
-dependencies = [
- "cranelift-codegen 0.116.1",
- "log",
- "smallvec",
- "target-lexicon",
 ]
 
 [[package]]
@@ -1406,17 +1322,11 @@ version = "0.130.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14db6b0e0e4994c581092df78d837be2072578f7cb2528f96a6cf895e56dee63"
 dependencies = [
- "cranelift-codegen 0.130.1",
+ "cranelift-codegen",
  "log",
  "smallvec",
  "target-lexicon",
 ]
-
-[[package]]
-name = "cranelift-isle"
-version = "0.116.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ca20d576e5070044d0a72a9effc2deacf4d6aa650403189d8ea50126483944d"
 
 [[package]]
 name = "cranelift-isle"
@@ -1426,44 +1336,33 @@ checksum = "ec66ea5025c7317383699778282ac98741d68444f956e3b1d7b62f12b7216e67"
 
 [[package]]
 name = "cranelift-jit"
-version = "0.116.1"
+version = "0.130.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e65c42755a719b09662b00c700daaf76cc35d5ace1f5c002ad404b591ff1978"
+checksum = "6bdd0bd399027467cc4da9c3906a82edec7c152630083473931589c4c6a204a6"
 dependencies = [
  "anyhow",
- "cranelift-codegen 0.116.1",
- "cranelift-control 0.116.1",
- "cranelift-entity 0.116.1",
+ "cranelift-codegen",
+ "cranelift-control",
+ "cranelift-entity",
  "cranelift-module",
- "cranelift-native 0.116.1",
+ "cranelift-native",
  "libc",
  "log",
  "region",
  "target-lexicon",
- "wasmtime-jit-icache-coherence",
- "windows-sys 0.59.0",
+ "wasmtime-internal-jit-icache-coherence",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "cranelift-module"
-version = "0.116.1"
+version = "0.130.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d55612bebcf16ff7306c8a6f5bdb6d45662b8aa1ee058ecce8807ad87db719b"
+checksum = "3ac54a8e9eea6444aae370d26eb8515bad89ff538d11d5c6f6c85ef1154ab253"
 dependencies = [
  "anyhow",
- "cranelift-codegen 0.116.1",
- "cranelift-control 0.116.1",
-]
-
-[[package]]
-name = "cranelift-native"
-version = "0.116.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8dee82f3f1f2c4cba9177f1cc5e350fe98764379bcd29340caa7b01f85076c7"
-dependencies = [
- "cranelift-codegen 0.116.1",
- "libc",
- "target-lexicon",
+ "cranelift-codegen",
+ "cranelift-control",
 ]
 
 [[package]]
@@ -1472,7 +1371,7 @@ version = "0.130.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "373ade56438e6232619d85678477d0a88a31b3581936e0503e61e96b546b0800"
 dependencies = [
- "cranelift-codegen 0.130.1",
+ "cranelift-codegen",
  "libc",
  "target-lexicon",
 ]
@@ -1849,11 +1748,11 @@ version = "1.0.0"
 dependencies = [
  "bumpalo",
  "camino",
- "cranelift-codegen 0.116.1",
- "cranelift-frontend 0.116.1",
+ "cranelift-codegen",
+ "cranelift-frontend",
  "cranelift-jit",
  "cranelift-module",
- "cranelift-native 0.116.1",
+ "cranelift-native",
  "criterion",
  "crossbeam-channel",
  "io-uring",
@@ -2253,12 +2152,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fallible-iterator"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
-
-[[package]]
 name = "fallible-streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2635,17 +2528,6 @@ checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
 dependencies = [
  "color_quant",
  "weezl",
-]
-
-[[package]]
-name = "gimli"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
-dependencies = [
- "fallible-iterator",
- "indexmap",
- "stable_deref_trait",
 ]
 
 [[package]]
@@ -5549,7 +5431,7 @@ version = "43.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "010dec3755eb61b2f1051ecb3611b718460b7a74c131e474de2af20a845938af"
 dependencies = [
- "cranelift-bitset 0.130.1",
+ "cranelift-bitset",
  "log",
  "pulley-macros",
  "wasmtime-internal-core",
@@ -5909,20 +5791,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "regalloc2"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc06e6b318142614e4a48bc725abbf08ff166694835c43c9dae5a9009704639a"
-dependencies = [
- "allocator-api2",
- "bumpalo",
- "hashbrown 0.15.5",
- "log",
- "rustc-hash",
- "smallvec",
 ]
 
 [[package]]
@@ -7670,7 +7538,7 @@ dependencies = [
  "encoding_rs",
  "futures",
  "fxprof-processed-profile",
- "gimli 0.33.0",
+ "gimli",
  "ittapi",
  "libc",
  "log",
@@ -7716,10 +7584,10 @@ checksum = "0b8b78abf3677d4a0a5db82e5015b4d085ff3a1b8b472cbb8c70d4b769f019ce"
 dependencies = [
  "anyhow",
  "cpp_demangle",
- "cranelift-bforest 0.130.1",
- "cranelift-bitset 0.130.1",
- "cranelift-entity 0.130.1",
- "gimli 0.33.0",
+ "cranelift-bforest",
+ "cranelift-bitset",
+ "cranelift-entity",
+ "gimli",
  "hashbrown 0.16.1",
  "indexmap",
  "log",
@@ -7799,12 +7667,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b3ca07b3e0bb3429674b173b5800577719d600774dd81bff58f775c0aaa64ee"
 dependencies = [
  "cfg-if",
- "cranelift-codegen 0.130.1",
- "cranelift-control 0.130.1",
- "cranelift-entity 0.130.1",
- "cranelift-frontend 0.130.1",
- "cranelift-native 0.130.1",
- "gimli 0.33.0",
+ "cranelift-codegen",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-frontend",
+ "cranelift-native",
+ "gimli",
  "itertools 0.14.0",
  "log",
  "object 0.38.1",
@@ -7865,7 +7733,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75eef0747e52dc545b075f64fd0e0cc237ae738e641266b1970e07e2d744bc32"
 dependencies = [
  "cfg-if",
- "cranelift-codegen 0.130.1",
+ "cranelift-codegen",
  "log",
  "object 0.38.1",
  "wasmtime-environ",
@@ -7888,8 +7756,8 @@ version = "43.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8007342bd12ff400293a817973f7ecd6f1d9a8549a53369a9c1af357166f1f1e"
 dependencies = [
- "cranelift-codegen 0.130.1",
- "gimli 0.33.0",
+ "cranelift-codegen",
+ "gimli",
  "log",
  "object 0.38.1",
  "target-lexicon",
@@ -7910,18 +7778,6 @@ dependencies = [
  "heck",
  "indexmap",
  "wit-parser 0.245.1",
-]
-
-[[package]]
-name = "wasmtime-jit-icache-coherence"
-version = "29.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec5e8552e01692e6c2e5293171704fed8abdec79d1a6995a0870ab190e5747d1"
-dependencies = [
- "anyhow",
- "cfg-if",
- "libc",
- "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8201,9 +8057,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb9f45f7172a2628c8317766e427babc0a400f9d10b1c0f0b0617c5ed5b79de6"
 dependencies = [
  "cranelift-assembler-x64",
- "cranelift-codegen 0.130.1",
- "gimli 0.33.0",
- "regalloc2 0.15.0",
+ "cranelift-codegen",
+ "gimli",
+ "regalloc2",
  "smallvec",
  "target-lexicon",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,11 +57,11 @@ path-clean = "1.0"
 pathdiff = { version = "0.2", features = ["camino"] }
 
 # JIT compilation
-cranelift-codegen = "0.116"
-cranelift-frontend = "0.116"
-cranelift-module = "0.116"
-cranelift-jit = "0.116"
-cranelift-native = "0.116"
+cranelift-codegen = "0.130"
+cranelift-frontend = "0.130"
+cranelift-module = "0.130"
+cranelift-jit = "0.130"
+cranelift-native = "0.130"
 target-lexicon = "0.13"
 
 # WASM backend (optional, enable with --features wasm)

--- a/src/jit/compiler.rs
+++ b/src/jit/compiler.rs
@@ -8,10 +8,12 @@ use std::sync::Arc;
 
 use cranelift_codegen::ir::condcodes::IntCC;
 use cranelift_codegen::ir::types::I64;
-use cranelift_codegen::ir::{AbiParam, Function, InstBuilder, MemFlags, Signature, UserFuncName};
+use cranelift_codegen::ir::{
+    AbiParam, BlockArg, Function, InstBuilder, MemFlags, Signature, UserFuncName,
+};
 use cranelift_codegen::isa::CallConv;
 use cranelift_codegen::settings::{self, Configurable};
-use cranelift_frontend::{FunctionBuilder, FunctionBuilderContext, Variable};
+use cranelift_frontend::{FunctionBuilder, FunctionBuilderContext};
 use cranelift_jit::{JITBuilder, JITModule};
 use cranelift_module::{FuncId, Linkage, Module};
 
@@ -23,12 +25,6 @@ use super::code::JitCode;
 use super::translate::FunctionTranslator;
 use super::vtable::{self, RuntimeHelpers};
 use super::JitError;
-
-/// Helper to create a Variable from a register/slot index
-#[inline]
-fn var(n: u32) -> Variable {
-    Variable::from_u32(n)
-}
 
 /// A member of a compilation group (SCC) for batch JIT compilation.
 pub struct BatchMember<'a> {
@@ -410,9 +406,11 @@ impl JitCompiler {
             std::cmp::max(lir.num_regs + lir.num_locals as u32, lir.num_locals as u32),
             local_var_base + num_locally_defined,
         );
-        // Declare 2 * max_logical Cranelift variables (tag + payload per slot)
-        for i in 0..(2 * max_logical) {
-            builder.declare_var(var(i), I64);
+        // Declare 2 * max_logical Cranelift variables (tag + payload per slot).
+        // declare_var allocates sequentially from 0, so the returned Variable
+        // indices match our var(i) scheme.
+        for _ in 0..(2 * max_logical) {
+            builder.declare_var(I64);
         }
         translator.arg_var_base = arg_var_base;
         translator.local_var_base = local_var_base;
@@ -506,7 +504,10 @@ impl JitCompiler {
                         builder
                             .ins()
                             .load(I64, MemFlags::trusted(), args_ptr, payload_offset);
-                    builder.ins().jump(merge_block, &[arg_tag, arg_payload]);
+                    builder.ins().jump(
+                        merge_block,
+                        &[BlockArg::Value(arg_tag), BlockArg::Value(arg_payload)],
+                    );
 
                     builder.switch_to_block(else_block);
                     builder.seal_block(else_block);
@@ -514,7 +515,10 @@ impl JitCompiler {
                         .ins()
                         .iconst(I64, crate::value::Value::NIL.tag as i64);
                     let nil_pay = builder.ins().iconst(I64, 0);
-                    builder.ins().jump(merge_block, &[nil_tag, nil_pay]);
+                    builder.ins().jump(
+                        merge_block,
+                        &[BlockArg::Value(nil_tag), BlockArg::Value(nil_pay)],
+                    );
 
                     builder.switch_to_block(merge_block);
                     builder.seal_block(merge_block);
@@ -550,9 +554,14 @@ impl JitCompiler {
             let cons_loop_body = builder.create_block();
             let cons_loop_exit = builder.create_block();
 
-            builder
-                .ins()
-                .jump(cons_loop_head, &[initial_i, empty_tag, empty_pay]);
+            builder.ins().jump(
+                cons_loop_head,
+                &[
+                    BlockArg::Value(initial_i),
+                    BlockArg::Value(empty_tag),
+                    BlockArg::Value(empty_pay),
+                ],
+            );
 
             // loop_head(i, acc_tag, acc_payload)
             builder.switch_to_block(cons_loop_head);
@@ -568,9 +577,16 @@ impl JitCompiler {
             builder.ins().brif(
                 cmp,
                 cons_loop_body,
-                &[i_param, acc_tag_param, acc_pay_param],
+                &[
+                    BlockArg::Value(i_param),
+                    BlockArg::Value(acc_tag_param),
+                    BlockArg::Value(acc_pay_param),
+                ],
                 cons_loop_exit,
-                &[acc_tag_param, acc_pay_param],
+                &[
+                    BlockArg::Value(acc_tag_param),
+                    BlockArg::Value(acc_pay_param),
+                ],
             );
 
             // loop_body(i, acc_tag, acc_payload)
@@ -596,9 +612,14 @@ impl JitCompiler {
             let new_acc_tag = builder.inst_results(call_inst)[0];
             let new_acc_pay = builder.inst_results(call_inst)[1];
             let new_i = builder.ins().isub(i_body, one);
-            builder
-                .ins()
-                .jump(cons_loop_head, &[new_i, new_acc_tag, new_acc_pay]);
+            builder.ins().jump(
+                cons_loop_head,
+                &[
+                    BlockArg::Value(new_i),
+                    BlockArg::Value(new_acc_tag),
+                    BlockArg::Value(new_acc_pay),
+                ],
+            );
 
             // loop_exit(acc_tag, acc_payload)
             builder.switch_to_block(cons_loop_exit);
@@ -660,7 +681,10 @@ impl JitCompiler {
                         builder
                             .ins()
                             .load(I64, MemFlags::trusted(), args_ptr, payload_offset);
-                    builder.ins().jump(merge_block, &[arg_tag, arg_payload]);
+                    builder.ins().jump(
+                        merge_block,
+                        &[BlockArg::Value(arg_tag), BlockArg::Value(arg_payload)],
+                    );
 
                     // else: nil
                     builder.switch_to_block(else_block);
@@ -669,7 +693,10 @@ impl JitCompiler {
                         .ins()
                         .iconst(I64, crate::value::Value::NIL.tag as i64);
                     let nil_pay = builder.ins().iconst(I64, 0);
-                    builder.ins().jump(merge_block, &[nil_tag, nil_pay]);
+                    builder.ins().jump(
+                        merge_block,
+                        &[BlockArg::Value(nil_tag), BlockArg::Value(nil_pay)],
+                    );
 
                     // merge
                     builder.switch_to_block(merge_block);

--- a/src/jit/fastpath.rs
+++ b/src/jit/fastpath.rs
@@ -14,7 +14,7 @@
 
 use cranelift_codegen::ir::condcodes::IntCC;
 use cranelift_codegen::ir::types::I64;
-use cranelift_codegen::ir::InstBuilder;
+use cranelift_codegen::ir::{BlockArg, InstBuilder};
 use cranelift_frontend::FunctionBuilder;
 use cranelift_jit::JITModule;
 use cranelift_module::{FuncId, Module};
@@ -138,7 +138,10 @@ pub(crate) fn emit_int_binop_fast_path(
             (tag, raw)
         }
     };
-    builder.ins().jump(merge_block, &[fast_tag, fast_payload]);
+    builder.ins().jump(
+        merge_block,
+        &[BlockArg::Value(fast_tag), BlockArg::Value(fast_payload)],
+    );
 
     // Slow block: call runtime helper
     builder.switch_to_block(slow_block);
@@ -150,7 +153,10 @@ pub(crate) fn emit_int_binop_fast_path(
         .call(func_ref, &[lhs_tag, lhs_payload, rhs_tag, rhs_payload]);
     let slow_tag = builder.inst_results(call)[0];
     let slow_payload = builder.inst_results(call)[1];
-    builder.ins().jump(merge_block, &[slow_tag, slow_payload]);
+    builder.ins().jump(
+        merge_block,
+        &[BlockArg::Value(slow_tag), BlockArg::Value(slow_payload)],
+    );
 
     // Merge block
     builder.switch_to_block(merge_block);
@@ -238,7 +244,10 @@ pub(crate) fn emit_int_cmpop_fast_path(
             builder.ins().select(cmp, tag_true, tag_false)
         }
     };
-    builder.ins().jump(merge_block, &[fast_tag, zero_payload]);
+    builder.ins().jump(
+        merge_block,
+        &[BlockArg::Value(fast_tag), BlockArg::Value(zero_payload)],
+    );
 
     // Slow block: call runtime helper
     builder.switch_to_block(slow_block);
@@ -250,7 +259,10 @@ pub(crate) fn emit_int_cmpop_fast_path(
         .call(func_ref, &[lhs_tag, lhs_payload, rhs_tag, rhs_payload]);
     let slow_tag = builder.inst_results(call)[0];
     let slow_payload = builder.inst_results(call)[1];
-    builder.ins().jump(merge_block, &[slow_tag, slow_payload]);
+    builder.ins().jump(
+        merge_block,
+        &[BlockArg::Value(slow_tag), BlockArg::Value(slow_payload)],
+    );
 
     builder.switch_to_block(merge_block);
     builder.seal_block(merge_block);
@@ -324,7 +336,10 @@ pub(crate) fn emit_unary_fast_path(
                 }
                 UnaryOp::Not => unreachable!(),
             };
-            builder.ins().jump(merge_block, &[fast_tag, fast_payload]);
+            builder.ins().jump(
+                merge_block,
+                &[BlockArg::Value(fast_tag), BlockArg::Value(fast_payload)],
+            );
 
             builder.switch_to_block(slow_block);
             builder.seal_block(slow_block);
@@ -333,7 +348,10 @@ pub(crate) fn emit_unary_fast_path(
             let call = builder.ins().call(func_ref, &[src_tag, src_payload]);
             let slow_tag = builder.inst_results(call)[0];
             let slow_payload = builder.inst_results(call)[1];
-            builder.ins().jump(merge_block, &[slow_tag, slow_payload]);
+            builder.ins().jump(
+                merge_block,
+                &[BlockArg::Value(slow_tag), BlockArg::Value(slow_payload)],
+            );
 
             builder.switch_to_block(merge_block);
             builder.seal_block(merge_block);


### PR DESCRIPTION
wasmtime 43 already pulled in cranelift 0.130.1 transitively, so the workspace carried two copies. Bumping the direct deps dedupes to one.

API adjustments in src/jit/:
- declare_var(Variable, Type) → declare_var(Type) -> Variable. Sequential auto-allocation matches the existing var(i) index scheme, so the per-register/slot mapping is preserved.
- jump/brif block args switched from &[Value] to &[BlockArg]; Values are wrapped via BlockArg::Value at the call sites.