### PR TITLE
Fix MCP server: plugin dispatch in JIT/WASM, make mcp target

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,8 @@
 [submodule "plugins"]
 	path = plugins
 	url = https://github.com/elle-lisp/plugins.git
+	branch = main
 [submodule "mcp"]
 	path = mcp
 	url = https://github.com/elle-lisp/mcp.git
+	branch = main

--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "elle-mcp": {
       "command": "elle",
-      "args": ["tools/mcp-server.lisp"]
+      "args": ["mcp/mcp-server.lisp"]
     }
   }
 }

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all elle dev docs docgen smoke test test-git clean help \
+.PHONY: all elle dev mcp docs docgen smoke test test-git clean help \
        smoke-vm smoke-jit smoke-wasm doctest
 
 .DEFAULT_GOAL := all
@@ -23,6 +23,12 @@ elle:  ## Build the Elle binary (release)
 
 dev:  ## Build the Elle binary (debug, fast compile)
 	cargo build -p elle --features wasm
+
+MCP_PATCH := --config 'patch."https://github.com/elle-lisp/elle".elle-plugin.path="elle-plugin"'
+
+mcp: elle  ## Build elle + MCP plugins (oxigraph, syn)
+	cargo build --release --manifest-path plugins/Cargo.toml --target-dir target \
+		-p elle-oxigraph -p elle-syn $(MCP_PATCH)
 
 # ── Docs ────────────────────────────────────────────────────────────
 

--- a/src/jit/calls.rs
+++ b/src/jit/calls.rs
@@ -186,9 +186,13 @@ pub extern "C" fn elle_jit_call(
     };
 
     // Dispatch to native function — zero-copy args via *const Value
-    if let Some(f) = func.as_native_fn() {
+    if let Some(def) = func.as_native_def() {
         let args_slice = args_ptr_to_value_slice(args_ptr, nargs);
-        let (bits, value) = f(args_slice);
+        let (bits, value) = if std::ptr::fn_addr_eq(def.func, crate::plugin_api::PLUGIN_SENTINEL) {
+            crate::plugin_api::call_plugin(def, args_slice)
+        } else {
+            (def.func)(args_slice)
+        };
         return jit_handle_primitive_signal(vm, bits, value);
     }
 
@@ -607,9 +611,13 @@ pub extern "C" fn elle_jit_tail_call(
     };
 
     // Handle native functions
-    if let Some(f) = func.as_native_fn() {
+    if let Some(def) = func.as_native_def() {
         let args_slice = args_ptr_to_value_slice(args_ptr, nargs);
-        let (bits, value) = f(args_slice);
+        let (bits, value) = if std::ptr::fn_addr_eq(def.func, crate::plugin_api::PLUGIN_SENTINEL) {
+            crate::plugin_api::call_plugin(def, args_slice)
+        } else {
+            (def.func)(args_slice)
+        };
         return jit_handle_primitive_signal(vm, bits, value);
     }
 

--- a/src/wasm/host.rs
+++ b/src/wasm/host.rs
@@ -235,7 +235,11 @@ impl ElleHost {
     /// Returns (signal_bits, result_value).
     pub fn call_primitive(&mut self, prim_id: u32, args: &[Value]) -> (SignalBits, Value) {
         let def = self.primitives[prim_id as usize];
-        (def.func)(args)
+        if std::ptr::fn_addr_eq(def.func, crate::plugin_api::PLUGIN_SENTINEL) {
+            crate::plugin_api::call_plugin(def, args)
+        } else {
+            (def.func)(args)
+        }
     }
 
     /// Handle SIG_IO from a primitive call.


### PR DESCRIPTION
JIT and WASM backends called plugin primitives directly through the sentinel function pointer instead of dispatching through call_plugin(). This caused a panic ("plugin primitive called without plugin dispatch") whenever a plugin primitive was invoked from JIT-compiled code.

- src/jit/calls.rs: add PLUGIN_SENTINEL check in elle_jit_call and elle_jit_tail_call, matching the existing check in src/vm/call.rs
- src/wasm/host.rs: add PLUGIN_SENTINEL check in call_primitive
- Makefile: add `make mcp` target that builds elle + oxigraph/syn plugins with --target-dir target so .so files land where elle discovers them
- .mcp.json: fix path to mcp/mcp-server.lisp (moved with submodule)
- .gitmodules: track main branch for plugins and mcp submodules
- plugins: update submodule to latest main; wrap unsafe Api::arg() calls, remove unused SIG_OK imports