### PR TITLE
Add eval tool: monadic bind over persistent Elle image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all elle dev plugins docs docgen smoke test plugin-tests test-git test-mcp check-plugin-list clean help \
+.PHONY: all elle dev plugins docs docgen smoke test plugin-tests test-git test-mcp mcp check-plugin-list clean help \
        smoke-vm smoke-jit smoke-wasm plugin-tests-vm plugin-tests-jit doctest
 
 .DEFAULT_GOAL := all
@@ -151,16 +151,11 @@ test-git:  ## Run git plugin integration tests (requires git, no network)
 	cargo build $(CARGO_PROFILE) -p elle -p elle-git
 	$(ELLE) tests/git.lisp
 
-test-mcp:  ## Run the MCP server integration test
-	@echo "=== MCP server integration test ==="
-	@# elle and its plugins MUST be built in a SINGLE cargo invocation so
-	@# that cargo's feature resolver produces one shared compilation of
-	@# the elle crate. Building them in separate `cargo build -p X` calls
-	@# yields two `libelle-*.rlib` artifacts with different HeapObject
-	@# layouts; the plugin's `Value::native_fn` values then deref as
-	@# garbage `LibHandle` in the main binary and calls fail with
-	@# `type-error: Cannot call <heap:...>`. See CONTRIBUTING.md.
+mcp:  ## Build elle + MCP plugins (oxigraph, syn)
 	cargo build $(CARGO_PROFILE) -p elle -p elle-oxigraph -p elle-syn
+
+test-mcp: mcp  ## Run the MCP server integration test
+	@echo "=== MCP server integration test ==="
 	@$(ELLE) tools/test-mcp.lisp $(ELLE) \
 		|| { echo "FAILED: MCP server integration test"; exit 1; }
 

--- a/docs/libraries.md
+++ b/docs/libraries.md
@@ -28,7 +28,7 @@ pattern and are imported via `(import "std/<name>")`.
 |--------|--------|-------------|
 | portrait | `(import "std/portrait")` | Semantic portraits from compile/analyze: signal profiles, phases, composition |
 | contract | `(import "std/contract")` | Compositional validation for function boundaries |
-| rdf | `(import "std/rdf")` | RDF triple generation for the Elle knowledge graph |
+| rdf | `(import "std/rdf/elle")` | RDF triple generation for the Elle knowledge graph |
 
 ## Observability
 

--- a/docs/mcp-eval.md
+++ b/docs/mcp-eval.md
@@ -1,0 +1,229 @@
+# MCP `eval` tool
+
+The `eval` tool collapses the MCP surface to a single verb: a monadic bind
+over a persistent Elle image held in the server. Every call submits a
+lambda and a list of input handles, the server applies the lambda to the
+values behind those handles, and returns a new handle for the result plus
+any captured I/O and metrics.
+
+This document is the contract. Tests in [`tools/test-mcp-eval.lisp`](../tools/test-mcp-eval.lisp) verify it.
+
+## Why one verb
+
+The existing tools (`portrait`, `impact`, `trace`, `signal_query`, etc.) are
+useful, but 20 named tools is a menu agents have to memorize. `eval` lets
+them be expressed as *well-known lambdas* the agent composes against the
+image, the same way they would in the REPL:
+
+```
+(portrait (analyze "lib/http.lisp") :request)
+```
+
+Nothing about that expression needs a bespoke tool. The agent writes the
+Elle, submits it through `eval`, and gets back a UUID naming the result.
+Subsequent calls compose against that UUID.
+
+Large values (a 1M-row SPARQL result, a compiled analysis, a huge string)
+never cross the JSON-RPC wire. They live in the image behind a handle and
+the agent probes them by submitting more lambdas.
+
+## Request schema
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 42,
+  "method": "tools/call",
+  "params": {
+    "name": "eval",
+    "arguments": {
+      "lambda":  "(fn [prev] (take 10 prev))",
+      "inputs":  ["01JFH...", "01JFK..."],
+      "timeout_ms": 5000
+    }
+  }
+}
+```
+
+**`lambda`** (string, required) — Elle source text. Must read as a single
+expression that evaluates to a callable. Typical shapes:
+
+- `(fn [prev] ...)` — unary, consumes one input handle
+- `(fn [] (... compute from scratch ...))` — nullary
+- `(fn [a b c] ...)` — n-ary; arity must match `(length inputs)`
+- `(fn [& args] ...)` — rest-arg form; `args` is the list of input values
+
+**`inputs`** (array of strings, optional; default `[]`) — handles produced
+by prior `eval` calls. Resolved positionally and passed as arguments to
+the lambda. An unknown handle returns a structured error before the
+lambda runs.
+
+**`timeout_ms`** (integer, optional; default `10000`) — wall-clock limit.
+If the lambda has not returned by this deadline, it is cancelled, stdout
+captured so far is returned, and the result is an error handle with
+`:reason :timeout`. Zero or negative disables the timeout.
+
+## Response schema
+
+`tools/call` always returns a JSON-RPC success envelope. The tool's own
+success/failure lives inside `content[0].text` as a JSON document with
+this shape:
+
+```json
+{
+  "ok":           true,
+  "handle":       "01JFH8K2CQZ...",
+  "kind":         ":map",
+  "shape":        {"count": 10, "keys_sample": [":name", ":file"]},
+  "stdout":       "hello\n",
+  "stderr":       "",
+  "duration_ns":  123456,
+  "fibers":       []
+}
+```
+
+| Field | Meaning |
+|-------|---------|
+| `ok` | `true` if the lambda returned normally, `false` if it threw (handle still valid — names the error value) |
+| `handle` | ULID/UUID addressing the result value in the image |
+| `kind` | Top-level type of the result as a keyword string — `:int`, `:string`, `:list`, `:map`, `:struct`, `:closure`, `:error`, `:nil`, `:fiber`, etc. Enough to decide the next probe lambda |
+| `shape` | Cheap structural hint: for collections, `count` and a sample; for structs, the trait name; for errors, `:reason`. Never ships the value itself |
+| `stdout` | Captured `*stdout*` output produced during the eval |
+| `stderr` | Captured `*stderr*` output |
+| `duration_ns` | Wall-clock nanoseconds the lambda ran (excluding handle bookkeeping) |
+| `fibers` | Handles of fibers the lambda spawned but did not join. Each is itself a valid handle to an image value (`:kind :fiber`) |
+
+On protocol-level errors (malformed JSON, unknown handle, lambda that
+fails to parse) the tool returns `isError: true` content with a
+structured message. The `ok: false` path is reserved for *the lambda
+itself threw* — which is not a protocol error, just a value the agent
+may want to inspect.
+
+## Handle semantics
+
+- Handles are ULIDs (sortable, URL-safe, 26 chars). They address entries
+  in a process-local handle table mapping `ULID → Value`.
+- Handles are stable for the lifetime of the server process. A handle
+  from five minutes ago is still valid if nothing has evicted it.
+- MVP retention: nothing is evicted. Every eval adds an entry. This is
+  acceptable for an interactive agent session; a future `pin`/`unpin` +
+  LRU will land when memory pressure becomes a concern.
+- A handle names exactly one Elle value. That value may be shared
+  structurally with other handles — the image does not copy on bind.
+- `:kind :error` handles carry a struct with at least `:reason`
+  (keyword), `:message` (string), `:caret` (string; source context when
+  available). Further fields may include `:locals` (map), `:fiber-mask`
+  (set), `:source-location` (string).
+
+## I/O rebinding
+
+Inside the lambda, `*stdout*`, `*stderr*`, and `*stdin*` are rebound via
+`parameterize` to in-memory byte buffers:
+
+- Writes to `*stdout*` / `*stderr*` accumulate in buffers; their contents
+  ship back as the `stdout` / `stderr` fields.
+- `*stdin*` is bound to an empty port; reads return `nil` (EOF)
+  immediately. Interactive input is out of scope.
+
+This means `println`, `eprintln`, `print`, `(io/write *stdout* ...)` all
+"just work" — the agent does not need to redirect anything manually. The
+server's own JSON-RPC stdio (saved at server startup) is unaffected; the
+response envelope still ships on the real stdout.
+
+## Capabilities
+
+MVP: the lambda inherits the server's full capabilities (FS, exec,
+network, FFI). This matches every existing tool — e.g. `verify_invariants`
+already evals user-supplied code with full privileges, `test_run` shells
+out.
+
+Future (tracked as a risk, not required for MVP): accept a `deny` mask in
+the request, spawn the lambda in a child fiber with `fiber/new body mask
+:deny ...`, and surface `:capability-denied` signals as structured errors.
+This is the general-purpose sandbox form of eval.
+
+## Fibers
+
+A lambda may spawn fibers with `fiber/new`, `ev/spawn`, etc. When the
+top-level lambda returns:
+
+- Fibers that have completed are forgotten.
+- Fibers still runnable or paused are captured as handles (each handle
+  names the fiber object, `:kind :fiber`). They continue to run in the
+  server's scheduler.
+- The agent can submit further lambdas against those fiber handles —
+  e.g. `(fn [f] (fiber/status f))`, `(fn [f] (fiber/join f))`,
+  `(fn [f] (fiber/cancel f))`.
+
+The `fibers` field in the response is in creation order. It is the agent's
+responsibility to track or cancel them; the server does not garbage-collect
+live fibers.
+
+## Errors
+
+Three error tiers, each surfaced differently:
+
+1. **Protocol error** — malformed JSON-RPC, unknown tool name,
+   unparseable lambda, unknown input handle, arity mismatch, lambda did
+   not evaluate to a callable. Returned as JSON-RPC `isError: true`
+   content with `{:error <keyword> :message <string>}`. No handle is
+   created.
+
+2. **Lambda threw** — the lambda ran and raised. Returned as `ok: false`
+   with a valid `handle` naming the error struct. `kind` is `:error`.
+   The agent inspects via further eval, e.g.
+   `(fn [e] (get e :caret))`.
+
+3. **Timeout** — the lambda was still running when `timeout_ms` elapsed.
+   The fiber is cancelled, captured output up to that point is returned,
+   and a synthetic error handle is created with `:reason :timeout`.
+
+All three tiers preserve captured `stdout` / `stderr` up to the point of
+failure. Partial output is diagnostically valuable.
+
+## Example session
+
+```
+# Submit nullary lambda, get a handle to a SPARQL result
+eval(lambda="(fn [] (ox:query store \"SELECT ?name WHERE { ?p a <urn:elle:Fn> ; <urn:elle:name> ?name }\"))")
+  -> {ok:true, handle:"01JFH...A", kind:":list", shape:{count: 3412}}
+
+# Probe the shape without shipping the list
+eval(lambda="(fn [rows] (take 3 rows))", inputs:["01JFH...A"])
+  -> {ok:true, handle:"01JFH...B", kind:":list", shape:{count: 3},
+      stdout:"",...}
+
+# Render the sample as text, ship it
+eval(lambda="(fn [sample] (string/join (map json/serialize sample) \"\\n\"))",
+     inputs:["01JFH...B"])
+  -> {ok:true, handle:"01JFH...C", kind:":string", shape:{bytes: 184}}
+
+# Actually read the string (small enough to ship)
+eval(lambda="(fn [s] s)", inputs:["01JFH...C"])
+  -> {ok:true, handle:"01JFH...D", kind:":string", shape:{bytes: 184},
+      stdout:"...",...}
+```
+
+## Non-goals (MVP)
+
+- **Cross-session handle persistence.** Handles live only for the server
+  process. Reconnect loses the image. Persistence to disk (pinning +
+  serializing values) is deferred.
+- **Pure-lambda memoization.** Submitting the same lambda + inputs twice
+  creates two handles today. Deduping on `(lambda-hash, input-uuids)`
+  when the lambda is signal-pure is a future optimization.
+- **Multi-client isolation.** One image per server process. Two clients
+  share the handle table. Per-client namespaces are deferred.
+- **Shipping the value directly.** The response never serializes the
+  result value — only `kind` and `shape`. If the agent wants the value,
+  they `eval` a projection lambda that returns something JSON-shaped and
+  read `stdout` or embed a `println`.
+
+## Supersedes
+
+Everything the existing 20 tools expose can be called from inside an eval
+lambda (they're already Elle functions: `compile/analyze`,
+`portrait-lib:render`, `ox:query`, etc.). The specialized tools remain
+for now to avoid breaking clients — they are essentially cached wrappers.
+The long-term direction is to phase them out in favor of eval +
+well-known lambdas.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -11,8 +11,9 @@ to an Elle codebase. The server is itself written in Elle
 
 The server maintains a persistent RDF knowledge graph (via the oxigraph
 plugin) that represents the structure of both Elle and Rust source code.
-It exposes 20 tools that let an AI agent query, analyze, refactor
-code through the graph, and orchestrate test runs with result tracking.
+It exposes 21 tools that let an AI agent query, analyze, evaluate,
+refactor code through the graph, and orchestrate test runs with result
+tracking.
 
 ## Tools
 
@@ -42,6 +43,12 @@ code through the graph, and orchestrate test runs with result tracking.
 | `compile_rename` | Binding-aware rename of a function or variable and all its references. Understands lexical scope — won't rename shadowed bindings. |
 | `compile_extract` | Extract a line range into a new function. Computes free variables (which become parameters) and infers the extracted function's signal. |
 | `compile_parallelize` | Check if a set of functions can safely run in parallel. Verifies no shared mutable captures. |
+
+### Evaluation
+
+| Tool | Description |
+|------|-------------|
+| `eval` | Evaluate an Elle lambda against the persistent image. Returns a handle (UUID) naming the result — large values stay in the image. Compose by passing prior handles as `inputs`. stdout/stderr are captured and returned. Optional `timeout_ms` (default 10000). |
 
 ### Cross-language tracing
 
@@ -127,9 +134,12 @@ HAVING (?captures > 1)
 | `rust:Type` | `rust:name`, `rust:file`, `rust:visibility`, `rust:attribute` |
 | `rust:Mod` | `rust:name`, `rust:file`, `rust:visibility`, `rust:attribute` |
 
-## Running the server
+## Building and running
 
 ```bash
