### PR TITLE
GTK4 overhaul: test suite, style cleanup, new modules, stdlib polish

### DIFF
--- a/demos/mandelbrot/mandelbrot.lisp
+++ b/demos/mandelbrot/mandelbrot.lisp
@@ -15,7 +15,9 @@
 
 # ── Libraries ─────────────────────────────────────────────────────
 
-(def b ((import "std/gtk4/bind")))
+(def gtk ((import "std/gtk4")))
+(def cr  ((import "std/cairo")))
+(def b   ((import "std/gtk4/bind")))
 
 (def [gpu-ok? gpu] (protect ((import "std/gpu"))))
 (def gpu-ctx
@@ -24,30 +26,6 @@
       (when ok? (println "GPU: enabled") ctx))))
 
 (when (not gpu-ctx) (println "GPU: not available, using CPU"))
-
-(def cairo (ffi/native "libcairo.so.2"))
-
-# ── GTK bindings not yet in lib/gtk4/bind ─────────────────────────
-
-(ffi/defbind gtk-app-new     b:libgtk "gtk_application_new"                :ptr  [:string :u32])
-(ffi/defbind gtk-app-win-new b:libgtk "gtk_application_window_new"         :ptr  [:ptr])
-(ffi/defbind gtk-queue-draw  b:libgtk "gtk_widget_queue_draw"              :void [:ptr])
-(ffi/defbind gtk-da-new      b:libgtk "gtk_drawing_area_new"               :ptr  [])
-(ffi/defbind gtk-da-set-cw   b:libgtk "gtk_drawing_area_set_content_width" :void [:ptr :int])
-(ffi/defbind gtk-da-set-ch   b:libgtk "gtk_drawing_area_set_content_height" :void [:ptr :int])
-(ffi/defbind gtk-da-draw-fn  b:libgtk "gtk_drawing_area_set_draw_func"     :void [:ptr :ptr :ptr :ptr])
-(ffi/defbind gtk-add-ctrl    b:libgtk "gtk_widget_add_controller"          :void [:ptr :ptr])
-(ffi/defbind gtk-click-new   b:libgtk "gtk_gesture_click_new"              :ptr  [])
-(ffi/defbind gtk-gesture-btn b:libgtk "gtk_gesture_single_set_button"      :void [:ptr :u32])
-(ffi/defbind gtk-get-btn     b:libgtk "gtk_gesture_single_get_current_button" :u32 [:ptr])
-(ffi/defbind gtk-scroll-new  b:libgtk "gtk_event_controller_scroll_new"    :ptr  [:u32])
-(ffi/defbind gtk-key-new     b:libgtk "gtk_event_controller_key_new"       :ptr  [])
-
-(ffi/defbind cairo-img-surface cairo "cairo_image_surface_create_for_data"  :ptr  [:ptr :int :int :int :int])
-(ffi/defbind cairo-set-source  cairo "cairo_set_source_surface"            :void [:ptr :ptr :double :double])
-(ffi/defbind cairo-paint       cairo "cairo_paint"                         :void [:ptr])
-(ffi/defbind cairo-surf-free   cairo "cairo_surface_destroy"               :void [:ptr])
-(ffi/defbind cairo-scale       cairo "cairo_scale"                         :void [:ptr :double :double])
 
 # ── Constants ─────────────────────────────────────────────────────
 
@@ -64,8 +42,7 @@
 # ── Mutable state ────────────────────────────────────────────────
 
 (def @view @{:cx -0.5  :cy 0.0  :scale 3.5  :iter (if gpu-ctx 256 32)})
-(def @da-widget nil)
-(def @app-window nil)
+(def @handle nil)
 (def @quit? false)
 (def @actual-w WIDTH)
 (def @actual-h HEIGHT)
@@ -275,31 +252,28 @@
 (defn refresh []
   (ev/spawn (fn []
     (compute-mandelbrot)
-    (when app-window
-      (b:gtk-window-set-title app-window
+    (when handle
+      (gtk:set-title handle
         (string "Mandelbrot — " (view :cx) " + " (view :cy)
-                "i  scale=" (view :scale) "  iter=" (view :iter))))
-    (when da-widget (gtk-queue-draw da-widget)))))
+                "i  scale=" (view :scale) "  iter=" (view :iter)))
+      (gtk:queue-draw handle :canvas)))))
 
 # ── GTK callbacks ────────────────────────────────────────────────
 
-(def CAIRO_FORMAT_ARGB32 0)
-(def SCROLL_VERTICAL     2)
-
-(defn on-draw [_da cr w h _data]
+(defn on-draw [_da cairo-ctx w h _data]
   (assign actual-w w)
   (assign actual-h h)
-  (def s (min (/ (float w) (float WIDTH)) (/ (float h) (float HEIGHT))))
-  (def ox (/ (- (float w) (* s (float WIDTH))) 2.0))
-  (def oy (/ (- (float h) (* s (float HEIGHT))) 2.0))
-  (def surf (cairo-img-surface pixel-buf CAIRO_FORMAT_ARGB32 WIDTH HEIGHT STRIDE))
-  (cairo-scale cr s s)
-  (cairo-set-source cr surf (/ ox s) (/ oy s))
-  (cairo-paint cr)
-  (cairo-surf-free surf))
+  (let* [s    (min (/ (float w) (float WIDTH)) (/ (float h) (float HEIGHT)))
+         ox   (/ (- (float w) (* s (float WIDTH))) 2.0)
+         oy   (/ (- (float h) (* s (float HEIGHT))) 2.0)
+         surf (cr:image-surface-for-data pixel-buf cr:FORMAT_ARGB32 WIDTH HEIGHT STRIDE)]
+    (cr:scale cairo-ctx s s)
+    (cr:set-source-surface cairo-ctx surf (/ ox s) (/ oy s))
+    (cr:paint cairo-ctx)
+    (cr:surface-destroy surf)))
 
