### PR TITLE
Gate Cranelift JIT behind `jit` feature flag (default on)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,13 +33,13 @@ camino = "1.2"
 path-clean = "1.0"
 pathdiff = { version = "0.2", features = ["camino"] }
 
-# JIT compilation
-cranelift-codegen = "0.130"
-cranelift-frontend = "0.130"
-cranelift-module = "0.130"
-cranelift-jit = "0.130"
-cranelift-native = "0.130"
-target-lexicon = "0.13"
+# JIT compilation (optional, enable with --features jit; on by default)
+cranelift-codegen = { version = "0.130", optional = true }
+cranelift-frontend = { version = "0.130", optional = true }
+cranelift-module = { version = "0.130", optional = true }
+cranelift-jit = { version = "0.130", optional = true }
+cranelift-native = { version = "0.130", optional = true }
+target-lexicon = { version = "0.13", optional = true }
 
 # WASM backend (optional, enable with --features wasm)
 wasmtime = { version = "43", features = ["incremental-cache"], optional = true }
@@ -54,7 +54,8 @@ proptest = "1.4"
 stats_alloc = { version = "0.1.10", features = ["nightly"] }
 
 [features]
-default = []
+default = ["jit"]
+jit = ["cranelift-codegen", "cranelift-frontend", "cranelift-module", "cranelift-jit", "cranelift-native", "target-lexicon"]
 wasm = ["wasmtime", "wasm-encoder"]
 mlir = ["melior"]
 

--- a/src/jit/AGENTS.md
+++ b/src/jit/AGENTS.md
@@ -324,7 +324,7 @@ No errors are silently swallowed.
 6. **Module lifetime.** `JitCode` keeps the `JITModule` alive via `Arc` so the
    native code isn't freed while still in use.
 
-7. **Always enabled.** JIT is a required dependency (Cranelift). No feature gate.
+7. **Enabled by default via `jit` Cargo feature.** Disable with `--no-default-features`.
 
 8. **VM pointer for runtime calls.** The 4th parameter is `vm` to support
    function calls, fiber access, and yield side-exit helpers.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,7 @@ pub mod ffi;
 pub mod formatter;
 pub mod hir;
 pub mod io;
+#[cfg(feature = "jit")]
 pub mod jit;
 pub mod lint;
 pub mod lir;

--- a/src/lir/emit/tests.rs
+++ b/src/lir/emit/tests.rs
@@ -134,6 +134,7 @@ fn test_yield_point_info_collected() {
     assert!(yield_points[0].stack_regs.is_empty());
 }
 
+#[cfg(feature = "jit")]
 #[test]
 fn test_yield_sentinel_distinct() {
     use crate::jit::dispatch::{TAIL_CALL_SENTINEL, YIELD_SENTINEL};

--- a/src/main.rs
+++ b/src/main.rs
@@ -486,6 +486,7 @@ fn run_repl(vm: &mut VM, symbols: &mut SymbolTable) -> bool {
     }
 }
 
