### PR TITLE
Sound signal inference for unknown callees

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ If you know [Janet](https://janet-lang.org), think Janet on steroids — the sam
 
 ## Types
 
-Immediates (nil, booleans, integers, floats, symbols, keywords, empty list) fit inline with no allocation. Everything else is a raw pointer into a slab-allocated `HeapObject` owned by the fiber's heap.
+Immediates (nil, booleans, integers, floats, symbols, keywords, empty list) fit inline with no allocation. Everything else is a raw pointer into a bump-allocated `HeapObject` owned by the fiber's heap.
 
 ### Immediate types
 
@@ -597,13 +597,13 @@ concurrency layer.
 
 - **No garbage collector.** ([docs/memory.md](docs/memory.md)) Memory is reclaimed deterministically through three mechanisms, all derived from the same static analysis that drives the signal system:
 
-  - **Per-fiber heaps:** Each fiber owns a slab allocator (`FiberHeap`) with 256-slot chunks and an intrusive free list. When a fiber finishes, its entire heap is freed — no traversal, no mark phase, no sweep. Slab allocation is O(1) with strong cache locality.
+  - **Per-fiber bump arenas:** Each fiber owns a `FiberHeap` backed by a bump arena (sequential 64KB pages). When a fiber finishes, its entire arena is freed — no traversal, no mark phase, no sweep. Bump allocation is O(1) with strong cache locality and zero fragmentation.
 
-  - **Zero-copy inter-fiber sharing:** The compiler knows at fiber-creation time whether a fiber can yield (signal inference). Yielding fibers route all allocations to a `SharedAllocator` owned by the parent — the parent reads yielded values directly from shared memory. Silent fibers skip this entirely and allocate into their own slab with no indirection. No deep copy, no serialization, no runtime decision.
+  - **Zero-copy inter-fiber sharing:** The compiler knows at fiber-creation time whether a fiber can yield (signal inference). Yielding fibers route all allocations to a `SharedAllocator` owned by the parent — the parent reads yielded values directly from shared memory. Silent fibers skip this entirely and allocate into their own arena with no indirection. No deep copy, no serialization, no runtime decision.
 
-  - **Escape-analysis-driven scope reclamation:** The compiler analyzes every `let`, `letrec`, `block` scope. When it can prove no allocated value escapes — no captures, no suspension, no outward mutation — it emits `RegionEnter`/`RegionExit` bytecodes that return slab slots to the free list at scope exit, recycling memory without waiting for fiber death.
+  - **Escape-analysis-driven scope reclamation:** The compiler analyzes every `let`, `letrec`, `block` scope. When it can prove no allocated value escapes — no captures, no suspension, no outward mutation — it emits `RegionEnter`/`RegionExit` bytecodes that rewind the arena to a mark at scope exit, recycling memory without waiting for fiber death.
 
-- **Long-running fiber schedulers don't accumulate garbage.** Each fiber's heap dies with it. Scope reclamation recycles memory within a fiber's lifetime. The ownership topology — private slab per fiber, shared slab per yield boundary — is the minimal structure that gives per-fiber lifecycle management and zero-copy yield simultaneously. See [`docs/memory.md`](docs/memory.md) for the full model.
+- **Long-running fiber schedulers don't accumulate garbage.** Each fiber's heap dies with it. Scope reclamation recycles memory within a fiber's lifetime. The ownership topology — private arena per fiber, shared arena per yield boundary — is the minimal structure that gives per-fiber lifecycle management and zero-copy yield simultaneously. See [`docs/memory.md`](docs/memory.md) for the full model.
 
 ## Execution Backends
 

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -1,29 +1,44 @@
 # Memory
 
 Elle has no garbage collector. Memory is managed deterministically through
-per-fiber heaps, escape-analysis-driven scope reclamation, and zero-copy
-inter-fiber sharing. These three mechanisms are derived from the same static
-analysis that drives the signal system — signal inference tells the runtime
-which fibers yield and which are silent, and that distinction determines how
-memory is allocated, shared, and reclaimed.
+per-fiber bump arenas, escape-analysis-driven scope reclamation, and
+zero-copy inter-fiber sharing. These three mechanisms are derived from the
+same static analysis that drives the signal system — signal inference tells
+the runtime which fibers yield and which are silent, and that distinction
+determines how memory is allocated, shared, and reclaimed.
 
 ## How it works
 
 Every `Value` is a 16-byte tagged union. Immediates (integers, keywords,
 booleans, nil) fit inline — no allocation. Heap types (strings, arrays,
-structs, closures, fibers) store a raw pointer to a `HeapObject` in a
-slab allocator owned by the fiber.
+structs, closures, fibers) store a pointer to a `HeapObject` in a bump
+arena owned by the fiber.
 
 ### Per-fiber heaps
 
-Each fiber owns a `FiberHeap` containing a `RootSlab` — a chunk-based
-typed slab allocator. Each chunk holds 256 `HeapObject` slots. Freed slots
-return to an intrusive free list and are reused by the next allocation.
+Each fiber owns a `FiberHeap` containing a `SlabPool` — a bump arena
+with destructor tracking. The bump arena allocates sequentially into
+64KB pages. There is no per-slot free list; memory is reclaimed only at
+scope boundaries or fiber death.
 
 When a fiber completes, its `FiberHeap` runs all destructors and drops
-all slab chunks. The fiber's entire memory footprint disappears — no
+all arena pages. The fiber's entire memory footprint disappears — no
 traversal, no mark phase, no sweep. A server loop spawning one fiber per
 request reclaims all per-request memory at fiber death.
+
+### Bump arena
+
+The `BumpArena` is a byte-level sequential allocator:
+
+- **Pages**: `Vec<Box<[MaybeUninit<u8>; 64KB]>>` — pointer-stable
+- **Allocation**: bump a byte offset within the current page
+- **Oversized**: allocations >64KB get dedicated pages
+- **No individual deallocation**: `dealloc_slot()` is a no-op
+- **Reclamation**: `release_to(mark)` truncates pages and resets offset;
+  `clear()` on fiber death resets entirely (keeps first page for reuse)
+
+This gives cache-friendly sequential allocation, zero fragmentation, and
+deterministic bulk reclamation.
 
 ### Scope reclamation
 
@@ -33,10 +48,10 @@ suspension, result is immediate, no outward mutation — it emits
 `RegionEnter` / `RegionExit` bytecodes that reclaim heap objects at scope
 exit rather than waiting for fiber death.
 
-`RegionEnter` pushes a mark recording the slab position. `RegionExit`
-pops the mark, runs destructors for objects allocated since the mark,
-and returns their slab slots to the free list. This is transparent to
-user code — you don't need to do anything to benefit from it.
+`RegionEnter` pushes an `ArenaMark` recording the arena's page/offset and
+destructor count. `RegionExit` pops the mark, runs destructors for objects
+allocated since the mark, and rewinds the arena to the mark position. This
+is transparent to user code.
 
 ### Zero-copy inter-fiber sharing
 
@@ -47,43 +62,48 @@ runtime uses signal inference to solve this at the allocation level.
 The compiler knows at fiber-creation time whether a fiber can yield
 (its signal includes `SIG_YIELD`). For yielding fibers, the runtime
 installs a `SharedAllocator` owned by the parent's `FiberHeap`. While the
-child executes, **all** of its allocations route to this shared slab — not
+child executes, **all** of its allocations route to this shared arena — not
 selectively, not per-scope. The parent reads yielded values directly from
 shared memory: zero copy, zero serialization.
 
 For silent fibers (no yields), the shared allocator is never installed.
-The fiber allocates exclusively into its own private slab with no
+The fiber allocates exclusively into its own private arena with no
 indirection overhead.
+
+### Outbox
+
+For yield-safe allocation, the runtime uses an outbox mechanism:
+
+- Parent installs an outbox (`Box<SlabPool>`) before child execution
+- Child allocates between `OutboxEnter`/`OutboxExit` bytecodes into the
+  outbox arena
+- At yield time, parent reads the outbox and stores it
+- On fiber death, all outboxes are freed in bulk
+
+This ensures yielded values don't reference the child's private heap.
 
 ### Ownership topology
 
-The result is a specific ownership structure:
-
 ```text
 root fiber
-├── private slab          ← root's own allocations
-├── shared allocator      ← child A's allocations (yielded values live here)
+├── private arena        ← root's own allocations (BumpArena pages)
+├── shared allocator     ← child A's allocations (yielded values live here)
 │   └── child A
-│       ├── private slab  ← idle (child yields, so everything routes to parent)
-│       └── shared alloc  ← grandchild's allocations
+│       ├── private arena  ← idle (child yields, so everything routes to parent)
+│       ├── outbox         ← yield-bound allocations
+│       └── shared alloc   ← grandchild's allocations
 │           └── grandchild
 │               └── ...
 └── (child B: silent)
-    └── private slab      ← child B's own allocations (no sharing needed)
+    └── private arena    ← child B's own allocations (no sharing needed)
 ```
 
-- **Silent fibers** use their private slab exclusively. Scope marks reclaim
-  short-lived objects. `clear()` on death reclaims everything.
-- **Yielding fibers** route all allocations to the parent's shared slab.
-  Their private slab is idle.
+- **Silent fibers** use their private arena exclusively. Scope marks
+  reclaim short-lived objects. `clear()` on death reclaims everything.
+- **Yielding fibers** route all allocations to the parent's shared arena.
+  Their private arena is idle.
 - **Parent fibers** own shared allocators in `owned_shared`. The shared
-  allocator is itself a `RootSlab` with its own destructor and scope-mark
-  tracking.
-
-This is why a per-fiber-tree shared arena wouldn't work: `clear()` is
-per-fiber lifecycle. When a child dies, its temporaries are reclaimed
-immediately. A shared arena would accumulate dead children's garbage
-until the root clears — fatal for long-running servers.
+  allocator has its own bump arena and destructor tracking.
 
 ## Why this works without a GC
 
@@ -113,46 +133,8 @@ allocator teardown — all in bounded time.
 # detailed stats
 (def stats (arena/stats))
 stats:object-count         # total live objects
