### PR TITLE
make libffi optional for the most lame of supported platforms

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -149,10 +149,26 @@ jobs:
         run: cargo build --release -p elle
       - name: Run smoke tests
         run: make smoke
-      - name: Build release binary (no JIT)
+
+  aarch64-noffi:
+    name: AArch64 No-FFI Smoke
+    needs: changes
+    runs-on: ubuntu-24.04-arm
+    if: needs.changes.outputs.source == 'true'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: aarch64-noffi
+      - name: Install GNU parallel
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y parallel
+      - name: Build release binary (no JIT, no FFI)
         run: cargo build --release --no-default-features -p elle
-      - name: Run smoke tests (VM only, no JIT)
-        run: make smoke-vm
+      - name: Run smoke tests (VM only, no JIT, no FFI)
+        run: make smoke-noffi
 
   android:
     name: Android Cross-Check
@@ -196,7 +212,7 @@ jobs:
 
   all-checks:
     name: All Checks Passed
-    needs: [changes, qa, tests-combined, tests, mlir, aarch64, android, macos]
+    needs: [changes, qa, tests-combined, tests, mlir, aarch64, aarch64-noffi, android, macos]
     runs-on: ubuntu-latest
     if: always()
     steps:
@@ -214,6 +230,9 @@ jobs:
         run: exit 1
       - name: Check aarch64
         if: needs.aarch64.result == 'failure'
+        run: exit 1
+      - name: Check aarch64-noffi
+        if: needs.aarch64-noffi.result == 'failure'
         run: exit 1
       - name: Check Android
         if: needs.android.result == 'failure'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ mimalloc = "0.1"
 rustc-hash = "2.0"
 smallvec = "1.11"
 libloading = "0.8"
-libffi = "5.1"
+libffi = { version = "5.1", optional = true }
 rustyline = "14"
 libc = "0.2"
 serde_json = "1.0"
@@ -54,7 +54,8 @@ proptest = "1.4"
 stats_alloc = { version = "0.1.10", features = ["nightly"] }
 
 [features]
-default = ["jit"]
+default = ["jit", "ffi"]
+ffi = ["libffi"]
 jit = ["cranelift-codegen", "cranelift-frontend", "cranelift-module", "cranelift-jit", "cranelift-native", "target-lexicon"]
 wasm = ["wasmtime", "wasm-encoder"]
 mlir = ["melior"]

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: all elle dev docs docgen smoke test test-git clean help \
-       smoke-vm smoke-jit smoke-wasm smoke-diff doctest
+       smoke-vm smoke-noffi smoke-jit smoke-wasm smoke-diff doctest
 
 .DEFAULT_GOAL := all
 
@@ -58,6 +58,9 @@ docgen: elle  ## Generate documentation site (Rust docs + Elle site)
 ELLE_SKIP_VM  := -e jit-rejections.lisp
 ELLE_SKIP_JIT := -e NOMATCH_PLACEHOLDER
 
+# FFI skip list: tests requiring libffi (skipped when built --no-default-features)
+ELLE_SKIP_FFI := -e ffi.lisp -e compress.lisp -e sqlite.lisp -e zmq.lisp -e git.lisp -e http.lisp
+
 # WASM backend skip list: tests requiring features not yet in WASM backend
 # (eval = dynamic compilation)
 WASM_SKIP := -e eval.lisp
@@ -69,6 +72,14 @@ smoke-vm:
 		parallel -j $(JOBS) --halt now,fail=1 --tag \
 			'timeout $(TIMEOUT) $(ELLE) --jit=0 {}' \
 		|| { echo "FAILED: elle scripts VM-only pass (JIT was disabled)"; exit 1; }