+#[cfg(feature = "jit")]
 fn print_jit_stats(vm: &VM) {
     let compiled = vm.jit_cache.len();
     let rejected = vm.jit_rejections.len();
@@ -630,6 +631,7 @@ fn main() {
         if scope_stats.scopes_analyzed > 0 {
             eprint!("{}", scope_stats);
         }
+        #[cfg(feature = "jit")]
         print_jit_stats(&vm);
         let cvc = elle::lir::closure_value_const_count();
         if cvc > 0 {

--- a/src/primitives/disassembly.rs
+++ b/src/primitives/disassembly.rs
@@ -95,6 +95,7 @@ pub(crate) fn prim_disjit(args: &[Value]) -> (SignalBits, Value) {
             ),
         );
     }
+    #[cfg(feature = "jit")]
     if let Some(closure) = args[0].as_closure() {
         let lir = match &closure.template.lir_function {
             Some(lir) => lir.clone(),
@@ -105,21 +106,26 @@ pub(crate) fn prim_disjit(args: &[Value]) -> (SignalBits, Value) {
             Err(_) => return (SIG_OK, Value::NIL),
         };
         match compiler.clif_text(&lir, None) {
-            Ok(lines) => (
-                SIG_OK,
-                Value::array_mut(lines.into_iter().map(Value::string).collect()),
-            ),
-            Err(_) => (SIG_OK, Value::NIL),
+            Ok(lines) => {
+                return (
+                    SIG_OK,
+                    Value::array_mut(lines.into_iter().map(Value::string).collect()),
+                )
+            }
+            Err(_) => return (SIG_OK, Value::NIL),
         }
-    } else {
-        (
-            SIG_ERROR,
-            error_val(
-                "type-error",
-                "disjit: argument must be a closure".to_string(),
-            ),
-        )
     }
+    #[cfg(not(feature = "jit"))]
+    if args[0].as_closure().is_some() {
+        return (SIG_OK, Value::NIL);
+    }
+    (
+        SIG_ERROR,
+        error_val(
+            "type-error",
+            "disjit: argument must be a closure".to_string(),
+        ),
+    )
 }
 
 /// Build the CFG struct from a closure's LIR.

--- a/src/vm/call.rs
+++ b/src/vm/call.rs
@@ -267,6 +267,7 @@ impl VM {
             // JIT compilation and dispatch.
             // Polymorphic closures are rejected by the JIT compiler itself.
             // Skip profiling for primitives (no LIR means not JIT-compilable).
+            #[cfg(feature = "jit")]
             if closure.template.lir_function.is_some() {
                 if let Some(bits) = self.try_jit_call(closure, &args, func) {
                     self.fiber.call_depth -= 1;

--- a/src/vm/core.rs
+++ b/src/vm/core.rs
@@ -11,6 +11,7 @@ use rustc_hash::FxHashMap;
 use std::collections::HashMap;
 use std::rc::Rc;
 
+#[cfg(feature = "jit")]
 use crate::jit::{JitCode, JitRejectionInfo};
 
 pub(crate) struct TailCallInfo {
@@ -69,6 +70,7 @@ pub struct VM {
     /// overwriting the child fiber's error origin.
     pub(crate) error_loc: Option<SourceLoc>,
     /// JIT code cache: bytecode pointer → compiled native code.
+    #[cfg(feature = "jit")]
     pub jit_cache: FxHashMap<*const u8, Rc<JitCode>>,
     /// Documentation for all named forms (primitives, special forms, macros).
     /// Keyed by name string for direct lookup via `doc` and `vm/primitive-meta`.
@@ -76,6 +78,7 @@ pub struct VM {
     /// JIT rejection log: bytecode pointer → rejection info.
     /// Records first rejection per closure template. Used by
     /// `(jit/rejections)` primitive and `--stats` CLI flag.
+    #[cfg(feature = "jit")]
     pub jit_rejections: FxHashMap<*const u8, JitRejectionInfo>,
     /// Cached Expander for runtime `eval`. Avoids re-loading the prelude
     /// on every eval call. Taken out during eval, put back after.
@@ -191,7 +194,9 @@ impl VM {
             pending_tail_call: None,
             pending_fiber_resume: None,
             error_loc: None,
+            #[cfg(feature = "jit")]
             jit_cache: FxHashMap::default(),
+            #[cfg(feature = "jit")]
             jit_rejections: FxHashMap::default(),
             docs: HashMap::new(),
             eval_expander: None,
@@ -235,6 +240,7 @@ impl VM {
         self.pending_fiber_resume = None;
         self.error_loc = None;
         self.closure_call_counts.clear();
+        #[cfg(feature = "jit")]
         self.jit_rejections.clear();
         self.location_map = LocationMap::new();
         self.loading_modules.clear();

--- a/src/vm/fiber.rs
+++ b/src/vm/fiber.rs
@@ -18,6 +18,7 @@
 //!
 //! SIG_TERMINAL signals are uncatchable — they pass through mask checks.
 
+#[cfg(feature = "jit")]
 use crate::jit::JitValue;
 use crate::value::error_val;
 use crate::value::fiber::FiberStatus;
@@ -754,6 +755,7 @@ impl VM {
     // primitive returns SIG_RESUME/SIG_PROPAGATE/SIG_ABORT in JIT context.
 
     /// Handle SIG_RESUME from a fiber primitive in JIT context.
+    #[cfg(feature = "jit")]
     ///
     /// Runs the child fiber synchronously and returns the result as `JitValue`.
     /// On error: sets fiber.signal, returns `JitValue::nil()`.
@@ -823,6 +825,7 @@ impl VM {
     }
 
     /// Handle SIG_PROPAGATE from fiber/propagate in JIT context.
+    #[cfg(feature = "jit")]
     pub(crate) fn handle_fiber_propagate_signal_jit(&mut self, fiber_value: Value) -> JitValue {
         use crate::jit::YIELD_SENTINEL;
 
@@ -862,6 +865,7 @@ impl VM {
     }
 
     /// Handle SIG_ABORT from fiber/abort in JIT context.
+    #[cfg(feature = "jit")]
     pub(crate) fn handle_fiber_abort_signal_jit(&mut self, fiber_value: Value) -> JitValue {
         use crate::jit::YIELD_SENTINEL;
 

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -12,6 +12,7 @@ pub mod env;
 pub mod eval;
 pub mod execute;
 pub mod fiber;
+#[cfg(feature = "jit")]
 mod jit_entry;
 pub mod literals;
 #[cfg(feature = "mlir")]

--- a/src/vm/run_on.rs
+++ b/src/vm/run_on.rs
@@ -16,6 +16,7 @@
 //! the tier rather than failing.
 
 use crate::value::{error_val_extra, SignalBits, Value, SIG_ERROR, SIG_OK};
+#[cfg(any(feature = "jit", feature = "wasm"))]
 use std::rc::Rc;
 
 use super::core::VM;
@@ -121,6 +122,7 @@ impl VM {
     ///
     /// Force-compiles the closure if it's not already cached; rejects
     /// with `:tier-rejected` if it has no LIR or the JIT compiler refuses.
+    #[cfg(feature = "jit")]
     pub fn invoke_closure_jit(
         &mut self,
         closure_val: Value,
@@ -325,6 +327,17 @@ impl VM {
         }
 
         (SIG_OK, result_jv.to_value())
+    }
+
+    /// Stub when JIT feature is disabled — always rejects with `:tier-rejected`.
+    #[cfg(not(feature = "jit"))]
+    pub fn invoke_closure_jit(
+        &mut self,
+        _closure_val: Value,
+        _closure: &crate::value::Closure,
+        _args: &[Value],
+    ) -> (SignalBits, Value) {
+        (SIG_ERROR, rejected("jit", "JIT feature not compiled in"))
     }
 
     /// Run a closure via the WASM backend (Wasmtime tiered compilation).

--- a/src/vm/signal.rs
+++ b/src/vm/signal.rs
@@ -593,6 +593,7 @@ impl VM {
                     }
                 }
             }
+            #[cfg(feature = "jit")]
             "jit/rejections" => {
                 use crate::value::heap::TableKey;
                 use std::collections::BTreeMap;
@@ -623,6 +624,9 @@ impl VM {
                     .collect();
                 (SIG_OK, crate::value::list(structs))
             }
+            #[cfg(not(feature = "jit"))]
+            "jit/rejections" => (SIG_OK, crate::value::list(vec![])),
+            #[cfg(feature = "jit")]
             "jit?" => {
                 if let Some(closure) = arg.as_closure() {
                     let ptr = closure.template.bytecode.as_ptr();
@@ -631,6 +635,8 @@ impl VM {
                     (SIG_OK, Value::FALSE)
                 }
             }
+            #[cfg(not(feature = "jit"))]
+            "jit?" => (SIG_OK, Value::FALSE),
             "vm/config" => self.dispatch_vm_config_read(arg),
             #[cfg(feature = "mlir")]
             "mlir/compile-spirv" => {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -136,6 +136,7 @@ fn eval_with_cache(
 
         // Reset per-case state
         c.vm.reset_fiber();
+        #[cfg(feature = "jit")]
         c.vm.jit_cache.clear();
 
         // Set context pointers (may have been cleared after previous eval)

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -31,6 +31,7 @@ mod signal_enforcement {
 mod signal_unsoundness {
     include!("signal_unsoundness.rs");
 }
+#[cfg(feature = "jit")]
 mod jit {
     include!("jit.rs");
 }

--- a/tests/unittests/mod.rs
+++ b/tests/unittests/mod.rs
@@ -17,6 +17,7 @@ mod bytecode_debug {
 mod hir_debug {
     include!("hir_debug.rs");
 }
+#[cfg(feature = "jit")]
 mod jit {
     include!("jit.rs");
 }

--- a/tests/unittests/primitives.rs
+++ b/tests/unittests/primitives.rs
@@ -1741,6 +1741,7 @@ fn test_json_serialize_errors() {
 }
 
 // Disassembly tests
+#[cfg(feature = "jit")]
 #[test]
 fn test_disjit_returns_array_for_pure_closure() {
     let (_vm, mut symbols, meta) = setup();
@@ -1839,6 +1840,7 @@ fn test_call_count_uncalled_closure() {
     );
 }
 
+#[cfg(feature = "jit")]
 #[test]
 fn test_call_count_after_calls() {
     let result = eval_full("(let [f (fn (x) x)] (f 1) (f 2) (f 3) (call-count f))").unwrap();


### PR DESCRIPTION
Android users can't compile Elle because cranelift-codegen generates enormous match tables that overwhelm the compiler on constrained targets. Gate the JIT behind an optional Cargo feature so they can build with `cargo build --no-default-features`.

Shared fields (closure_call_counts, jit_enabled, jit_hotness_threshold) stay unconditional since the WASM tier uses them too. JIT-type-dependent fields (jit_cache, jit_rejections) and all JIT code paths are gated. Stubs return sensible defaults: jit? → false, jit/rejections → (), disjit → nil, invoke_closure_jit → :tier-rejected.