+# Build elle + MCP plugins (oxigraph, syn) in one invocation
+make mcp
+
 # Default store location: .elle-mcp/store/ (auto-created)
 elle tools/mcp-server.lisp
 
@@ -145,10 +155,13 @@ The `.elle-mcp/` directory is gitignored by default.
 
 ## Startup behavior
 
-The server responds to `initialize` immediately. Graph population (Elle
-primitives, Rust function triples) runs in a background fiber so the
-server can handle requests while the graph loads. This keeps MCP client
-connection timeouts from firing on large codebases.
+Elle primitive triples are loaded synchronously at startup (fast).
+Rust function triples load in a background fiber so the server can
+handle requests while the graph loads. This keeps MCP client connection
+timeouts from firing on large codebases.
+
+SPARQL queries sent via `sparql_query` have a 30-second timeout.
+Lines longer than 10 MB on stdin are rejected with a `-32600` error.
 
 When population completes, the server emits a JSON-RPC notification:
 
@@ -413,7 +426,7 @@ Results are stored as RDF triples:
     elle:passed true ;
     elle:duration 32 ;
     elle:timestamp "2026-04-15T..." ;
-    elle:failing-tests () ;
+    elle:failed-count 0 ;
     elle:stderr "" .
 ```
 
@@ -468,7 +481,8 @@ and code understanding.
 |------|---------|
 | [`tools/elle-graph.lisp`](../tools/elle-graph.lisp) | Extract RDF triples from Elle source files |
 | [`tools/rust-graph.lisp`](../tools/rust-graph.lisp) | Extract RDF triples from Rust source files via syn plugin |
-| [`tools/rust-rdf-lib.lisp`](../tools/rust-rdf-lib.lisp) | Shared library for Rust→RDF extraction |
+| [`lib/rdf/elle.lisp`](../lib/rdf/elle.lisp) | Elle→RDF triple generation (`std/rdf/elle`) |
+| [`lib/rdf/rust.lisp`](../lib/rdf/rust.lisp) | Rust→RDF triple generation (`std/rdf/rust`) |
 | [`tools/load-all.lisp`](../tools/load-all.lisp) | Extract both graphs and load into the store |
 | [`tools/demo-queries.lisp`](../tools/demo-queries.lisp) | Example SPARQL queries |
 | [`tools/test-mcp.lisp`](../tools/test-mcp.lisp) | Smoke test: spawns server, exercises all tools |

--- a/docs/stdlib.md
+++ b/docs/stdlib.md
@@ -22,7 +22,7 @@ a closure returning a struct.
 | mqtt | `(import "std/mqtt")` | MQTT client wrapper |
 | portrait | `(import "std/portrait")` | Semantic portraits |
 | process | `(import "std/process")` | Erlang-style processes |
-| rdf | `(import "std/rdf")` | RDF knowledge graph |
+| rdf | `(import "std/rdf/elle")` | RDF knowledge graph |
 | redis | `(import "std/redis")` | Redis client |
 | sync | `(import "std/sync")` | Synchronization primitives |
 | telemetry | `(import "std/telemetry")` | Tracing and metrics |

--- a/lib/rdf/elle.lisp
+++ b/lib/rdf/elle.lisp
@@ -1,4 +1,4 @@
-## lib/rdf.lisp — RDF triple generation for the Elle knowledge graph
+## lib/rdf/elle.lisp — RDF triple generation for Elle source analysis
 ##
 ## Canonical representation of Elle semantic data as N-Triples.
 ## Used by both the batch extractor (tools/semantic-graph.lisp) and the
@@ -6,7 +6,7 @@
 ## schema for the knowledge graph.
 ##
 ## Usage:
-##   (def rdf ((import "std/rdf")))
+##   (def rdf ((import "std/rdf/elle")))
 ##   (def triples (rdf:primitives))       # N-Triples string for all Rust prims
 ##   (def triples (rdf:file analysis "path.lisp"))  # for an analyzed Elle file
 

--- a/lib/rdf/rust.lisp
+++ b/lib/rdf/rust.lisp
@@ -1,0 +1,222 @@
+## lib/rdf/rust.lisp — RDF triple generation for Rust source
+##
+## Parses .rs files with the syn plugin and emits N-Triples for functions,
+## structs, enums, traits, and call edges. Also extracts PRIMITIVES tables
+## to link Elle primitives to their Rust implementations.
+##
+## Usage:
+##   (def syn (import "plugin/syn"))
+##   (def rust-rdf ((import "std/rdf/rust") syn))
+##   (def triples (rust-rdf:file "src/main.rs"))
+##   (def links   (rust-rdf:primitive-links "src/primitives/io.rs"))
+
+(fn [syn]
+
+# ── Namespace ──────────────────────────────────────────────────────────
+
+(def ns "urn:rust")
+(def elle-ns "urn:elle")
+(def rdf-type "<http://www.w3.org/1999/02/22-rdf-syntax-ns#type>")
+
+# ── Encoding helpers ───────────────────────────────────────────────────
+
+(defn encode-name [name]
+  "Percent-encode chars invalid in IRI path segments."
+  (-> name
+    (string/replace "%" "%25")
+    (string/replace " " "%20")
+    (string/replace "*" "%2A")
+    (string/replace ">" "%3E")
+    (string/replace "<" "%3C")
+    (string/replace "?" "%3F")
+    (string/replace "#" "%23")
+    (string/replace "!" "%21")
+    (string/replace "'" "%27")
+    (string/replace "[" "%5B")
+    (string/replace "]" "%5D")
+    (string/replace "(" "%28")
+    (string/replace ")" "%29")
+    (string/replace "{" "%7B")
+    (string/replace "}" "%7D")
+    (string/replace "\"" "%22")
+    (string/replace "," "%2C")
+    (string/replace ";" "%3B")
+    (string/replace "`" "%60")
+    (string/replace "@" "%40")
+    (string/replace "+" "%2B")
+    (string/replace "=" "%3D")
+    (string/replace "|" "%7C")
+    (string/replace "\\" "%5C")
+    (string/replace "^" "%5E")))
+
+(defn iri [s]
+  (string/format "<{}>" s))
+
+(defn rust-iri [kind name]
+  (iri (string/format "{}:{}:{}" ns kind (encode-name (string name)))))
+
+(defn elle-iri [name]
+  (iri (string/format "{}:fn:{}" elle-ns (encode-name (string name)))))
+
+(defn pred [p]
+  (iri (string/format "{}:{}" ns p)))
+
+(defn elle-pred [p]
+  (iri (string/format "{}:{}" elle-ns p)))
+
+(defn lit [s]
+  "Escape a string for N-Triples literal."
+  (var escaped (-> (string s)
+                 (string/replace "\\" "\\\\")
+                 (string/replace "\"" "\\\"")
+                 (string/replace "\n" "\\n")))
+  (string/format "\"{}\"" escaped))
+
+# ── Triple buffer ─────────────────────────────────────────────────────
+
+(defn make-buffer []
+  @"")
+
+(defn triple [buf s p o]
+  (push buf (string/format "{} {} {} .\n" s p o)))
+
+# ── Item emitters ─────────────────────────────────────────────────────
+
+(defn emit-visibility [buf subj item]
+  (triple buf subj (pred "visibility") (lit (string (syn:visibility item)))))
+
+(defn emit-attributes [buf subj item]
+  (each attr in (syn:attributes item)
+    (triple buf subj (pred "attribute") (lit attr))))
+
+(defn emit-fn [buf item file]
+  (let* [[info (syn:fn-info item)]
+         [name (get info :name)]
+         [subj (rust-iri "fn" name)]]
+    (triple buf subj rdf-type (iri (string/format "{}:Fn" ns)))
+    (triple buf subj (pred "name") (lit name))
+    (triple buf subj (pred "file") (lit file))
+    (when (get info :line)
+      (triple buf subj (pred "line") (lit (string (get info :line)))))
+    (each arg in (get info :args)
+      (triple buf subj (pred "param") (lit (get arg :name)))
+      (triple buf subj (pred "param-type")
+              (lit (string/format "{}:{}" (get arg :name) (get arg :type)))))
+    (when (get info :return-type)
+      (triple buf subj (pred "return-type") (lit (get info :return-type))))
+    (when (get info :async?)
+      (triple buf subj (pred "async") (lit "true")))
+    (when (get info :unsafe?)
+      (triple buf subj (pred "unsafe") (lit "true")))
+    (emit-visibility buf subj item)
+    (emit-attributes buf subj item)
+    (let [[[ok? calls] (protect (syn:fn-calls item))]]
+      (when ok?
+        (each callee in calls
+          (triple buf subj (pred "calls") (rust-iri "fn" callee)))))))
+
+(defn emit-struct [buf item file]
+  (let* [[info (syn:struct-fields item)]
+         [name (get info :name)]
+         [subj (rust-iri "struct" name)]
+         [line (syn:item-line item)]]
+    (triple buf subj rdf-type (iri (string/format "{}:Struct" ns)))
+    (triple buf subj (pred "name") (lit name))
+    (triple buf subj (pred "file") (lit file))
+    (when line (triple buf subj (pred "line") (lit (string line))))
+    (triple buf subj (pred "kind") (lit (string (get info :kind))))
+    (each field in (get info :fields)
+      (when (get field :name)
+        (triple buf subj (pred "field") (lit (get field :name)))
+        (triple buf subj (pred "field-type")
+                (lit (string/format "{}:{}" (get field :name) (get field :type))))))
+    (emit-visibility buf subj item)
+    (emit-attributes buf subj item)))
+
+(defn emit-enum [buf item file]
+  (let* [[info (syn:enum-variants item)]
+         [name (get info :name)]
+         [subj (rust-iri "enum" name)]
+         [line (syn:item-line item)]]
+    (triple buf subj rdf-type (iri (string/format "{}:Enum" ns)))
+    (triple buf subj (pred "name") (lit name))
+    (triple buf subj (pred "file") (lit file))
+    (when line (triple buf subj (pred "line") (lit (string line))))
+    (each variant in (get info :variants)
+      (triple buf subj (pred "variant") (lit (get variant :name))))
+    (emit-visibility buf subj item)
+    (emit-attributes buf subj item)))
+
+(defn emit-named [buf kind-str item file]
+  (let* [[name (syn:item-name item)]
+         [subj (rust-iri kind-str name)]
+         [line (syn:item-line item)]]
+    (triple buf subj rdf-type (iri (string/format "{}:{}" ns kind-str)))
+    (triple buf subj (pred "name") (lit name))
+    (triple buf subj (pred "file") (lit file))
+    (when line (triple buf subj (pred "line") (lit (string line))))
+    (emit-visibility buf subj item)
+    (emit-attributes buf subj item)))
+
+(defn emit-use [buf item file]
+  (let* [[path (syn:to-string item)]
+         [subj (iri (string/format "{}:use:{}:{}" ns (encode-name file) (encode-name path)))]]
+    (triple buf subj rdf-type (iri (string/format "{}:Use" ns)))
+    (triple buf subj (pred "path") (lit path))
+    (triple buf subj (pred "file") (lit file))
+    (emit-visibility buf subj item)))
+
+# ── File extraction ───────────────────────────────────────────────────
+
+(defn extract-file [file]
+  "Parse a Rust file and return N-Triples for all items."
+  (var buf (make-buffer))
+  (var src (file/read file))
+  (var tree (syn:parse-file src))
+  (each item in (syn:items tree)
+    (case (syn:item-kind item)
+      :fn      (emit-fn buf item file)
+      :struct  (emit-struct buf item file)
+      :enum    (emit-enum buf item file)
+      :trait   (emit-named buf "Trait" item file)
+      :const   (emit-named buf "Const" item file)
+      :static  (emit-named buf "Static" item file)
+      :type    (emit-named buf "Type" item file)
+      :mod     (emit-named buf "Mod" item file)
+      :use     (emit-use buf item file)
+      nil))
+  (freeze buf))
+
+# ── Primitive cross-links ─────────────────────────────────────────────
+
+(defn extract-primitive-links [file]
+  "Parse a Rust file and return N-Triples linking Elle primitives to Rust fns."
+  (var buf (make-buffer))
+  (var src (file/read file))
+  (var tree (syn:parse-file src))
+  (each item in (syn:items tree)
+    (when (and (= (syn:item-kind item) :const)
+               (= (syn:item-name item) "PRIMITIVES"))
+      (let [[[ok? defs] (protect (syn:primitive-defs item))]]
+        (when ok?
+          (each def in defs
+            (var elle-name (get def :name))
+            (var rust-fn   (get def :func))
+            (triple buf (elle-iri elle-name)
+                    (elle-pred "implemented-by")
+                    (rust-iri "fn" rust-fn))
+            (triple buf (rust-iri "fn" rust-fn)
+                    (pred "implements")
+                    (elle-iri elle-name)))))))
+  (freeze buf))
+
+# ── Export ────────────────────────────────────────────────────────────
+
+{:file             extract-file
+ :primitive-links  extract-primitive-links
+ :make-buffer      make-buffer
+ :triple           triple
+ :rust-iri         rust-iri
+ :pred             pred
+ :lit              lit
+ :encode-name      encode-name})  # end closure