-(defn on-click [gesture _n x y _data]
-  (let* [btn    (gtk-get-btn gesture)
+(defn on-click [gesture n x y]
+  (let* [btn    (b:gtk-gesture-single-get-current-button gesture)
          aspect (/ (float HEIGHT) (float WIDTH))
          scale  (view :scale)
          nx     (/ x (float actual-w))
@@ -313,16 +287,16 @@
       (put view :scale (* scale factor))
       (refresh))))
 
-(defn on-scroll [_ctrl _dx dy _data]
+(defn on-scroll [dx dy]
   (put view :scale (* (view :scale) (if (< dy 0.0) (/ 1.0 1.5) 1.5)))
   (refresh)
   1)
 
-(defn on-key [_ctrl keyval _keycode _state _data]
+(defn on-key [keyval keycode state]
   (let [step (/ (view :scale) 4.0)]
     (cond
       ((or (= keyval 0xff1b) (= keyval 0x71))           # ESC / Q
-        (when app-window (b:gtk-window-destroy app-window))
+        (gtk:close handle)
         (assign quit? true) 1)
       ((= keyval 0x72)                                    # R
         (put view :cx -0.5) (put view :cy 0.0)
@@ -340,58 +314,25 @@
         (refresh) 1)
       (true 0))))
 
-# ── Activate ─────────────────────────────────────────────────────
-
-(defn on-activate [app _data]
-  (def win (gtk-app-win-new app))
-  (assign app-window win)
-  (b:gtk-window-set-default-size win WIDTH HEIGHT)
-
-  (def da (gtk-da-new))
-  (assign da-widget da)
-  (gtk-da-set-cw da WIDTH)
-  (gtk-da-set-ch da HEIGHT)
-
-  (gtk-da-draw-fn da
-    (ffi/callback (ffi/signature :void [:ptr :ptr :int :int :ptr]) on-draw)
-    nil nil)
-
-  (let [click (gtk-click-new)]
-    (gtk-gesture-btn click 0)
-    (b:g-signal-connect-data click "pressed"
-      (ffi/callback (ffi/signature :void [:ptr :int :double :double :ptr]) on-click)
-      nil nil 0)
-    (gtk-add-ctrl da click))
-
-  (let [scroll (gtk-scroll-new SCROLL_VERTICAL)]
-    (b:g-signal-connect-data scroll "scroll"
-      (ffi/callback (ffi/signature :int [:ptr :double :double :ptr]) on-scroll)
-      nil nil 0)
-    (gtk-add-ctrl da scroll))
-
-  (let [keys (gtk-key-new)]
-    (b:g-signal-connect-data keys "key-pressed"
-      (ffi/callback (ffi/signature :int [:ptr :u32 :u32 :u32 :ptr]) on-key)
-      nil nil 0)
-    (gtk-add-ctrl win keys))
-
-  (b:gtk-window-set-child win da)
-  (when gpu-ctx (b:gtk-window-fullscreen win))
-  (b:gtk-window-present win)
-
-  (when (not gpu-ctx) (init-workers)))
-
 # ── Main ─────────────────────────────────────────────────────────
 
 (println "Mandelbrot Explorer")
 (println "  left-click: zoom in    right-click: zoom out    scroll: zoom")
 (println "  arrows: pan    +/-: iterations    r: reset    q: quit")
 
-(b:gtk-init)
-(def app (gtk-app-new "org.elle.mandelbrot" 32))
-(b:g-signal-connect-data app "activate"
-  (ffi/callback (ffi/signature :void [:ptr :ptr]) on-activate)
-  nil nil 0)
+(assign handle
+  (gtk:app/new "org.elle.mandelbrot"
+    (fn [h]
+      (b:gtk-window-set-default-size h:window WIDTH HEIGHT)
+      (gtk:build h
+        [:drawing-area {:id :canvas :width WIDTH :height HEIGHT
+                        :on-draw on-draw}])
+      (gtk:on-click h :canvas on-click)
+      (gtk:on-scroll h :canvas on-scroll)
+      (gtk:on-key h :window on-key)
+      (when gpu-ctx (b:gtk-window-fullscreen h:window))
+      (when (not gpu-ctx) (init-workers)))
+    :flags 32))
 
 (ev/spawn (fn [] (refresh)))
-(b:run-app app :quit (fn [] quit?))
+(gtk:app/run handle :quit (fn [] quit?))

--- a/lib/cairo.lisp
+++ b/lib/cairo.lisp
@@ -1,0 +1,94 @@
+(elle/epoch 8)
+## lib/cairo.lisp — Cairo 2D graphics bindings
+##
+## Standalone module for Cairo rendering. Not GTK-specific — usable
+## with any surface target (image buffers, PDF, SVG, X11, Wayland).
+##
+## Usage:
+##   (def cairo ((import "std/cairo")))
+##   (def surf (cairo:image-surface-for-data buf cairo:FORMAT_ARGB32 w h stride))
+##   (cairo:scale cr sx sy)
+##   (cairo:set-source-surface cr surf 0.0 0.0)
+##   (cairo:paint cr)
+##   (cairo:surface-destroy surf)
+
+(fn []
+
+(def lib (ffi/native "libcairo.so.2"))
+
+# ── Constants ────────────────────────────────────────────────────
+
+(def FORMAT_ARGB32  0)
+(def FORMAT_RGB24   1)
+(def FORMAT_A8      2)
+(def FORMAT_A1      3)
+
+# ── Surfaces ─────────────────────────────────────────────────────
+
+(ffi/defbind image-surface          lib "cairo_image_surface_create"           :ptr  [:int :int :int])
+(ffi/defbind image-surface-for-data lib "cairo_image_surface_create_for_data"  :ptr  [:ptr :int :int :int :int])
+(ffi/defbind surface-destroy        lib "cairo_surface_destroy"                :void [:ptr])
+(ffi/defbind surface-flush          lib "cairo_surface_flush"                  :void [:ptr])
+
+# ── Context lifecycle ────────────────────────────────────────────
+
+(ffi/defbind create  lib "cairo_create"  :ptr  [:ptr])
+(ffi/defbind destroy lib "cairo_destroy" :void [:ptr])
+(ffi/defbind save    lib "cairo_save"    :void [:ptr])
+(ffi/defbind restore lib "cairo_restore" :void [:ptr])
+
+# ── Transforms ───────────────────────────────────────────────────
+
+(ffi/defbind scale     lib "cairo_scale"     :void [:ptr :double :double])
+(ffi/defbind translate lib "cairo_translate" :void [:ptr :double :double])
+(ffi/defbind rotate    lib "cairo_rotate"    :void [:ptr :double])
+
+# ── Source ───────────────────────────────────────────────────────
+
+(ffi/defbind set-source-rgb     lib "cairo_set_source_rgb"     :void [:ptr :double :double :double])
+(ffi/defbind set-source-rgba    lib "cairo_set_source_rgba"    :void [:ptr :double :double :double :double])
+(ffi/defbind set-source-surface lib "cairo_set_source_surface" :void [:ptr :ptr :double :double])
+
+# ── Drawing ──────────────────────────────────────────────────────
+
+(ffi/defbind paint          lib "cairo_paint"          :void [:ptr])
+(ffi/defbind paint-with-alpha lib "cairo_paint_with_alpha" :void [:ptr :double])
+(ffi/defbind stroke         lib "cairo_stroke"         :void [:ptr])
+(ffi/defbind fill           lib "cairo_fill"           :void [:ptr])
+(ffi/defbind set-line-width lib "cairo_set_line_width" :void [:ptr :double])
+
+# ── Path ─────────────────────────────────────────────────────────
+
+(ffi/defbind move-to  lib "cairo_move_to"  :void [:ptr :double :double])
+(ffi/defbind line-to  lib "cairo_line_to"  :void [:ptr :double :double])
+(ffi/defbind curve-to lib "cairo_curve_to" :void [:ptr :double :double :double :double :double :double])
+(ffi/defbind arc      lib "cairo_arc"      :void [:ptr :double :double :double :double :double])
+(ffi/defbind rectangle lib "cairo_rectangle" :void [:ptr :double :double :double :double])
+(ffi/defbind close-path lib "cairo_close_path" :void [:ptr])
+(ffi/defbind new-path   lib "cairo_new_path"   :void [:ptr])
+
+# ── Export ───────────────────────────────────────────────────────
+
+{# constants
+ :FORMAT_ARGB32 FORMAT_ARGB32 :FORMAT_RGB24 FORMAT_RGB24
+ :FORMAT_A8 FORMAT_A8 :FORMAT_A1 FORMAT_A1
+ # surfaces
+ :image-surface image-surface
+ :image-surface-for-data image-surface-for-data
+ :surface-destroy surface-destroy :surface-flush surface-flush
+ # context
+ :create create :destroy destroy :save save :restore restore
+ # transforms
+ :scale scale :translate translate :rotate rotate
+ # source
+ :set-source-rgb set-source-rgb :set-source-rgba set-source-rgba
+ :set-source-surface set-source-surface
+ # drawing
+ :paint paint :paint-with-alpha paint-with-alpha
+ :stroke stroke :fill fill :set-line-width set-line-width
+ # path
+ :move-to move-to :line-to line-to :curve-to curve-to
+ :arc arc :rectangle rectangle
+ :close-path close-path :new-path new-path}
+
+) # end (fn [])

--- a/lib/color.lisp
+++ b/lib/color.lisp
@@ -15,6 +15,11 @@
 
 (fn []
 
+  # ── Helpers ────────────────────────────────────────────────────────
+
+  (defn clamp01 [x] (max 0.0 (min 1.0 x)))
+  (defn normalize-hue [h] (if (< h 0.0) (+ h 360.0) h))
+
   # ── Construction ───────────────────────────────────────────────────
 
   (defn rgb [r g b]
@@ -47,7 +52,7 @@
   # ── sRGB ↔ HSL ────────────────────────────────────────────────────
 
   (defn rgb->hsl [c]
-    (let* [r (get c :r) g (get c :g) b (get c :b)
+    (let* [r c:r g c:g b c:b
            mx (max r (max g b))
            mn (min r (min g b))
            d  (- mx mn)
@@ -60,12 +65,12 @@
                    ((= mx g) (* 60.0 (+ (/ (- b r) d) 2.0)))
                    (true     (* 60.0 (+ (/ (- r g) d) 4.0)))))]
       {:space :hsl
-       :h (if (< h 0.0) (+ h 360.0) h)
-       :s (max 0.0 (min 1.0 s))
-       :l (max 0.0 (min 1.0 l))}))
+       :h (normalize-hue h)
+       :s (clamp01 s)
+       :l (clamp01 l)}))
 
   (defn hsl->rgb [c]
-    (let* [h (get c :h) s (get c :s) l (get c :l)
+    (let* [h c:h s c:s l c:l
            ch  (* (- 1.0 (abs (- (* 2.0 l) 1.0))) s)
            hp  (/ (fmod h 360.0) 60.0)
            x   (* ch (- 1.0 (abs (- (fmod hp 2.0) 1.0))))
@@ -83,23 +88,23 @@
   # ── sRGB ↔ XYZ (D65) ──────────────────────────────────────────────
 
   (defn rgb->xyz [c]
-    (let* [rl (srgb-to-linear (get c :r))
-           gl (srgb-to-linear (get c :g))
-           bl (srgb-to-linear (get c :b))]
+    (let* [rl (srgb-to-linear c:r)
+           gl (srgb-to-linear c:g)
+           bl (srgb-to-linear c:b)]
       {:space :xyz
        :x (+ (* 0.4124564 rl) (* 0.3575761 gl) (* 0.1804375 bl))
        :y (+ (* 0.2126729 rl) (* 0.7151522 gl) (* 0.0721750 bl))
        :z (+ (* 0.0193339 rl) (* 0.1191920 gl) (* 0.9503041 bl))}))
 
   (defn xyz->rgb [c]
-    (let* [x (get c :x) y (get c :y) z (get c :z)
+    (let* [x c:x y c:y z c:z
            rl (+ (* 3.2404542  x) (* -1.5371385 y) (* -0.4985314 z))
            gl (+ (* -0.9692660 x) (* 1.8760108  y) (* 0.0415560  z))
            bl (+ (* 0.0556434  x) (* -0.2040259 y) (* 1.0572252  z))]
       {:space :srgb
-       :r (max 0.0 (min 1.0 (linear-to-srgb rl)))
-       :g (max 0.0 (min 1.0 (linear-to-srgb gl)))
-       :b (max 0.0 (min 1.0 (linear-to-srgb bl)))}))
+       :r (clamp01 (linear-to-srgb rl))
+       :g (clamp01 (linear-to-srgb gl))
+       :b (clamp01 (linear-to-srgb bl))}))
 
   # ── XYZ ↔ Lab (D65) ───────────────────────────────────────────────
 
@@ -120,16 +125,16 @@
         (/ (- (* 116.0 t) 16.0) LAB-K))))
 
   (defn xyz->lab [c]
-    (let* [fx (lab-f (/ (get c :x) D65-X))
-           fy (lab-f (/ (get c :y) D65-Y))
-           fz (lab-f (/ (get c :z) D65-Z))]
+    (let* [fx (lab-f (/ c:x D65-X))
+           fy (lab-f (/ c:y D65-Y))
+           fz (lab-f (/ c:z D65-Z))]
       {:space :lab
        :l (- (* 116.0 fy) 16.0)
        :a (* 500.0 (- fx fy))
        :b (* 200.0 (- fy fz))}))
 
   (defn lab->xyz [c]
-    (let* [l (get c :l) a (get c :a) b (get c :b)
+    (let* [l c:l a c:a b c:b
            fy (/ (+ l 16.0) 116.0)
            fx (+ (/ a 500.0) fy)
            fz (- fy (/ b 200.0))]
@@ -148,9 +153,9 @@
   ## sRGB → Linear → Oklab → Oklch
 
   (defn rgb->oklab [c]
-    (let* [rl (srgb-to-linear (get c :r))
-           gl (srgb-to-linear (get c :g))
-           bl (srgb-to-linear (get c :b))
+    (let* [rl (srgb-to-linear c:r)
+           gl (srgb-to-linear c:g)
+           bl (srgb-to-linear c:b)
            l_ (+ (* 0.4122214708 rl) (* 0.5363325363 gl) (* 0.0514459929 bl))
            m_ (+ (* 0.2119034982 rl) (* 0.6806995451 gl) (* 0.1073969566 bl))
            s_ (+ (* 0.0883024619 rl) (* 0.2817188376 gl) (* 0.6299787005 bl))
@@ -161,7 +166,7 @@
        :b (+ (* 0.0259040371 l) (* 0.7827717662 m) (* -0.8086757660 s))}))
 
   (defn oklab->rgb [c]
-    (let* [L (get c :l) A (get c :a) B (get c :b)
+    (let* [L c:l A c:a B c:b
            l_ (+ L (* 0.3963377774 A) (* 0.2158037573 B))
            m_ (+ L (* -0.1055613458 A) (* -0.0638541728 B))
            s_ (+ L (* -0.0894841775 A) (* -1.2914855480 B))
@@ -170,28 +175,22 @@
            gl (+ (* -1.2684380046 l) (* 2.6097574011 m) (* -0.3413193965 s))
            bl (+ (* -0.0041960863 l) (* -0.7034186147 m) (* 1.7076147010 s))]
       {:space :srgb
-       :r (max 0.0 (min 1.0 (linear-to-srgb rl)))
-       :g (max 0.0 (min 1.0 (linear-to-srgb gl)))
-       :b (max 0.0 (min 1.0 (linear-to-srgb bl)))}))
+       :r (clamp01 (linear-to-srgb rl))
+       :g (clamp01 (linear-to-srgb gl))
+       :b (clamp01 (linear-to-srgb bl))}))
 
   (def DEG (/ 180.0 (math/pi)))
   (def RAD (/ (math/pi) 180.0))
 
   (defn oklab->oklch [c]
-    (let* [a (get c :a) b (get c :b)
+    (let* [a c:a b c:b
            ch (math/sqrt (+ (* a a) (* b b)))
            h  (* (math/atan2 b a) DEG)]
-      {:space :oklch
-       :l (get c :l)
-       :c ch
-       :h (if (< h 0.0) (+ h 360.0) h)}))
+      {:space :oklch :l c:l :c ch :h (normalize-hue h)}))
 
   (defn oklch->oklab [c]
-    (let* [ch (get c :c) h (* (get c :h) RAD)]
-      {:space :oklab
-       :l (get c :l)
-       :a (* ch (math/cos h))
-       :b (* ch (math/sin h))}))
+    (let* [ch c:c h (* c:h RAD)]
+      {:space :oklab :l c:l :a (* ch (math/cos h)) :b (* ch (math/sin h))}))
 
   (defn rgb->oklch [c] (oklab->oklch (rgb->oklab c)))
   (defn oklch->rgb [c] (oklab->rgb (oklch->oklab c)))
@@ -199,14 +198,14 @@
   # ── Conversion dispatch ───────────────────────────────────────────
 
   (defn to-srgb [c]
-    (match (get c :space)
+    (match c:space
       (:srgb  c)
       (:hsl   (hsl->rgb c))
       (:lab   (lab->rgb c))
       (:xyz   (xyz->rgb c))
       (:oklab (oklab->rgb c))
       (:oklch (oklch->rgb c))
-      (_      (error {:error :color-error :message (string "unknown space " (get c :space))}))))
+      (_      (error {:error :color-error :message (string "unknown space " c:space)}))))
 
   (defn convert [c space]
     (let [s (to-srgb c)]
@@ -225,9 +224,9 @@
     (let* [a (to-srgb c1) b (to-srgb c2)
            t (float t) inv (- 1.0 t)]
       {:space :srgb
-       :r (+ (* (get a :r) inv) (* (get b :r) t))
-       :g (+ (* (get a :g) inv) (* (get b :g) t))
-       :b (+ (* (get a :b) inv) (* (get b :b) t))}))
+       :r (+ (* a:r inv) (* b:r t))
+       :g (+ (* a:g inv) (* b:g t))
+       :b (+ (* a:b inv) (* b:b t))}))
 
   (defn gradient [c1 c2 n]
     (let [steps (max 2 n)]
@@ -236,28 +235,28 @@
 
   (defn lighten [c amount]
     (let [h (convert c :hsl)]
-      (hsl->rgb (put h :l (max 0.0 (min 1.0 (+ (get h :l) (float amount))))))))
+      (hsl->rgb (put h :l (clamp01 (+ h:l (float amount)))))))
 
   (defn darken [c amount]
     (lighten c (- (float amount))))
 
   (defn saturate [c amount]
     (let [h (convert c :hsl)]
-      (hsl->rgb (put h :s (max 0.0 (min 1.0 (+ (get h :s) (float amount))))))))
+      (hsl->rgb (put h :s (clamp01 (+ h:s (float amount)))))))
 
   (defn desaturate [c amount]
     (saturate c (- (float amount))))
 
   (defn complement [c]
     (let [h (convert c :hsl)]
-      (hsl->rgb (put h :h (fmod (+ (get h :h) 180.0) 360.0)))))
+      (hsl->rgb (put h :h (fmod (+ h:h 180.0) 360.0)))))
 
   # ── CIEDE2000 color distance ───────────────────────────────────────
 
   (defn distance [c1 c2]
     (let* [a (convert c1 :lab) b (convert c2 :lab)
-           l1 (get a :l) a1 (get a :a) b1 (get a :b)
-           l2 (get b :l) a2 (get b :a) b2 (get b :b)
+           l1 a:l a1 a:a b1 a:b
+           l2 b:l a2 b:a b2 b:b
            dl (- l2 l1)
            lb (/ (+ l1 l2) 2.0)
            c1s (math/sqrt (+ (* a1 a1) (* b1 b1)))
@@ -309,10 +308,10 @@
 
   (defn to-rgba8 [c]
     (let [s (to-srgb c)]
-      [(integer (* (max 0.0 (min 1.0 (get s :r))) 255.0))
-       (integer (* (max 0.0 (min 1.0 (get s :g))) 255.0))
-       (integer (* (max 0.0 (min 1.0 (get s :b))) 255.0))
-       (integer (* (max 0.0 (min 1.0 (or (get s :a) 1.0))) 255.0))]))
+      [(integer (* (clamp01 s:r) 255.0))
+       (integer (* (clamp01 s:g) 255.0))
+       (integer (* (clamp01 s:b) 255.0))
+       (integer (* (clamp01 (or s:a 1.0)) 255.0))]))
 
   (defn from-rgba8 [r g b a]
     {:space :srgb

--- a/lib/dns.lisp
+++ b/lib/dns.lisp
@@ -178,13 +178,10 @@
 
 (defn format-ipv6 [buf offset]
   "Format 16 bytes at offset as colon-separated IPv6 address (full form)."
-  (def @groups @[])
-  (def @i 0)
-  (while (< i 8)
-    (let [val (read-u16 buf (+ offset (* i 2)))]
-      (push groups (number->string val 16)))
-    (assign i (+ i 1)))
-  (string/join (freeze groups) ":"))
+  (string/join
+    (map (fn [i] (number->string (read-u16 buf (+ offset (* i 2))) 16))
+         (range 8))
+    ":"))
 
 (defn parse-records [buf offset count]
   "Parse 'count' resource records starting at offset.
@@ -253,16 +250,13 @@
 
 (defn parse-resolv-conf [text]
   "Parse /etc/resolv.conf and return a list of nameserver IP strings."
-  (def @servers @[])
-  (each line in (string/split text "\n")
-    (let [trimmed (string/trim line)]
-      (when (string/starts-with? trimmed "nameserver")
-        (let [parts (string/split trimmed " ")]
-          (when (>= (length parts) 2)
-            (let [addr (string/trim (get parts 1))]
-              (unless (empty? addr)
-                (push servers addr))))))))
-  (freeze servers))
+  (let* [lines   (map string/trim (string/split text "\n"))
+         ns-lines (filter (fn [l] (string/starts-with? l "nameserver")) lines)
+         addrs   (map (fn [l]
+                    (let [parts (string/split l " ")]
+                      (when (>= (length parts) 2) (string/trim (parts 1)))))
+                  ns-lines)]
+    (freeze (filter (fn [a] (and a (not (empty? a)))) addrs))))
 
 (defn read-nameservers []
   "Read nameserver list from /etc/resolv.conf. Returns array of IP strings.

--- a/lib/gtk4.lisp
+++ b/lib/gtk4.lisp
@@ -18,9 +18,10 @@
 
 (fn []
 
-(def b  ((import "std/gtk4/bind")))
-(def w  ((import "std/gtk4/widgets")))
-(def wv ((import "std/gtk4/webview")))
+(def b   ((import "std/gtk4/bind")))
+(def w   ((import "std/gtk4/widgets")))
+(def wv  ((import "std/gtk4/webview")))
+(def app ((import "std/gtk4/app")))
 
 # ── Callback signatures ──────────────────────────────────────────
 
@@ -32,18 +33,13 @@
   "Initialize GTK and create a window. Returns a mutable window handle."
   (b:gtk-init)
   (let* [win-ptr (b:gtk-window-new)
-         handle @{:window win-ptr
-                   :widgets @{}
-                   :events @[]
-                   :close-requested false
-                   :callbacks @[]
-                   :css-provider nil}]
+         handle  (w:make-handle win-ptr)]
     (b:gtk-window-set-title win-ptr (or opts:title "Elle"))
     (when (and opts:width opts:height)
       (b:gtk-window-set-default-size win-ptr opts:width opts:height))
     (let [cb (ffi/callback sig-close
                 (fn (widget)
-                  (put handle :close-requested true)
+                  (put handle :open false)
                   1))]
       (push handle:callbacks cb)
       (b:g-signal-connect-data win-ptr "close-request" cb nil nil 0))
@@ -52,23 +48,34 @@
 
 (defn gtk4/open? (handle)
   "Check if the window is still open."
-  (not handle:close-requested))
+  handle:open)
 
 (defn gtk4/close (handle)
   "Destroy the window."
   (b:gtk-window-destroy handle:window)
-  (put handle :close-requested true)
+  (put handle :open false)
   nil)
 
+(defn drain-events (handle)
+  "Freeze and clear the event queue, returning the events."
+  (let [events (freeze handle:events)]
+    (put handle :events @[])
+    events))
+
 (defn gtk4/poll (handle)
-  "Pump the GLib main loop, drain and return events."
+  "Pump the GLib main loop non-blocking, drain and return events."
   (let [ctx (b:g-main-context-default)]
     (while (nonzero? (b:g-main-context-pending ctx))
       (b:g-main-context-iteration ctx 0)))
-  (let [events (freeze handle:events)]
-    (while (nonempty? handle:events)
-      (pop handle:events))
-    events))
+  (drain-events handle))
+
+(defn gtk4/wait (handle)
+  "Block until GTK events arrive, then drain and return them.
+   Yields to the Elle scheduler via ev/poll-fd on GLib's event sources."
+  (let [ctx (b:g-main-context-default)]
+    (while (empty? handle:events)
+      (b:glib-wait ctx)))
+  (drain-events handle))
 
 # ── Tree builder ──────────────────────────────────────────────────
 
@@ -120,6 +127,8 @@
            (:center-box  (w:make-center-box handle props))
            (:overlay     (w:make-overlay handle props))
            (:revealer    (w:make-revealer handle props))
+           # drawing
+           (:drawing-area (w:make-drawing-area handle props))
            # special
            (:webview     (wv:make-webview handle props))
            (_            (error (string "gtk4:build: unknown widget type " tag))))]
@@ -131,19 +140,19 @@
   (match tag
     ((or :v-box :h-box)
       (each child in children
-        (w:box-append widget (build-widget handle child))))
+        (b:gtk-box-append widget (build-widget handle child))))
     (:scroll-area
       (when (nonempty? children)
-        (w:scroll-set-child widget (build-widget handle (children 0)))))
+        (b:gtk-scrolled-window-set-child widget (build-widget handle (children 0)))))
     (:expander
       (when (nonempty? children)
-        (w:expander-set-child widget (build-widget handle (children 0)))))
+        (b:gtk-expander-set-child widget (build-widget handle (children 0)))))
     (:frame
       (when (nonempty? children)
-        (w:frame-set-child widget (build-widget handle (children 0)))))
+        (b:gtk-frame-set-child widget (build-widget handle (children 0)))))
     (:revealer
       (when (nonempty? children)
-        (w:revealer-set-child widget (build-widget handle (children 0)))))
+        (b:gtk-revealer-set-child widget (build-widget handle (children 0)))))
     (:grid
       (add-grid-children handle widget props children))
     (:stack
@@ -184,7 +193,7 @@
              row   (or cp:row auto-row)
              cs    (or cp:col-span 1)
              rs    (or cp:row-span 1)]
