### PR TITLE
Migrate MCP server to epoch 8; disable static TLS re-exec hack (#747)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,7 @@ multi-function compilation, yield side-exit, polymorphic dispatch, and
 cross-thread LIR transfer. Current state: all instruction types supported,
 adaptive tiering, direct self-calls and intra-group calls.
 
+- #737: JIT tail-call trampoline; squelch enforcement in compile/run-on
 - #736: Upgrade Cranelift 0.116 to 0.130 (deduplicate with Wasmtime 43)
 - #720: Sendable channels; JIT SuspendingCall fix; LIR transfer for worker-thread JIT
 - #714: SDL3 bindings; JIT polymorphic+SuspendingCall fixes; upvalue index widened to u16
@@ -145,6 +146,7 @@ MLIR backend lowers LIR to arith/func/cf dialects and JIT-compiles via
 ExecutionEngine. Vulkan compute dispatches async via io_uring fence fds.
 SPIR-V is generated at runtime from Elle code (no GLSL).
 
+- #737: MLIR/SPIR-V float support, differential testing harness (`compile/run-on` across 4 tiers), `LirInstr::Convert`, `ValueConst`
 - #727: Vulkan compute (async dispatch, buffer pooling), SPIR-V emitter (runtime bytecode gen), MLIR backend (melior 0.27), GPU eligibility analysis, SignalBits widened to u64
 
 ---
@@ -211,6 +213,8 @@ Core language features: destructuring, match, parameters, macros, epochs,
 binding forms. The language settled on `def`/`var`/`defn`/`fn` with bracket
 syntax for bindings, `true`/`false` literals, and `#` for comments.
 
+- #737: Epoch 8: immutable-by-default bindings with `@` prefix for opt-in mutability; `integer`/`float` coercion split from `parse-int`/`parse-float`
+- #742: Epoch 7: flat let bindings (Clojure-style `[a 1 b 2]` replaces `[[a 1] [b 2]]`)
 - #648: Epoch-based migration system for breaking language changes
 - #652: Remove assertions.lisp; consolidate to built-in assert; elle rewrite tool
 - #656: Consolidate sync output primitives; print/println/eprint/eprintln; parameterize-aware
@@ -332,6 +336,7 @@ Pure Elle libraries for HTTP, DNS, Redis, IRC, TLS, process management,
 telemetry, contracts, synchronization, AWS, and more. Libraries use the
 closure-as-module pattern and are imported via `(import "std/<name>")`.
 
+- #745: Fix TLS read silently dropping final plaintext segment on TCP close
 - #735: HTTP: chunked transfer, HTTPS/TLS, query params, redirects, compression, SSE
 - #724: IRC module with IRCv3, CAP negotiation, SASL, auto-PONG
 - #715: Move 9 plugins from Rust to native Elle (base64, compress, git, glob, semver, sqlite, uuid, cli, watch)

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -95,6 +95,35 @@ end-devlog-instructions -->
 
 Per-PR entries capturing significant development work, generated from
 git history by reading actual diffs. Most recent first.
+
+## [#737](https://github.com/elle-lisp/elle/pull/737) — MLIR/SPIR-V float support, differential testing harness, epoch 8 immutable-by-default bindings
+[`19fd778a`](https://github.com/elle-lisp/elle/commit/19fd778a) · 2026-04-18 · `compiler` `lir` `jit` `epoch`
+
+Massive multi-front commit spanning execution backends and language semantics. Adds a `compile/run-on` primitive that force-dispatches closures on any of four tiers (:bytecode, :jit, :wasm, :mlir-cpu), enabling a differential testing harness (`tests/diff/`) that runs the same closure on all eligible tiers and asserts agreement. MLIR-CPU and SPIR-V backends gain full float support (typed arithmetic, mixed int/float promotion, float comparisons, bool returns, captures as extra parameters, within-block type reassignment). The JIT gains a tail-call trampoline, and squelch enforcement is added to the compile/run-on dispatch path. Introduces `integer`/`float` as numeric-only coercion (string parsing split to `parse-int`/`parse-float`), a `LirInstr::Convert` for type conversions that makes them GPU-eligible, and immutable constant propagation in the lowerer via `ValueConst`. Epoch 8 introduces immutable-by-default bindings with `@` prefix for opt-in mutability, gated on source epoch so older files remain compatible. 363 files changed.
+
+---
+
+## [#746](https://github.com/elle-lisp/elle/pull/746) — Add DEVLOG.md and CHANGELOG.md from git history
+[`f13573ea`](https://github.com/elle-lisp/elle/commit/f13573ea) · 2026-04-18 · `docs`
+
+Generates two project history documents from the full commit log. DEVLOG.md contains per-PR entries for all 368 squash-merged PRs with narrative summaries written from the actual diffs. CHANGELOG.md provides an agent-optimized summary grouped by narrative arc (memory model, execution backends, signal system, compiler pipeline, etc.). Both files are self-documenting with embedded generation instructions and are linked from README.md and QUICKSTART.md.
+
+---
+
+## [#745](https://github.com/elle-lisp/elle/pull/745) — Fix TLS read silently dropping final plaintext segment on TCP close
+[`fcc70ef2`](https://github.com/elle-lisp/elle/commit/fcc70ef2) · 2026-04-18 · `tls` `bugfix`
+
+When a TLS peer sends `close_notify` in the same record as application data, `port/read` returned nil before draining the plaintext buffer, silently dropping the last segment. The fix adds one final `read-plaintext-fn` call on EOF to flush any remaining buffered plaintext before signaling end-of-stream. A one-file, six-line change in `lib/tls.lisp`.
+
+---
+
+## [#742](https://github.com/elle-lisp/elle/pull/742) — Epoch 7: flat let bindings (Clojure-style alternating name/value)
+[`4b8a2f1d`](https://github.com/elle-lisp/elle/commit/4b8a2f1d) · 2026-04-17 · `language` `epoch` `compiler`
+
+Switches `let`, `let*`, `letrec`, `if-let`, `when-let`, and `when-ok` from nested-pair bindings `[[a 1] [b 2]]` to flat alternating name/value pairs `[a 1 b 2]`, matching Clojure style. Destructuring patterns (which start with `[`) are still recognized unambiguously. Epoch 6 files are migrated transparently at compile time via a new `FlattenBindings` epoch transform. The change touches 314 files: stride-2 iteration in the HIR binding analyzer, flat `Array` generation in syntax-case expansion, all 18 prelude macros rewritten, and mechanical migration of ~280 `.lisp` files across stdlib, lib, tests, demos, and tools. Backward compatibility is verified by `tests/elle/epoch6.lisp`.
+
+---
+
 ## [#744](https://github.com/elle-lisp/elle/pull/744) — Plugins submodule bump (second pass)
 [`107ea501`](https://github.com/elle-lisp/elle/commit/107ea501) · 2026-04-17 · `submodule`
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -508,33 +508,22 @@ fn print_jit_stats(vm: &VM) {
 }
 
 fn main() {
-    // Ensure enough static TLS space for dlopen'd plugins.
-    // GLIBC_TUNABLES is read by the dynamic linker before main(), so if
-    // it's missing we must re-exec ourselves with it set.
-    #[cfg(target_os = "linux")]
-    {
-        use std::os::unix::process::CommandExt;
-
-        let key = "GLIBC_TUNABLES";
-        let needed = "glibc.rtld.optional_static_tls=65536";
-        let already_set = env::var(key)
-            .map(|v| v.contains("glibc.rtld.optional_static_tls"))
-            .unwrap_or(false);
-        if !already_set {
-            // Merge with any existing tunables
-            let new_val = match env::var(key) {
-                Ok(existing) if !existing.is_empty() => format!("{}:{}", existing, needed),
-                _ => needed.to_string(),
-            };
-            let exe = env::current_exe().expect("failed to get current exe path");
-            let err = std::process::Command::new(exe)
-                .args(&env::args().collect::<Vec<_>>()[1..])
-                .env(key, &new_val)
-                .exec();
-            eprintln!("elle: re-exec failed: {}", err);
-            std::process::exit(1);
-        }
-    }
+    // DISABLED (2026-04-18): static TLS re-exec hack for dlopen'd plugins.
+    //
+    // Was: set GLIBC_TUNABLES=glibc.rtld.optional_static_tls=65536 and
+    // re-exec the process so the dynamic linker sees it before main().
+    // This reserved 64KB of optional static TLS for C++ plugins loaded
+    // via dlopen (e.g. oxigraph).
+    //
+    // Removed because:
+    //   - Linux/glibc only; no-op on musl, Bionic (Android), macOS
+    //   - The re-exec changes PID, breaking strace/gdb workflows
+    //   - current_exe() can fail in chroots/containers
+    //   - MCP server and all plugins load fine without it on glibc 2.39+
+    //
+    // If plugin loading fails with "cannot allocate memory in static TLS
+    // block", restore the block from git (commit 9ed7b880) or set
+    // GLIBC_TUNABLES manually before launching elle.
 
     let args: Vec<String> = env::args().collect();
 


### PR DESCRIPTION
- MCP submodule: `elle rewrite` all 9 .lisp files from epoch 6 to 8 (var→def @, flat let bindings, flat multi-binding lets; 723 edits)
- Disable GLIBC_TUNABLES static TLS re-exec hack in main.rs — plugins load fine without it on modern glibc; document how to restore if needed
- DEVLOG.md: add entries for #737, #742, #745, #746
- CHANGELOG.md: add entries under MLIR/GPU, JIT, Language, Stdlib arcs

The MCP server was broken by epoch 7+8 landing without migrating the submodule. The actual failure was `var` (removed in epoch 8) being parsed as a malformed let binding. The TLS hack was unrelated.