--- a/src/primitives/modules.rs
+++ b/src/primitives/modules.rs
@@ -60,8 +60,8 @@ pub(crate) fn resolve_import(spec: &str) -> Option<String> {
         }
     }
 
-    // Fast path: already exists with the given name (full path or relative)
-    if as_path.exists() {
+    // Fast path: already exists as a file (skip directories — no semantics for them)
+    if as_path.is_file() {
         return Some(spec.to_string());
     }
 

--- a/tests/elle/graph-bench.lisp
+++ b/tests/elle/graph-bench.lisp
@@ -105,7 +105,7 @@
 
 # ── RDF generation ─────────────────────────────────────────────────────
 
-(def rdf ((import "std/rdf")))
+(def rdf ((import "std/rdf/elle")))
 
 (assign t0 (clock/monotonic))
 (def pt (rdf:primitives))

--- a/tests/elle/rdf.lisp
+++ b/tests/elle/rdf.lisp
@@ -1,6 +1,6 @@
 ## tests/elle/rdf.lisp — verify lib/rdf.lisp triple generation
 
-(def rdf ((import "std/rdf")))
+(def rdf ((import "std/rdf/elle")))
 
 # ── Primitive triples ──────────────────────────────────────────────────
 

--- a/tools/mcp-server.lisp
+++ b/tools/mcp-server.lisp
@@ -37,9 +37,10 @@
 (def rdf ((import "std/rdf")))
 (def rust-rdf ((import "tools/rust-rdf-lib") syn))
 
-# ── Watch library ───────────────────────────────────────────────────────
+# ── Watch + UUID libraries ──────────────────────────────────────────────
 
 (def watch ((import "std/watch")))
+(def uuid-lib ((import "std/uuid")))
 
 # ── Store initialization ─────────────────────────────────────────────────
 
@@ -131,6 +132,45 @@
 (defn invalidate-cache [path]
   "Remove a path from the analysis cache so it is re-analyzed on next access."
   (put analysis-cache path nil))
+
+# ── Eval handle table ───────────────────────────────────────────────────
+
+(def eval-handles @{})
+
+(defn handle-put [value]
+  "Store a value in the handle table, return its UUID."
+  (let [[id (uuid-lib:v4)]]
+    (put eval-handles id {:value value})
+    id))
+
+(defn handle-get [id]
+  "Retrieve a value by handle. Errors if the handle is unknown."
+  (let [[entry (get eval-handles id)]]
+    (when (nil? entry)
+      (error {:error :unknown-handle :message (string "unknown handle: " id)}))
+    (get entry :value)))
+
+(defn value-kind [val is-error]
+  "Kind string for a value. Reports :error when the eval failed."
+  (if is-error ":error" (string ":" (type-of val))))
+
+(defn value-shape [val]
+  "Cheap shape hint: count for collections, keys_sample for structs."
+  (case (type-of val)
+    :array   {:count (length val)}
+    :@array  {:count (length val)}
+    :list    {:count (length val)}
+    :struct  (let [[ks (keys val)]]
+               {:count (length ks)
+                :keys_sample (freeze (take 5 ks))})
+    :@struct (let [[ks (keys val)]]
+               {:count (length ks)
+                :keys_sample (freeze (take 5 ks))})
+    :string  {:bytes (length val)}
+    :@string {:bytes (length val)}
+    :set     {:count (length val)}
+    :@set    {:count (length val)}
+    nil))
 
 # ── Signal diff (for watch notifications) ────────────────────────────────
 
@@ -323,6 +363,19 @@
                               :function {:type "string" :description "Function name to trace"}
                               :depth    {:type "integer" :description "Max Rust call depth (default: 2)"}}
                  :required ["path" "function"]}})