-        (w:grid-attach grid cw col row cs rs)
+        (b:gtk-grid-attach grid cw col row cs rs)
         (assign auto-col (+ col cs))
         (when (>= auto-col cols)
           (assign auto-col 0)
@@ -219,70 +228,70 @@
 
 (defn gtk4/rebuild (handle id spec)
   "Replace a container's children by rebuilding from spec."
-  (when-let [{:ptr ptr :type type} (handle:widgets id)]
-    (let [child (build-widget handle spec)]
+  (when-let [wgt (handle:widgets id)]
+    (let [{:ptr ptr :type type} wgt
+          child (build-widget handle spec)]
       (match type
-        ((or :box :scroll-area :frame :expander :revealer)
-          (match type
-            (:box         (b:gtk-box-append ptr child))
-            (:scroll-area (b:gtk-scrolled-window-set-child ptr child))
-            (:frame       (b:gtk-frame-set-child ptr child))
-            (:expander    (b:gtk-expander-set-child ptr child))
-            (:revealer    (b:gtk-revealer-set-child ptr child))
-            (_            nil)))
+        (:box         (b:gtk-box-append ptr child))
+        (:scroll-area (b:gtk-scrolled-window-set-child ptr child))
+        (:frame       (b:gtk-frame-set-child ptr child))
+        (:expander    (b:gtk-expander-set-child ptr child))
+        (:revealer    (b:gtk-revealer-set-child ptr child))
         (_ nil)))))
 
 # ── Widget access ─────────────────────────────────────────────────
 
 (defn gtk4/set (handle id value)
   "Set a widget's text or value by id."
-  (when-let [{:ptr ptr :type type} (handle:widgets id)]
-    (match type
-      ((or :label :heading) (b:gtk-label-set-text ptr (string value)))
-      (:button        (b:gtk-button-set-label ptr (string value)))
-      (:text-input    (b:gtk-editable-set-text ptr (string value)))
-      (:text-edit     (-> (b:gtk-text-view-get-buffer ptr)
-                       (b:gtk-text-buffer-set-text (string value) -1)))
-      (:checkbox      (b:gtk-check-button-set-active ptr (w:bool->int value)))
-      (:switch        (b:gtk-switch-set-active ptr (w:bool->int value)))
-      (:toggle-button (b:gtk-toggle-button-set-active ptr (w:bool->int value)))
-      (:slider        (b:gtk-range-set-value ptr value))
-      (:spin-button   (b:gtk-spin-button-set-value ptr value))
-      (:combo-box     (b:gtk-drop-down-set-selected ptr value))
-      (:progress-bar  (b:gtk-progress-bar-set-fraction ptr value))
-      (:spinner       (if value (b:gtk-spinner-start ptr) (b:gtk-spinner-stop ptr)))
-      (_ nil))))
+  (when-let [wgt (handle:widgets id)]
+    (let [{:ptr ptr :type type} wgt]
+      (match type
+        ((or :label :heading) (b:gtk-label-set-text ptr (string value)))
+        (:button        (b:gtk-button-set-label ptr (string value)))
+        (:text-input    (b:gtk-editable-set-text ptr (string value)))
+        (:text-edit     (-> (b:gtk-text-view-get-buffer ptr)
+                         (b:gtk-text-buffer-set-text (string value) -1)))
+        (:checkbox      (b:gtk-check-button-set-active ptr (w:bool->int value)))
+        (:switch        (b:gtk-switch-set-active ptr (w:bool->int value)))
+        (:toggle-button (b:gtk-toggle-button-set-active ptr (w:bool->int value)))
+        (:slider        (b:gtk-range-set-value ptr value))
+        (:spin-button   (b:gtk-spin-button-set-value ptr value))
+        (:combo-box     (b:gtk-drop-down-set-selected ptr value))
+        (:progress-bar  (b:gtk-progress-bar-set-fraction ptr value))
+        (:spinner       (if value (b:gtk-spinner-start ptr) (b:gtk-spinner-stop ptr)))
+        (_ nil)))))
 
 (defn gtk4/get (handle id)
   "Get a widget's current text or value by id."
-  (when-let [{:ptr ptr :type type} (handle:widgets id)]
-    (match type
-      ((or :label :heading) (ffi/string (b:gtk-label-get-text ptr)))
-      (:button        (ffi/string (b:gtk-button-get-label ptr)))
-      (:text-input    (ffi/string (b:gtk-editable-get-text ptr)))
-      (:text-edit     (let [buf (b:gtk-text-view-get-buffer ptr)]
-                        (ffi/with-stack [[start 80] [end 80]]
-                          (b:gtk-text-buffer-get-start-iter buf start)
-                          (b:gtk-text-buffer-get-end-iter buf end)
-                          (ffi/string (b:gtk-text-buffer-get-text buf start end 0)))))
-      (:checkbox      (nonzero? (b:gtk-check-button-get-active ptr)))
-      (:switch        (nonzero? (b:gtk-switch-get-active ptr)))
-      (:toggle-button (nonzero? (b:gtk-toggle-button-get-active ptr)))
-      (:slider        (b:gtk-range-get-value ptr))
-      (:spin-button   (b:gtk-spin-button-get-value ptr))
-      (:combo-box     (b:gtk-drop-down-get-selected ptr))
-      (:progress-bar  (b:gtk-progress-bar-get-fraction ptr))
-      (_ nil))))
+  (when-let [wgt (handle:widgets id)]
+    (let [{:ptr ptr :type type} wgt]
+      (match type
+        ((or :label :heading) (ffi/string (b:gtk-label-get-text ptr)))
+        (:button        (ffi/string (b:gtk-button-get-label ptr)))
+        (:text-input    (ffi/string (b:gtk-editable-get-text ptr)))
+        (:text-edit     (let [buf (b:gtk-text-view-get-buffer ptr)]
+                          (ffi/with-stack [[start 80] [end 80]]
+                            (b:gtk-text-buffer-get-start-iter buf start)
+                            (b:gtk-text-buffer-get-end-iter buf end)
+                            (ffi/string (b:gtk-text-buffer-get-text buf start end 0)))))
+        (:checkbox      (nonzero? (b:gtk-check-button-get-active ptr)))
+        (:switch        (nonzero? (b:gtk-switch-get-active ptr)))
+        (:toggle-button (nonzero? (b:gtk-toggle-button-get-active ptr)))
+        (:slider        (b:gtk-range-get-value ptr))
+        (:spin-button   (b:gtk-spin-button-get-value ptr))
+        (:combo-box     (b:gtk-drop-down-get-selected ptr))
+        (:progress-bar  (b:gtk-progress-bar-get-fraction ptr))
+        (_ nil)))))
 
 (defn gtk4/set-visible (handle id visible)
   "Show or hide a widget."
-  (when-let [{:ptr ptr} (handle:widgets id)]
-    (b:gtk-widget-set-visible ptr (w:bool->int visible))))
+  (when-let [wgt (handle:widgets id)]
+    (b:gtk-widget-set-visible wgt:ptr (w:bool->int visible))))
 
 (defn gtk4/set-sensitive (handle id sensitive)
   "Enable or disable a widget."
-  (when-let [{:ptr ptr} (handle:widgets id)]
-    (b:gtk-widget-set-sensitive ptr (w:bool->int sensitive))))
+  (when-let [wgt (handle:widgets id)]
+    (b:gtk-widget-set-sensitive wgt:ptr (w:bool->int sensitive))))
 
 (defn gtk4/set-title (handle title)
   "Change the window title."
@@ -301,8 +310,8 @@
 
 (defn gtk4/set-stack-page (handle id page-name)
   "Switch the visible page of a GtkStack."
-  (when-let [{:ptr ptr} (handle:widgets id)]
-    (b:gtk-stack-set-visible-child-name ptr (string page-name))))
+  (when-let [wgt (handle:widgets id)]
+    (b:gtk-stack-set-visible-child-name wgt:ptr (string page-name))))
 
 # ── WebView passthrough ───────────────────────────────────────────
 
