### PR TITLE
Fix TLS read losing buffered plaintext on TCP close

### DIFF
--- a/lib/tls.lisp
+++ b/lib/tls.lisp
@@ -178,8 +178,13 @@
           (when (> (length buffered) 0)
             (break buffered)))
         # Plaintext buffer empty — read from network.
+        # Use 16384 to match TLS max record size.
         (let [data (port/read port 16384)]  # async
-          (when (nil? data) (break nil))         # EOF
+          (when (nil? data)
+            # TCP closed. process-fn may have buffered plaintext from
+            # a segment that also contained close_notify. One final drain.
+            (let [final (read-plaintext-fn tls n)]
+              (break (if (> (length final) 0) final nil))))
           (process-fn tls data)
           # INVARIANT: Send outgoing after every tls/process.
           # TLS 1.3 post-handshake messages (NewSessionTicket, KeyUpdate) must


### PR DESCRIPTION
When the peer sends close_notify in the same TLS record as application data, port/read returns nil before we drain the plaintext buffer. Do one final read-plaintext-fn call on EOF so the last segment is not silently dropped.

drive_state_machine in the TLS plugin was returning after processing a single TLS record (ReadTraffic → Some("has-data")), but rustls's process_tls_records consumes all incoming bytes and may buffer multiple decoded records internally. The state machine transitions ReadTraffic → WriteTraffic ("ready") after each record. The fix: after has-data", loop back to drain more records; when we see "ready" after having gotten data, return "has-data" to the caller with all plaintext accumulated.