+
+(def tool-eval
+  {:name "eval"
+   :description "Evaluate an Elle lambda against the persistent image. Returns a handle (UUID) naming the result — large values stay in the image. Compose by passing prior handles as inputs. stdout/stderr are captured and returned."
+   :inputSchema {:type "object"
+                 :properties {:lambda     {:type "string"
+                                           :description "Elle source for a callable expression, e.g. \"(fn [prev] (take 10 prev))\""}
+                              :inputs     {:type "array"
+                                           :items {:type "string"}
+                                           :description "Handles from prior eval calls, passed positionally as arguments"}
+                              :timeout_ms {:type "integer"
+                                           :description "Wall-clock timeout in milliseconds (default: 10000; 0 to disable)"}}
+                 :required ["lambda"]}})
 
 # ── SPARQL tool handlers ─────────────────────────────────────────────────
 
@@ -670,6 +723,107 @@
 
   (text-content (freeze out)))
 
+# ── Eval tool handler ──────────────────────────────────────────────────
+
+(defn call-eval [arguments]
+  (let* [[lambda-src (get arguments "lambda")]
+         [input-ids  (or (get arguments "inputs") [])]
+         [timeout-ms (or (get arguments "timeout_ms") 10000)]]
+
+    (when (nil? lambda-src)
+      (error {:error :invalid-params :message "missing required parameter: lambda"}))
+
+    # Parse the lambda source
+    (var parsed nil)
+    (let [[[ok? val] (protect (read lambda-src))]]
+      (if ok? (assign parsed val)
+        (error {:error :parse-error
+                :message (string "cannot parse lambda: " (get val :message))})))
+
+    # Eval to get a callable value
+    (var callable nil)
+    (let [[[ok? val] (protect (eval parsed))]]
+      (if ok? (assign callable val)
+        (error {:error :eval-error
+                :message (string "lambda eval failed: " (get val :message))})))
+
+    (when (not (callable? callable))
+      (error {:error :type-error
+              :message (string "lambda must evaluate to a callable, got "
+                         (type-of callable))}))
+
+    # Resolve input handles
+    (var input-vals @[])
+    (each id in input-ids
+      (push input-vals (handle-get id)))
+
+    # Arity check for closures
+    (when (= (type-of callable) :closure)
+      (let [[a (arity callable)]
+            [n (length input-ids)]]
+        (cond
+          ((nil? a)     nil)
+          ((integer? a) (unless (= a n)
+                          (error {:error :arity-mismatch
+                                  :message (string "lambda expects " a " args, got " n)})))
+          (true         (unless (>= n (first a))
+                          (error {:error :arity-mismatch
+                                  :message (string "lambda expects at least "
+                                             (first a) " args, got " n)}))))))
+
+    # Set up temp files for I/O capture
+    (file/mkdir-all ".elle-mcp")
+    (let* [[eval-id (uuid-lib:v4)]
+           [out-path (string ".elle-mcp/eval-" eval-id "-out")]
+           [err-path (string ".elle-mcp/eval-" eval-id "-err")]
+           [out-port (port/open out-path :write)]
+           [err-port (port/open err-path :write)]]
+      (defer (begin
+               (protect (file/delete out-path))
+               (protect (file/delete err-path)))
+
+        # Execute with I/O capture and optional timeout
+        (let* [[input-list (freeze input-vals)]
+               [thunk (fn []
+                        (parameterize ((*stdout* out-port) (*stderr* err-port))
+                          (apply callable input-list)))]
+               [start (clock/monotonic)]
+               [[ok? result] (if (and timeout-ms (> timeout-ms 0))
+                               (protect (ev/timeout (/ timeout-ms 1000) thunk))
+                               (protect (thunk)))]
+               [duration-ns (int (* (- (clock/monotonic) start) 1000000000))]]
+
+          # Flush and close captured I/O ports
+          (protect (port/flush out-port))
+          (protect (port/flush err-port))
+          (protect (port/close out-port))
+          (protect (port/close err-port))
+
+          # Read captured output
+          (var stdout-text "")
+          (var stderr-text "")
+          (let [[[rd-ok? rd-val] (protect (file/read out-path))]]
+            (when rd-ok? (assign stdout-text rd-val)))
+          (let [[[rd-ok? rd-val] (protect (file/read err-path))]]
+            (when rd-ok? (assign stderr-text rd-val)))
+
+          # Build response
+          (let* [[handle (handle-put result)]
+                 [kind (value-kind result (not ok?))]
+                 [shape (if ok?
+                          (value-shape result)
+                          {:reason (get result :error)
+                           :message (get result :message)})]]
+            (text-content (json/serialize
+              {:ok ok?
+               :handle handle
+               :kind kind
+               :shape shape
+               :stdout stdout-text
+               :stderr stderr-text
+               :duration_ns duration-ns
+               :fibers []}))))))))
+
 # ── Test orchestration ───────────────────────────────────────────────────
 
 (def tool-test-run
@@ -734,7 +888,7 @@
   [tool-ping tool-sparql-query tool-sparql-update tool-load-rdf tool-dump-rdf
    tool-analyze-file tool-portrait tool-signal-query tool-impact
    tool-verify-invariants tool-compile-rename tool-compile-extract
-   tool-compile-parallelize tool-trace
+   tool-compile-parallelize tool-trace tool-eval
    tool-test-run tool-test-status tool-test-history tool-test-gate
    tool-push-ready tool-push-wip])
 