@@ -315,8 +324,9 @@
 
 (defn gtk4/add (handle parent-id spec)
   "Add a widget to a container."
-  (when-let [{:ptr ptr :type type} (handle:widgets parent-id)]
-    (let [child (build-widget handle spec)]
+  (when-let [wgt (handle:widgets parent-id)]
+    (let [{:ptr ptr :type type} wgt
+          child (build-widget handle spec)]
       (match type
         (:box         (b:gtk-box-append ptr child))
         (:scroll-area (b:gtk-scrolled-window-set-child ptr child))
@@ -324,9 +334,31 @@
 
 (defn gtk4/remove (handle id)
   "Remove a widget from its parent."
-  (when-let [{:ptr ptr} (handle:widgets id)]
-    (b:gtk-widget-unparent ptr)
+  (when-let [wgt (handle:widgets id)]
+    (b:gtk-widget-unparent wgt:ptr)
     (put handle:widgets id nil)))
+
+(defn gtk4/queue-draw (handle id)
+  "Invalidate a widget, triggering a redraw."
+  (when-let [wgt (handle:widgets id)]
+    (b:gtk-widget-queue-draw wgt:ptr)))
+
+# ── Event controllers ────────────────────────────────────────────
+
+(defn gtk4/on-click (handle id handler)
+  "Add a click handler to a widget. handler: (fn [gesture n x y])."
+  (when-let [wgt (handle:widgets id)]
+    (w:add-click handle wgt:ptr handler)))
+
+(defn gtk4/on-scroll (handle id handler)
+  "Add a scroll handler to a widget. handler: (fn [dx dy]) → int."
+  (when-let [wgt (handle:widgets id)]
+    (w:add-scroll handle wgt:ptr handler)))
+
+(defn gtk4/on-key (handle id handler)
+  "Add a key handler to a widget. handler: (fn [keyval keycode state]) → int."
+  (when-let [wgt (handle:widgets id)]
+    (w:add-key handle wgt:ptr handler)))
 
 # ── Export ────────────────────────────────────────────────────────
 
@@ -334,6 +366,7 @@
  :close      gtk4/close
  :open?      gtk4/open?
  :poll       gtk4/poll
+ :wait       gtk4/wait
  :build      gtk4/build
  :rebuild    gtk4/rebuild
  :set        gtk4/set
@@ -345,9 +378,19 @@
  :set-stack-page gtk4/set-stack-page
  :add        gtk4/add
  :remove     gtk4/remove
+ :queue-draw gtk4/queue-draw
+ :on-click   gtk4/on-click
+ :on-scroll  gtk4/on-scroll
+ :on-key     gtk4/on-key
  :eval       gtk4/eval
  :send       gtk4/send
  :load-html  gtk4/load-html
- :load-url   gtk4/load-url}
+ :load-url   gtk4/load-url
+ # app lifecycle
+ :app/new    app:new
+ :app/run    app:run
+ :app/window app:window
+ :parse-spec parse-spec
+ :json-escape wv:json-escape}
 
 ) # end (fn [])

--- a/lib/gtk4/app.lisp
+++ b/lib/gtk4/app.lisp
@@ -1,0 +1,64 @@
+(elle/epoch 8)
+## lib/gtk4/app.lisp — GtkApplication lifecycle wrapper
+##
+## Alternative to gtk4/open for apps that need GtkApplication features
+## (single instance, DBus activation, command-line handling).
+##
+## Usage:
+##   (def app ((import "std/gtk4/app")))
+##   (def my-app (app:new "org.example.myapp" (fn [handle]
+##     (app:build handle [:v-box {:spacing 8}
+##       [:label {:id :msg} "Hello"]
+##       [:button {:id :ok} "OK"]])
+##     (app:set-title handle "My App"))))
+##   (app:run my-app :quit (fn [] done?))
+
+(fn []
+
+(def b ((import "std/gtk4/bind")))
+(def w ((import "std/gtk4/widgets")))
+
+# ── Callback signatures ──────────────────────────────────────────
+
+(def sig-activate (ffi/signature :void [:ptr :ptr]))
+
+# ── Application lifecycle ────────────────────────────────────────
+
+(defn app/new (app-id on-activate &named @flags)
+  "Create a GtkApplication. on-activate receives a window handle."
+  (default flags 0)
+  (b:gtk-init)
+  (let* [app    (b:gtk-application-new app-id flags)
+         handle (w:make-handle nil)
+         cb     (ffi/callback sig-activate
+                  (fn (app-ptr data)
+                    (let [win (b:gtk-application-window-new app-ptr)]
+                      (put handle :window win)
+                      (w:register-widget handle :window win :window)
+                      (b:gtk-window-present win)
+                      (on-activate handle))))]
+    (put handle :app app)
+    (push handle:callbacks cb)
+    (b:g-signal-connect-data app "activate" cb nil nil 0)
+    handle))
+
+(defn app/run (handle &named @quit)
+  "Run the GtkApplication event loop. Blocks until quit returns true."
+  (default quit (fn [] false))
+  (let [ctx (b:g-main-context-default)]
+    (b:g-application-register handle:app nil nil)
+    (b:g-application-activate handle:app)
+    (while (not (quit))
+      (b:glib-wait ctx))))
+
+(defn app/window (handle)
+  "Get the application window pointer."
+  handle:window)
+
+# ── Export ────────────────────────────────────────────────────────
+
+{:new app/new
+ :run app/run
+ :window app/window}
+
+) # end (fn [])

--- a/lib/gtk4/bind.lisp
+++ b/lib/gtk4/bind.lisp
@@ -1,7 +1,8 @@
 (elle/epoch 8)
-## lib/gtk4/bind.lisp — Raw FFI bindings to GTK4, GLib, GObject, WebKit
+## lib/gtk4/bind.lisp — FFI bindings and low-level helpers for GTK4, GLib, GObject, WebKit
 ##
-## Pure ffi/defbind declarations. No logic.
+## Raw ffi/defbind declarations plus glib-wait (scheduler integration)
+## and run-app (GApplication event loop).
 
 (fn []
 
@@ -44,7 +45,29 @@
 (ffi/defbind gtk-widget-set-margin-bottom libgtk "gtk_widget_set_margin_bottom" :void [:ptr :int])
 (ffi/defbind gtk-widget-set-halign libgtk "gtk_widget_set_halign"        :void  [:ptr :int])
 (ffi/defbind gtk-widget-set-valign libgtk "gtk_widget_set_valign"        :void  [:ptr :int])
-(ffi/defbind gtk-widget-unparent  libgtk "gtk_widget_unparent"           :void  [:ptr])
+(ffi/defbind gtk-widget-unparent       libgtk "gtk_widget_unparent"           :void  [:ptr])
+(ffi/defbind gtk-widget-queue-draw     libgtk "gtk_widget_queue_draw"          :void  [:ptr])
+(ffi/defbind gtk-widget-add-controller libgtk "gtk_widget_add_controller"      :void  [:ptr :ptr])
+
+# ── GtkDrawingArea ──────────────────────────────────────────────
+
+(ffi/defbind gtk-drawing-area-new              libgtk "gtk_drawing_area_new"               :ptr  [])
+(ffi/defbind gtk-drawing-area-set-content-width  libgtk "gtk_drawing_area_set_content_width"  :void [:ptr :int])
+(ffi/defbind gtk-drawing-area-set-content-height libgtk "gtk_drawing_area_set_content_height" :void [:ptr :int])
+(ffi/defbind gtk-drawing-area-set-draw-func    libgtk "gtk_drawing_area_set_draw_func"     :void [:ptr :ptr :ptr :ptr])
+
+# ── GtkApplication ──────────────────────────────────────────────
+
+(ffi/defbind gtk-application-new        libgtk "gtk_application_new"        :ptr [:string :u32])
+(ffi/defbind gtk-application-window-new libgtk "gtk_application_window_new" :ptr [:ptr])
+
+# ── Event controllers ───────────────────────────────────────────
+
+(ffi/defbind gtk-gesture-click-new          libgtk "gtk_gesture_click_new"              :ptr  [])
+(ffi/defbind gtk-gesture-single-set-button  libgtk "gtk_gesture_single_set_button"      :void [:ptr :u32])
+(ffi/defbind gtk-gesture-single-get-current-button libgtk "gtk_gesture_single_get_current_button" :u32 [:ptr])
+(ffi/defbind gtk-event-controller-scroll-new libgtk "gtk_event_controller_scroll_new"   :ptr  [:u32])
+(ffi/defbind gtk-event-controller-key-new    libgtk "gtk_event_controller_key_new"      :ptr  [])
 
 # ── GtkBox ────────────────────────────────────────────────────────
 
@@ -229,6 +252,36 @@
 (ffi/defbind g-main-context-default   libglib "g_main_context_default"   :ptr   [])
 (ffi/defbind g-main-context-iteration libglib "g_main_context_iteration" :int   [:ptr :int])
 (ffi/defbind g-main-context-pending   libglib "g_main_context_pending"   :int   [:ptr])
+(ffi/defbind g-main-context-prepare   libglib "g_main_context_prepare"   :int   [:ptr :ptr])
+(ffi/defbind g-main-context-query     libglib "g_main_context_query"     :int   [:ptr :int :ptr :ptr :int])
+(ffi/defbind g-main-context-check     libglib "g_main_context_check"     :int   [:ptr :int :ptr :int])
+(ffi/defbind g-main-context-dispatch  libglib "g_main_context_dispatch"  :void  [:ptr])
+
+(def MAX_POLL_FDS 64)
+(def GPOLLFD_SIZE 8)
+
+(defn glib-wait (ctx)
+  "Yield to Elle's scheduler until GLib has events ready, then dispatch.
+   Uses prepare/query/check/dispatch with ev/poll-fd on the primary fd."
+  (ffi/with-stack [[priority 4] [timeout 4] [fds (* MAX_POLL_FDS GPOLLFD_SIZE)]]
+    (g-main-context-prepare ctx priority)
+    (let* [pri  (ffi/read priority :int)
+           nfds (g-main-context-query ctx pri timeout fds MAX_POLL_FDS)
+           tms  (ffi/read timeout :int)]
+      # Zero all revents fields
+      (each i in (range nfds)
+        (ffi/write (ptr/add fds (+ (* i GPOLLFD_SIZE) 6)) :u16 0))
+      # Block on the primary fd or respect the timeout
+      (when (not (zero? tms))
+        (if (> nfds 0)
+          (let* [fd0     (ffi/read fds :int)
+                 tsec    (if (< tms 0) 60.0 (/ tms 1000.0))
+                 revents (ev/poll-fd fd0 :read-write tsec)]
+            (when (> revents 0)
+              (ffi/write (ptr/add fds 6) :u16 revents)))
+          (ev/sleep (if (> tms 0) (/ tms 1000.0) 0))))
+      (when (nonzero? (g-main-context-check ctx pri fds nfds))
+        (g-main-context-dispatch ctx)))))
 
 # ── GApplication ─────────────────────────────────────────────────
 
@@ -241,17 +294,16 @@
 
 (defn run-app [app &named @quit]
   "Cooperative GTK event loop. Registers and activates the app, then
-   pumps g_main_context_iteration non-blocking, yielding to Elle's
-   scheduler between iterations.
+   blocks on GLib's event sources via ev/poll-fd, yielding to Elle's
+   scheduler between dispatches.
    quit: a nullary function returning true when the loop should exit.
          If omitted, runs forever."
   (default quit (fn [] false))
   (g-application-register app nil nil)
   (g-application-activate app)
-  (def ctx (g-main-context-default))
-  (while (not (quit))
-    (g-main-context-iteration ctx 0)
-    (ev/sleep 0.001)))
+  (let [ctx (g-main-context-default)]
+    (while (not (quit))
+      (glib-wait ctx))))
 
 # ── GObject signals ──────────────────────────────────────────────
 
@@ -321,6 +373,22 @@
  :gtk-widget-set-halign gtk-widget-set-halign
  :gtk-widget-set-valign gtk-widget-set-valign
  :gtk-widget-unparent gtk-widget-unparent
+ :gtk-widget-queue-draw gtk-widget-queue-draw
+ :gtk-widget-add-controller gtk-widget-add-controller
+ # drawing area
+ :gtk-drawing-area-new gtk-drawing-area-new
+ :gtk-drawing-area-set-content-width gtk-drawing-area-set-content-width
+ :gtk-drawing-area-set-content-height gtk-drawing-area-set-content-height
+ :gtk-drawing-area-set-draw-func gtk-drawing-area-set-draw-func
+ # application
+ :gtk-application-new gtk-application-new
+ :gtk-application-window-new gtk-application-window-new
+ # event controllers
+ :gtk-gesture-click-new gtk-gesture-click-new
+ :gtk-gesture-single-set-button gtk-gesture-single-set-button
+ :gtk-gesture-single-get-current-button gtk-gesture-single-get-current-button
+ :gtk-event-controller-scroll-new gtk-event-controller-scroll-new
+ :gtk-event-controller-key-new gtk-event-controller-key-new
  # box
  :gtk-box-new gtk-box-new
  :gtk-box-append gtk-box-append
@@ -447,6 +515,7 @@
  :g-main-context-default g-main-context-default
  :g-main-context-iteration g-main-context-iteration
  :g-main-context-pending g-main-context-pending
+ :glib-wait glib-wait
  # gio / application
  :g-application-register g-application-register
  :g-application-activate g-application-activate

--- a/lib/gtk4/webview.lisp
+++ b/lib/gtk4/webview.lisp
@@ -30,49 +30,42 @@
   "Create a WebKit WebView with JS→Elle IPC via user content manager."
   (let* [ptr (b:webkit-web-view-new)
          id  props:id
-         ucm (b:webkit-web-view-get-user-content-manager ptr)]
-    (b:webkit-ucm-register-script-message-handler ucm "elle" nil)
-    (let [cb (ffi/callback sig-void-ptr-ptr-ptr
+         ucm (b:webkit-web-view-get-user-content-manager ptr)
+         cb  (ffi/callback sig-void-ptr-ptr-ptr
                 (fn (manager js-value data)
                   (let [cstr (b:jsc-value-to-string js-value)]
                     (unless (w:null? cstr)
                       (w:emit win-handle
                         {:type :webview :id id
                          :value (ffi/string cstr)})))))]
-      (w:connect win-handle ucm "script-message-received::elle"
-                 sig-void-ptr-ptr-ptr cb))
-    (when props:height (b:gtk-widget-set-size-request ptr -1 props:height))
-    (when props:width  (b:gtk-widget-set-size-request ptr props:width -1))
-    (b:gtk-widget-set-hexpand ptr 1)
-    (b:gtk-widget-set-vexpand ptr 1)
-    (w:apply-common-props ptr props)
+    (b:webkit-ucm-register-script-message-handler ucm "elle" nil)
+    (w:connect win-handle ucm "script-message-received::elle" cb)
     (when props:html (b:webkit-web-view-load-html ptr props:html nil))
     (when props:url  (b:webkit-web-view-load-uri ptr props:url))
-    (w:register-widget win-handle id ptr :webview)
-    ptr))
+    (w:make-widget win-handle (merge props {:hexpand true :vexpand true}) ptr :webview)))
 
 # ── Operations ────────────────────────────────────────────────────
 
 (defn webview-eval (win-handle id js)
   "Evaluate JavaScript in a webview. Fire-and-forget."
-  (when-let [{:ptr ptr} (win-handle:widgets id)]
-    (b:webkit-web-view-evaluate-javascript ptr js -1 nil nil nil nil)))
+  (when-let [wgt (win-handle:widgets id)]
+    (b:webkit-web-view-evaluate-javascript wgt:ptr js -1 nil nil nil nil)))
 
 (defn webview-send (win-handle id msg)
   "Send a string message to webview JS via window.elle.onMessage callback."
-  (-> (string "if(window.elle&&window.elle.onMessage)window.elle.onMessage("
-              (json-escape msg) ")")
-    (webview-eval win-handle id)))
+  (webview-eval win-handle id
+    (string "if(window.elle&&window.elle.onMessage)window.elle.onMessage("
+            (json-escape msg) ")")))
 
 (defn webview-load-html (win-handle id html)
   "Load HTML string into webview."
-  (when-let [{:ptr ptr} (win-handle:widgets id)]
-    (b:webkit-web-view-load-html ptr html nil)))
+  (when-let [wgt (win-handle:widgets id)]
+    (b:webkit-web-view-load-html wgt:ptr html nil)))
 
 (defn webview-load-url (win-handle id url)
   "Navigate webview to URL."
-  (when-let [{:ptr ptr} (win-handle:widgets id)]
-    (b:webkit-web-view-load-uri ptr url)))
+  (when-let [wgt (win-handle:widgets id)]
+    (b:webkit-web-view-load-uri wgt:ptr url)))
 
 # ── Export ────────────────────────────────────────────────────────
 