+
+smoke-noffi:
+	@echo "=== elle scripts (VM, no JIT, no FFI) ==="
+	@printf '%s\n' tests/elle/*.lisp | \
+		grep -v $(ELLE_SKIP_VM) | grep -v $(ELLE_SKIP_FFI) | \
+		parallel -j $(JOBS) --halt now,fail=1 --tag \
+			'timeout $(TIMEOUT) $(ELLE) --jit=0 {}' \
+		|| { echo "FAILED: elle scripts VM-only pass (no JIT, no FFI)"; exit 1; }
 
 smoke-jit:
 	@echo "=== elle scripts (JIT enabled, threshold=1) ==="

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,8 @@
 fn main() {
-    if std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("android") {
+    // libgcc is only needed for libffi on Android (__clear_cache symbol).
+    if std::env::var("CARGO_FEATURE_FFI").is_ok()
+        && std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("android")
+    {
         println!("cargo:rustc-link-lib=gcc");
     }
 }

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -2,16 +2,25 @@
 //!
 //! Enables calling C functions from Elle code. This module is being rebuilt
 //! to match the design in docs/ffi.md.
+//!
+//! The `ffi` cargo feature gates the libffi-dependent call/callback
+//! machinery. Type descriptors and library loading are always available.
 
+#[cfg(feature = "ffi")]
 pub mod call;
+#[cfg(feature = "ffi")]
 pub mod callback;
+#[cfg(feature = "ffi")]
 pub(crate) mod from_c;
 pub mod loader;
+#[cfg(feature = "ffi")]
 pub mod marshal;
 pub mod primitives;
+#[cfg(feature = "ffi")]
 pub(crate) mod to_c;
 pub mod types;
 
+#[cfg(feature = "ffi")]
 use callback::CallbackStore;
 use loader::LibraryHandle;
 use std::collections::HashMap;
@@ -23,6 +32,7 @@ pub(crate) struct FFISubsystem {
     /// Next library ID to assign
     next_lib_id: u32,
     /// Active FFI callbacks: code_ptr -> ActiveCallback
+    #[cfg(feature = "ffi")]
     callbacks: CallbackStore,
 }
 
@@ -32,6 +42,7 @@ impl FFISubsystem {
         FFISubsystem {
             libraries: HashMap::new(),
             next_lib_id: 1,
+            #[cfg(feature = "ffi")]
             callbacks: CallbackStore::new(),
         }
     }
@@ -62,6 +73,7 @@ impl FFISubsystem {
     }
 
     /// Get mutable access to the callback store.
+    #[cfg(feature = "ffi")]
     pub fn callbacks_mut(&mut self) -> &mut CallbackStore {
         &mut self.callbacks
     }

--- a/src/primitives/ffi.rs
+++ b/src/primitives/ffi.rs
@@ -90,6 +90,7 @@ mod tests {
     use crate::value::fiber::{SIG_ERROR, SIG_OK};
     use crate::value::Value;
 
+    #[cfg(feature = "ffi")]
     use super::super::calling::prim_ffi_call;
     use super::super::loading::{prim_ffi_native, prim_ffi_signature};
     use super::super::memory::{
@@ -202,6 +203,7 @@ mod tests {
         assert_eq!(result.0, SIG_ERROR);
     }
 
+    #[cfg(feature = "ffi")]
     #[test]
     fn test_ffi_call_arity_error() {
         let result = prim_ffi_call(&[]);
@@ -230,6 +232,7 @@ mod tests {
         assert_eq!(sig.fixed_args, Some(2));
     }
 
+    #[cfg(feature = "ffi")]
     #[test]
     fn test_ffi_signature_cif_caching() {
         let result = prim_ffi_signature(&[

--- a/src/primitives/loading.rs
+++ b/src/primitives/loading.rs
@@ -211,6 +211,7 @@ pub(crate) fn prim_ffi_signature(args: &[Value]) -> (SignalBits, Value) {
     (SIG_OK, Value::ffi_signature(sig))
 }
 
+#[cfg(feature = "ffi")]
 pub(crate) fn prim_ffi_callback(args: &[Value]) -> (SignalBits, Value) {
     if args.len() != 2 {
         return (
@@ -295,6 +296,7 @@ pub(crate) fn prim_ffi_callback(args: &[Value]) -> (SignalBits, Value) {
     (SIG_OK, Value::pointer(code_ptr))
 }
 
+#[cfg(feature = "ffi")]
 pub(crate) fn prim_ffi_callback_free(args: &[Value]) -> (SignalBits, Value) {
     if args.len() != 1 {
         return (
@@ -379,6 +381,11 @@ pub(crate) const PRIMITIVES: &[PrimitiveDef] = &[
         example: "(ffi/signature :int [:ptr :size :ptr :int] 3)",
         aliases: &[],
     },
+];
+
+/// Callback primitives (require libffi).
+#[cfg(feature = "ffi")]
+pub(crate) const CALLBACK_PRIMITIVES: &[PrimitiveDef] = &[
     PrimitiveDef {
         name: "ffi/callback",
         func: prim_ffi_callback,

--- a/src/primitives/memory.rs
+++ b/src/primitives/memory.rs
@@ -302,6 +302,7 @@ pub fn prim_ffi_read(args: &[Value]) -> (SignalBits, Value) {
                     error_val("ffi-error", "ffi/read: cannot read void"),
                 )
             }
+            #[cfg(feature = "ffi")]
             TypeDesc::Struct(_) | TypeDesc::Array(_, _) => {
                 match crate::ffi::marshal::read_value_from_buffer(ptr, &desc) {
                     Ok(val) => val,
@@ -312,6 +313,13 @@ pub fn prim_ffi_read(args: &[Value]) -> (SignalBits, Value) {
                         )
                     }
                 }
+            }
+            #[cfg(not(feature = "ffi"))]
+            TypeDesc::Struct(_) | TypeDesc::Array(_, _) => {
+                return (
+                    SIG_ERROR,
+                    error_val("ffi-error", "ffi/read: struct/array requires `ffi` feature"),
+                )
             }
         };
         (SIG_OK, val)
@@ -506,6 +514,7 @@ pub fn prim_ffi_write(args: &[Value]) -> (SignalBits, Value) {
                     error_val("ffi-error", "ffi/write: use ptr type for writing pointers"),
                 )
             }
+            #[cfg(feature = "ffi")]
             TypeDesc::Struct(_) | TypeDesc::Array(_, _) => {
                 match crate::ffi::marshal::write_value_to_buffer(ptr, value, &desc) {
                     Ok(_owned) => {
@@ -520,6 +529,16 @@ pub fn prim_ffi_write(args: &[Value]) -> (SignalBits, Value) {
                         )
                     }
                 }
+            }
+            #[cfg(not(feature = "ffi"))]
+            TypeDesc::Struct(_) | TypeDesc::Array(_, _) => {
+                return (
+                    SIG_ERROR,
+                    error_val(
+                        "ffi-error",
+                        "ffi/write: struct/array requires `ffi` feature",
+                    ),
+                )
             }
         }
     }

--- a/src/primitives/mod.rs
+++ b/src/primitives/mod.rs
@@ -6,6 +6,7 @@ pub mod array;
 pub mod bitwise;
 pub mod r#box;
 pub mod bytes;
+#[cfg(feature = "ffi")]
 pub mod calling;
 pub mod chan;
 pub mod comparison;

--- a/src/primitives/registration.rs
+++ b/src/primitives/registration.rs
@@ -2,17 +2,22 @@ use crate::symbol::SymbolTable;
 use crate::value::Value;
 use crate::vm::VM;
 
+#[cfg(feature = "ffi")]
+use super::calling;
 use super::def::{Doc, PrimitiveDef, PrimitiveMeta};
 use super::{
-    allocator, arena, arithmetic, array, bitwise, bytes, calling, chan, comparison, compile,
-    concurrency, config, convert, coroutines, debug, disassembly, display, fiber_introspect,
-    fibers, fileio, format, introspection, io, json, list, loading, logic, lstruct, math, memory,
-    meta, modules, net, package, parameters, path, ports, r#box, read, sets, sort, stream, string,
-    structs, subprocess, time, traits, types, unix, watch,
+    allocator, arena, arithmetic, array, bitwise, bytes, chan, comparison, compile, concurrency,
+    config, convert, coroutines, debug, disassembly, display, fiber_introspect, fibers, fileio,
+    format, introspection, io, json, list, loading, logic, lstruct, math, memory, meta, modules,
+    net, package, parameters, path, ports, r#box, read, sets, sort, stream, string, structs,
+    subprocess, time, traits, types, unix, watch,
 };
 
 /// All primitive tables. Each module exports a `const PRIMITIVES`
 /// array; this list is the single place that enumerates them.
+///
+/// Tables gated behind `ffi` are appended via `ffi_tables()` below
+/// because `const` arrays cannot contain conditional entries.
 pub(crate) const ALL_TABLES: &[&[PrimitiveDef]] = &[
     allocator::PRIMITIVES,
     arena::PRIMITIVES,
@@ -20,7 +25,6 @@ pub(crate) const ALL_TABLES: &[&[PrimitiveDef]] = &[
     array::PRIMITIVES,
     bitwise::PRIMITIVES,
     bytes::PRIMITIVES,
-    calling::PRIMITIVES,
     r#box::PRIMITIVES,
     chan::PRIMITIVES,
     compile::PRIMITIVES,
@@ -66,11 +70,22 @@ pub(crate) const ALL_TABLES: &[&[PrimitiveDef]] = &[
     watch::PRIMITIVES,
 ];
 
+/// Primitive tables that require the `ffi` feature (libffi).
+#[cfg(feature = "ffi")]
+fn ffi_tables() -> &'static [&'static [PrimitiveDef]] {
+    &[calling::PRIMITIVES, loading::CALLBACK_PRIMITIVES]
+}
+
+#[cfg(not(feature = "ffi"))]
+fn ffi_tables() -> &'static [&'static [PrimitiveDef]] {
+    &[]
+}
+
 /// Register all primitive functions with the VM and build metadata.
 pub fn register_primitives(vm: &mut VM, symbols: &mut SymbolTable) -> PrimitiveMeta {
     let mut meta = PrimitiveMeta::new();
 
-    for table in ALL_TABLES {
+    for table in ALL_TABLES.iter().chain(ffi_tables().iter()) {
         for def in *table {
             let sym_id = symbols.intern(def.name);
             let native_val = Value::native_fn(def);
@@ -114,7 +129,7 @@ pub fn register_primitives(vm: &mut VM, symbols: &mut SymbolTable) -> PrimitiveM
 pub fn build_primitive_meta(symbols: &mut SymbolTable) -> PrimitiveMeta {
     let mut meta = PrimitiveMeta::new();
 
-    for table in ALL_TABLES {
+    for table in ALL_TABLES.iter().chain(ffi_tables().iter()) {
         for def in *table {
             let sym_id = symbols.intern(def.name);
             meta.signals.insert(sym_id, def.signal);
@@ -140,7 +155,7 @@ pub fn build_primitive_meta(symbols: &mut SymbolTable) -> PrimitiveMeta {
 /// with a SymbolTable that hasn't had `register_primitives` called on it.
 /// Idempotent — safe to call multiple times.
 pub fn intern_primitive_names(symbols: &mut SymbolTable) {
-    for table in ALL_TABLES {
+    for table in ALL_TABLES.iter().chain(ffi_tables().iter()) {
         for def in *table {
             symbols.intern(def.name);
             for alias in def.aliases {

--- a/src/value/fiberheap/mod.rs
+++ b/src/value/fiberheap/mod.rs
@@ -36,6 +36,7 @@
 //! `Box` provides pointer stability — the raw pointer remains valid even when
 //! `owned_shared` grows. Teardown happens on `clear()` or `Drop`.
 
+#[cfg(feature = "ffi")]
 use std::cell::RefCell;
 use std::rc::Rc;
 
@@ -1085,10 +1086,13 @@ impl FiberHeap {
                 obj: obj.clone(),
                 traits: *traits,
             }),
-            HeapObject::FFISignature(sig, cif) => outbox.alloc(HeapObject::FFISignature(
-                sig.clone(),
-                RefCell::new(cif.borrow().clone()),
-            )),
+            HeapObject::FFISignature(sig, cif) => {
+                #[cfg(feature = "ffi")]
+                let new_cif = RefCell::new(cif.borrow().clone());
+                #[cfg(not(feature = "ffi"))]
+                let new_cif = *cif;
+                outbox.alloc(HeapObject::FFISignature(sig.clone(), new_cif))
+            }
             HeapObject::FFIType(t) => outbox.alloc(HeapObject::FFIType(t.clone())),
             HeapObject::ThreadHandle { handle, traits } => outbox.alloc(HeapObject::ThreadHandle {
                 handle: handle.clone(),

--- a/src/value/heap.rs
+++ b/src/value/heap.rs
@@ -18,6 +18,16 @@ use crate::value::Value;
 pub use crate::value::closure::Closure;
 pub use crate::value::types::{Arity, NativeFn, PrimFn, TableKey};
 
+/// CIF cache type for FFI signatures.
+///
+/// When the `ffi` feature is enabled, this holds a lazily-prepared libffi CIF.
+/// When disabled, it is a zero-cost unit type — FFI signatures can still be
+/// created and stored, but `ffi/call` (which needs the CIF) is unavailable.
+#[cfg(feature = "ffi")]
+pub type CifCache = RefCell<Option<libffi::middle::Cif>>;
+#[cfg(not(feature = "ffi"))]
+pub type CifCache = ();
+
 /// Cons cell for list construction.
 pub struct Cons {
     pub first: Value,
@@ -235,10 +245,8 @@ pub enum HeapObject {
 
     /// Reified FFI function signature with optional cached CIF.
     /// The CIF is lazily prepared on first use and reused thereafter.
-    FFISignature(
-        crate::ffi::types::Signature,
-        RefCell<Option<libffi::middle::Cif>>,
-    ),
+    /// When the `ffi` feature is disabled, the CIF cache is a unit type.
+    FFISignature(crate::ffi::types::Signature, CifCache),
 
     /// Reified FFI compound type descriptor (struct or array layout)
     FFIType(crate::ffi::types::TypeDesc),

--- a/src/value/repr/accessors.rs
+++ b/src/value/repr/accessors.rs
@@ -626,7 +626,7 @@ impl Value {
             return None;
         }
         match unsafe { deref(*self) } {
-            HeapObject::FFISignature(sig, _) => Some(sig),
+            HeapObject::FFISignature(sig, ..) => Some(sig),
             _ => None,
         }
     }
@@ -648,6 +648,7 @@ impl Value {
     /// Returns None if this is not an FFI signature.
     ///
     /// The CIF is lazily prepared on first access and cached for reuse.
+    #[cfg(feature = "ffi")]
     pub fn get_or_prepare_cif(&self) -> Option<std::cell::Ref<'_, libffi::middle::Cif>> {
         use crate::value::heap::{deref, HeapObject};
         if !self.is_ffi_sig() {

--- a/src/value/repr/constructors.rs
+++ b/src/value/repr/constructors.rs
@@ -311,9 +311,12 @@ impl Value {
     /// Create an FFI signature value.
     #[inline]
     pub fn ffi_signature(sig: crate::ffi::types::Signature) -> Self {
-        use crate::value::heap::{alloc, HeapObject};
-        use std::cell::RefCell;
-        alloc(HeapObject::FFISignature(sig, RefCell::new(None)))
+        use crate::value::heap::{alloc, CifCache, HeapObject};
+        #[cfg(feature = "ffi")]
+        let cache: CifCache = std::cell::RefCell::new(None);
+        #[cfg(not(feature = "ffi"))]
+        let cache: CifCache = ();
+        alloc(HeapObject::FFISignature(sig, cache))
     }
 
     /// Create an FFI compound type descriptor value.

--- a/tests/elle/ffi.lisp
+++ b/tests/elle/ffi.lisp
@@ -3,6 +3,28 @@
 ## FFI integration tests
 ## Tests the full pipeline: Elle source → compiler → VM → libffi → C
 
+## ── ffi/with-stack ────────────────────────────────────────────────────
+
+(ffi/with-stack [[p :int 42]]
+  (assert (= (ffi/read p :int) 42) "ffi/with-stack typed scalar"))
+
+(ffi/with-stack [[buf 16]]
+  (ffi/write buf :int 99)
+  (assert (= (ffi/read buf :int) 99) "ffi/with-stack raw buffer"))
+
+(ffi/with-stack [[a :int 10] [b :int 20]]
+  (assert (= (+ (ffi/read a :int) (ffi/read b :int)) 30) "ffi/with-stack multiple"))
+
+## ── ffi/pin ───────────────────────────────────────────────────────────
+
+(let* [ptr (ffi/pin (bytes 72 101 108))]
+  (assert (= (ffi/read ptr :u8) 72) "ffi/pin first byte")
+  (ffi/free ptr))
+
+(let* [ptr (ffi/pin "Hi")]
+  (assert (= (ffi/read ptr :u8) 72) "ffi/pin string")
+  (ffi/free ptr))
+
 ## ── Type introspection ──────────────────────────────────────────────
 
 (assert (= (ffi/size :i32) 4) "ffi/size :i32")

--- a/tests/elle/primitives.lisp
+++ b/tests/elle/primitives.lisp
@@ -132,28 +132,6 @@
 (assert (= |1 2 3| @|1 2 3|) "set = @set")
 (assert (not= [1 2] @[1 3]) "cross-mut different contents")
 
-## ── ffi/with-stack ────────────────────────────────────────────────────
-
-(ffi/with-stack [[p :int 42]]
-  (assert (= (ffi/read p :int) 42) "ffi/with-stack typed scalar"))
-
-(ffi/with-stack [[buf 16]]
-  (ffi/write buf :int 99)
-  (assert (= (ffi/read buf :int) 99) "ffi/with-stack raw buffer"))
-
-(ffi/with-stack [[a :int 10] [b :int 20]]
-  (assert (= (+ (ffi/read a :int) (ffi/read b :int)) 30) "ffi/with-stack multiple"))
-
-## ── ffi/pin ───────────────────────────────────────────────────────────
-
-(let* [ptr (ffi/pin (bytes 72 101 108))]
-  (assert (= (ffi/read ptr :u8) 72) "ffi/pin first byte")
-  (ffi/free ptr))
-
-(let* [ptr (ffi/pin "Hi")]
-  (assert (= (ffi/read ptr :u8) 72) "ffi/pin string")
-  (ffi/free ptr))
-
 ## ── nonzero? ──────────────────────────────────────────────────────────
 
 (assert (nonzero? 1) "nonzero? positive int")


### PR DESCRIPTION
Make the libffi dependency optional, controlled by a new `ffi` Cargo feature that is enabled by default. When disabled, the ffi module's type descriptors, library loading, and signature creation remain available, but libffi-dependent functionality (ffi/call, ffi/callback, CIF caching, struct/array marshalling) is compiled out.

Changes:
- Cargo.toml: libffi optional, `ffi` feature added to defaults
- build.rs: Android libgcc link gated behind CARGO_FEATURE_FFI
- src/ffi/mod.rs: gate call, callback, marshal, to_c, from_c modules
- src/value/heap.rs: CifCache type alias (RefCell<Cif> or ())
- src/value/repr: gate get_or_prepare_cif, adjust constructors
- src/value/fiberheap: conditional CIF cloning in outbox copy
- src/primitives: gate calling module, split callback primitives, gate struct/array marshal paths in memory.rs
- src/primitives/registration.rs: ffi_tables() for conditional primitive registration