@@ -949,6 +1103,7 @@
     "compile_extract"     (call-compile-extract arguments)
     "compile_parallelize" (call-compile-parallelize arguments)
     "trace"               (call-trace arguments)
+    "eval"                (call-eval arguments)
     "test_run"            (call-test-run arguments)
     "test_status"         (call-test-status arguments)
     "test_history"        (call-test-history arguments)

--- a/tools/mcp-server.lisp
+++ b/tools/mcp-server.lisp
@@ -31,11 +31,17 @@
 (def saved-stderr (*stderr*))
 
 (def ox (import "plugin/oxigraph"))
-(def syn (import "plugin/syn"))
 (def glob ((import "std/glob")))
 (def portrait-lib ((import "std/portrait")))
-(def rdf ((import "std/rdf")))
-(def rust-rdf ((import "tools/rust-rdf-lib") syn))
+(def rdf ((import "std/rdf/elle")))
+
+# syn plugin is optional — Rust graph features are disabled without it.
+(var syn nil)
+(var rust-rdf nil)
+(let [[[ok? s] (protect (import "plugin/syn"))]]
+  (when ok?
+    (assign syn s)
+    (assign rust-rdf ((import "std/rdf/rust") syn))))
 
 # ── Watch + UUID libraries ──────────────────────────────────────────────
 
@@ -53,9 +59,21 @@
     (true                          ".elle-mcp/store")))
 
 (defn nuke-store [path]
-  "Delete a corrupt store directory so it can be recreated fresh."
-  (each entry in (glob:glob (string path "/*"))
-    (file/delete entry))
+  "Delete a corrupt store directory so it can be recreated fresh.
+   Refuses to delete if no oxigraph marker file (LOCK) is found."
+  (let [[entries (glob:glob (string path "/*"))]]
+    (when (not (empty? entries))
+      (var has-marker false)
+      (each e in entries
+        (when (or (string/ends-with? e "/LOCK")
+                  (string/ends-with? e "/CURRENT"))
+          (assign has-marker true)))
+      (unless has-marker
+        (error {:error :safety
+                :message (string "refusing to nuke " path
+                          ": does not look like an oxigraph store")}))
+      (each entry in entries
+        (file/delete entry))))
   nil)
 
 (defn open-store [path]
@@ -87,20 +105,22 @@
 (defn populate-rust []
   "Parse source .rs files, load Rust triples and primitive cross-links.
    Yields between files so the main loop can process requests.
-   Scans only source directories to avoid the deep target/ tree."
-  (var files @[])
-  (each pattern in rust-source-globs
-    (each f in (glob:glob pattern)
-      (push files f)))
-  (var count 0)
-  (each file in files
-    (when-ok [_ (begin
-                  (ox:load store (rust-rdf:file file) :ntriples)
-                  (ox:load store (rust-rdf:primitive-links file) :ntriples))]
-      (assign count (inc count)))
-    (yield nil))
-  (flush-store)
-  count)
+   Skips entirely when the syn plugin is not available."
+  (if (nil? rust-rdf) 0
+    (begin
+      (var files @[])
+      (each pattern in rust-source-globs
+        (each f in (glob:glob pattern)
+          (push files f)))
+      (var count 0)
+      (each file in files
+        (when-ok [_ (begin
+                      (ox:load store (rust-rdf:file file) :ntriples)
+                      (ox:load store (rust-rdf:primitive-links file) :ntriples))]
+          (assign count (inc count)))
+        (yield nil))
+      (flush-store)
+      count)))
 
 (defn clear-file-triples [path]
   "Remove all triples for a file from the RDF store."
@@ -109,7 +129,10 @@
       (string/replace path "\\" "\\\\"))))
 
 (defn populate-file [analysis path]
-  "Load triples for an analyzed file, replacing any existing."
+  "Load triples for an analyzed file, replacing any existing.
+   Delete-then-load is not atomic, but both are FFI calls (no yield),
+   so the gap is crash-only — a crash between them loses triples for
+   this file until the next analyze repopulates them."
   (clear-file-triples path)
   (ox:load store (rdf:file analysis path) :ntriples)
   (flush-store))
@@ -117,17 +140,24 @@
 # ── Analysis cache ───────────────────────────────────────────────────────
 
 (def analysis-cache @{})
+(def analyzing-map @{})
 
 (defn get-or-analyze [path]
-  "Return cached analysis or analyze the file fresh."
+  "Return cached analysis or analyze the file fresh.
+   Guards against concurrent analysis of the same file — if another
+   fiber is already analyzing this path, returns the stale cache entry."
   (var cached (get analysis-cache path))
   (if (not (nil? cached))
     cached
-    (begin
-      (var result (compile/analyze (file/read path) {:file path}))
-      (put analysis-cache path result)
-      (populate-file result path)
-      result)))
+    (if (not (nil? (get analyzing-map path)))
+      nil
+      (begin
+        (put analyzing-map path true)
+        (defer (put analyzing-map path nil)
+          (var result (compile/analyze (file/read path) {:file path}))
+          (put analysis-cache path result)
+          (populate-file result path)
+          result)))))
 
 (defn invalidate-cache [path]
   "Remove a path from the analysis cache so it is re-analyzed on next access."
@@ -237,7 +267,13 @@
   [{:type "text" :text text :isError true}])
 
 (defn send-response [response]
-  (println (json/serialize response)))
+  (println (json/serialize response))
+  (port/flush (*stdout*)))
+
+(defn err-msg [e]
+  "Safely extract a message from any error value.
+   Works on structs (extracts :message), strings, and other types."
+  (if (struct? e) (or (get e :message) (string e)) (string e)))
 
 (defn ->list [coll]
   "Convert any collection to a list for string/join."
@@ -383,13 +419,13 @@
   (let [[query (get arguments "query")]]
     (when (nil? query)
       (error {:error :invalid-params :message "missing required parameter: query"}))
-    (let [[[ok? result] (protect (ox:query store query))]]
+    (let [[[ok? result] (protect (ev/timeout 30 (fn [] (ox:query store query))))]]
       (if ok?
         (text-content (cond
           ((boolean? result) (if result "true" "false"))
           ((array? result)   (if (empty? result) "No results." (json/pretty result)))
           (true              (string result))))
-        (error-content (string/format "SPARQL error: {}" (get result :message)))))))
+        (error-content (string/format "SPARQL error: {}" (err-msg result)))))))
 
 (defn call-sparql-update [arguments]
   (let [[update-str (get arguments "update")]]
@@ -398,7 +434,7 @@
     (let [[[ok? result] (protect (ox:update store update-str))]]
       (if ok?
         (begin (flush-store) (text-content "Update executed successfully."))
-        (error-content (string/format "SPARQL update error: {}" (get result :message)))))))
+        (error-content (string/format "SPARQL update error: {}" (err-msg result)))))))
 
 (defn call-load-rdf [arguments]
   (let [[data (get arguments "data")]
@@ -410,14 +446,14 @@
     (let [[[ok? result] (protect (ox:load store data (keyword fmt)))]]
       (if ok?
         (begin (flush-store) (text-content "RDF data loaded successfully."))
-        (error-content (string/format "Load error: {}" (get result :message)))))))
+        (error-content (string/format "Load error: {}" (err-msg result)))))))
 
 (defn call-dump-rdf [arguments]
   (let* [[fmt (or (get arguments "format") "turtle")]
          [[ok? result] (protect (ox:dump store (keyword fmt)))]]
     (if ok?
       (text-content result)
-      (error-content (string/format "Dump error: {}" (get result :message))))))
+      (error-content (string/format "Dump error: {}" (err-msg result))))))
 
 # ── Semantic tool handlers ───────────────────────────────────────────────
 