@@ -80,6 +73,7 @@
  :eval webview-eval
  :send webview-send
  :load-html webview-load-html
- :load-url webview-load-url}
+ :load-url webview-load-url
+ :json-escape json-escape}
 
 ) # end (fn [])

--- a/lib/gtk4/widgets.lisp
+++ b/lib/gtk4/widgets.lisp
@@ -47,8 +47,13 @@
       (b:gtk-widget-set-margin-end ptr m)
       (b:gtk-widget-set-margin-top ptr m)
       (b:gtk-widget-set-margin-bottom ptr m)))
-  (when props:width  (b:gtk-widget-set-size-request ptr props:width -1))
-  (when props:height (b:gtk-widget-set-size-request ptr -1 props:height)))
+  (when (or props:width props:height)
+    (b:gtk-widget-set-size-request ptr (or props:width -1) (or props:height -1))))
+
+(defn make-handle (win-ptr)
+  "Create a mutable window handle with standard fields."
+  @{:window win-ptr :widgets @{} :events @[]
+    :open true :callbacks @[] :css-provider nil})
 
 (defn register-widget (win-handle id ptr type)
   "Store widget in the registry by id."
@@ -116,21 +121,13 @@
                   {:type type :id id :active (nonzero? (getter ptr))})))]
     (connect win-handle ptr "toggled" cb)))
 