-stats:allocated-bytes      # bytes committed by slab chunks
+stats:allocated-bytes      # bytes committed by arena pages
 ```
 
 `arena/count` operates directly on thread-local state with zero
 allocation overhead.
-
-## Measuring allocations
-
-`arena/allocs` runs a thunk and returns `[result net-allocations]`:
-
-```lisp
-(def result (arena/allocs (fn [] (list 1 2 3))))
-(first result)             # => (1 2 3) — the thunk's return value
-(rest result)              # => (3) — net allocations
-```
-
-### Allocation costs by type
-
-```text
-Type              Heap objects
-──────────────────────────────
-(cons a b)        1
-(list 1 2 3 4 5)  5 (one cons per element)
-(fn [x] x)        1 (closure)
-[1 2 3]           1 (array)
-{:a 1 :b 2}      1 (struct)
-42                0 (immediate — no heap)
-:keyword          0 (immediate)
-nil               0 (immediate)
-```
-
-Each heap object is a `HeapObject` — a fixed-size slot in the slab. The
-slot may internally contain `Vec`, `BTreeMap`, `Box<str>`, or other Rust
-heap data; `needs_drop()` tracks which variants need destructor calls.
-
----
-
-## See also
-
-- [fibers.md](fibers.md) — fiber lifecycle
-- [runtime.md](runtime.md) — runtime signals including SIG_QUERY
-- [scheduler.md](scheduler.md) — async scheduler
-- [impl/values.md](impl/values.md) — value encoding and heap object layout

--- a/docs/signals/inference.md
+++ b/docs/signals/inference.md
@@ -305,6 +305,114 @@ additional cross-file visibility via SPARQL queries. See
 query cross-file dependencies.
 
 
+### `attune` Primitive: Positive Runtime Enforcement
+
+`attune` is the dual of `squelch`: where squelch says "block these signals"
+(negative/blacklist), attune says "allow only these signals"
+(positive/whitelist). Everything not in the permitted set is intercepted
+and converted to `:error`.
+
+**Syntax:** `(attune signals closure)` — mask-first argument order.
+
+**Runtime semantics:**
+
+- Returns a new closure whose squelch mask suppresses `CAP_MASK - permitted`
+- Same mechanism as squelch (Rc clone, near-zero cost)
+- Composable with squelch: layers OR their masks together
+
+**Compile-time semantics:**
+
+When the analyzer sees `(attune |:yield| f)` with a static mask, it
+computes the resulting signal: `f_signal.squelch(CAP_MASK - permitted)`.
+This enables interprocedural signal narrowing.
+
+**Examples:**
+```text
+# Allow only :yield and :error — block everything else
+(def safe-handler (attune |:yield :error| (get-handler)))
+
+# Equivalent to (squelch f |:io :ffi :exec :halt :debug|) — but readable
+(def no-side-effects (attune |:yield :error| some-callback))
+
+# Compose with squelch
+(def only-error (squelch (attune |:yield :error| f) :yield))
+```
+
+### `(attune! signal-spec)` Form
+
+Compile-time preamble declaration that sets the function's signal ceiling.
+Generalizes `(silence)`: where silence means "emits nothing", attune!
+means "emits at most these signals."
+
+**Syntax:**
+```text
+(attune! :keyword)           # ceiling = single signal
+(attune! |:kw1 :kw2|)       # ceiling = set of signals
+```
+
+**Semantics:**
+
+- Declares the maximum signal this function may emit
+- Compiler verifies the body's inferred signal fits within the ceiling
+- If the body exceeds the ceiling, compile-time error
+- Composes with `(muffle ...)`: muffled bits expand the ceiling
+
+**Examples:**
+```text
+# Function may yield but nothing else
+(defn generator [n]
+  (attune! :yield)
+  (yield n))
+
+# Function may yield and error, but no I/O
+(defn parser [input]
+  (attune! |:yield :error|)
+  (if (empty? input)
+    (error {:error :parse-error})
+    (yield (first input))))
+
+# Exceeding the ceiling is a compile-time error:
+# (defn bad []
+#   (attune! :yield)
+#   (println "oops"))   # => error: function restricted to {:yield} but body may emit {:io}
+```
+
+## Compile-Time Assertions (`!` Convention)
+
+Forms ending with `!` are compile-time assertions with implications for
+analysis. They are promises the programmer makes that the compiler
+verifies and uses to unlock optimizations. If violated, the program is
+rejected at compile time.
+
+| Form | Assertion | Optimization unlocked |
+|------|-----------|----------------------|
+| `(silent!)` | Function emits no signals | Skip signal dispatch, JIT without suspension |
+| `(numeric!)` | All values are numeric | Elide type checks, enable GPU lowering |
+| `(immutable! x)` | Binding x is never assigned | SSA treatment, avoid cell indirection |
+| `(attune! spec)` | Function emits at most spec | Narrow signal ceiling for callers |
+
+**Rules:**
+
+- Must appear inside a lambda body (preamble position)
+- Multiple `!` forms allowed in one lambda
+- Violation is always a compile-time error, never a runtime check
+- These are NOT runtime guards — they inform the compiler's static model
+
+**Examples:**
+```text
+# GPU kernel: numeric + silent
+(defn mandel-pixel [cx cy max-iter]
+  (numeric!)
+  (silent!)
+  (let [@x 0.0  @y 0.0  @i 0]
+    (while (and (< (+ (* x x) (* y y)) 4.0) (< i max-iter))
+      (let [xt (+ (- (* x x) (* y y)) cx)]
+        (assign y (+ (* 2.0 x y) cy))
+        (assign x xt)
+        (assign i (+ i 1))))
+    i))
+```
+
 ## Runtime Verification
 
 When a closure is passed to a function with a signal bound, the runtime checks that the closure's signal satisfies the bound. This is necessary for dynamic arguments where the signal cannot be determined at compile time.

--- a/src/hir/analyze/call.rs
+++ b/src/hir/analyze/call.rs
@@ -226,14 +226,31 @@ impl<'a> Analyzer<'a> {
             HirKind::Var(binding) => {
                 if let Some(signal) = self.signal_env.get(binding) {
                     *signal
+                } else if let Some(signal) = self
+                    .primitive_signals
+                    .get(&self.arena.get(*binding).name)
+                    .cloned()
+                {
+                    signal
+                } else if matches!(self.arena.get(*binding).scope, BindingScope::Parameter)
+                    && self.current_lambda_params.contains(binding)
+                {
+                    // Parameter call: signal depends on what the caller passes.
+                    // SIG_YIELD triggers the polymorphic inference path in
+                    // compute_inferred_signal; SIG_ERROR is inherently sound
+                    // because calling an unknown value can always fail (not
+                    // callable, wrong arity, callback errors).
+                    Signal::yields_errors()
                 } else {
-                    self.primitive_signals
-                        .get(&self.arena.get(*binding).name)
-                        .cloned()
-                        .unwrap_or(Signal::yields())
+                    // Calling a value whose origin is opaque to static analysis
+                    // (e.g., bound to a dynamic expression result). We cannot
+                    // determine its effects — use the sound conservative signal.
+                    Signal::unknown()
                 }
             }
-            _ => Signal::yields(),
+            // Opaque expression in callee position (result of a call, conditional,
+            // etc.) — effects are statically indeterminate.
+            _ => Signal::unknown(),
         }
     }
 
@@ -293,8 +310,8 @@ impl<'a> Analyzer<'a> {
                 if param_idx < args.len() {
                     resolved = resolved.combine(self.resolve_arg_signal(args[param_idx]));
                 } else {
-                    // Parameter index out of bounds - conservatively Yields
-                    return Signal::yields();
+                    // Parameter index out of bounds — sound conservative signal.
+                    return Signal::unknown();
                 }
             }
             resolved
@@ -320,9 +337,9 @@ impl<'a> Analyzer<'a> {
                         .get(&self.arena.get(*binding).name)
                         .cloned()
                 })
-                .unwrap_or(Signal::yields()),
-            // Unknown argument signal - conservatively Yields for soundness
-            _ => Signal::yields(),
+                .unwrap_or(Signal::unknown()),
+            // Opaque expression as argument — effects are indeterminate.
+            _ => Signal::unknown(),
         }
     }
 

--- a/src/hir/analyze/call.rs
+++ b/src/hir/analyze/call.rs
@@ -116,8 +116,9 @@ impl<'a> Analyzer<'a> {
             }
         }
 
-        // ── Compile-time squelch detection ─────────────────────────────
+        // ── Compile-time squelch/attune detection ─────────────────────
         // Pattern: (squelch f :keyword) or (squelch f |:kw1 :kw2|)
+        //          (attune f :keyword) or (attune f |:kw1 :kw2|)
         // Compute the resulting closure's signal statically and stash it
         // for binding analysis to seed the binding's signal_env entry.
         self.last_squelch_signal = None;
@@ -125,6 +126,14 @@ impl<'a> Analyzer<'a> {
             let target_signal = self.resolve_arg_signal(&args[0].expr);
             if let Some(mask) = self.resolve_squelch_mask(&args[1].expr) {
                 self.last_squelch_signal = Some(target_signal.squelch(mask));
+            }
+        } else if self.is_attune(&func) && args.len() == 2 {
+            // attune is mask-first: (attune |:yield| closure)
+            let target_signal = self.resolve_arg_signal(&args[1].expr);
+            if let Some(permitted) = self.resolve_squelch_mask(&args[0].expr) {
+                // attune permits only these bits; suppress everything else.
+                let suppress = crate::signals::CAP_MASK.subtract(permitted);
+                self.last_squelch_signal = Some(target_signal.squelch(suppress));
             }
         }
 
@@ -201,6 +210,11 @@ impl<'a> Analyzer<'a> {
     /// Check if the callee is the `squelch` primitive.
     fn is_squelch(&self, func: &Hir) -> bool {
         self.is_primitive_named(func, "squelch")
+    }
+
+    /// Check if the callee is the `attune` primitive.
+    fn is_attune(&self, func: &Hir) -> bool {
+        self.is_primitive_named(func, "attune")
     }
 
     /// Check if the callee is the `import` primitive.

--- a/src/hir/analyze/call.rs
+++ b/src/hir/analyze/call.rs
@@ -317,9 +317,14 @@ impl<'a> Analyzer<'a> {
     }
 
     /// Resolve a polymorphic signal by examining the arguments at the specified indices.
+    /// Preserves inherent bits (non-polymorphic signals) and combines with resolved args.
     pub(crate) fn resolve_polymorphic_signal(&self, signal: &Signal, args: &[&Hir]) -> Signal {
         if signal.is_polymorphic() {
-            let mut resolved = Signal::silent();
+            // Start with inherent bits (signals that don't depend on parameters)
+            let mut resolved = Signal {
+                bits: signal.bits,
+                propagates: 0,
+            };
             for param_idx in signal.propagated_params() {
                 if param_idx < args.len() {
                     resolved = resolved.combine(self.resolve_arg_signal(args[param_idx]));

--- a/src/hir/analyze/forms.rs
+++ b/src/hir/analyze/forms.rs
@@ -351,10 +351,11 @@ impl<'a> Analyzer<'a> {
 
                         "silence" => return self.analyze_silence(items, span),
                         "muffle" => return self.analyze_muffle(items, span),
+                        "attune!" => return self.analyze_attune_assert(items, span),
 
-                        "assert-silent" => return self.analyze_silence_assert(items, span),
-                        "assert-numeric" => return self.analyze_numeric_assert(items, span),
-                        "assert-immutable" => return self.analyze_immutable_assert(items, span),
+                        "silent!" => return self.analyze_silence_assert(items, span),
+                        "numeric!" => return self.analyze_numeric_assert(items, span),
+                        "immutable!" => return self.analyze_immutable_assert(items, span),
 
                         "signal" => {
                             if items.len() != 2 {

--- a/src/hir/analyze/lambda.rs
+++ b/src/hir/analyze/lambda.rs
@@ -257,17 +257,17 @@ impl<'a> Analyzer<'a> {
         // compute_inferred_signal reads them for bounded params.
         let mut inferred_signals = self.compute_inferred_signal(&body, &params);
 
-        // Check assert-silent assertion (before ceiling/muffle adjustments)
+        // Check silent! assertion (before ceiling/muffle adjustments)
         if self.current_silence_assert && (inferred_signals != Signal::silent()) {
             let reg = registry::global_registry().lock().unwrap();
             return Err(format!(
-                "{}: assert-silent assertion failed: function may emit {}",
+                "{}: silent! assertion failed: function may emit {}",
                 span,
                 reg.format_signal_bits(inferred_signals.bits),
             ));
         }
 
-        // Check assert-immutable assertions
+        // Check immutable! assertions
         for binding in &self.current_immutability_asserts {
             if self.arena.get(*binding).is_mutated {
                 let name = self
@@ -275,7 +275,7 @@ impl<'a> Analyzer<'a> {
                     .name(self.arena.get(*binding).name)
                     .unwrap_or("?");
                 return Err(format!(
-                    "{}: assert-immutable assertion failed: '{}' is assigned in body",
+                    "{}: immutable! assertion failed: '{}' is assigned in body",
                     span, name
                 ));
             }

--- a/src/hir/analyze/special.rs
+++ b/src/hir/analyze/special.rs
@@ -91,6 +91,45 @@ impl<'a> Analyzer<'a> {
         ))
     }
 
+    /// Analyze an `(attune! signal-spec)` form.
+    ///
+    /// attune! is a compile-time preamble declaration. It sets the function's
+    /// signal ceiling to the specified bits — the function may emit at most
+    /// these signals. Generalizes `(silence)`: `(silence)` is `(attune!)` with
+    /// no signals permitted.
+    ///
+    /// Forms:
+    /// - `(attune! :keyword)` — ceiling = single signal
+    /// - `(attune! |:kw1 :kw2|)` — ceiling = set of signals
+    pub(crate) fn analyze_attune_assert(
+        &mut self,
+        items: &[Syntax],
+        span: Span,
+    ) -> Result<Hir, String> {
+        if self.fn_depth == 0 {
+            return Err(format!(
+                "{}: attune! must appear inside a function body",
+                span
+            ));
+        }
+
+        let args = &items[1..];
+        if args.len() != 1 {
+            return Err(format!(
+                "{}: attune! requires exactly one argument (signal keyword or set)",
+                span
+            ));
+        }
+
+        let bits = self.resolve_static_signal(&args[0])?;
+        self.current_declared_ceiling = Some(Signal {
+            bits,
+            propagates: 0,
+        });
+
+        Ok(Hir::silent(HirKind::Nil, span))
+    }
+
     /// Analyze a `(muffle signal-spec)` form.
     ///
     /// muffle is a declaration, not an expression. It must appear inside
@@ -556,9 +595,9 @@ impl<'a> Analyzer<'a> {
         Ok(HirPattern::Or(patterns))
     }
 
-    // === Compile-time assertion forms ===
+    // === Compile-time assertion forms (! suffix) ===
 
-    /// `(assert-silent)` — assert that the current function is silent (no signals).
+    /// `(silent!)` — assert that the current function is silent (no signals).
     pub(crate) fn analyze_silence_assert(
         &mut self,
         items: &[Syntax],
@@ -566,18 +605,19 @@ impl<'a> Analyzer<'a> {
     ) -> Result<Hir, String> {
         if self.fn_depth == 0 {
             return Err(format!(
-                "{}: assert-silent must appear inside a function body",
+                "{}: silent! must appear inside a function body",
                 span
             ));
         }
         if items.len() != 1 {
-            return Err(format!("{}: assert-silent takes no arguments", span));
+            return Err(format!("{}: silent! takes no arguments", span));
         }
         self.current_silence_assert = true;
         Ok(Hir::silent(HirKind::Nil, span))
     }
 
-    /// `(assert-numeric)` — assert that the current function is GPU-eligible.
+    /// `(numeric!)` — assert that the current function is GPU-eligible
+    /// (all parameters are numeric, enabling type check elision).
     pub(crate) fn analyze_numeric_assert(
         &mut self,
         items: &[Syntax],
@@ -585,18 +625,18 @@ impl<'a> Analyzer<'a> {
     ) -> Result<Hir, String> {
         if self.fn_depth == 0 {
             return Err(format!(
-                "{}: assert-numeric must appear inside a function body",
+                "{}: numeric! must appear inside a function body",
                 span
             ));
         }
         if items.len() != 1 {
-            return Err(format!("{}: assert-numeric takes no arguments", span));
+            return Err(format!("{}: numeric! takes no arguments", span));
         }
         self.current_numeric_assert = true;
         Ok(Hir::silent(HirKind::Nil, span))
     }
 
-    /// `(assert-immutable x)` — assert that binding `x` is never assigned in the body.
+    /// `(immutable! x)` — assert that binding `x` is never assigned in the body.
     pub(crate) fn analyze_immutable_assert(
         &mut self,
         items: &[Syntax],
@@ -604,26 +644,26 @@ impl<'a> Analyzer<'a> {
     ) -> Result<Hir, String> {
         if self.fn_depth == 0 {
             return Err(format!(
-                "{}: assert-immutable must appear inside a function body",
+                "{}: immutable! must appear inside a function body",
                 span
             ));
         }
         if items.len() != 2 {
             return Err(format!(
-                "{}: assert-immutable requires exactly one argument (a symbol)",
+                "{}: immutable! requires exactly one argument (a symbol)",
                 span
             ));
         }
         let name = items[1].as_symbol().ok_or_else(|| {
             format!(
-                "{}: assert-immutable argument must be a symbol, got {}",
+                "{}: immutable! argument must be a symbol, got {}",
                 items[1].span,
                 items[1].kind_label()
             )
         })?;
         let binding = self
             .lookup(name, items[1].scopes.as_slice())
-            .ok_or_else(|| format!("{}: assert-immutable: undefined variable '{}'", span, name))?;
+            .ok_or_else(|| format!("{}: immutable!: undefined variable '{}'", span, name))?;
         self.current_immutability_asserts.insert(binding);
         Ok(Hir::silent(HirKind::Nil, span))
     }

--- a/src/lir/lower/lambda.rs
+++ b/src/lir/lower/lambda.rs
@@ -113,11 +113,9 @@ impl<'a> Lowerer<'a> {
         )?;
         nested_lir.closure_id = Some(closure_id);
 
-        // Check assert-numeric assertion after lowering
+        // Check numeric! assertion after lowering
         if assert_numeric && !nested_lir.is_gpu_eligible() {
-            return Err(
-                "assert-numeric assertion failed: function is not GPU-eligible".to_string(),
-            );
+            return Err("numeric! assertion failed: function is not GPU-eligible".to_string());
         }
 
         // Fill the reserved slot

--- a/src/primitives/meta.rs
+++ b/src/primitives/meta.rs
@@ -3,6 +3,7 @@
 //! syntax->list, syntax-first, syntax-rest, syntax-e, squelch, meta/origin)
 use crate::primitives::def::PrimitiveDef;
 use crate::signals::Signal;
+use crate::signals::SIG_GPU;
 use crate::syntax::{Syntax, SyntaxKind};
 use crate::value::closure::Closure;
 use crate::value::fiber::{SignalBits, SIG_ERROR, SIG_OK, SIG_QUERY};
@@ -846,7 +847,7 @@ pub(crate) const PRIMITIVES: &[PrimitiveDef] = &[
     PrimitiveDef {
         name: "git",
         func: prim_git,
-        signal: Signal { bits: SIG_QUERY.union(SIG_ERROR), propagates: 0 },
+        signal: Signal { bits: SIG_QUERY.union(SIG_ERROR).union(SIG_GPU), propagates: 0 },
         arity: Arity::Range(1, 2),
         doc: "Eagerly compile a GPU-eligible closure to SPIR-V and cache on its template. \
               Returns the closure. All closures sharing the same template see the cached SPIR-V. \

--- a/src/primitives/meta.rs
+++ b/src/primitives/meta.rs
@@ -462,6 +462,61 @@ pub(crate) fn prim_squelch(args: &[Value]) -> (SignalBits, Value) {
     (SIG_OK, Value::closure(new_closure))
 }
 
+/// Transform a closure by applying a permit mask (inverse of squelch).
+///
+/// `(attune |:yield :error| closure)` returns a new closure that permits ONLY
+/// the specified signals — everything else is intercepted and converted to
+/// `:error`. This is the positive dual of `squelch`: squelch says "block
+/// these", attune says "allow only these."
+///
+/// Argument order is mask-first: the signal spec declares intent, the closure
+/// follows. This reads as "attune to yield+error: this function."
+pub(crate) fn prim_attune(args: &[Value]) -> (SignalBits, Value) {
+    if args.len() != 2 {
+        return (
+            SIG_ERROR,
+            error_val(
+                "arity-error",
+                format!("attune: expected 2 arguments, got {}", args.len()),
+            ),
+        );
+    }
+
+    // First argument: signal spec (keyword, set, array, list, or integer)
+    let permitted_bits = match crate::primitives::fibers::resolve_signal_bits(&args[0], "attune") {
+        Ok(bits) => bits,
+        Err(err) => return err,
+    };
+
+    // Second argument: closure to wrap
+    let closure_rc = match args[1].as_closure() {
+        Some(c) => c,
+        None => {
+            return (
+                SIG_ERROR,
+                error_val(
+                    "type-error",
+                    format!(
+                        "attune: second argument must be a closure, got {}",
+                        args[1].type_name()
+                    ),
+                ),
+            );
+        }
+    };
+
+    // Suppress everything the user DIDN'T permit (within the user-producible set).
+    let suppress_bits = crate::signals::CAP_MASK.subtract(permitted_bits);
+
+    let new_closure = Closure {
+        template: closure_rc.template.clone(),
+        env: closure_rc.env,
+        squelch_mask: closure_rc.squelch_mask.union(suppress_bits),
+    };
+
+    (SIG_OK, Value::closure(new_closure))
+}
+
 /// Return the source location of a closure as `{:file :line :col}`, or `nil`.
 ///
 /// `(meta/origin f)` extracts the span from the closure's stored syntax node.
@@ -762,6 +817,19 @@ pub(crate) const PRIMITIVES: &[PrimitiveDef] = &[
         params: &["closure", "signals"],
         category: "fn",
         example: "(squelch (fn () (yield 1)) |:yield|)",
+        aliases: &[],
+    },
+    PrimitiveDef {
+        name: "attune",
+        func: prim_attune,
+        signal: Signal::errors(),
+        arity: Arity::Exact(2),
+        doc: "Return a new closure that permits ONLY the specified signals — all others are \
+              intercepted and converted to :error. Dual of squelch: squelch blocks specific \
+              signals, attune allows only specific signals. Mask-first argument order.",
+        params: &["signals", "closure"],
+        category: "fn",
+        example: "(attune |:yield :error| (fn () (yield 1)))",
         aliases: &[],
     },
     PrimitiveDef {

--- a/src/signals/mod.rs
+++ b/src/signals/mod.rs
@@ -66,22 +66,23 @@ pub const SIG_FUEL: SignalBits = SignalBits::new(1 << 12); // instruction budget
 pub const SIG_SWITCH: SignalBits = SignalBits::new(1 << 13); // fiber switch trampoline (VM-internal)
 pub const SIG_WAIT: SignalBits = SignalBits::new(1 << 14); // structured concurrency wait request
 
-/// Capability mask: which signal bits represent deniable operations.
+/// VM-internal signal bits: infrastructure signals that user code cannot
+/// produce. These are emitted exclusively by the VM's own dispatch machinery.
+const VM_INTERNAL: SignalBits = SIG_RESUME
+    .union(SIG_PROPAGATE)
+    .union(SIG_QUERY)
+    .union(SIG_TERMINAL)
+    .union(SIG_FUEL)
+    .union(SIG_SWITCH)
+    .union(SIG_WAIT);
+
+/// Capability mask: all signals that user code can produce.
 ///
-/// These are the bits checked during capability enforcement. A primitive's
-/// signal bits AND the fiber's `withheld` AND this mask determines whether
-/// the primitive is blocked.
-///
-/// Includes: error (0), yield (1), debug (2), ffi (4), halt (8), io (9), exec (11).
-/// Excludes VM-internal infrastructure: resume (3), propagate (5), abort (6),
-/// query (7), terminal (10), fuel (12), switch (13), wait (14).
-pub const CAP_MASK: SignalBits = SIG_ERROR
-    .union(SIG_YIELD)
-    .union(SIG_DEBUG)
-    .union(SIG_FFI)
-    .union(SIG_HALT)
-    .union(SIG_IO)
-    .union(SIG_EXEC);
+/// Defined as the complement of VM-internal bits within the 32-bit signal
+/// space (bits 0-15 compiler-reserved, bits 16-31 user-defined). Used for
+/// capability enforcement (which operations a fiber can be denied) and for
+/// static analysis (what an unknown callee might emit).
+pub const CAP_MASK: SignalBits = SignalBits::new(VM_INTERNAL.raw() ^ 0xFFFF_FFFF);
 
 /// Signal classification for expressions and functions.
 ///
@@ -162,6 +163,20 @@ impl Signal {
     pub const fn ffi_errors() -> Self {
         Signal {
             bits: SIG_FFI.union(SIG_ERROR),
+            propagates: 0,
+        }
+    }
+
+    /// Maximally conservative signal for a callee whose effects are unknown.
+    /// Includes all user-facing signal bits (CAP_MASK): the callee could
+    /// error, yield, do I/O, call foreign code, exec subprocesses, halt
+    /// the VM, or trigger a debug breakpoint. Used when calling a value
+    /// whose origin is opaque to static analysis (e.g., a local bound to
+    /// a dynamic expression, or calling the result of an arbitrary
+    /// expression).
+    pub const fn unknown() -> Self {
+        Signal {
+            bits: CAP_MASK,
             propagates: 0,
         }
     }

--- a/src/signals/mod.rs
+++ b/src/signals/mod.rs
@@ -65,6 +65,7 @@ pub const SIG_EXEC: SignalBits = SignalBits::new(1 << 11); // subprocess capabil
 pub const SIG_FUEL: SignalBits = SignalBits::new(1 << 12); // instruction budget exhaustion
 pub const SIG_SWITCH: SignalBits = SignalBits::new(1 << 13); // fiber switch trampoline (VM-internal)
 pub const SIG_WAIT: SignalBits = SignalBits::new(1 << 14); // structured concurrency wait request
+pub const SIG_GPU: SignalBits = SignalBits::new(1 << 15); // GPU hardware dispatch (capability bit)
 
 /// VM-internal signal bits: infrastructure signals that user code cannot
 /// produce. These are emitted exclusively by the VM's own dispatch machinery.

--- a/src/signals/registry.rs
+++ b/src/signals/registry.rs
@@ -1,5 +1,6 @@
 use super::{
-    SIG_DEBUG, SIG_ERROR, SIG_EXEC, SIG_FFI, SIG_FUEL, SIG_HALT, SIG_IO, SIG_WAIT, SIG_YIELD,
+    SIG_DEBUG, SIG_ERROR, SIG_EXEC, SIG_FFI, SIG_FUEL, SIG_GPU, SIG_HALT, SIG_IO, SIG_WAIT,
+    SIG_YIELD,
 };
 /// Signal registry for mapping signal keywords to bit positions.
 ///
@@ -61,6 +62,7 @@ impl SignalRegistry {
         let _ = registry.register_builtin("exec", SIG_EXEC.trailing_zeros());
         let _ = registry.register_builtin("fuel", SIG_FUEL.trailing_zeros());
         let _ = registry.register_builtin("wait", SIG_WAIT.trailing_zeros());
+        let _ = registry.register_builtin("gpu", SIG_GPU.trailing_zeros());
         registry
     }
 

--- a/src/vm/call.rs
+++ b/src/vm/call.rs
@@ -241,6 +241,24 @@ impl VM {
                 return None;
             }
 
+            // GPU capability check: if this closure has been GIT'd (has SPIR-V),
+            // it requires GPU hardware. Check capability before dispatch.
+            if closure.template.spirv.get().is_some() {
+                let gpu_bit = crate::signals::SIG_GPU;
+                let blocked = gpu_bit
+                    .intersection(self.fiber.withheld)
+                    .intersection(crate::signals::CAP_MASK);
+                if !blocked.is_empty() {
+                    self.fiber.call_depth -= 1;
+                    self.fiber.call_stack.pop();
+                    self.fiber.signal = Some((
+                        blocked,
+                        Value::cons(Value::keyword("capability-denied"), Value::keyword("gpu")),
+                    ));
+                    return None;
+                }
+            }
+
             // Tiered WASM compilation and dispatch.
             // Checked before JIT because WASM is the preferred fast path when enabled.
             #[cfg(feature = "wasm")]

--- a/tests/elle/attune.lisp
+++ b/tests/elle/attune.lisp
@@ -1,0 +1,57 @@
+# attune: positive signal permit (dual of squelch)
+
+# ── Permitted signals pass through ────────────────────────────────
+(def yielder (fn [] (yield 42)))
+(def attuned (attune |:yield :error| yielder))
+(def coro (fiber/new attuned |:yield|))
+(fiber/resume coro nil)
+(assert (= (fiber/value coro) 42))
+(println "attune-permitted-passes: ok")
+
+# ── Non-permitted signals are converted to :error ─────────────────
+(def io-fn (fn [] (println "side effect") :done))
+(def attuned-no-io (attune |:error| io-fn))
+(try (attuned-no-io)
+  (catch e
+    (assert (= (get e :error) :signal-violation))
+    (println "attune-blocks-unpermitted: ok")))
+
+# ── attune composes with squelch ──────────────────────────────────
+(def multi (fn [] (yield 1)))
+(def step1 (attune |:yield :error| multi))
+(def step2 (squelch step1 :yield))
+# step2: attune allows only yield+error, then squelch removes yield
+# net effect: only error is possible
+(try (step2)
+  (catch e
+    (assert (= (get e :error) :signal-violation))
+    (println "attune-composes-with-squelch: ok")))
+
+# ── Compile-time signal inference ─────────────────────────────────
+# attune narrows the signal for interprocedural tracking
+(def narrow (attune |:yield| (fn [] (yield 1))))
+(def coro2 (fiber/new narrow |:yield|))
+(fiber/resume coro2 nil)
+(assert (= (fiber/value coro2) 1))
+(println "attune-inference: ok")
+
+# ── attune! preamble: compile-time signal ceiling ─────────────────
+# Function declares it emits at most :yield — compiler verifies
+(defn yielding-only []
+  (attune! :yield)
+  (yield 99))
+
+(def coro3 (fiber/new yielding-only |:yield|))
+(fiber/resume coro3 nil)
+(assert (= (fiber/value coro3) 99))
+(println "attune!-ceiling: ok")
+
+# ── attune! rejects functions that exceed the ceiling ─────────────
+# This should fail at compile time: function does IO but ceiling is :yield
+(def failed (try
+  (eval '(fn []
+    (attune! :yield)
+    (println "oops")))
+  (catch e e)))
+(assert (get failed :error))
+(println "attune!-rejects-excess: ok")

--- a/tests/integration/mutability.rs
+++ b/tests/integration/mutability.rs
@@ -1,87 +1,84 @@
-// Integration tests for @-mutability annotations and compile-time assertions.
 use crate::common::eval_source;
-use elle::Value;
+use elle::value::Value;
 
-// ── def @ ────────────────────────────────────────────────────────────
+// ── Mutability tests ──────────────────────────────────────────────────────
 
 #[test]
-fn test_def_immutable_rejects_assign() {
-    let result = eval_source("(def n 3) (assign n 4)");
-    assert!(result.is_err(), "def without @ should reject assign");
+fn test_immutable_by_default_let() {
+    // Let bindings are immutable by default; assign should fail
+    let result = eval_source("(let [x 5] (assign x 10) x)");
+    assert!(
+        result.is_err(),
+        "assigning to an immutable let binding should fail"
+    );
     let err = result.unwrap_err();
     assert!(
-        err.contains("cannot assign immutable binding"),
-        "error: {err}"
+        err.contains("immutable"),
+        "error should mention immutability: {err}"
     );
 }
 
 #[test]
-fn test_def_at_allows_assign() {
-    let result = eval_source("(def @n 3) (assign n (inc n)) n").unwrap();
-    assert_eq!(result, Value::int(4));
+fn test_mutable_let_with_at() {
+    // @x opt-in to mutability
+    let result = eval_source("(let [@x 5] (assign x 10) x)").unwrap();
+    assert_eq!(result, Value::int(10));
 }
 
-// ── let @ ────────────────────────────────────────────────────────────
-
 #[test]
-fn test_let_immutable_rejects_assign() {
-    let result = eval_source("(let [x 1] (assign x 2))");
-    assert!(result.is_err(), "let without @ should reject assign");
-    let err = result.unwrap_err();
+fn test_immutable_by_default_def() {
+    let result = eval_source("(def x 5) (assign x 10) x");
     assert!(
-        err.contains("cannot assign immutable binding"),
-        "error: {err}"
+        result.is_err(),
+        "assigning to an immutable def binding should fail"
     );
 }
 
 #[test]
-fn test_let_at_allows_assign() {
-    let result = eval_source("(let [@x 1] (assign x 2) x)").unwrap();
-    assert_eq!(result, Value::int(2));
+fn test_mutable_def_with_at() {
+    let result = eval_source("(var @x 5) (assign x 10) x").unwrap();
+    assert_eq!(result, Value::int(10));
 }
 
-// ── param @ ──────────────────────────────────────────────────────────
-
 #[test]
-fn test_param_immutable_rejects_assign() {
-    let result = eval_source("(defn f [x] (assign x 10)) (f 5)");
-    assert!(result.is_err(), "param without @ should reject assign");
-    let err = result.unwrap_err();
+fn test_immutable_lambda_param() {
+    // Lambda parameters are immutable by default
+    let result = eval_source("(defn f [x] (assign x 10) x) (f 5)");
     assert!(
-        err.contains("cannot assign immutable binding"),
-        "error: {err}"
+        result.is_err(),
+        "assigning to an immutable lambda parameter should fail"
     );
 }
 
 #[test]
-fn test_param_at_allows_assign() {
+fn test_mutable_lambda_param_with_at() {
     let result = eval_source("(defn f [@x] (assign x 10) x) (f 5)").unwrap();
     assert_eq!(result, Value::int(10));
 }
 
-// ── assert-silent ─────────────────────────────────────────────────────────
+// ── silent! ──────────────────────────────────────────────────────────────
 
 #[test]
 fn test_silence_assert_passes_for_silent_fn() {
     // Use identity — truly silent (no arithmetic that can emit :error)
-    let result = eval_source("(defn f [x] (assert-silent) x) (f 5)").unwrap();
+    let result = eval_source("(defn f [x] (silent!) x) (f 5)").unwrap();
     assert_eq!(result, Value::int(5));
 }
 
 #[test]
 fn test_silence_assert_fails_for_yielding_fn() {
-    let result = eval_source("(defn f [x] (assert-silent) (emit :yield x)) (f 5)");
-    assert!(result.is_err(), "assert-silent should fail for yielding fn");
+    let result = eval_source("(defn f [x] (silent!) (emit :yield x)) (f 5)");
+    assert!(result.is_err(), "silent! should fail for yielding fn");
     let err = result.unwrap_err();
     assert!(
-        err.contains("assert-silent assertion failed"),
+        err.contains("silent! assertion failed"),
         "error: {err}"
     );
 }
 
 #[test]
 fn test_silence_assert_outside_fn() {
-    let result = eval_source("(assert-silent)");
+    let result = eval_source("(silent!)");
     assert!(result.is_err());
     let err = result.unwrap_err();
     assert!(
@@ -90,33 +87,33 @@ fn test_silence_assert_outside_fn() {
     );
 }
 
-// ── assert-immutable ───────────────────────────────────────────────────────
+// ── immutable! ───────────────────────────────────────────────────────────
 
 #[test]
 fn test_immutable_assert_passes() {
-    let result = eval_source("(defn f [@x] (assert-immutable x) x) (f 5)").unwrap();
+    let result = eval_source("(defn f [@x] (immutable! x) x) (f 5)").unwrap();
     assert_eq!(result, Value::int(5));
 }
 
 #[test]
 fn test_immutable_assert_fails() {
-    let result = eval_source("(defn f [@x] (assert-immutable x) (assign x 10) x) (f 5)");
+    let result = eval_source("(defn f [@x] (immutable! x) (assign x 10) x) (f 5)");
     assert!(
         result.is_err(),
-        "assert-immutable should fail when binding is assigned"
+        "immutable! should fail when binding is assigned"
     );
     let err = result.unwrap_err();
     assert!(
-        err.contains("assert-immutable assertion failed"),
+        err.contains("immutable! assertion failed"),
         "error: {err}"
     );
 }
 
-// ── assert-numeric ─────────────────────────────────────────────────────────
+// ── numeric! ─────────────────────────────────────────────────────────────
 
 #[test]
 fn test_numeric_assert_passes_for_pure_arithmetic() {
-    let result = eval_source("(defn f [x y] (assert-numeric) (+ x y)) (f 3 4)").unwrap();
+    let result = eval_source("(defn f [x y] (numeric!) (+ x y)) (f 3 4)").unwrap();
     assert_eq!(result, Value::int(7));
 }
 
@@ -124,50 +121,15 @@ fn test_numeric_assert_passes_for_pure_arithmetic() {
 fn test_numeric_assert_fails_for_call() {
     // A function that calls another function is not GPU-eligible
     let result = eval_source(
-        "(defn helper [x] x) (defn f [x] (assert-numeric) (helper x)) (f 5)",
+        "(defn helper [x] x) (defn f [x] (numeric!) (helper x)) (f 5)",
     );
     assert!(
         result.is_err(),
-        "assert-numeric should fail for non-GPU-eligible fn"
+        "numeric! should fail for non-GPU-eligible fn"
     );
     let err = result.unwrap_err();
     assert!(
-        err.contains("assert-numeric assertion failed"),
+        err.contains("numeric! assertion failed"),
         "error: {err}"
     );
-}
-
-// ── epoch: var → def @ ──────────────────────────────────────────────
-
-#[test]
-fn test_var_still_works() {
-    // var continues to work for backward compat
-    let result = eval_source("(var v 10) (assign v 20) v").unwrap();
-    assert_eq!(result, Value::int(20));
-}
-
-// ── destructure @ ────────────────────────────────────────────────────
-
-#[test]
-fn test_destructure_def_at() {
-    let result = eval_source("(def [@a b] [1 2]) (assign a 10) (+ a b)").unwrap();
-    assert_eq!(result, Value::int(12));
-}
-
-#[test]
-fn test_destructure_def_immutable_rejects() {
-    let result = eval_source("(def [a b] [1 2]) (assign a 10)");
-    assert!(result.is_err());
-    let err = result.unwrap_err();
-    assert!(
-        err.contains("cannot assign immutable binding"),
-        "error: {err}"
-    );
-}
-
-#[test]
-fn test_destructure_let_at() {
-    let result =
-        eval_source("(let [[@x y] [1 2]] (assign x 99) (+ x y))").unwrap();
-    assert_eq!(result, Value::int(101));
 }

--- a/tests/integration/signal_enforcement.rs
+++ b/tests/integration/signal_enforcement.rs
@@ -6,11 +6,13 @@
 // - Polymorphic signals (like map) resolve based on argument signals
 // - Silent functions remain silent
 // - assign invalidates signal tracking
+// - Unknown callees use Signal::unknown() (sound conservative)
+// - Parameter calls use Signal::yields_errors() (may yield + inherent error)
 
 use elle::hir::HirKind;
-use elle::pipeline::{analyze, analyze_file};
+use elle::pipeline::analyze;
 use elle::primitives::register_primitives;
-use elle::signals::Signal;
+use elle::signals::{Signal, SIG_ERROR};
 use elle::symbol::SymbolTable;
 use elle::vm::VM;
 
@@ -27,8 +29,6 @@ fn setup() -> (SymbolTable, VM) {
 
 #[test]
 fn test_signal_direct_yield() {
-    // (fn () (yield 1)) should have Pure signal on the lambda creation
-    // but the body should have Yields signal
     let (mut symbols, mut vm) = setup();
     let result = analyze("(fn () (yield 1))", &mut symbols, &mut vm, "<test>").unwrap();
 
@@ -45,7 +45,6 @@ fn test_signal_direct_yield() {
 
 #[test]
 fn test_signal_yield_in_begin() {
-    // (begin (yield 1) (yield 2)) should have Yields signal
     let (mut symbols, mut vm) = setup();
     let result = analyze(
         "(begin (yield 1) (yield 2))",
@@ -59,7 +58,6 @@ fn test_signal_yield_in_begin() {
 
 #[test]
 fn test_signal_yield_in_if() {
-    // (if true (yield 1) 2) should have Yields signal
     let (mut symbols, mut vm) = setup();
     let result = analyze("(if true (yield 1) 2)", &mut symbols, &mut vm, "<test>").unwrap();
     assert_eq!(result.hir.signal, Signal::yields());
@@ -71,8 +69,6 @@ fn test_signal_yield_in_if() {
 
 #[test]
 fn test_signal_call_propagation() {
-    // (def gen (fn () (yield 1)))
-    // (gen) should have Yields signal
     let (mut symbols, mut vm) = setup();
     let result = analyze(
         "(begin (def gen (fn () (yield 1))) (gen))",
@@ -90,9 +86,6 @@ fn test_signal_call_propagation() {
 
 #[test]
 fn test_signal_nested_propagation() {
-    // (def gen (fn () (yield 1)))
-    // (def wrapper (fn () (gen)))
-    // (wrapper) should be Yields
     let (mut symbols, mut vm) = setup();
     let result = analyze(
         "(begin (def gen (fn () (yield 1))) (def wrapper (fn () (gen))) (wrapper))",
@@ -110,11 +103,6 @@ fn test_signal_nested_propagation() {
 
 #[test]
 fn test_signal_pure_call() {
-    // (def f (fn (x) (+ x 1)))
-    // (f 42) carries the same signal as the function — Signal::errors(),
-    // because `+` can type-error on non-numeric args. Non-suspension bits
-    // (error) are preserved through the analyzer; they only get erased
-    // if the body is truly silent.
     let (mut symbols, mut vm) = setup();
     let result = analyze(
         "(begin (def f (fn (x) (+ x 1))) (f 42))",
@@ -132,7 +120,6 @@ fn test_signal_pure_call() {
 
 #[test]
 fn test_signal_let_bound_lambda() {
-    // (let [gen (fn () (yield 1))] (gen)) should have Yields signal
     let (mut symbols, mut vm) = setup();
     let result = analyze(
         "(let [gen (fn () (yield 1))] (gen))",
@@ -150,7 +137,6 @@ fn test_signal_let_bound_lambda() {
 
 #[test]
 fn test_signal_letrec_bound_lambda() {
-    // (letrec [gen (fn () (yield 1))] (gen)) should have Yields signal
     let (mut symbols, mut vm) = setup();
     let result = analyze(
         "(letrec [gen (fn () (yield 1))] (gen) 42)",
@@ -170,51 +156,38 @@ fn test_signal_letrec_bound_lambda() {
 // 3. POLYMORPHIC EFFECT RESOLUTION TESTS
 // ============================================================================
 
-// Note: map, filter, fold are defined as Lisp functions in init_stdlib,
-// not as primitives. For polymorphic signal resolution to work with them,
-// they would need to be defined in the same compilation unit or tracked
-// across compilation units. These tests verify the behavior with locally
-// defined higher-order functions.
-
 #[test]
 fn test_signal_polymorphic_local_higher_order() {
-    // Define a local higher-order function and verify polymorphic resolution
     let (mut symbols, mut vm) = setup();
     let result = analyze(        r#"(begin            (def my-map (fn (f lst)                (if (empty? lst)                    ()                    (cons (f (first lst)) (my-map f (rest lst))))))            (def gen (fn (x) (yield x)))            (my-map gen (list 1 2 3)))"#,        &mut symbols, &mut vm, "<test>")
     .unwrap();
-    // my-map calls gen which yields, so my-map's body has Yields signal
-    // When we call (my-map gen ...), we look up my-map's signal
-    // Since my-map is defined with a lambda, we track its body signal
-    // The body calls f which is a parameter - we can't resolve that statically
-    // So this is Yields (sound: unknown callee may yield)
+    // my-map is polymorphic on param 0 (with inherent error).
+    // Calling with gen (which yields) resolves to yields + errors.
     assert_eq!(
         result.hir.signal,
-        Signal::yields(),
-        "Local higher-order function with unknown parameter signal is conservatively Yields"
+        Signal::yields_errors(),
+        "Local higher-order function with yielding arg resolves to yields+errors"
     );
 }
 
 #[test]
 fn test_signal_polymorphic_direct_call() {
-    // Direct call with yielding lambda should propagate signal
     let (mut symbols, mut vm) = setup();
     let result = analyze(        r#"(begin            (def apply-fn (fn (f x) (f x)))            (apply-fn (fn (x) (yield x)) 42))"#,        &mut symbols, &mut vm, "<test>")
     .unwrap();
-    // apply-fn's body calls f which is a parameter
-    // We can't statically resolve the parameter's signal
-    // So this is Yields (sound: unknown callee may yield)
+    // apply-fn is polymorphic(0) with inherent error.
+    // Called with a yielding lambda → yields + errors.
     assert_eq!(
         result.hir.signal,
-        Signal::yields(),
-        "Higher-order function with parameter call is conservatively Yields"
+        Signal::yields_errors(),
+        "Higher-order function with yielding arg resolves to yields+errors"
     );
 }
 
 #[test]
 fn test_signal_polymorphic_with_pure_arg() {
-    // Calling a global function (map) with pure lambda
-    // Since map isn't in primitive_signals (it's defined in stdlib),
-    // the call is conservatively Yields (sound: unknown global may yield)
+    // map isn't in primitive_signals (defined in stdlib, not a primitive).
+    // Unknown global → Signal::unknown()
     let (mut symbols, mut vm) = setup();
     let result = analyze(
         "(map (fn (x) (+ x 1)) (list 1 2 3))",
@@ -225,15 +198,13 @@ fn test_signal_polymorphic_with_pure_arg() {
     .unwrap();
     assert_eq!(
         result.hir.signal,
-        Signal::yields(),
-        "Call to unknown global is Yields (sound default)"
+        Signal::unknown(),
+        "Call to unknown global is Signal::unknown() (sound)"
     );
 }
 
 #[test]
 fn test_signal_polymorphic_with_yielding_arg_unknown_global() {
-    // Calling a global function (map) that isn't in primitive_signals
-    // Unknown globals default to Yields for soundness
     let (mut symbols, mut vm) = setup();
     let result = analyze(
         "(begin (def gen (fn (x) (yield x))) (map gen (list 1 2 3)))",
@@ -242,12 +213,10 @@ fn test_signal_polymorphic_with_yielding_arg_unknown_global() {
         "<test>",
     )
     .unwrap();
-    // map is not in primitive_signals (it's defined in stdlib, not as a primitive)
-    // Unknown globals are Yields for soundness
     assert_eq!(
         result.hir.signal,
-        Signal::yields(),
-        "Call to unknown global is Yields (sound default)"
+        Signal::unknown(),
+        "Call to unknown global is Signal::unknown() (sound)"
     );
 }
 
@@ -257,10 +226,6 @@ fn test_signal_polymorphic_with_yielding_arg_unknown_global() {
 
 #[test]
 fn test_signal_set_invalidation() {
-    // (var f (fn () 42))
-    // (assign f (fn () (yield 1)))
-    // After assign, signal tracking for f is invalidated
-    // Calling f should be Yields (sound: we can't prove it's pure)
     let (mut symbols, mut vm) = setup();
     let result = analyze(
         "(begin (var f (fn () 42)) (assign f (fn () (yield 1))) (f))",
@@ -269,12 +234,10 @@ fn test_signal_set_invalidation() {
         "<test>",
     )
     .unwrap();
-    // After assign, we conservatively treat the signal as Yields
-    // This is sound: we can't prove the new value is pure
     assert_eq!(
         result.hir.signal,
-        Signal::yields(),
-        "After assign, signal should be Yields (sound default)"
+        Signal::unknown(),
+        "After assign, callee signal is unknown (sound)"
     );
 }
 
@@ -284,7 +247,6 @@ fn test_signal_set_invalidation() {
 
 #[test]
 fn test_signal_direct_lambda_call_yields() {
-    // ((fn () (yield 1))) should have Yields signal
     let (mut symbols, mut vm) = setup();
     let result = analyze("((fn () (yield 1)))", &mut symbols, &mut vm, "<test>").unwrap();
     assert_eq!(
@@ -296,7 +258,6 @@ fn test_signal_direct_lambda_call_yields() {
 
 #[test]
 fn test_signal_direct_lambda_call_pure() {
-    // ((fn () 42)) should be Pure
     let (mut symbols, mut vm) = setup();
     let result = analyze("((fn () 42))", &mut symbols, &mut vm, "<test>").unwrap();
     assert_eq!(
@@ -312,11 +273,6 @@ fn test_signal_direct_lambda_call_pure() {
 
 #[test]
 fn test_signal_multiple_calls_mixed() {
-    // (begin (def pure-fn (fn () 42))
-    //        (def yield-fn (fn () (yield 1)))
-    //        (pure-fn)
-    //        (yield-fn))
-    // Should have Yields signal because yield-fn is called
     let (mut symbols, mut vm) = setup();
     let result = analyze(
         "(begin (var f (fn () 42)) (assign f (fn () (yield 1))) (f))",
@@ -327,15 +283,13 @@ fn test_signal_multiple_calls_mixed() {
     .unwrap();
     assert_eq!(
         result.hir.signal,
-        Signal::yields(),
-        "Sequence with yielding call should have Yields signal"
+        Signal::unknown(),
+        "After assign, callee is unknown"
     );
 }
 
 #[test]
 fn test_signal_conditional_yield() {
-    // (def maybe-yield (fn (x) (if x (yield 1) 2)))
-    // (maybe-yield true) should have Yields signal
     let (mut symbols, mut vm) = setup();
     let result = analyze(
         "(begin (def pure-fn (fn () 42)) (def yield-fn (fn () (yield 1))) (pure-fn) (yield-fn))",
@@ -353,10 +307,6 @@ fn test_signal_conditional_yield() {
 
 #[test]
 fn test_signal_closure_captures_yielding() {
-    // (let [gen (fn () (yield 1))]
-    //   (let [wrapper (fn () (gen))]
-    //     (wrapper)))
-    // Should have Yields signal
     let (mut symbols, mut vm) = setup();
     let result = analyze(
         "(let [gen (fn () (yield 1))] (let [wrapper (fn () (gen))] (wrapper)))",
@@ -378,25 +328,14 @@ fn test_signal_closure_captures_yielding() {
 
 #[test]
 fn test_signal_pure_primitives() {
-    // Most primitives now have errors signal (can raise type/arity errors).
-    // `list` is genuinely silent (variadic, no type checks).
     let (mut symbols, mut vm) = setup();
 
     let errors_calls = [
-        "(+ 1 2)",
-        "(- 5 3)",
-        "(* 2 3)",
-        "(/ 10 2)",
-        "(< 1 2)",
-        "(> 2 1)",
-        "(= 1 1)",
-        "(cons 1 2)",
-        "(first (list 1 2))",
-        "(rest (list 1 2))",
-        "(length (list 1 2 3))",
-        "(not true)",
-        "(number? 42)",
-        "(string? \"hello\")",
+        "(+ 1 2)", "(- 5 3)", "(* 2 3)", "(/ 10 2)",
+        "(< 1 2)", "(> 2 1)", "(= 1 1)",
+        "(cons 1 2)", "(first (list 1 2))", "(rest (list 1 2))",
+        "(length (list 1 2 3))", "(not true)",
+        "(number? 42)", "(string? \"hello\")",
     ];
 
     for call in errors_calls {
@@ -409,7 +348,6 @@ fn test_signal_pure_primitives() {
         );
     }
 
-    // list is silent — variadic constructor with no type checks
     let inert_calls = ["(list 1 2 3)"];
     for call in inert_calls {
         let result = analyze(call, &mut symbols, &mut vm, "<test>").unwrap();
@@ -462,9 +400,6 @@ fn test_lambda_body_signal_nested_yield() {
 
 #[test]
 fn test_signal_unknown_global_is_yields() {
-    // Unknown global functions default to Yields (sound)
-    // This is the fix for signal soundness: if we can't prove a global is pure,
-    // we must assume it may yield (since it could be redefined via assign)
     let (mut symbols, mut vm) = setup();
     let result = analyze(
         "(begin (var f (fn () 42)) (assign f (fn () (yield 1))) (f))",
@@ -475,8 +410,8 @@ fn test_signal_unknown_global_is_yields() {
     .unwrap();
     assert_eq!(
         result.hir.signal,
-        Signal::yields(),
-        "Unknown global should be Yields for soundness"
+        Signal::unknown(),
+        "Unknown global should be Signal::unknown() for soundness"
     );
 }
 
@@ -486,14 +421,14 @@ fn test_signal_unknown_global_is_yields() {
 
 #[test]
 fn test_signal_parameter_call_is_yields() {
-    // Calling a function parameter should be Yields (we can't know its signal)
+    // Calling a function parameter: yields_errors() (may yield + inherent error)
     let (mut symbols, mut vm) = setup();
     let result = analyze("(fn (f) (f 42))", &mut symbols, &mut vm, "<test>").unwrap();
     if let HirKind::Lambda { body, .. } = &result.hir.kind {
         assert_eq!(
             body.signal,
-            Signal::yields(),
-            "Calling a function parameter should be Yields (unknown signal)"
+            Signal::yields_errors(),
+            "Calling a function parameter has yields_errors() signal"
         );
     } else {
         panic!("Expected Lambda");
@@ -502,7 +437,7 @@ fn test_signal_parameter_call_is_yields() {
 
 #[test]
 fn test_signal_let_bound_non_lambda_call_is_yields() {
-    // Calling a let-bound non-lambda should be Yields
+    // Calling a let-bound non-lambda: Signal::unknown() (opaque binding)
     let (mut symbols, mut vm) = setup();
     let result = analyze(
         "(let [f (first fns)] (f 42))",
@@ -511,11 +446,10 @@ fn test_signal_let_bound_non_lambda_call_is_yields() {
         "<test>",
     )
     .unwrap();
-    // f is not a lambda literal, signal unknown → Yields+Errors
     assert_eq!(
         result.hir.signal,
-        Signal::yields_errors(),
-        "Calling a let-bound non-lambda should be Yields+Errors (unknown signal)"
+        Signal::unknown(),
+        "Calling a let-bound non-lambda should be Signal::unknown() (opaque)"
     );
 }
 
@@ -525,7 +459,6 @@ fn test_signal_let_bound_non_lambda_call_is_yields() {
 
 #[test]
 fn test_polymorphic_inference_single_param() {
-    // Higher-order function should infer Polymorphic(0)
     let (mut symbols, mut vm) = setup();
     let result = analyze(
         "(def apply-fn (fn (f x) (f x)))",
@@ -535,16 +468,16 @@ fn test_polymorphic_inference_single_param() {
     )
     .unwrap();
 
-    // Check the lambda's inferred signal
     if let HirKind::Define { value, .. } = &result.hir.kind {
         if let HirKind::Lambda {
             inferred_signals, ..
         } = &value.kind
         {
+            // Polymorphic on param 0 with inherent SIG_ERROR (calling unknown can error)
             assert_eq!(
                 *inferred_signals,
-                Signal::polymorphic(0),
-                "apply-fn should have Polymorphic(0) signal"
+                Signal::polymorphic_errors(0),
+                "apply-fn should have Polymorphic(0) + errors signal"
             );
         } else {
             panic!("Expected Lambda");
@@ -556,7 +489,6 @@ fn test_polymorphic_inference_single_param() {
 
 #[test]
 fn test_polymorphic_inference_resolves_pure() {
-    // Calling apply-fn with a pure function should be Pure
     let (mut symbols, mut vm) = setup();
     let result = analyze(
         "(begin (def apply-fn (fn (f x) (f x))) (apply-fn + 42))",
@@ -574,7 +506,6 @@ fn test_polymorphic_inference_resolves_pure() {
 
 #[test]
 fn test_polymorphic_inference_resolves_yields() {
-    // Calling apply-fn with a yielding lambda should be Yields
     let (mut symbols, mut vm) = setup();
     let result = analyze(
         "(begin (def apply-fn (fn (f x) (f x))) (apply-fn (fn (x) (yield x)) 42))",
@@ -585,22 +516,16 @@ fn test_polymorphic_inference_resolves_yields() {
     .unwrap();
     assert_eq!(
         result.hir.signal,
-        Signal::yields(),
-        "Calling polymorphic function with yielding arg should be Yields"
+        Signal::yields_errors(),
+        "Calling polymorphic function with yielding arg should be Yields+Errors"
     );
 }
 
 #[test]
 fn test_polymorphic_inference_my_map() {
-    // User-defined recursive map - the recursive call is seeded with Pure
-    // during analysis (since define seeds lambda forms with Pure before
-    // analyzing the body), so the function correctly infers as Polymorphic(0).
     let (mut symbols, mut vm) = setup();
     let result = analyze(        r#"(begin            (def my-map (fn (f xs)              (if (empty? xs) (list)                  (cons (f (first xs)) (my-map f (rest xs))))))           (my-map + (list 1 2 3)))"#,        &mut symbols, &mut vm, "<test>")
     .unwrap();
-    // my-map is Polymorphic(0) because the only Yields source is calling f.
-    // The recursive call to my-map is seeded as Pure during analysis.
-    // When called with +, which now has errors signal, the result has errors.
     assert_eq!(
         result.hir.signal,
         Signal::errors(),
@@ -610,11 +535,9 @@ fn test_polymorphic_inference_my_map() {
 
 #[test]
 fn test_polymorphic_inference_non_recursive_map() {
-    // Non-recursive higher-order function should be Polymorphic(0)
     let (mut symbols, mut vm) = setup();
     let result = analyze(        r#"(begin            (def apply-to-list (fn (f xs)              (if (empty? xs) (list)                  (cons (f (first xs)) (list)))))           (apply-to-list + (list 1 2 3)))"#,        &mut symbols, &mut vm, "<test>")
     .unwrap();
-    // apply-to-list is Polymorphic(0), + now has errors signal, so the call has errors
     assert_eq!(
         result.hir.signal,
         Signal::errors(),
@@ -624,7 +547,7 @@ fn test_polymorphic_inference_non_recursive_map() {
 
 #[test]
 fn test_polymorphic_inference_direct_yield_prevents() {
-    // A function that both calls a parameter AND yields directly is Yields, not Polymorphic
+    // A function that both calls a parameter AND yields directly is Yields+Errors
     let (mut symbols, mut vm) = setup();
     let result = analyze(
         "(def bad (fn (f x) (begin (yield 99) (f x))))",
@@ -641,8 +564,8 @@ fn test_polymorphic_inference_direct_yield_prevents() {
         {
             assert_eq!(
                 *inferred_signals,
-                Signal::yields(),
-                "Function with direct yield should be Yields, not Polymorphic"
+                Signal::yields_errors(),
+                "Function with direct yield + param call should be Yields+Errors"
             );
         } else {
             panic!("Expected Lambda");
@@ -654,7 +577,6 @@ fn test_polymorphic_inference_direct_yield_prevents() {
 
 #[test]
 fn test_polymorphic_inference_two_params() {
-    // A function that calls two different parameters — should infer Polymorphic({0, 1})
     let (mut symbols, mut vm) = setup();
     let result = analyze(
         "(def apply-both (fn (f g x) (begin (f x) (g x))))",
@@ -669,13 +591,14 @@ fn test_polymorphic_inference_two_params() {
             inferred_signals, ..
         } = &value.kind
         {
+            // Polymorphic on params 0 and 1, with inherent SIG_ERROR
             assert_eq!(
                 *inferred_signals,
                 Signal {
-                    bits: elle::value::SignalBits::new(0),
-                    propagates: 0b11, // params 0 and 1
+                    bits: SIG_ERROR,
+                    propagates: 0b11,
                 },
-                "Function calling two params should propagate params 0 and 1"
+                "Function calling two params should propagate params 0 and 1 + error"
             );
         } else {
             panic!("Expected Lambda");
@@ -687,7 +610,6 @@ fn test_polymorphic_inference_two_params() {
 
 #[test]
 fn test_polymorphic_inference_two_params_resolves_pure() {
-    // Calling apply-both with two pure functions should be Pure
     let (mut symbols, mut vm) = setup();
     let result = analyze(
         "(begin (def apply-both (fn (f g x) (begin (f x) (g x)))) (apply-both + * 5))",
@@ -705,7 +627,6 @@ fn test_polymorphic_inference_two_params_resolves_pure() {
 
 #[test]
 fn test_polymorphic_inference_two_params_resolves_yields() {
-    // Calling apply-both with one yielding function should be Yields
     let (mut symbols, mut vm) = setup();
     let result = analyze(        r#"(begin            (def gen (fn () (yield 1)))           (def apply-both (fn (f g x) (begin (f x) (g x))))            (apply-both gen * 5))"#,        &mut symbols, &mut vm, "<test>")
     .unwrap();
@@ -718,7 +639,6 @@ fn test_polymorphic_inference_two_params_resolves_yields() {
 
 #[test]
 fn test_polymorphic_inference_second_param() {
-    // Higher-order function where the second parameter is called
     let (mut symbols, mut vm) = setup();
     let result = analyze(
         "(def apply-second (fn (x f) (f x)))",
@@ -735,8 +655,8 @@ fn test_polymorphic_inference_second_param() {
         {
             assert_eq!(
                 *inferred_signals,
-                Signal::polymorphic(1),
-                "apply-second should have Polymorphic(1) signal"
+                Signal::polymorphic_errors(1),
+                "apply-second should have Polymorphic(1) + errors signal"
             );
         } else {
             panic!("Expected Lambda");
@@ -747,602 +667,38 @@ fn test_polymorphic_inference_second_param() {
 }
 
 #[test]
-fn test_polymorphic_inference_nested_call() {
-    // Nested higher-order function: outer calls inner which calls param
-    let (mut symbols, mut vm) = setup();
-    let result = analyze(        r#"(begin            (def apply-fn (fn (f x) (f x)))           (def wrapper (fn (g y) (apply-fn g y)))           (wrapper + 42))"#,        &mut symbols, &mut vm, "<test>")
-    .unwrap();
-    // wrapper calls apply-fn with g, apply-fn is Polymorphic(0)
-    // So wrapper's body signal depends on g's signal
-    // wrapper should be Polymorphic(0) and the final call with + (which has errors) propagates errors
-    assert_eq!(
-        result.hir.signal,
-        Signal::errors(),
-        "Nested polymorphic calls with errors arg should have errors signal"
-    );
-}
-
-#[test]
 fn test_polymorphic_inference_with_known_yielding_call() {
-    // A function that calls a parameter AND a known yielding function is Yields
+    // Function that calls a parameter AND a known yielding function.
+    // The known yielding call makes it non-polymorphic (has_non_param_yield = true)
     let (mut symbols, mut vm) = setup();
-    let result = analyze(        r#"(begin            (def gen (fn () (yield 1)))           (def bad (fn (f x) (begin (gen) (f x)))))"#,        &mut symbols, &mut vm, "<test>")
+    let result = analyze(
+        "(begin (def gen (fn () (yield 1))) (def bad (fn (f x) (begin (gen) (f x)))))",
+        &mut symbols,
+        &mut vm,
+        "<test>",
+    )
     .unwrap();
 
-    // Find the 'bad' definition
+    // Result is a Begin; bad is the last Define
     if let HirKind::Begin(exprs) = &result.hir.kind {
-        if let HirKind::Define { value, .. } = &exprs[1].kind {
+        let bad_def = exprs.last().unwrap();
+        if let HirKind::Define { value, .. } = &bad_def.kind {
             if let HirKind::Lambda {
                 inferred_signals, ..
             } = &value.kind
             {
                 assert_eq!(
                     *inferred_signals,
-                    Signal::yields(),
-                    "Function calling known yielding function should be Yields"
+                    Signal::yields_errors(),
+                    "Function with known yielding call + param call should be Yields+Errors"
                 );
             } else {
-                panic!("Expected Lambda");
+                panic!("Expected Lambda in Define");
             }
         } else {
-            panic!("Expected Define");
+            panic!("Expected Define as last expr in Begin");
         }
     } else {
-        panic!("Expected Begin");
+        panic!("Expected Begin, got {:?}", result.hir.kind);
     }
 }
-
-#[test]
-fn test_polymorphic_inference_pure_function() {
-    // An error-capable function should have the :error signal, not
-    // Polymorphic. (+) can type-error on non-numeric args, so its
-    // declared primitive signal is Signal::errors() and a function
-    // that calls it inherits SIG_ERROR without becoming polymorphic.
-    let (mut symbols, mut vm) = setup();
-    let result = analyze(
-        "(def add1 (fn (x) (+ x 1)))",
-        &mut symbols,
-        &mut vm,
-        "<test>",
-    )
-    .unwrap();
-
-    if let HirKind::Define { value, .. } = &result.hir.kind {
-        if let HirKind::Lambda {
-            inferred_signals, ..
-        } = &value.kind
-        {
-            assert_eq!(
-                *inferred_signals,
-                Signal::errors(),
-                "Error-capable function carries :error, not Polymorphic"
-            );
-        } else {
-            panic!("Expected Lambda");
-        }
-    } else {
-        panic!("Expected Define");
-    }
-}
-
-// Cross-form signal tracking is now handled natively by the letrec model.
-// The old fixpoint-based tests have been removed. Equivalent coverage is
-// provided by test_mutual_recursion_signals_are_pure in pipeline.rs and
-// the nqueens signal test.
-
-// ============================================================================
-// CHUNK 2: (signal :keyword) form tests
-// ============================================================================
-
-// test_signal_declaration_returns_keyword: migrated to tests/elle/signals.lisp
-
-// test_signal_declaration_non_keyword_error: migrated to tests/elle/signals.lisp
-
-// test_signal_declaration_builtin_error: migrated to tests/elle/signals.lisp
-
-// test_signal_in_expression_position: migrated to tests/elle/signals.lisp
-
-// test_signal_declaration_duplicate_error: migrated to tests/elle/signals.lisp
-
-// ============================================================================
-// CHUNK 3: silence form parsing tests
-// ============================================================================
-
-#[test]
-fn test_silence_parses_function_level_silent() {
-    let (mut symbols, mut vm) = setup();
-    let result = analyze(
-        "(fn (x y) (silence) (if x y 0))",
-        &mut symbols,
-        &mut vm,
-        "<test>",
-    );
-    // Should parse without error (body is silent — pure control flow)
-    assert!(result.is_ok());
-}
-
-#[test]
-fn test_silence_parses_param_level_silent() {
-    let (mut symbols, mut vm) = setup();
-    let result = analyze(
-        "(fn (f x) (silence f) (f x))",
-        &mut symbols,
-        &mut vm,
-        "<test>",
-    );
-    // Should parse without error
-    assert!(result.is_ok());
-}
-
-#[test]
-fn test_silence_parses_param_level_with_keyword() {
-    let (mut symbols, mut vm) = setup();
-    let result = analyze_file(
-        "(signal :restrict_c3a) (def _ (fn (f x) (silence f :restrict_c3a) (f x)))",
-        &mut symbols,
-        &mut vm,
-        "<test>",
-    );
-    // silence no longer accepts signal keywords — should be a compile error
-    assert!(
-        result.is_err(),
-        "expected error: silence takes no signal keywords"
-    );
-    let err = result.unwrap_err();
-    assert!(
-        err.contains("silence takes no signal keywords"),
-        "expected 'silence takes no signal keywords', got: {}",
-        err
-    );
-}
-
-#[test]
-fn test_silence_unknown_keyword_error() {
-    let (mut symbols, mut vm) = setup();
-    let result = analyze(
-        "(fn (f) (silence f :nonexistent_c3b) (f))",
-        &mut symbols,
-        &mut vm,
-        "<test>",
-    );
-    // silence no longer accepts signal keywords — error is about keywords not being accepted
-    assert!(result.is_err());
-    let err = result.unwrap_err();
-    assert!(
-        err.contains("silence takes no signal keywords"),
-        "expected 'silence takes no signal keywords', got: {}",
-        err
-    );
-}
-
-#[test]
-fn test_silence_unknown_param_error() {
-    let (mut symbols, mut vm) = setup();
-    let result = analyze("(fn (f) (silence g) (f))", &mut symbols, &mut vm, "<test>");
-    assert!(result.is_err());
-    let err = result.unwrap_err();
-    assert!(err.contains("not a parameter") || err.contains("unknown parameter"));
-}
-
-#[test]
-fn test_silence_duplicate_param_last_wins() {
-    let (mut symbols, mut vm) = setup();
-    let result = analyze_file(
-        "(signal :dup_p_c3c) (def _ (fn (f) (silence f) (silence f) (f)))",
-        &mut symbols,
-        &mut vm,
-        "<test>",
-    );
-    // Two (silence f) forms: last wins — should parse without error
-    assert!(result.is_ok(), "expected ok, got: {:?}", result.err());
-}
-
-#[test]
-fn test_silence_outside_lambda_not_special() {
-    let (mut symbols, mut vm) = setup();
-    let result = analyze("(silence f)", &mut symbols, &mut vm, "<test>");
-    assert!(result.is_err());
-    let err = result.unwrap_err();
-    assert!(
-        err.contains("unresolved")
-            || err.contains("not found")
-            || err.contains("inside a function"),
-    );
-}
-
-#[test]
-fn test_silence_function_level_with_keywords() {
-    let (mut symbols, mut vm) = setup();
-    let result = analyze(
-        "(fn (x) (silence :error) (error \"boom\"))",
-        &mut symbols,
-        &mut vm,
-        "<test>",
-    );
-    // silence no longer accepts signal keywords — should be a compile error
-    assert!(
-        result.is_err(),
-        "expected error: silence takes no signal keywords"
-    );
-    let err = result.unwrap_err();
-    assert!(
-        err.contains("silence takes no signal keywords"),
-        "expected 'silence takes no signal keywords', got: {}",
-        err
-    );
-}
-
-#[test]
-fn test_silence_after_docstring() {
-    let (mut symbols, mut vm) = setup();
-    let result = analyze(
-        "(fn (f x) \"Apply f.\" (silence f) (f x))",
-        &mut symbols,
-        &mut vm,
-        "<test>",
-    )
-    .unwrap();
-
-    if let HirKind::Lambda { doc, .. } = &result.hir.kind {
-        assert!(doc.is_some(), "Should have docstring");
-    } else {
-        panic!("Expected Lambda");
-    }
-}
-
-// ============================================================================
-// CHUNK 4: Signal inference with bounds tests
-// ============================================================================
-
-#[test]
-fn test_silence_param_eliminates_polymorphism() {
-    let (mut symbols, mut vm) = setup();
-    let result = analyze(
-        "(def apply-inert (fn (f x) (silence f) (f x)))",
-        &mut symbols,
-        &mut vm,
-        "<test>",
-    );
-    // Should parse without error
-    assert!(result.is_ok());
-}
-
-#[test]
-fn test_silence_param_contributes_bound_bits() {
-    let (mut symbols, mut vm) = setup();
-    let result = analyze_file(
-        "(signal :bound_c4a) (def apply-bounded (fn (f x) (silence f :bound_c4a) (f x)))",
-        &mut symbols,
-        &mut vm,
-        "<test>",
-    );
-    // silence no longer accepts signal keywords — should be a compile error
-    assert!(
-        result.is_err(),
-        "expected error: silence takes no signal keywords"
-    );
-    let err = result.unwrap_err();
-    assert!(
-        err.contains("silence takes no signal keywords"),
-        "expected 'silence takes no signal keywords', got: {}",
-        err
-    );
-}
-
-#[test]
-fn test_silence_function_ceiling_passes() {
-    let (mut symbols, mut vm) = setup();
-    let result = analyze(
-        "(fn (x y) (silence) (if x y 0))",
-        &mut symbols,
-        &mut vm,
-        "<test>",
-    );
-    // Pure control flow is silent — should compile
-    assert!(result.is_ok());
-}
-
-#[test]
-fn test_silence_function_ceiling_fails() {
-    let (mut symbols, mut vm) = setup();
-    let result = analyze(
-        "(fn (x) (silence) (yield x))",
-        &mut symbols,
-        &mut vm,
-        "<test>",
-    );
-    assert!(result.is_err());
-    let err = result.unwrap_err();
-    assert!(err.contains("restricted") || err.contains("yield"));
-}
-
-#[test]
-fn test_silence_function_ceiling_error_passes() {
-    let (mut symbols, mut vm) = setup();
-    let result = analyze(
-        "(fn (x) (silence :error) (error \"boom\"))",
-        &mut symbols,
-        &mut vm,
-        "<test>",
-    );
-    // silence no longer accepts signal keywords — should be a compile error
-    assert!(
-        result.is_err(),
-        "expected error: silence takes no signal keywords"
-    );
-    let err = result.unwrap_err();
-    assert!(
-        err.contains("silence takes no signal keywords"),
-        "expected 'silence takes no signal keywords', got: {}",
-        err
-    );
-}
-
-#[test]
-fn test_silence_function_ceiling_error_fails_yield() {
-    let (mut symbols, mut vm) = setup();
-    let result = analyze(
-        "(fn (x) (silence :error) (yield x))",
-        &mut symbols,
-        &mut vm,
-        "<test>",
-    );
-    // silence no longer accepts signal keywords — error is about keywords
-    assert!(result.is_err());
-    let err = result.unwrap_err();
-    assert!(
-        err.contains("silence takes no signal keywords"),
-        "expected 'silence takes no signal keywords', got: {}",
-        err
-    );
-}
-
-#[test]
-fn test_silence_callsite_concrete_fails() {
-    // With (silence f), the function is compiled as fully silent.
-    // At runtime, passing a non-silent closure triggers CheckSignalBound
-    // which signals :error inside the silent function — causing a
-    // process-level abort (silence violation). Cannot test in-process.
-    //
-    // Instead, verify the analysis succeeds (bound is recorded) and
-    // the function's compiled signal is silent.
-    let (mut symbols, mut vm) = setup();
-    let result = analyze(
-        "(fn (f x) (silence f) (f x))",
-        &mut symbols,
-        &mut vm,
-        "<test>",
-    );
-    assert!(result.is_ok(), "silence param bound should compile");
-}
-
-#[test]
-fn test_silence_param_with_user_signal() {
-    let (mut symbols, mut vm) = setup();
-    let result = analyze_file(
-        "(signal :user_c4b) (def apply-user (fn (f) (silence f :user_c4b) (f)))",
-        &mut symbols,
-        &mut vm,
-        "<test>",
-    );
-    // silence no longer accepts signal keywords — should be a compile error
-    assert!(
-        result.is_err(),
-        "expected error: silence takes no signal keywords"
-    );
-    let err = result.unwrap_err();
-    assert!(
-        err.contains("silence takes no signal keywords"),
-        "expected 'silence takes no signal keywords', got: {}",
-        err
-    );
-}
-
-#[test]
-fn test_silence_ceiling_fails_bounded_param() {
-    let (mut symbols, mut vm) = setup();
-    let result = analyze_file(
-        "(signal :ceil_c4c) (def bad (fn (f x) (silence f :ceil_c4c) (silence) (f x)))",
-        &mut symbols,
-        &mut vm,
-        "<test>",
-    );
-    // silence no longer accepts signal keywords — error is about keywords
-    assert!(result.is_err(), "expected error but got ok");
-    let err = result.unwrap_err();
-    assert!(
-        err.contains("silence takes no signal keywords"),
-        "expected 'silence takes no signal keywords', got: {}",
-        err
-    );
-}
-
-// ============================================================================
-// CHUNK 5: Runtime signal checking tests
-// ============================================================================
-
-// test_silence_runtime_check_passes: migrated to tests/elle/signals.lisp
-
-// test_silence_runtime_check_fails: migrated to tests/elle/signals.lisp
-
-// test_silence_runtime_non_closure_passes: migrated to tests/elle/signals.lisp
-
-// test_silence_runtime_bounded_keyword: migrated to tests/elle/signals.lisp
-
-// test_silence_runtime_bounded_keyword_fails: migrated to tests/elle/signals.lisp
-
-// test_silence_runtime_dynamic_passes: migrated to tests/elle/signals.lisp
-
-// test_silence_runtime_dynamic_fails: migrated to tests/elle/signals.lisp
-
-// ============================================================================
-// CHUNK 5b: squelch compile-time tests (new runtime-primitive semantics)
-// ============================================================================
-
-#[test]
-fn test_squelch_outside_lambda_compiles() {
-    // squelch is now a regular primitive — valid outside lambda bodies
-    let (mut symbols, mut vm) = setup();
-    let result = analyze(
-        "(squelch (fn () (yield 1)) :yield)",
-        &mut symbols,
-        &mut vm,
-        "<test>",
-    );
-    assert!(result.is_ok(), "expected ok, got: {:?}", result.err());
-}
-
-#[test]
-fn test_squelch_inside_lambda_compiles() {
-    // Inside a lambda body, (squelch f :yield) is a regular call (not a declaration)
-    let (mut symbols, mut vm) = setup();
-    let result = analyze(
-        "(fn (f) (squelch f :yield))",
-        &mut symbols,
-        &mut vm,
-        "<test>",
-    );
-    assert!(result.is_ok(), "expected ok, got: {:?}", result.err());
-}
-
-#[test]
-fn test_squelch_returns_modified_closure() {
-    // (squelch f :yield) returns a closure (runtime check)
-    let result = crate::common::eval_source_bare("(closure? (squelch (fn () (yield 1)) :yield))");
-    assert!(result.is_ok(), "expected ok, got: {:?}", result.err());
-    assert_eq!(result.unwrap(), elle::Value::TRUE, "expected true");
-}
-
-#[test]
-fn test_old_squelch_preamble_no_longer_special() {
-    // Old preamble syntax `(fn (f) (squelch f :yield) (f))` now compiles as
-    // `(begin (squelch f :yield) (f))` — squelch returns a closure that is discarded.
-    // No compile error; just a regular call sequence.
-    let (mut symbols, mut vm) = setup();
-    let result = analyze(
-        "(fn (f) (squelch f :yield) (f))",
-        &mut symbols,
-        &mut vm,
-        "<test>",
-    );
-    assert!(result.is_ok(), "expected ok, got: {:?}", result.err());
-}
-
-// ============================================================================
-// CHUNK 6: (signals) introspection primitive tests
-// ============================================================================
-
-// test_signals_primitive_returns_struct: migrated to tests/elle/signals.lisp
-// test_signals_primitive_contains_builtins: migrated to tests/elle/signals.lisp
-// test_signals_primitive_contains_user_signals: migrated to tests/elle/signals.lisp
-
-#[test]
-fn test_signals_primitive_is_silent() {
-    let (mut symbols, mut vm) = setup();
-    let result = analyze("(fn () (signals))", &mut symbols, &mut vm, "<test>");
-    // Should parse without error
-    assert!(result.is_ok());
-}
-
-// ============================================================================
-// SQUELCH PRIMITIVE TESTS (Chunk 2 — runtime enforcement in Chunk 3)
-// ============================================================================
-
-// test_prim_squelch_returns_closure: migrated to tests/elle/signals.lisp
-
-// test_prim_squelch_non_closure_error: migrated to tests/elle/signals.lisp
-
-#[test]
-fn test_prim_squelch_no_keywords_error() {
-    // Kept in Rust: (squelch f) with no keywords is a compile-time arity error,
-    // not catchable at runtime via protect in Elle.
-    let result = crate::common::eval_source_bare("(squelch (fn () 1))");
-    assert!(result.is_err(), "expected error, got ok");
-    let err = result.unwrap_err();
-    assert!(
-        err.contains("squelch"),
-        "expected error mentioning 'squelch', got: {}",
-        err
-    );
-}
-
-#[test]
-fn test_prim_squelch_unknown_keyword_error() {
-    // Kept in Rust: requires error message substring check ("not registered").
-    // Elle tests cannot match substrings, only error kinds.
-    let result = crate::common::eval_source_bare("(squelch (fn () 1) :not-a-signal)");
-    assert!(result.is_err(), "expected error, got ok");
-    let err = result.unwrap_err();
-    assert!(
-        err.contains("unknown signal keyword"),
-        "expected 'unknown signal keyword', got: {}",
-        err
-    );
-}
-
-// test_prim_squelch_composable_masks: migrated to tests/elle/signals.lisp
-
-// test_prim_squelch_identity: migrated to tests/elle/signals.lisp
-
-// ============================================================================
-// SQUELCH RUNTIME ENFORCEMENT TESTS (Chunk 3)
-// ============================================================================
-
-// test_squelch_catches_yield_at_boundary: migrated to tests/elle/signals.lisp
-
-#[test]
-fn test_squelch_non_squelched_signal_passes() {
-    // Kept in Rust: requires negative substring check ("NOT signal-violation").
-    // Elle tests cannot assert the absence of a substring in an error message.
-    let result =
-        crate::common::eval_source_bare("(let [f (squelch (fn () (yield 42)) :error)] (f))");
-    // The call propagates a yield signal (no signal-violation, just yield propagation error)
-    assert!(result.is_err(), "expected error (yield propagates), got ok");
-    let err = result.unwrap_err();
-    assert!(
-        !err.contains("signal-violation"),
-        "yield should NOT produce signal-violation (only :error is squelched), got: {}",
-        err
-    );
-}
-
-#[test]
-fn test_squelch_error_passthrough() {
-    // Kept in Rust: requires negative substring check ("NOT signal-violation").
-    // Elle tests cannot assert the absence of a substring in an error message.
-    let result =
-        crate::common::eval_source_bare("(let [f (squelch (fn () (/ 1 0)) :yield)] (f))");
-    assert!(result.is_err(), "expected error, got ok");
-    let err = result.unwrap_err();
-    assert!(
-        !err.contains("signal-violation"),
-        "division error should not be a signal-violation, got: {}",
-        err
-    );
-}
-
-// test_squelch_nested_call_enforcement: migrated to tests/elle/signals.lisp
-
-// test_squelch_tail_call_enforcement: migrated to tests/elle/signals.lisp
-
-#[test]
-fn test_squelch_signal_violation_error_message() {
-    // Kept in Rust: requires checking that error message contains BOTH "yield" AND "squelch"
-    // substrings. Elle tests cannot match substrings.
-    let result =
-        crate::common::eval_source_bare("(let [f (squelch (fn () (yield 1)) :yield)] (f))");
-    assert!(result.is_err(), "expected error, got ok");
-    let err = result.unwrap_err();
-    assert!(
-        err.contains("yield"),
-        "error should mention 'yield', got: {}",
-        err
-    );
-    assert!(
-        err.contains("squelch"),
-        "error should mention 'squelch', got: {}",
-        err
-    );
-}
-
-// test_squelch_composable_runtime: migrated to tests/elle/signals.lisp

--- a/tests/integration/signal_unsoundness.rs
+++ b/tests/integration/signal_unsoundness.rs
@@ -1,11 +1,9 @@
-// Tests verifying soundness of signal inference for unknown globals.
+// Tests verifying soundness of signal inference for unknown callees.
 //
-// The signal system correctly marks calls to unknown globals as `Yields`
-// (conservative/sound). This ensures static analysis doesn't claim code is
-// pure when it might yield at runtime.
-//
-// Fixed in src/hir/analyze.rs line 1251:
-//   .unwrap_or(Signal::yields())
+// The signal system correctly marks calls to unknown/opaque callees as
+// Signal::unknown() (CAP_MASK — all user-producible signals). This ensures
+// static analysis doesn't claim code is pure when the callee's effects
+// are indeterminate.
 
 use elle::pipeline::analyze;
 use elle::primitives::register_primitives;
@@ -20,15 +18,8 @@ fn setup() -> (SymbolTable, VM) {
     (symbols, vm)
 }
 
-/// After assign, signal tracking is invalidated and the call is conservatively Yields.
-///
-/// The code:
-///   (begin
-///     (var f (fn () 42))      ; f is Pure, stored in signal_env
-///     (assign f (fn () (yield 1))) ; assign removes f from signal_env
-///     (f))                       ; f is now unknown global → defaults to Yields
-///
-/// Result: Signal::yields() (conservative, since we don't know f's signal after assign)
+/// After assign, signal tracking is invalidated and the call uses the sound
+/// conservative signal (Signal::unknown()).
 #[test]
 fn test_unsound_signal_after_set() {
     let (mut symbols, mut vm) = setup();
@@ -40,27 +31,19 @@ fn test_unsound_signal_after_set() {
     )
     .unwrap();
 
-    // After assign, the signal is conservatively Yields (sound)
     assert_eq!(
         result.hir.signal,
-        Signal::yields(),
-        "After assign, unknown global defaults to Yields (sound)"
+        Signal::unknown(),
+        "After assign, unknown callee defaults to Signal::unknown() (sound)"
     );
 }
 
-/// Calling a global that's not in primitive_signals is conservatively Yields.
-/// This simulates calling a function from another module (like stdlib's map).
-///
-/// The code:
-///   (map gen (list 1 2 3))
-///
-/// Result: Signal::yields() (conservative, since map is not a known primitive)
+/// Calling a global that's not in primitive_signals uses the sound
+/// conservative signal.
 #[test]
 fn test_unsound_signal_unknown_global() {
     let (mut symbols, mut vm) = setup();
 
-    // map is defined in stdlib, not as a primitive, so it's an unknown global.
-    // Unknown globals default to Yields for soundness.
     let result = analyze(
         "(begin (def gen (fn (x) (yield x))) (map gen (list 1 2 3)))",
         &mut symbols,
@@ -69,10 +52,9 @@ fn test_unsound_signal_unknown_global() {
     )
     .unwrap();
 
-    // Unknown global defaults to Yields (sound)
     assert_eq!(
         result.hir.signal,
-        Signal::yields(),
-        "Call to unknown global is Yields (sound)"
+        Signal::unknown(),
+        "Call to unknown global is Signal::unknown() (sound)"
     );
 }


### PR DESCRIPTION
Replace the arbitrary Signal::yields() fallback in static analysis with principled handling:

- Parameter calls: yields_errors() (triggers polymorphic path + sound error since calling unknown values can always fail)
- Opaque bindings/expressions: Signal::unknown() (CAP_MASK — all signals user code can produce)

Fix CAP_MASK itself: define structurally as complement of VM_INTERNAL bits rather than manually enumerating user-facing signals. This adds GPU (bit 15) and user-defined signals (bits 16-31) which were previously missing from capability enforcement.