@@ -569,7 +605,7 @@
     (if ok?
       (assign invariants result)
       (error {:error :parse-error
-              :message (string/format "cannot parse invariants: {}" (get result :message))})))
+              :message (string/format "cannot parse invariants: {}" (err-msg result))})))
 
   (var out @"")
   (var pass-count 0)
@@ -583,7 +619,7 @@
       (if ok?
         (assign actual result)
         (begin
-          (push out (string/format "  x {} — query error: {}\n" name (get result :message)))
+          (push out (string/format "  x {} — query error: {}\n" name (err-msg result)))
           (assign fail-count (+ fail-count 1)))))
     (when (not (nil? actual))
       (if (= actual expected)
@@ -661,6 +697,9 @@
   (freeze out))
 
 (defn call-trace [arguments]
+  (when (nil? rust-rdf)
+    (error {:error :unavailable
+            :message "trace requires the syn plugin (plugin/syn not found)"}))
   (var path (get arguments "path"))
   (var fn-name (get arguments "function"))
   (var max-depth (or (get arguments "depth") 2))
@@ -738,14 +777,14 @@
     (let [[[ok? val] (protect (read lambda-src))]]
       (if ok? (assign parsed val)
         (error {:error :parse-error
-                :message (string "cannot parse lambda: " (get val :message))})))
+                :message (string "cannot parse lambda: " (err-msg val))})))
 
     # Eval to get a callable value
     (var callable nil)
     (let [[[ok? val] (protect (eval parsed))]]
       (if ok? (assign callable val)
         (error {:error :eval-error
-                :message (string "lambda eval failed: " (get val :message))})))
+                :message (string "lambda eval failed: " (err-msg val))})))
 
     (when (not (callable? callable))
       (error {:error :type-error
@@ -813,7 +852,7 @@
                  [shape (if ok?
                           (value-shape result)
                           {:reason (get result :error)
-                           :message (get result :message)})]]
+                           :message (err-msg result)})]]
             (text-content (json/serialize
               {:ok ok?
                :handle handle
@@ -928,10 +967,21 @@
       (push failures {:message (string/trim line)})))
   (freeze failures))
 
+(defn turtle-escape [s]
+  "Escape a string for embedding in a Turtle literal."
+  (var esc (string/replace s "\\" "\\\\"))
+  (assign esc (string/replace esc "\"" "\\\""))
+  (assign esc (string/replace esc "\n" "\\n"))
+  (assign esc (string/replace esc "\r" "\\r"))
+  esc)
+
 (defn store-test-result [sha mode clean passed duration failures stderr]
-  "Store test result as RDF triples."
+  "Store test result as RDF triples, including truncated stderr."
   (let* [[iri (string/format "urn:test:{}:{}" sha mode)]
          [timestamp (clock/realtime)]
+         [trunc-stderr (if (> (length stderr) 10000)
+                         (string (slice stderr 0 10000) "\n...[truncated]")
+                         stderr)]
          [ttl (string/format
                "<{}> a <urn:elle:TestRun> ;
                    <urn:elle:sha> \"{}\" ;
@@ -940,13 +990,16 @@
                    <urn:elle:passed> {} ;
                    <urn:elle:duration> {} ;
                    <urn:elle:timestamp> \"{}\" ;
-                   <urn:elle:failed-count> {} ."
+                   <urn:elle:failed-count> {} ;
+                   <urn:elle:stderr> \"{}\" ."
                iri sha mode
                (if clean "true" "false")
                (if passed "true" "false")
                duration timestamp
-               (length failures))]]
-    # Delete old result for this sha+mode
+               (length failures)
+               (turtle-escape trunc-stderr))]]
+    # Delete old result for this sha+mode, then insert new.
+    # Both are FFI calls (no yield), so the gap is crash-only.
     (protect (ox:update store
       (string/format "DELETE WHERE {{ <{}> ?p ?o . }}" iri)))
     (protect (ox:load store ttl :turtle))
@@ -1133,7 +1186,7 @@
         (jsonrpc-result id {:content content})
         (jsonrpc-result id {:content (error-content
                                        (string/format "Internal error: {}"
-                                         (get content :message)))
+                                         (err-msg content)))
                             :isError true})))))
 
 (defn handle-ping [id _params]
@@ -1159,10 +1212,10 @@
 
 # Population fiber — yields between work units so the main loop
 # can process requests between FFI calls.
+(populate-primitives)
+(eprintln "  primitives: loaded")
+
 (def populator (fiber/new (fn []
-  (populate-primitives)
-  (yield nil)
-  (eprintln "  primitives: loaded")
   (var count (populate-rust))
   (eprintln "  rust: " count " files loaded")
   (send-response {:jsonrpc "2.0"
@@ -1170,7 +1223,7 @@
                   :params {:primitives true :rust count}}))
   |:yield|))
 
-# Kick off population — runs populate-primitives, then yields
+# Initial resume — starts populate-rust, runs until first (yield nil)
 (fiber/resume populator nil)
 
 (defn tick-populator []
@@ -1178,31 +1231,39 @@
   (when (= (fiber/status populator) :paused)
     (fiber/resume populator nil)))
 
-# Watcher fiber
+# Watcher fiber — restarts on crash, capped at 5 attempts.
 (eprintln "  watch: enabled")
 (ev/spawn (fn []
-  (var watcher (watch:start "." :filter ".lisp"))
-  (watch:each watcher (fn [event]
-    (let [[path (get event :path)]]
-      (when (and (string/ends-with? path ".lisp")
-                 (contains? |:create :modify| (get event :kind)))
-        (let [[[ok? err] (protect
-                (begin
-                  (var old-analysis (get analysis-cache path))
-                  (var old-sigs (when (not (nil? old-analysis))
-                                  (snapshot-signals old-analysis)))
-                  (invalidate-cache path)
-                  (var new-analysis (get-or-analyze path))
-                  (var new-sigs (snapshot-signals new-analysis))
-                  (when (not (nil? old-sigs))
-                    (var diff (diff-signals old-sigs new-sigs))
-                    (when (or (not (empty? (get diff :added)))
-                              (not (empty? (get diff :removed)))
-                              (not (empty? (get diff :changed))))
-                      (send-response (build-notification path diff))))
-                  (eprintln "  re-analyzed: " path)))]]
-          (unless ok?
-            (eprintln "  watch error for " path ": " (string err))))))))))
+  (var restarts 0)
+  (while (< restarts 5)
+    (let [[[ok? err] (protect
+            (begin
+              (var watcher (watch:start "." :filter ".lisp"))
+              (watch:each watcher (fn [event]
+                (let [[path (get event :path)]]
+                  (when (and (string/ends-with? path ".lisp")
+                             (contains? |:create :modify| (get event :kind)))
+                    (let [[[ok? err] (protect
+                            (begin
+                              (var old-analysis (get analysis-cache path))
+                              (var old-sigs (when (not (nil? old-analysis))
+                                              (snapshot-signals old-analysis)))
+                              (invalidate-cache path)
+                              (var new-analysis (get-or-analyze path))
+                              (var new-sigs (snapshot-signals new-analysis))
+                              (when (not (nil? old-sigs))
+                                (var diff (diff-signals old-sigs new-sigs))
+                                (when (or (not (empty? (get diff :added)))
+                                          (not (empty? (get diff :removed)))
+                                          (not (empty? (get diff :changed))))
+                                  (send-response (build-notification path diff))))
+                              (eprintln "  re-analyzed: " path)))]]
+                      (unless ok?
+                        (eprintln "  watch error for " path ": " (err-msg err))))))))))]]
+      (unless ok?
+        (eprintln "  watcher crashed (" (inc restarts) "/5): " (err-msg err))
+        (assign restarts (inc restarts))
+        (ev/sleep 1))))))
 
 (forever
   (let [[line (port/read-line (*stdin*))]]
@@ -1210,14 +1271,16 @@
       (eprintln "stdin closed, shutting down")
       (break))
     (tick-populator)
-    (unless (empty? line)
-      (let [[[ok? msg] (protect (json/parse line))]]
-        (if (not ok?)
-          (begin
-            (eprintln "JSON parse error: " (get msg :message))
-            (send-response (jsonrpc-error nil -32700 "parse error")))
-          (let [[response (handle-request msg)]]
-            (unless (nil? response)
-              (send-response response))))))))
+    (if (> (length line) 10000000)
+      (send-response (jsonrpc-error nil -32600 "request too large"))
+      (unless (empty? line)
+        (let [[[ok? msg] (protect (json/parse line))]]
+          (if (not ok?)
+            (begin
+              (eprintln "JSON parse error: " (err-msg msg))
+              (send-response (jsonrpc-error nil -32700 "parse error")))
+            (let [[response (handle-request msg)]]
+              (unless (nil? response)
+                (send-response response)))))))))
 
 ) # end parameterize