-(defn on-changed (win-handle ptr id type getter)
-  "Wire a change signal that emits {:type type :id id :value string}."
+(defn on-changed (win-handle ptr id type getter signal)
+  "Wire a change signal that emits {:type type :id id :value value}."
   (let [cb (ffi/callback sig-clicked
               (fn (widget data)
                 (emit win-handle
                   {:type type :id id :value (getter ptr)})))]
-    (connect win-handle ptr "changed" cb)))
-
-(defn on-value-changed (win-handle ptr id type getter)
-  "Wire a 'value-changed' signal."
-  (let [cb (ffi/callback sig-clicked
-              (fn (widget data)
-                (emit win-handle
-                  {:type type :id id :value (getter ptr)})))]
-    (connect win-handle ptr "value-changed" cb)))
+    (connect win-handle ptr signal cb)))
 
 (defn make-button (win-handle props text)
   (let [ptr (b:gtk-button-new-with-label (or text ""))]
@@ -150,7 +147,7 @@
     (when props:hint  (b:gtk-entry-set-placeholder-text ptr props:hint))
     (when props:value (b:gtk-editable-set-text ptr props:value))
     (on-changed win-handle ptr props:id :text
-      (fn (p) (ffi/string (b:gtk-editable-get-text p))))
+      (fn (p) (ffi/string (b:gtk-editable-get-text p))) "changed")
     (make-widget win-handle props ptr :text-input)))
 
 (defn make-text-edit (win-handle props)
@@ -169,15 +166,15 @@
     (make-widget win-handle props ptr :checkbox)))
 
 (defn make-switch (win-handle props)
-  (let [ptr (b:gtk-switch-new)
-        id  props:id]
-    (when props:active (b:gtk-switch-set-active ptr 1))
-    (let [cb (ffi/callback sig-state-set
+  (let* [ptr (b:gtk-switch-new)
+         id  props:id
+         cb  (ffi/callback sig-state-set
                 (fn (widget state data)
                   (emit win-handle
                     {:type :switch :id id :active (nonzero? state)})
                   0))]
-      (connect win-handle ptr "state-set" cb))
+    (when props:active (b:gtk-switch-set-active ptr 1))
+    (connect win-handle ptr "state-set" cb)
     (make-widget win-handle props ptr :switch)))
 
 (defn make-slider (win-handle props)
@@ -186,7 +183,7 @@
          step (or props:step 1.0)
          ptr (b:gtk-scale-new-with-range b:GTK_ORIENTATION_HORIZONTAL mn mx step)]
     (when props:value (b:gtk-range-set-value ptr props:value))
-    (on-value-changed win-handle ptr props:id :slider b:gtk-range-get-value)
+    (on-changed win-handle ptr props:id :slider b:gtk-range-get-value "value-changed")
     (make-widget win-handle props ptr :slider)))
 
 (defn make-spin-button (win-handle props)
@@ -195,7 +192,7 @@
          step (or props:step 1.0)
          ptr (b:gtk-spin-button-new-with-range mn mx step)]
     (when props:value (b:gtk-spin-button-set-value ptr props:value))
-    (on-value-changed win-handle ptr props:id :spin b:gtk-spin-button-get-value)
+    (on-changed win-handle ptr props:id :spin b:gtk-spin-button-get-value "value-changed")
     (make-widget win-handle props ptr :spin-button)))
 
 (defn make-combo-box (win-handle props items)
@@ -220,21 +217,21 @@
     (make-widget win-handle props ptr :combo-box)))
 
 (defn make-search-entry (win-handle props)
-  (let [ptr (b:gtk-search-entry-new)]
-    (let [cb (ffi/callback sig-clicked
+  (let* [ptr (b:gtk-search-entry-new)
+         cb  (ffi/callback sig-clicked
                 (fn (widget data)
                   (emit win-handle
                     {:type :search :id props:id
                      :value (ffi/string (b:gtk-editable-get-text ptr))})))]
-      (connect win-handle ptr "search-changed" cb))
+    (connect win-handle ptr "search-changed" cb)
     (make-widget win-handle props ptr :search-entry)))
 
 (defn make-calendar (win-handle props)
-  (let [ptr (b:gtk-calendar-new)]
-    (let [cb (ffi/callback sig-clicked
+  (let* [ptr (b:gtk-calendar-new)
+         cb  (ffi/callback sig-clicked
                 (fn (widget data)
                   (emit win-handle {:type :calendar :id props:id})))]
-      (connect win-handle ptr "day-selected" cb))
+    (connect win-handle ptr "day-selected" cb)
     (make-widget win-handle props ptr :calendar)))
 
 # ── Layout widgets ────────────────────────────────────────────────
@@ -303,20 +300,63 @@
     (when props:revealed (b:gtk-revealer-set-reveal-child ptr 1))
     (make-widget win-handle props ptr :revealer)))
 
-# ── Container child helpers (called by tree builder) ──────────────
+# ── Drawing ──────────────────────────────────────────────────────
 
-(defn box-append (parent child) (b:gtk-box-append parent child))
-(defn scroll-set-child (p c)   (b:gtk-scrolled-window-set-child p c))
-(defn expander-set-child (p c) (b:gtk-expander-set-child p c))
-(defn frame-set-child (p c)    (b:gtk-frame-set-child p c))
-(defn revealer-set-child (p c) (b:gtk-revealer-set-child p c))
-(defn grid-attach (p c col row cs rs) (b:gtk-grid-attach p c col row cs rs))
+(def sig-draw (ffi/signature :void [:ptr :ptr :int :int :ptr]))
+
+(defn make-drawing-area (win-handle props)
+  (let [ptr (b:gtk-drawing-area-new)]
+    (when props:width  (b:gtk-drawing-area-set-content-width ptr props:width))
+    (when props:height (b:gtk-drawing-area-set-content-height ptr props:height))
+    (when props:on-draw
+      (let [cb (ffi/callback sig-draw props:on-draw)]
+        (push win-handle:callbacks cb)
+        (b:gtk-drawing-area-set-draw-func ptr cb nil nil)))
+    (make-widget win-handle props ptr :drawing-area)))
+
+# ── Event controllers ────────────────────────────────────────────
+
+(def sig-click-pressed (ffi/signature :void [:ptr :int :double :double :ptr]))
+(def sig-scroll        (ffi/signature :int  [:ptr :double :double :ptr]))
+(def sig-key-pressed   (ffi/signature :int  [:ptr :u32 :u32 :u32 :ptr]))
+
+(def SCROLL_VERTICAL 2)
+
+(defn add-click (win-handle ptr handler)
+  "Add a click controller. handler: (fn [gesture n x y])."
+  (let* [click (b:gtk-gesture-click-new)
+         cb    (ffi/callback sig-click-pressed
+                 (fn (gesture n x y data) (handler gesture n x y)))]
+    (b:gtk-gesture-single-set-button click 0)
+    (push win-handle:callbacks cb)
+    (b:g-signal-connect-data click "pressed" cb nil nil 0)
+    (b:gtk-widget-add-controller ptr click)))
+
+(defn add-scroll (win-handle ptr handler)
+  "Add a scroll controller. handler: (fn [dx dy]) → int."
+  (let* [scroll (b:gtk-event-controller-scroll-new SCROLL_VERTICAL)
+         cb     (ffi/callback sig-scroll
+                  (fn (ctrl dx dy data) (handler dx dy)))]
+    (push win-handle:callbacks cb)
+    (b:g-signal-connect-data scroll "scroll" cb nil nil 0)
+    (b:gtk-widget-add-controller ptr scroll)))
+
+(defn add-key (win-handle ptr handler)
+  "Add a key controller. handler: (fn [keyval keycode state]) → int."
+  (let* [keys (b:gtk-event-controller-key-new)
+         cb   (ffi/callback sig-key-pressed
+                (fn (ctrl keyval keycode state data)
+                  (handler keyval keycode state)))]
+    (push win-handle:callbacks cb)
+    (b:g-signal-connect-data keys "key-pressed" cb nil nil 0)
+    (b:gtk-widget-add-controller ptr keys)))
 
 # ── Export ────────────────────────────────────────────────────────
 
 {:null? null? :bool->int bool->int
  :connect connect :emit emit
  :apply-common-props apply-common-props
+ :make-handle make-handle
  :register-widget register-widget :make-widget make-widget
  # display
  :make-label make-label :make-heading make-heading
@@ -337,9 +377,10 @@
  :make-notebook make-notebook :make-paned make-paned
  :make-center-box make-center-box :make-overlay make-overlay
  :make-revealer make-revealer
- # child ops
- :box-append box-append :scroll-set-child scroll-set-child
- :expander-set-child expander-set-child :frame-set-child frame-set-child
- :revealer-set-child revealer-set-child :grid-attach grid-attach}
+ # drawing
+ :make-drawing-area make-drawing-area
+ # event controllers
+ :add-click add-click :add-scroll add-scroll :add-key add-key
+ :SCROLL_VERTICAL SCROLL_VERTICAL}
 
 ) # end (fn [])

--- a/tests/elle/lib/cli.lisp
+++ b/tests/elle/lib/cli.lisp
@@ -1,0 +1,105 @@
+(elle/epoch 8)
+
+# ── CLI argument parsing test suite ──────────────────────────────
+
+(def cli ((import "std/cli")))
+
+# ── Basic flag ───────────────────────────────────────────────────
+
+(let [r (cli:parse {:name "app"
+                     :args [{:name "verbose" :short "v" :action :flag}]}
+           ["app" "-v"])]
+  (assert (= r:verbose true) "short flag"))
+
+# ── Long option with value ───────────────────────────────────────
+
+(let [r (cli:parse {:name "app"
+                     :args [{:name "output" :long "output"}]}
+           ["app" "--output" "file.txt"])]
+  (assert (= r:output "file.txt") "long option value"))
+
+# ── Long option with = syntax ────────────────────────────────────
+
+(let [r (cli:parse {:name "app"
+                     :args [{:name "output" :long "output"}]}
+           ["app" "--output=file.txt"])]
+  (assert (= r:output "file.txt") "long option = syntax"))
+
+# ── Default value ────────────────────────────────────────────────
+
+(let [r (cli:parse {:name "app"
+                     :args [{:name "port" :long "port" :default "8080"}]}
+           ["app"])]
+  (assert (= r:port "8080") "default value"))
+
+# ── Count action ─────────────────────────────────────────────────
+
+(let [r (cli:parse {:name "app"
+                     :args [{:name "verbose" :short "v" :action :count}]}
+           ["app" "-vvv"])]
+  (assert (= r:verbose 3) "stacked count"))
+
+# ── Append action ────────────────────────────────────────────────
+
+(let [r (cli:parse {:name "app"
+                     :args [{:name "include" :long "include" :action :append}]}
+           ["app" "--include" "a" "--include" "b"])]
+  (assert (= (length r:include) 2) "append count")
+  (assert (= (r:include 0) "a") "append first")
+  (assert (= (r:include 1) "b") "append second"))
+
+# ── Positional argument ─────────────────────────────────────────
+
+(let [r (cli:parse {:name "app"
+                     :args [{:name "file"}]}
+           ["app" "input.txt"])]
+  (assert (= r:file "input.txt") "positional"))
+
+# ── Mixed flags and positionals ──────────────────────────────────
+
+(let [r (cli:parse {:name "app"
+                     :args [{:name "verbose" :short "v" :action :flag}
+                            {:name "output" :long "output"}
+                            {:name "file"}]}
+           ["app" "-v" "--output" "out.txt" "in.txt"])]
+  (assert (= r:verbose true) "mixed: flag")
+  (assert (= r:output "out.txt") "mixed: option")
+  (assert (= r:file "in.txt") "mixed: positional"))
+
+# ── Required arg missing ─────────────────────────────────────────
+
+(let [[ok _] (protect
+               (cli:parse {:name "app"
+                            :args [{:name "file" :required true}]}
+                 ["app"]))]
+  (assert (not ok) "required missing errors"))
+
+# ── Unknown option errors ────────────────────────────────────────
+
+(let [[ok _] (protect
+               (cli:parse {:name "app" :args []}
+                 ["app" "--bogus"]))]
+  (assert (not ok) "unknown long option errors"))
+
+(let [[ok _] (protect
+               (cli:parse {:name "app" :args []}
+                 ["app" "-x"]))]
+  (assert (not ok) "unknown short option errors"))
+
+# ── Subcommands ──────────────────────────────────────────────────
+
+(let [r (cli:parse {:name "app"
+                     :args [{:name "verbose" :short "v" :action :flag}]
+                     :commands [{:name "build"
+                                 :args [{:name "target" :long "target"}]}]}
+           ["app" "-v" "build" "--target" "release"])]
+  (assert (= r:verbose true) "subcommand: parent flag")
+  (assert (= r:command "build") "subcommand: name")
+  (assert (= r:command-args:target "release") "subcommand: child option"))
+
+# ── Empty argv ───────────────────────────────────────────────────
+
+(let [r (cli:parse {:name "app" :args []} ["app"])]
+  (assert (struct? r) "empty argv returns struct"))
+
+(println "cli: all tests passed")

--- a/tests/elle/lib/gtk4.lisp
+++ b/tests/elle/lib/gtk4.lisp
@@ -1,0 +1,326 @@
+(elle/epoch 8)
+
+# ── GTK4 test suite ──────────────────────────────────────────────
+#
+# Pure spec-parsing tests run unconditionally.
+# Integration tests (widget lifecycle, set/get) require GTK4 libs
+# and a display; skipped gracefully when unavailable.
+
+(def [ok gtk] (protect ((import "std/gtk4"))))
+(unless ok
+  (println "gtk4: skipping — GTK4 libraries not available")
+  (exit 0))
+
+# ── parse-spec ───────────────────────────────────────────────────
+
+(println "gtk4: testing parse-spec")
+
+# bare tag
+(let [[tag props specs text] (gtk:parse-spec [:button])]
+  (assert (= tag :button) "parse-spec: bare tag")
+  (assert (= props {}) "parse-spec: bare tag → empty props")
+  (assert (empty? specs) "parse-spec: bare tag → no children")
+  (assert (nil? text) "parse-spec: bare tag → no text"))
+
+# tag + text (no props)
+(let [[tag props specs text] (gtk:parse-spec [:label "hello"])]
+  (assert (= tag :label) "parse-spec: tag+text → tag")
+  (assert (= props {}) "parse-spec: tag+text → empty props")
+  (assert (empty? specs) "parse-spec: tag+text → no child specs")
+  (assert (= text "hello") "parse-spec: tag+text → text"))
+
+# tag + props (no text, no children)
+(let [[tag props specs text] (gtk:parse-spec [:slider {:min 0 :max 100}])]
+  (assert (= tag :slider) "parse-spec: tag+props → tag")
+  (assert (= props:min 0) "parse-spec: tag+props → min")
+  (assert (= props:max 100) "parse-spec: tag+props → max")
+  (assert (empty? specs) "parse-spec: tag+props → no children")
+  (assert (nil? text) "parse-spec: tag+props → no text"))
+
+# tag + props + text
+(let [[tag props specs text] (gtk:parse-spec [:button {:id :ok} "OK"])]
+  (assert (= tag :button) "parse-spec: full → tag")
+  (assert (= props:id :ok) "parse-spec: full → props:id")
+  (assert (empty? specs) "parse-spec: full → no child specs")
+  (assert (= text "OK") "parse-spec: full → text"))
+
+# tag + props + children
+(let [[tag props specs text] (gtk:parse-spec [:v-box {:spacing 8}
+                                               [:label "a"]
+                                               [:label "b"]])]
+  (assert (= tag :v-box) "parse-spec: container → tag")
+  (assert (= props:spacing 8) "parse-spec: container → spacing")
+  (assert (= (length specs) 2) "parse-spec: container → 2 children")
+  (assert (nil? text) "parse-spec: container → no text"))
+
+# tag + children (no props)
+(let [[tag props specs text] (gtk:parse-spec [:v-box [:label "a"]])]
+  (assert (= tag :v-box) "parse-spec: no-props container → tag")
+  (assert (= props {}) "parse-spec: no-props container → empty props")
+  (assert (= (length specs) 1) "parse-spec: no-props container → 1 child")
+  (assert (nil? text) "parse-spec: no-props container → no text"))
+
+# mixed text and child specs
+(let [[tag props specs text] (gtk:parse-spec [:expander {} "Details"
+                                               [:label "body"]])]
+  (assert (= tag :expander) "parse-spec: mixed → tag")
+  (assert (= text "Details") "parse-spec: mixed → text")
+  (assert (= (length specs) 1) "parse-spec: mixed → 1 child spec"))
+
+(println "gtk4: parse-spec OK")
+
+# ── json-escape ──────────────────────────────────────────────────
+
+(println "gtk4: testing json-escape")
+
+(assert (= (gtk:json-escape "hello") "\"hello\"")
+  "json-escape: plain string")
+
+(assert (= (gtk:json-escape "") "\"\"")
+  "json-escape: empty string")
+
+(assert (= (gtk:json-escape "he\"llo") "\"he\\\"llo\"")
+  "json-escape: embedded quotes")
+
+(assert (= (gtk:json-escape "a\\b") "\"a\\\\b\"")
+  "json-escape: backslash")
+
+(assert (= (gtk:json-escape "line1\nline2") "\"line1\\nline2\"")
+  "json-escape: newline")
+
+(assert (= (gtk:json-escape "a\rb") "\"a\\rb\"")
+  "json-escape: carriage return")
+
+(assert (= (gtk:json-escape "a\"b\\c\nd") "\"a\\\"b\\\\c\\nd\"")
+  "json-escape: multiple escapes")
+
+(println "gtk4: json-escape OK")
+
+# ── Integration tests (require display) ──────────────────────────
+
+(def [live-ok win] (protect (gtk:open {:title "Elle GTK4 Test"
+                                        :width 200 :height 200})))
+(unless live-ok
+  (println "gtk4: pure tests passed (no display for integration)")
+  (exit 0))
+
+(println "gtk4: testing window lifecycle")
+(assert (gtk:open? win) "open? true after open")
+
+# ── Build widget tree ────────────────────────────────────────────
+
+(println "gtk4: testing build")
+
+(gtk:build win
+  [:v-box {:id :root :spacing 4}
+    [:label {:id :lbl} "Hello"]
+    [:heading {:id :hdg} "Title"]
+    [:button {:id :btn} "Click"]
+    [:checkbox {:id :chk} "Check me"]
+    [:switch {:id :sw}]
+    [:toggle-button {:id :tgl} "Toggle"]
+    [:slider {:id :sld :min 0.0 :max 100.0 :value 50.0}]
+    [:spin-button {:id :spin :min 0.0 :max 100.0 :value 25.0}]
+    [:text-input {:id :inp :value "initial"}]
+    [:text-edit {:id :edit}]
+    [:progress-bar {:id :prog :value 0.5}]
+    [:separator {}]
+    [:spacer {}]
+    [:spinner {:id :spnr}]])
+
+# ── set/get roundtrip ────────────────────────────────────────────
+
+(println "gtk4: testing set/get")
+
+# label
+(gtk:set win :lbl "Updated")
+(assert (= (gtk:get win :lbl) "Updated") "label set/get")
+
+# heading
+(gtk:set win :hdg "New Title")
+(assert (= (gtk:get win :hdg) "New Title") "heading set/get")
+
+# button
+(gtk:set win :btn "New Label")
+(assert (= (gtk:get win :btn) "New Label") "button set/get")
+
+# text-input
+(gtk:set win :inp "edited")
+(assert (= (gtk:get win :inp) "edited") "text-input set/get")
+
+# text-edit
+(gtk:set win :edit "multi\nline")
+(assert (= (gtk:get win :edit) "multi\nline") "text-edit set/get")
+
+# checkbox
+(gtk:set win :chk true)
+(assert (= (gtk:get win :chk) true) "checkbox set true")
+(gtk:set win :chk false)
+(assert (= (gtk:get win :chk) false) "checkbox set false")
+
+# switch
+(gtk:set win :sw true)
+(assert (= (gtk:get win :sw) true) "switch set true")
+(gtk:set win :sw false)
+(assert (= (gtk:get win :sw) false) "switch set false")
+
+# toggle-button
+(gtk:set win :tgl true)
+(assert (= (gtk:get win :tgl) true) "toggle-button set true")
+(gtk:set win :tgl false)
+(assert (= (gtk:get win :tgl) false) "toggle-button set false")
+
+# slider
+(gtk:set win :sld 75.0)
+(assert (= (gtk:get win :sld) 75.0) "slider set/get")
+
+# spin-button
+(gtk:set win :spin 42.0)
+(assert (= (gtk:get win :spin) 42.0) "spin-button set/get")
+
+# progress-bar
+(gtk:set win :prog 0.8)
+(assert (= (gtk:get win :prog) 0.8) "progress-bar set/get")
+
+# spinner (set true starts, set false stops — no getter)
+(gtk:set win :spnr true)
+(gtk:set win :spnr false)
+
+(println "gtk4: set/get OK")
+
+# ── poll ─────────────────────────────────────────────────────────
+
+(println "gtk4: testing poll")
+
+(def events (gtk:poll win))
+(assert (array? events) "poll returns array")
+
+# ── nonexistent widget ───────────────────────────────────────────
+
+(assert (nil? (gtk:get win :nonexistent)) "get nonexistent → nil")
+
+# ── visibility and sensitivity ───────────────────────────────────
+
+(println "gtk4: testing visibility/sensitivity")
+
+(gtk:set-visible win :lbl false)
+(gtk:set-visible win :lbl true)
+(gtk:set-sensitive win :btn false)
+(gtk:set-sensitive win :btn true)
+
+# ── set-title ────────────────────────────────────────────────────
+
+(gtk:set-title win "Updated Title")
+
+# ── load-css ─────────────────────────────────────────────────────
+
+(println "gtk4: testing CSS")
+
+(gtk:load-css win "button { color: red; }")
+# loading CSS again reuses the provider
+(gtk:load-css win "label { font-weight: bold; }")
+
+# ── add / remove ─────────────────────────────────────────────────
+
+(println "gtk4: testing add/remove")
+
+(gtk:add win :root [:label {:id :added} "New"])
+(assert (= (gtk:get win :added) "New") "added widget accessible")
+
+(gtk:remove win :added)
+(assert (nil? (gtk:get win :added)) "removed widget gone")
+
+# ── rebuild ──────────────────────────────────────────────────────
+
+(println "gtk4: testing rebuild")
+
+(gtk:rebuild win :root [:label {:id :rebuilt} "Rebuilt"])
+(assert (= (gtk:get win :rebuilt) "Rebuilt") "rebuild adds widget")
+
+# ── nested containers ────────────────────────────────────────────
+
+(println "gtk4: testing nested containers")
+
+(gtk:add win :root
+  [:h-box {:id :nested :spacing 4}
+    [:label {:id :n1} "Left"]
+    [:label {:id :n2} "Right"]])
+(assert (= (gtk:get win :n1) "Left") "nested child 1")
+(assert (= (gtk:get win :n2) "Right") "nested child 2")
+
+# ── scroll-area ──────────────────────────────────────────────────
+
+(gtk:add win :root
+  [:scroll-area {:id :scr :height 100}
+    [:label {:id :scr-child} "Scrollable"]])
+(assert (= (gtk:get win :scr-child) "Scrollable") "scroll-area child")
+
+# ── frame ────────────────────────────────────────────────────────
+
+(gtk:add win :root
+  [:frame {:id :frm} "Frame Title"
+    [:label {:id :frm-child} "Framed"]])
+(assert (= (gtk:get win :frm-child) "Framed") "frame child")
+
+# ── expander ─────────────────────────────────────────────────────
+
+(gtk:add win :root
+  [:expander {:id :exp :expanded true} "Expand"
+    [:label {:id :exp-child} "Hidden"]])
+(assert (= (gtk:get win :exp-child) "Hidden") "expander child")
+
+# ── revealer ─────────────────────────────────────────────────────
+
+(gtk:add win :root
+  [:revealer {:id :rev :revealed true}
+    [:label {:id :rev-child} "Revealed"]])
+(assert (= (gtk:get win :rev-child) "Revealed") "revealer child")
+
+# ── grid ─────────────────────────────────────────────────────────
+
+(gtk:add win :root
+  [:grid {:id :grd :columns 2 :row-spacing 4 :col-spacing 4}
+    [:label {:id :g1} "A"]
+    [:label {:id :g2} "B"]
+    [:label {:id :g3} "C"]
+    [:label {:id :g4} "D"]])
+(assert (= (gtk:get win :g1) "A") "grid child 1")
+(assert (= (gtk:get win :g4) "D") "grid child 4")
+
+# ── paned ────────────────────────────────────────────────────────
+
+(gtk:add win :root
+  [:paned {:id :pnd}
+    [:label {:id :pnd-start} "Start"]
+    [:label {:id :pnd-end} "End"]])
+(assert (= (gtk:get win :pnd-start) "Start") "paned start")
+(assert (= (gtk:get win :pnd-end) "End") "paned end")
+
+# ── center-box ───────────────────────────────────────────────────
+
+(gtk:add win :root
+  [:center-box {:id :cb}
+    [:label {:id :cb-s} "S"]
+    [:label {:id :cb-c} "C"]
+    [:label {:id :cb-e} "E"]])
+(assert (= (gtk:get win :cb-s) "S") "center-box start")
+(assert (= (gtk:get win :cb-c) "C") "center-box center")
+(assert (= (gtk:get win :cb-e) "E") "center-box end")
+
+# ── overlay ──────────────────────────────────────────────────────
+
+(gtk:add win :root
+  [:overlay {:id :ovl}
+    [:label {:id :ovl-main} "Main"]
+    [:label {:id :ovl-over} "Over"]])
+(assert (= (gtk:get win :ovl-main) "Main") "overlay main child")
+(assert (= (gtk:get win :ovl-over) "Over") "overlay overlay child")
+
+# ── close ────────────────────────────────────────────────────────
+
+(println "gtk4: testing close")
+
+(gtk:close win)
+(assert (not (gtk:open? win)) "open? false after close")
+
+(println "gtk4: all tests passed")


### PR DESCRIPTION
GTK4 modules:
- Add comprehensive test suite (35 tests: pure + integration)
- Fix when-let struct destructuring on nil (all widget access functions)
- Fix apply-common-props width/height clobbering (single set-size-request call)
- Replace :close-requested double-negation with :open flag
- Add make-handle shared helper, drain-events, glib-wait (ev/poll-fd)
- Add gtk4/wait (blocking event loop via prepare/query/check/dispatch)
- Add drawing-area widget, event controllers (click/scroll/key)
- Add GtkApplication lifecycle (lib/gtk4/app.lisp)
- Flatten rebuild double-match, merge on-changed/on-value-changed
- Remove trivial wrapper indirection, fix nested lets, fix indentation
- Refactor mandelbrot demo to use std/gtk4 + std/cairo (removes 20 local bindings)

New modules:
- lib/cairo.lisp — standalone Cairo 2D graphics (28 bindings)
- lib/gtk4/app.lisp — GtkApplication wrapper with window handle

Stdlib polish:
- color.lisp: add clamp01/normalize-hue helpers, replace (get c :field) with c:field accessor syntax throughout (~30 sites), eliminate repeated clamping
- dns.lisp: replace mutable format-ipv6 and parse-resolv-conf with map/filter
- cli.lisp: add test suite (14 cases: flags, options, positionals, subcommands)