--- a/tools/portrait-demo.lisp
+++ b/tools/portrait-demo.lisp
@@ -4,7 +4,7 @@
 ## Elle/Rust boundary, revealing properties the programmer never declared.
 
 (def portrait ((import "std/portrait")))
-(def rdf ((import "std/rdf")))
+(def rdf ((import "std/rdf/elle")))
 
 (def src (file/read "examples/pipeline.lisp"))
 (def a (compile/analyze src {:file "examples/pipeline.lisp"}))

--- a/tools/semantic-graph.lisp
+++ b/tools/semantic-graph.lisp
@@ -8,7 +8,7 @@
 ## Usage:
 ##   elle tools/semantic-graph.lisp -- file1.lisp file2.lisp ...
 
-(def rdf ((import "std/rdf")))
+(def rdf ((import "std/rdf/elle")))
 
 (var args (drop 1 (sys/args)))
 

--- a/tools/test-eval.lisp
+++ b/tools/test-eval.lisp
@@ -1,0 +1,279 @@
+#!/usr/bin/env elle
+## test-eval.lisp — integration test for the MCP eval tool
+##
+## Spawns the MCP server, exercises the eval tool contract documented
+## in docs/mcp-eval.md.  Counter-factual: these tests must FAIL before
+## the eval tool is implemented, and PASS after.
+##
+## Usage:
+##   elle tools/test-eval.lisp                    # uses "elle" in PATH
+##   elle tools/test-eval.lisp ./target/debug/elle
+
+(elle/epoch 5)
+
+# ── Configuration ────────────────────────────────────────────────────────
+
+(def test-args (sys/args))
+
+(def elle-bin
+  (cond
+    ((not (empty? test-args)) (first test-args))
+    ((sys/env "ELLE_BIN")     (sys/env "ELLE_BIN"))
+    (true                     "elle")))
+
+(def test-store "./target/elle-eval-test-store")
+
+# ── Test harness ─────────────────────────────────────────────────────────
+
+(var pass-count 0)
+(var fail-count 0)
+
+(defn test [name ok? msg]
+  "Assert a condition; abort the suite on first failure."
+  (if ok?
+    (begin
+      (println "  PASS  " name)
+      (assign pass-count (inc pass-count)))
+    (begin
+      (println "  FAIL  " name " — " msg)
+      (assign fail-count (inc fail-count))
+      (error {:error :test-failure :message (string name ": " msg)}))))
+
+(defn rm-rf [path]
+  (let [[[ok? _] (protect (subprocess/system "rm" ["-rf" path]))]]
+    nil))
+
+# ── JSON-RPC I/O helpers ────────────────────────────────────────────────
+
+(var notification-buffer @[])
+
+(defn send [pin msg]
+  (port/write pin (json/serialize msg))
+  (port/write pin "\n")
+  (port/flush pin))
+
+(defn recv-response [pout want-id]
+  "Read messages until one with id=want-id arrives."
+  (var result nil)
+  (while (nil? result)
+    (let [[line (port/read-line pout)]]
+      (when (nil? line)
+        (error {:error :eof :message "server closed stdout"}))
+      (let [[msg (json/parse line)]]
+        (if (and (not (nil? (get msg "id"))) (= (get msg "id") want-id))
+          (assign result msg)
+          (when (not (nil? (get msg "method")))
+            (push notification-buffer msg))))))
+  result)
+
+(defn call-tool [pin pout id name args]
+  (send pin {:jsonrpc "2.0" :id id :method "tools/call"
+             :params {:name name :arguments args}})
+  (recv-response pout id))
+
+(defn tool-text [response]
+  "Extract content[0].text from a tools/call response."
+  (get (get (get (get response "result") "content") 0) "text"))
+
+(defn tool-error? [response]
+  "True if the tool response has isError."
+  (get (get response "result") "isError"))
+
+(defn eval-result [response]
+  "Parse the eval tool's JSON payload."
+  (json/parse (tool-text response)))
+
+# ── Main ────────────────────────────────────────────────────────────────
+
+(println "── MCP eval tool integration test ──")
+(println "  elle-bin:  " elle-bin)
+(println "  store:     " test-store)
+
+(rm-rf test-store)
+
+(def proc
+  (subprocess/exec elle-bin ["tools/mcp-server.lisp" "--" test-store]))
+(def pin  (get proc :stdin))
+(def pout (get proc :stdout))
+
+# Handles saved across tests
+(var handle-42  nil)
+(var handle-43  nil)
+(var handle-85  nil)
+(var handle-err nil)
+
+(defer (begin (subprocess/kill proc) (rm-rf test-store))
+
+  # ── Initialize ────────────────────────────────────────────────────────
+  (let [[[ok? r] (protect
+      (ev/timeout 10 (fn []
+        (send pin {:jsonrpc "2.0" :id 1 :method "initialize"
+                   :params {:protocolVersion "2025-03-26"
+                            :capabilities {}
+                            :clientInfo {:name "test-eval" :version "0.1"}}})
+        (recv-response pout 1))))]]
+    (test "initialize" ok? "server did not respond within 10 seconds"))
+
+  (send pin {:jsonrpc "2.0" :method "notifications/initialized"})
+
+  # ── Verify eval tool is listed ────────────────────────────────────────
+  (send pin {:jsonrpc "2.0" :id 2 :method "tools/list" :params {}})
+  (let* [[r (recv-response pout 2)]
+         [tools (get (get r "result") "tools")]
+         [names (map (fn [t] (get t "name")) tools)]
+         [has-eval (not (nil? (find (fn [n] (= n "eval")) names)))]]
+    (test "tools/list: eval is listed" has-eval
+      (string "tool list does not contain 'eval': " (string/join (->list names) ", "))))
+
+  # ── 1. Nullary eval — compute a value from nothing ────────────────────
+  (let* [[r (call-tool pin pout 10 "eval"
+              {:lambda "(fn [] 42)"})]
+         [payload (eval-result r)]]
+    (test "eval nullary: ok" (get payload "ok") (tool-text r))
+    (test "eval nullary: kind is :integer"
+      (= (get payload "kind") ":integer")
+      (string "got kind " (get payload "kind")))
+    (test "eval nullary: has handle"
+      (not (nil? (get payload "handle")))
+      "missing handle")
+    (assign handle-42 (get payload "handle")))
+
+  # ── 2. Unary eval — compose against a prior handle ────────────────────
+  (let* [[r (call-tool pin pout 11 "eval"
+              {:lambda "(fn [n] (+ n 1))"
+               :inputs [handle-42]})]
+         [payload (eval-result r)]]
+    (test "eval unary: ok" (get payload "ok") (tool-text r))
+    (test "eval unary: kind is :integer"
+      (= (get payload "kind") ":integer")
+      (string "got kind " (get payload "kind")))
+    (assign handle-43 (get payload "handle")))
+
+  # ── 3. Verify value — project it via identity + println ───────────────
+  (let* [[r (call-tool pin pout 12 "eval"
+              {:lambda "(fn [v] (println v) v)"
+               :inputs [handle-43]})]
+         [payload (eval-result r)]]
+    (test "eval project: stdout captures println"
+      (string/contains? (get payload "stdout") "43")
+      (string "stdout was: " (get payload "stdout")))
+    (test "eval project: kind is :integer"
+      (= (get payload "kind") ":integer")
+      (string "got kind " (get payload "kind"))))
+
+  # ── 4. Multi-arity — combine two handles ──────────────────────────────
+  (let* [[r (call-tool pin pout 13 "eval"
+              {:lambda "(fn [a b] (+ a b))"
+               :inputs [handle-42 handle-43]})]
+         [payload (eval-result r)]]
+    (test "eval multi-arity: ok" (get payload "ok") (tool-text r))
+    (assign handle-85 (get payload "handle")))
+
+  # ── 5. String value — kind and shape ──────────────────────────────────
+  (let* [[r (call-tool pin pout 14 "eval"
+              {:lambda "(fn [] \"hello world\")"})]
+         [payload (eval-result r)]]
+    (test "eval string: ok" (get payload "ok") (tool-text r))
+    (test "eval string: kind is :string"
+      (= (get payload "kind") ":string")
+      (string "got kind " (get payload "kind"))))
+
+  # ── 6. Collection value — shape has count ─────────────────────────────
+  (let* [[r (call-tool pin pout 15 "eval"
+              {:lambda "(fn [] [1 2 3 4 5])"})]
+         [payload (eval-result r)]]
+    (test "eval collection: ok" (get payload "ok") (tool-text r))
+    (test "eval collection: kind is :array"
+      (= (get payload "kind") ":array")
+      (string "got kind " (get payload "kind")))
+    (test "eval collection: shape has count"
+      (= (get (get payload "shape") "count") 5)
+      (string "shape: " (json/serialize (get payload "shape")))))
+
+  # ── 7. Lambda that throws — ok:false with error handle ────────────────
+  (let* [[r (call-tool pin pout 16 "eval"
+              {:lambda "(fn [] (error {:error :boom :message \"kaboom\"}))"})]
+         [payload (eval-result r)]]
+    (test "eval throw: ok is false" (not (get payload "ok")) (tool-text r))
+    (test "eval throw: kind is :error"
+      (= (get payload "kind") ":error")
+      (string "got kind " (get payload "kind")))
+    (test "eval throw: has handle"
+      (not (nil? (get payload "handle")))
+      "missing error handle")
+    (assign handle-err (get payload "handle")))
+
+  # ── 8. Probe error handle — get the reason ────────────────────────────
+  (let* [[r (call-tool pin pout 17 "eval"
+              {:lambda "(fn [e] (get e :message))"
+               :inputs [handle-err]})]
+         [payload (eval-result r)]]
+    (test "eval probe error: ok" (get payload "ok") (tool-text r))
+    (test "eval probe error: kind is :string"
+      (= (get payload "kind") ":string")
+      (string "got kind " (get payload "kind"))))
+
+  # ── 9. Unknown handle — protocol error ────────────────────────────────
+  (let* [[r (call-tool pin pout 18 "eval"
+              {:lambda "(fn [x] x)"
+               :inputs ["nonexistent-handle-12345"]})]
+         [is-err (tool-error? r)]]
+    (test "eval unknown handle: isError" is-err
+      (string "expected isError, got: " (tool-text r))))
+
+  # ── 10. Arity mismatch — protocol error ──────────────────────────────
+  (let* [[r (call-tool pin pout 19 "eval"
+              {:lambda "(fn [a b] (+ a b))"
+               :inputs [handle-42]})]
+         [is-err (tool-error? r)]]
+    (test "eval arity mismatch: isError" is-err
+      (string "expected isError, got: " (tool-text r))))
+
+  # ── 11. Non-callable lambda — protocol error ─────────────────────────
+  (let* [[r (call-tool pin pout 20 "eval"
+              {:lambda "42"})]
+         [is-err (tool-error? r)]]
+    (test "eval non-callable: isError" is-err
+      (string "expected isError, got: " (tool-text r))))
+
+  # ── 12. Stderr capture ───────────────────────────────────────────────
+  (let* [[r (call-tool pin pout 21 "eval"
+              {:lambda "(fn [] (eprintln \"debug info\") :ok)"})]
+         [payload (eval-result r)]]
+    (test "eval stderr: ok" (get payload "ok") (tool-text r))
+    (test "eval stderr: captured"
+      (string/contains? (get payload "stderr") "debug info")
+      (string "stderr was: " (get payload "stderr"))))
+
+  # ── 13. Timeout ──────────────────────────────────────────────────────
+  (let* [[r (call-tool pin pout 22 "eval"
+              {:lambda "(fn [] (ev/sleep 100))"
+               :timeout_ms 200})]
+         [payload (eval-result r)]]
+    (test "eval timeout: ok is false" (not (get payload "ok")) (tool-text r))
+    (test "eval timeout: kind is :error"
+      (= (get payload "kind") ":error")
+      (string "got kind " (get payload "kind"))))
+
+  # ── 14. Duration is present ──────────────────────────────────────────
+  (let* [[r (call-tool pin pout 23 "eval"
+              {:lambda "(fn [] (+ 1 2 3))"})]
+         [payload (eval-result r)]]
+    (test "eval duration: present and positive"
+      (> (get payload "duration_ns") 0)
+      (string "duration_ns: " (get payload "duration_ns"))))
+
+  # ── 15. Inputs default to empty ──────────────────────────────────────
+  (let* [[r (call-tool pin pout 24 "eval"
+              {:lambda "(fn [] :no-inputs)"})]
+         [payload (eval-result r)]]
+    (test "eval no-inputs: ok" (get payload "ok") (tool-text r))
+    (test "eval no-inputs: kind is :keyword"
+      (= (get payload "kind") ":keyword")
+      (string "got kind " (get payload "kind"))))
+
+  (println "")
+  (println (string pass-count " passed, " fail-count " failed"))
+  (when (> fail-count 0)
+    (error {:error :test-failure :message (string fail-count " tests failed")}))
+  (println "all eval tests passed."))

--- a/tools/test-mcp.lisp
+++ b/tools/test-mcp.lisp
@@ -142,9 +142,9 @@
   (send pin {:jsonrpc "2.0" :id 2 :method "tools/list" :params {}})
   (let [[r (recv-response pout 2)]]
     (let [[tools (get (get r "result") "tools")]]
-      (test "tools/list: exposes 20 tools"
-        (= (length tools) 20)
-        (string "expected 20, got " (length tools)))))
+      (test "tools/list: exposes 21 tools"
+        (= (length tools) 21)
+        (string "expected 21, got " (length tools)))))
 
   ## ── 3. ping ───────────────────────────────────────────────────────────
   (send pin {:jsonrpc "2.0" :id 3 :method "ping" :params {}})

--- a/tools/test-mcp.lisp
+++ b/tools/test-mcp.lisp
@@ -250,5 +250,47 @@
     (test "unknown method: returns error object"
       (not (nil? (get r "error"))) "expected error response"))
 
+  ## ── 13. err-msg: struct error has readable message ──────────────────
+  ## Trigger an error via a bad SPARQL query — the error message should
+  ## contain useful info, not "nil" (which happens if the error is a
+  ## string and the old code calls (get string-error :message)).
+  (let [[r (call-tool pin pout 13 "sparql_query"
+             {:query "THIS IS NOT VALID SPARQL"})]]
+    (let [[text (tool-text r)]]
+      (test "err-msg: SPARQL error has readable message"
+        (and (string/contains? text "SPARQL error")
+             (not (string/contains? text "nil")))
+        (string "got: " text))))
+
+  ## ── 14. err-msg: tool dispatch error has readable message ────────────
+  ## Call a tool with bad arguments that causes an internal error.
+  ## The error message in the response should not be "nil".
+  (let [[r (call-tool pin pout 14 "verify_invariants"
+             {:path "/nonexistent/invariants.lisp"})]]
+    (let [[text (tool-text r)]]
+      (test "err-msg: tool error has readable message"
+        (not (string/contains? text "Internal error: nil"))
+        (string "got: " text))))
+
+  ## ── 15. flush: response arrives immediately ──────────────────────────
+  ## After sending a ping, the response should arrive within 5 seconds.
+  ## This verifies flush is working (without flush, pipe-buffered stdout
+  ## may not deliver the response until the buffer fills).
+  (let [[[ok? r] (protect (ev/timeout 5 (fn []
+      (send pin {:jsonrpc "2.0" :id 15 :method "ping" :params {}})
+      (recv-response pout 15))))]]
+    (test "flush: ping response arrives promptly" ok?
+      "response was not delivered within 5 seconds"))
+
+  ## ── 16. async dispatch: concurrent requests ──────────────────────────
+  ## Send two pings back-to-back; both should get responses.
+  (send pin {:jsonrpc "2.0" :id 16 :method "ping" :params {}})
+  (send pin {:jsonrpc "2.0" :id 17 :method "ping" :params {}})
+  (let [[[ok? _] (protect (ev/timeout 10 (fn []
+      (recv-response pout 16)
+      (recv-response pout 17))))]]
+    (test "async: concurrent pings both respond" ok?
+      "did not receive both responses within 10 seconds"))
+
   (println "")
   (println "all MCP tests passed."))


### PR DESCRIPTION

eval accepts an Elle lambda + input handles (UUIDs from prior evals),
applies the lambda to the resolved values, and returns a new handle
naming the result. stdout/stderr are captured via parameterize to temp
files. Large values stay in the image — agents probe them by
submitting further lambdas.

Response includes: handle, ok, kind, shape, stdout, stderr,
duration_ns, fibers. Errors produce handles too (ok:false, kind:error)
so agents can inspect them through further eval calls.

Contract documented in docs/mcp-eval.md. 30 integration tests in
tools/test-eval.lisp covering: nullary/unary/multi-arity eval,
handle chaining, stdout/stderr capture, error handles, error probing,
unknown handle, arity mismatch, non-callable, timeout, duration.