### PR TITLE
WebSocket, gRPC, and supporting changes (#763)

### DIFF
--- a/README.md
+++ b/README.md
@@ -778,7 +778,9 @@ See [docs/libraries.md](docs/libraries.md) for full documentation.
   | `glob` | Filesystem glob pattern matching |
   | `gtk4` | GTK4 bindings via FFI (pure Elle, no plugin) |
   | `hash` | Streaming hash helpers (ports, coroutines) |
+  | `grpc` | gRPC client over HTTP/2 with length-prefixed framing |
   | `http` | Pure Elle HTTP/1.1 client and server |
+  | `http2` | HTTP/2 client and server (h2 over TLS + h2c cleartext) |
   | `irc` | Coroutine-based IRCv3 client with SASL |
   | `lua` | Lua compatibility prelude |
   | `mqtt` | MQTT client (uses the `mqtt` plugin for packet codec) |
@@ -799,6 +801,7 @@ See [docs/libraries.md](docs/libraries.md) for full documentation.
   | `gpu` | GPU compute via MLIR → SPIR-V → Vulkan |
   | `spirv` | Hand-written SPIR-V compute shader DSL |
   | `wayland` | Wayland compositor bindings via FFI |
+  | `websocket` | WebSocket client and server (RFC 6455, ws:// and wss://) |
   | `zmq` | ZeroMQ bindings via FFI |
 
 ## Plugins

--- a/demos/gpu/mandelbrot.lisp
+++ b/demos/gpu/mandelbrot.lisp
@@ -7,7 +7,8 @@
 ## The shader uses loops and local variables (Phase 1a builder extensions).
 ## Output is iteration counts as f32 values.
 
-(def gpu ((import "std/gpu")))
+(def vk  (import "plugin/vulkan"))
+(def gpu ((import "std/gpu") :vulkan vk))
 
 (def ctx (gpu:init))
 (println "GPU initialized")

--- a/demos/gpu/vecadd.lisp
+++ b/demos/gpu/vecadd.lisp
@@ -5,7 +5,8 @@
 ## is compiled from SPIR-V emitted at runtime — no GLSL, no offline
 ## tools, just Elle generating GPU bytecode.
 
-(def gpu ((import "std/gpu")))
+(def vk  (import "plugin/vulkan"))
+(def gpu ((import "std/gpu") :vulkan vk))
 
 (def ctx (gpu:init))
 (println "GPU initialized")

--- a/demos/mandelbrot/mandelbrot.lisp
+++ b/demos/mandelbrot/mandelbrot.lisp
@@ -19,7 +19,8 @@
 (def cr  ((import "std/cairo")))
 (def b   ((import "std/gtk4/bind")))
 
-(def [gpu-ok? gpu] (protect ((import "std/gpu"))))
+(def [vk-ok? vk-plugin] (protect (import "plugin/vulkan")))
+(def [gpu-ok? gpu] (when vk-ok? (protect ((import "std/gpu") :vulkan vk-plugin))))
 (def gpu-ctx
   (when gpu-ok?
     (let [[ok? ctx] (protect (gpu:init))]
@@ -79,7 +80,7 @@
 
 # ── GPU backend ──────────────────────────────────────────────────
 
-(def gpu-plugin (when gpu-ctx (import "plugin/vulkan")))
+(def gpu-plugin (when gpu-ctx vk-plugin))
 
 # Shader compiled once — max-iter passed via params buffer, not baked in
 (def gpu-shader

--- a/docs/stdlib.md
+++ b/docs/stdlib.md
@@ -19,6 +19,8 @@ a closure returning a struct.
 | hash | `(import "std/hash")` | Streaming hash convenience |
 | http | `(import "std/http")` | HTTP/1.1 client and server |
 | http2 | `(import "std/http2")` | HTTP/2 client and server (h2 + h2c) |
+| websocket | `(import "std/websocket")` | WebSocket client and server (RFC 6455) |
+| grpc | `(import "std/grpc")` | gRPC client over HTTP/2 |
 | lua | `(import "std/lua")` | Lua compat helpers |
 | mqtt | `(import "std/mqtt")` | MQTT client wrapper |
 | portrait | `(import "std/portrait")` | Semantic portraits |
@@ -80,6 +82,13 @@ enumerate, or `(doc fn-name)` for documentation.
 (doc +)                    # shows arity, params, examples
 (vm/primitive-meta "+")    # returns full metadata struct
 ```
+
+### IEEE 754 bitcast
+
+| Primitive | Arity | Description |
+|-----------|-------|-------------|
+| `math/f32-bits` | 1 | Return the IEEE 754 f32 bit pattern of a number as an integer |
+| `math/f32-from-bits` | 1 | Reinterpret an integer as an IEEE 754 f32 bit pattern |
 
 ---
 

--- a/lib/AGENTS.md
+++ b/lib/AGENTS.md
@@ -11,6 +11,8 @@ depend on other modules or plugins take them as arguments.
 | `http.lisp` | HTTP/1.1 client and server over TCP |
 | `http2.lisp` | HTTP/2 client and server (h2 over TLS + h2c cleartext) |
 | `http2/` | HTTP/2 submodules (huffman, hpack, frame, stream) — see [`http2/AGENTS.md`](http2/AGENTS.md) |
+| `websocket.lisp` | WebSocket client and server (RFC 6455, ws:// and wss://) |
+| `grpc.lisp` | gRPC client over HTTP/2 with length-prefixed framing |
 | `tls.lisp` | TLS 1.2/1.3 client and server (with ALPN support) |
 | `redis.lisp` | Redis client (RESP2) over TCP |
 | `dns.lisp` | DNS client (RFC 1035) |

--- a/lib/gpu.lisp
+++ b/lib/gpu.lisp
@@ -4,7 +4,8 @@
 ## Wraps the vulkan plugin and SPIR-V emitter.
 ##
 ## Usage:
-##   (def gpu ((import "std/gpu")))
+##   (def vk  (import "plugin/vulkan"))
+##   (def gpu ((import "std/gpu") :vulkan vk))
 ##   (def ctx (gpu:init))
 ##
 ##   ## compile shader at runtime — no offline tools needed
@@ -17,9 +18,9 @@
 ##   (def result (gpu:run shader [4 1 1]
 ##                  [(gpu:input a) (gpu:input b) (gpu:output 1024)]))
 
-(fn []
+(fn [&named vulkan]
 
-(def plugin (import "plugin/vulkan"))
+(def plugin vulkan)
 (def spv    ((import "std/spirv")))
 
 ## ── Context ────────────────────────────────────────────────────

--- a/lib/grpc.lisp
+++ b/lib/grpc.lisp
@@ -1,0 +1,118 @@
+## lib/grpc.lisp — gRPC client for Elle
+##
+## Layers on lib/http2 for transport; adds gRPC framing and trailer handling.
+##
+## Usage:
+##   (def pb    (import "plugin/protobuf"))
+##   (def http2 ((import "std/http2")))
+##   (def grpc  ((import "std/grpc") :http2 http2 :protobuf pb))
+##
+##   (def schema (pb:schema (port/read-all (port/open "service.proto" :read))))
+##   (def conn   (grpc:connect "/run/user/1000/myservice.sock"))
+##   (def resp   (grpc:call-decode conn schema "/pkg.Svc/Method"
+##                  "pkg.Request" {} "pkg.Response"))
+##   (grpc:close conn)
+
+(elle/epoch 8)
+
+(fn [&named http2 protobuf]
+
+  ## ── gRPC message framing ─────────────────────────────────────────────
+  ## Each gRPC message: 1 byte compressed flag + 4 byte big-endian length + payload
+
+  (defn grpc-encode [message-bytes]
+    "Wrap protobuf bytes in gRPC length-prefixed frame."
+    (let [len (length message-bytes)]
+      (concat (bytes 0                              # not compressed
+                     (bit/shr len 24)
+                     (bit/and (bit/shr len 16) 0xff)
+                     (bit/and (bit/shr len 8) 0xff)
+                     (bit/and len 0xff))
+              message-bytes)))
+
+  (defn grpc-decode [frame-bytes]
+    "Extract protobuf bytes from gRPC length-prefixed frame.
+     Returns the payload bytes, or nil if frame is empty."
+    (when (and frame-bytes (>= (length frame-bytes) 5))
+      (let [len (bit/or (bit/shl (get frame-bytes 1) 24)
+                        (bit/shl (get frame-bytes 2) 16)
+                        (bit/shl (get frame-bytes 3) 8)
+                        (get frame-bytes 4))]
+        (when (>= (length frame-bytes) (+ 5 len))
+          (slice frame-bytes 5 (+ 5 len))))))
+
+  ## ── Connect ────────────────────────────────────────────────────────
+
+  (defn grpc-connect [socket-path]
+    "Connect to a gRPC server over a Unix socket. Returns an h2 session."
+    (let* [port (unix/connect socket-path)
+           transport (http2:unix-transport port)]
+      (http2:connect nil :transport transport)))
+
+  ## ── Collect gRPC response from stream ──────────────────────────────
+
+  (defn collect-grpc-response [s]
+    "Read data + trailers from an h2 stream. Returns raw gRPC frame bytes.
+     Raises on grpc-status != 0."
+    (let [@resp-headers nil
+          @resp-data @[]
+          @done false]
+      (while (not done)
+        (let [msg (s:data-queue:take)]
+          (cond
+            ((= msg:type :headers)
+             (if (nil? resp-headers)
+               (assign resp-headers msg:headers)
+               ## Trailers — check grpc-status
+               (let [status-pair (first (filter (fn [h] (= (get h 0) "grpc-status")) msg:headers))]
+                 (when (and status-pair (not (= (get status-pair 1) "0")))
+                   (let [msg-pair (first (filter (fn [h] (= (get h 0) "grpc-message")) msg:headers))]
+                     (error {:error :grpc-error
+                             :code (parse-int (get status-pair 1))
+                             :message (if msg-pair (get msg-pair 1) "unknown error")})))))
+             (when msg:end-stream (assign done true)))
+            ((= msg:type :data)
+             (push resp-data msg:data)
+             (when msg:end-stream (assign done true)))
+            ((= msg:type :rst)
+             (error {:error :grpc-error :reason :stream-reset
+                     :code msg:code}))
+            (true (assign done true)))))
+      (let [all-data (if (empty? resp-data)
+                       (bytes)
+                       (apply concat (freeze resp-data)))]
+        (grpc-decode all-data))))
+
+  ## ── Unary RPC call ─────────────────────────────────────────────────
+
+  (defn grpc-call [session schema method request-type request-struct]
+    "Make a unary gRPC call. Returns raw protobuf bytes of response."
+    (let* [body (grpc-encode (protobuf:encode schema request-type request-struct))
+           stream (http2:send-raw session "POST" method
+                    :body body
+                    :headers [["content-type" "application/grpc"]
+                              ["te" "trailers"]])]
+      (collect-grpc-response stream)))
+
+  (defn grpc-call-decode [session schema method request-type request-struct response-type]
+    "Make a unary gRPC call and decode the response.
+     Returns the decoded Elle struct."
+    (let [raw (grpc-call session schema method request-type request-struct)]
+      (if (nil? raw)
+        {}
+        (protobuf:decode schema response-type raw))))
+
+  ## ── Close ──────────────────────────────────────────────────────────
+
+  (defn grpc-close [session]
+    "Close a gRPC connection gracefully."
+    (http2:close session))
+
+  ## ── Exports ────────────────────────────────────────────────────────
+
+  {:connect    grpc-connect
+   :call       grpc-call
+   :call-decode grpc-call-decode
+   :close      grpc-close
+   :encode     grpc-encode
+   :decode     grpc-decode})

--- a/lib/http2.lisp
+++ b/lib/http2.lisp
@@ -103,10 +103,14 @@
         {:transport (tcp-transport (tcp/connect ip url-parsed:port)) :tls-conn nil})))
 
   ## ── Default settings ───────────────────────────────────────────────────
+  ## 1MB windows and 256KB frames for large gRPC responses.
+
+  (def INITIAL-WINDOW (* 1024 1024))
+  (def MAX-FRAME (* 256 1024))
 
   (def default-settings
-    [[C:settings-initial-window-size 65535]
-     [C:settings-max-frame-size      16384]
+    [[C:settings-initial-window-size INITIAL-WINDOW]
+     [C:settings-max-frame-size      MAX-FRAME]
      [C:settings-enable-push         0]])
 
   ## ── Session struct ─────────────────────────────────────────────────────
@@ -114,24 +118,25 @@
   ##   :hpack-encoder :hpack-decoder :local-settings :remote-settings
   ##   :conn-flow :write-queue :reader-fiber :writer-fiber :closed? :host}
 
-  (defn make-session [transport host is-server?]
+  (defn make-session [transport host is-server? &named scheme]
     @{:transport      transport
       :is-server?     is-server?
       :host           host
+      :scheme         (or scheme "http")
       :streams        @{}
       :next-stream-id (if is-server? 2 1)
       :hpack-encoder  (hpack:make-encoder)
       :hpack-decoder  (hpack:make-decoder)
       :local-settings {:header-table-size 4096
-                       :initial-window-size 65535
-                       :max-frame-size 16384
+                       :initial-window-size INITIAL-WINDOW
+                       :max-frame-size MAX-FRAME
                        :max-concurrent-streams 100
                        :enable-push 0}
       :remote-settings {:header-table-size 4096
                         :initial-window-size 65535
                         :max-frame-size 16384
                         :max-concurrent-streams 100}
-      :conn-flow      (stream:make-flow-control 65535)
+      :conn-flow      (stream:make-flow-control INITIAL-WINDOW)
       :write-queue    (sync:make-queue 256)
       :reader-fiber   nil
       :writer-fiber   nil
@@ -329,6 +334,12 @@
     # Send our SETTINGS
     (let [[ftype flags sid payload] (frame:make-settings-frame default-settings)]
       (frame:write-frame session:transport ftype flags sid payload))
+    # Connection window starts at 65535 per RFC 9113 regardless of SETTINGS.
+    # Send WINDOW_UPDATE on stream 0 to bring it up to INITIAL-WINDOW.
+    (let [delta (- INITIAL-WINDOW 65535)]
+      (when (> delta 0)
+        (let [[ftype flags sid payload] (frame:make-window-update-frame 0 delta)]
+          (frame:write-frame session:transport ftype flags sid payload))))
     (session:transport:flush)
     # Read the server's SETTINGS (first frame must be SETTINGS)
     (let [f (frame:read-frame session:transport
@@ -344,14 +355,17 @@
 
   ## ── Client: connect ────────────────────────────────────────────────────
 
-  (defn h2-connect [url]
-    "Open an HTTP/2 session. Returns a session struct."
-    (let* [parsed (parse-url url)
-           {:transport t :tls-conn tc} (open-transport parsed)
-           session (make-session t parsed:host false)]
-      # Perform the handshake synchronously before starting fibers
+  (defn h2-connect [url &named transport host]
+    "Open an HTTP/2 session. Returns a session struct.
+     When :transport is provided, uses it directly (for Unix sockets etc.)
+     instead of parsing URL and opening TCP. Optional :host sets authority header."
+    (let [session
+          (if transport
+            (make-session transport (or host "localhost") false)
+            (let* [parsed (parse-url url)
+                   {:transport t :tls-conn tc} (open-transport parsed)]
+              (make-session t parsed:host false :scheme parsed:scheme)))]
       (client-handshake session)
-      # Start reader and writer fibers
       (put session :writer-fiber
            (ev/spawn (fn [] (writer-loop session))))
       (put session :reader-fiber
@@ -371,7 +385,7 @@
            authority session:host
            pseudo [[":method" method]
                    [":path" path]
-                   [":scheme" "https"]
+                   [":scheme" (or session:scheme "http")]
                    [":authority" authority]]
            all-headers (if (nil? headers) pseudo (concat pseudo headers))
            header-block (hpack:encode session:hpack-encoder all-headers)
@@ -430,6 +444,64 @@
                       (bytes)
                       (apply concat (freeze resp-body)))}))))
 
+  ## ── Client: send-raw (returns stream for caller to collect) ────────────
+
+  (defn h2-send-raw [session method path &named body headers]
+    "Send request, return stream for caller to collect response.
+     Unlike h2:send, does NOT wait for or collect the response."
+    (when session:closed?
+      (error {:error :h2-error :reason :connection-closed
+              :message "session is closed"}))
+    (let* [sid session:next-stream-id
+           _ (put session :next-stream-id (+ sid 2))
+           s (get-stream session sid)
+           authority session:host
+           pseudo [[":method" method]
+                   [":path" path]
+                   [":scheme" (or session:scheme "http")]
+                   [":authority" authority]]
+           all-headers (if (nil? headers) pseudo (concat pseudo headers))
+           header-block (hpack:encode session:hpack-encoder all-headers)
+           has-body (and body (> (length body) 0))]
+      # Send HEADERS
+      (let [[ftype flags sid2 payload]
+            (frame:make-headers-frame sid header-block (not has-body) true)]
+        (stream:transition s :send-headers)
+        (send-frame session ftype flags sid2 payload))
+      # Send DATA if body present
+      (when has-body
+        (let* [body-bytes (if (string? body) (bytes body) body)
+               max-frame (get session:remote-settings :max-frame-size)
+               @offset 0
+               total (length body-bytes)]
+          (while (< offset total)
+            (let* [remaining (- total offset)
+                   chunk-size (min remaining max-frame)
+                   chunk (slice body-bytes offset (+ offset chunk-size))
+                   end? (= (+ offset chunk-size) total)
+                   [ftype flags sid2 payload]
+                   (frame:make-data-frame sid chunk end?)]
+              (send-frame session ftype flags sid2 payload)
+              (assign offset (+ offset chunk-size))))
+          (stream:transition s :send-end-stream)))
+      s))
+
+  ## ── Unix socket transport ────────────────────────────────────────────
+
+  (defn unix-transport [port]
+    "Wrap a Unix socket port as an HTTP/2 transport."
+    (def @wbuf-parts @[])
+    {:read  (fn [n] (port/read port n))
+     :write (fn [data]
+              (let [d (if (bytes? data) data (bytes data))]
+                (push wbuf-parts d)))
+     :flush (fn []
+              (when (> (length wbuf-parts) 0)
+                (let [combined (apply concat (freeze wbuf-parts))]
+                  (port/write port combined)
+                  (assign wbuf-parts @[]))))
+     :close (fn [] (port/close port))})
+
   ## ── Client: one-shot API ───────────────────────────────────────────────
 
   (defn h2-request [method url &named body headers]
@@ -459,9 +531,14 @@
       (send-goaway session session:last-stream-id C:err-no-error)
       # Shutdown writer
       (session:write-queue:put :shutdown)
-      # Close transport
+      # Close transport — unblocks reader fiber's read
       (let [[ok? _] (protect (session:transport:close))]
-        nil))
+        nil)
+      # Wait for fibers to exit so the scheduler has no dangling work
+      (when session:writer-fiber
+        (ev/join-protected session:writer-fiber))
+      (when session:reader-fiber
+        (ev/join-protected session:reader-fiber)))
     nil)
 
   ## ── Server ─────────────────────────────────────────────────────────────
@@ -706,7 +783,9 @@
    :request  h2-request
    :connect  h2-connect
    :send     h2-send
+   :send-raw h2-send-raw
    :close    h2-close
    :serve    h2-serve
    :parse-url parse-url
+   :unix-transport unix-transport
    :test     run-tests})

--- a/lib/websocket.lisp
+++ b/lib/websocket.lisp
@@ -1,0 +1,474 @@
+(elle/epoch 8)
+## lib/websocket.lisp — WebSocket client and server (RFC 6455)
+##
+## Parameterized module:
+##   (def hash (import "plugin/hash"))
+##   (def rand (import "plugin/random"))
+##   (def ws   ((import "std/websocket") :hash hash :random rand))
+##
+## With TLS (for wss://):
+##   (def tls-plug ((import "plugin/tls")))
+##   (def tls ((import "std/tls") tls-plug))
+##   (def ws  ((import "std/websocket") :hash hash :random rand :tls tls))
+##
+## Client:
+##   (def conn (ws:connect "ws://localhost:8080/chat"))
+##   (ws:send conn "hello")
+##   (def msg (ws:recv conn))
+##   (ws:close conn)
+##
+## Server:
+##   (def listener (tcp/listen "127.0.0.1" 8080))
+##   (ws:serve listener (fn [conn]
+##     (forever
+##       (let [msg (ws:recv conn)]
+##         (when (= msg:type :close) (break nil))
+##         (ws:send conn msg:data)))))
+
+(fn [&named tls hash random]
+
+  ## ── Internal imports ────────────────────────────────────────────────
+
+  (def b64 ((import "std/base64")))
+
+  ## ── Constants ───────────────────────────────────────────────────────
+
+  (def WS-GUID "258EAFA5-E914-47DA-95CA-5AB9DC76B585")
+
+  (def OP-CONTINUATION 0)
+  (def OP-TEXT         1)
+  (def OP-BINARY       2)
+  (def OP-CLOSE        8)
+  (def OP-PING         9)
+  (def OP-PONG        10)
+
+  ## ── URL parsing ─────────────────────────────────────────────────────
+
+  (defn ws-parse-url [url]
+    "Parse a WebSocket URL. Supports ws:// and wss://."
+    (let* [is-wss (string/starts-with? url "wss://")
+           is-ws  (string/starts-with? url "ws://")
+           _ (when (not (or is-wss is-ws))
+               (error {:error :ws-error :reason :unsupported-scheme :url url
+                       :message "URL must start with ws:// or wss://"}))
+           prefix-len (if is-wss 6 5)
+           scheme (if is-wss "wss" "ws")
+           default-port (if is-wss 443 80)
+           tail (slice url prefix-len)
+           slash (string/find tail "/")
+           auth (if (nil? slash) tail (slice tail 0 slash))
+           path (if (nil? slash) "/" (slice tail slash))
+           colon (string/find auth ":")
+           host (if (nil? colon) auth (slice auth 0 colon))
+           port (if (nil? colon) default-port (parse-int (slice auth (inc colon))))]
+      (when (empty? host)
+        (error {:error :ws-error :reason :empty-host :url url :message "empty host"}))
+      {:scheme scheme :host host :port port :path path}))
+
+  ## ── Transport abstraction ───────────────────────────────────────────
+
+  (defn tcp-transport [port]
+    "Wrap a TCP port as a transport with buffered writes."
+    (def @wbuf-parts @[])
+    {:read      (fn [n] (port/read port n))
+     :read-line (fn [] (port/read-line port))
+     :write     (fn [data]
+                  (let [d (if (bytes? data) data (bytes data))]
+                    (push wbuf-parts d)))
+     :flush     (fn []
+                  (when (> (length wbuf-parts) 0)
+                    (let [combined (apply concat (freeze wbuf-parts))]
+                      (port/write port combined)
+                      (assign wbuf-parts @[]))))
+     :close     (fn [] (port/close port))})
+
+  (defn tls-transport [conn]
+    "Wrap a TLS connection as a transport."
+    {:read      (fn [n] (tls:read conn n))
+     :read-line (fn [] (tls:read-line conn))
+     :write     (fn [data] (tls:write conn data))
+     :flush     (fn [] nil)
+     :close     (fn [] (tls:close conn))})
+
+  (defn open-transport [parsed]
+    "Open transport to parsed URL's host:port."
+    (let [ip (first (sys/resolve parsed:host))]
+      (if (= parsed:scheme "wss")
+        (begin
+          (when (nil? tls)
+            (error {:error :ws-error :reason :tls-not-configured
+                    :message "wss:// requires :tls plugin passed to (import \"std/websocket\")"}))
+          (tls-transport (tls:connect parsed:host parsed:port {})))
+        (tcp-transport (tcp/connect ip parsed:port)))))
+
+  ## ── Transport helpers ───────────────────────────────────────────────
+
+  (defn t-read [t n] (t:read n))
+  (defn t-read-line [t] (t:read-line))
+  (defn t-write [t data] (t:write data))
+  (defn t-flush [t] (t:flush))
+  (defn t-close [t] (t:close))
+
+  (defn read-exact [t n]
+    "Read exactly n bytes from transport, looping on short reads."
+    (def @remaining n)
+    (def @parts @[])
+    (while (> remaining 0)
+      (let [chunk (t-read t remaining)]
+        (when (nil? chunk)
+          (error {:error :ws-error :reason :unexpected-eof
+                  :message "unexpected EOF reading from transport"}))
+        (let [b (if (bytes? chunk) chunk (bytes chunk))]
+          (push parts b)
+          (assign remaining (- remaining (length b))))))
+    (if (= (length parts) 1)
+      (first (freeze parts))
+      (apply concat (freeze parts))))
+
+  ## ── Handshake helpers ───────────────────────────────────────────────
+
+  (defn compute-accept-key [client-key]
+    "Compute Sec-WebSocket-Accept from client key (RFC 6455 section 4.2.2)."
+    (b64:encode (hash:sha1 (bytes (string client-key WS-GUID)))))
+
+  (defn generate-key []
+    "Generate a random 16-byte Sec-WebSocket-Key, base64-encoded."
+    (b64:encode (random:csprng-bytes 16)))
+
+  ## ── Frame codec ─────────────────────────────────────────────────────
+
+  (defn apply-mask [data mask-key]
+    "XOR each byte of data with mask-key[i % 4]."
+    (let [result (thaw data)
+          len (length data)]
+      (def @i 0)
+      (while (< i len)
+        (put result i (bit/xor (get data i) (get mask-key (% i 4))))
+        (assign i (inc i)))
+      (freeze result)))
+
+  (defn encode-frame [opcode payload &named mask? fin]
+    "Encode a WebSocket frame. mask? true for client frames."
+    (let* [do-fin (if (nil? fin) true fin)
+           do-mask (if (nil? mask?) false mask?)
+           payload-bytes (if (bytes? payload) payload (bytes payload))
+           plen (length payload-bytes)
+           byte0 (bit/or (if do-fin 0x80 0) (bit/and opcode 0x0F))
+           mask-bit (if do-mask 0x80 0)]
+      (def @header @b[])
+      (push header byte0)
+      (cond
+        ((< plen 126)
+         (push header (bit/or mask-bit plen)))
+        ((< plen 65536)
+         (push header (bit/or mask-bit 126))
+         (push header (bit/and (bit/shr plen 8) 0xFF))
+         (push header (bit/and plen 0xFF)))
+        (true
+         (push header (bit/or mask-bit 127))
+         (push header (bit/and (bit/shr plen 56) 0xFF))
+         (push header (bit/and (bit/shr plen 48) 0xFF))
+         (push header (bit/and (bit/shr plen 40) 0xFF))
+         (push header (bit/and (bit/shr plen 32) 0xFF))
+         (push header (bit/and (bit/shr plen 24) 0xFF))
+         (push header (bit/and (bit/shr plen 16) 0xFF))
+         (push header (bit/and (bit/shr plen 8) 0xFF))
+         (push header (bit/and plen 0xFF))))
+      (if do-mask
+        (let* [mask-key (random:csprng-bytes 4)
+               masked (apply-mask payload-bytes mask-key)]
+          (concat (freeze header) mask-key masked))
+        (concat (freeze header) payload-bytes))))
+
+  (defn decode-frame [t]
+    "Read and decode a WebSocket frame from transport.
+     Returns {:fin :opcode :payload} or nil on EOF."
+    (let [hdr (t-read t 2)]
+      (if (or (nil? hdr) (< (length hdr) 2))
+        nil
+        (let* [byte0 (get hdr 0)
+               byte1 (get hdr 1)
+               fin (= (bit/and byte0 0x80) 0x80)
+               opcode (bit/and byte0 0x0F)
+               masked (= (bit/and byte1 0x80) 0x80)
+               plen (bit/and byte1 0x7F)
+               payload-len
+               (cond
+                 ((= plen 126)
+                  (let [ext (read-exact t 2)]
+                    (bit/or (bit/shl (get ext 0) 8) (get ext 1))))
+                 ((= plen 127)
+                  (let [ext (read-exact t 8)]
+                    (bit/or (bit/shl (get ext 0) 56)
+                            (bit/shl (get ext 1) 48)
+                            (bit/shl (get ext 2) 40)
+                            (bit/shl (get ext 3) 32)
+                            (bit/shl (get ext 4) 24)
+                            (bit/shl (get ext 5) 16)
+                            (bit/shl (get ext 6) 8)
+                            (get ext 7))))
+                 (true plen))
+               mask-key (when masked (read-exact t 4))
+               raw (if (> payload-len 0) (read-exact t payload-len) (bytes))
+               payload (if masked (apply-mask raw mask-key) raw)]
+          {:fin fin :opcode opcode :payload payload}))))
+
+  ## ── Message reassembly ──────────────────────────────────────────────
+
+  (defn recv-message [conn]
+    "Read frames until a complete message is assembled.
+     Auto-pongs on ping. Returns {:type :text/:binary/:close :data payload}."
+    (let [t conn:transport
+          @parts @[]
+          @msg-opcode nil
+          @result nil]
+      (forever
+        (let [frame (decode-frame t)]
+          (if (nil? frame)
+            (begin
+              (assign result {:type :close :data (bytes) :code 1006 :reason "EOF"})
+              (break nil))
+            (let [op frame:opcode]
+              (cond
+                ((= op OP-PING)
+                 (let [pong (encode-frame OP-PONG frame:payload
+                              :mask? conn:is-client?)]
+                   (t-write t pong)
+                   (t-flush t)))
+                ((= op OP-PONG) nil)
+                ((= op OP-CLOSE)
+                 (let* [payload frame:payload
+                       code (if (>= (length payload) 2)
+                              (bit/or (bit/shl (get payload 0) 8) (get payload 1))
+                              1005)
+                       reason (if (> (length payload) 2)
+                                (string (slice payload 2))
+                                "")]
+                   (assign result {:type :close :data payload :code code :reason reason})
+                   (break nil)))
+                (true
+                 (when (not (= op OP-CONTINUATION))
+                   (assign msg-opcode op))
+                 (push parts frame:payload)
+                 (when frame:fin
+                   (let* [data (if (= (length parts) 1)
+                                 (first (freeze parts))
+                                 (apply concat (freeze parts)))
+                          type (if (= msg-opcode OP-TEXT) :text :binary)]
+                     (assign result {:type type :data data})
+                     (break nil)))))))))
+      result))
+
+  ## ── Connection struct ───────────────────────────────────────────────
+
+  (defn make-conn [transport is-client?]
+    {:transport transport :is-client? is-client?})
+
+  ## ── Client API ──────────────────────────────────────────────────────
+
+  (defn ws-connect [url &named headers]
+    "Connect to a WebSocket server. Returns a connection struct."
+    (let* [parsed (ws-parse-url url)
+           t (open-transport parsed)
+           key (generate-key)
+           host-str (if (or (and (= parsed:scheme "ws") (= parsed:port 80))
+                            (and (= parsed:scheme "wss") (= parsed:port 443)))
+                      parsed:host
+                      (string parsed:host ":" parsed:port))
+           req (string "GET " parsed:path " HTTP/1.1\r\n"
+                       "Host: " host-str "\r\n"
+                       "Upgrade: websocket\r\n"
+                       "Connection: Upgrade\r\n"
+                       "Sec-WebSocket-Key: " key "\r\n"
+                       "Sec-WebSocket-Version: 13\r\n")]
+      (def @req-str req)
+      (when headers
+        (each [name value] in headers
+          (assign req-str (string req-str name ": " value "\r\n"))))
+      (assign req-str (string req-str "\r\n"))
+      (t-write t req-str)
+      (t-flush t)
+      (let [status-line (t-read-line t)]
+        (when (or (nil? status-line)
+                  (not (string/contains? status-line "101")))
+          (error {:error :ws-error :reason :handshake-failed
+                  :message (string "expected 101 Switching Protocols, got: " status-line)}))
+        (def @accept-key nil)
+        (forever
+          (let [line (t-read-line t)]
+            (when (or (nil? line) (empty? line) (= line "\r"))
+              (break nil))
+            (let [colon (string/find line ":")]
+              (when colon
+                (let [name (string/lowercase (string/trim (slice line 0 colon)))
+                      value (string/trim (slice line (+ colon 1)))]
+                  (when (= name "sec-websocket-accept")
+                    (assign accept-key value)))))))
+        (let [expected (compute-accept-key key)]
+          (when (not (= accept-key expected))
+            (t-close t)
+            (error {:error :ws-error :reason :invalid-accept-key
+                    :expected expected :got accept-key
+                    :message "server Sec-WebSocket-Accept does not match"}))
+          (make-conn t true)))))
+
+  (defn ws-send [conn data]
+    "Send a text or binary message over a WebSocket connection."
+    (let* [is-text (string? data)
+           opcode (if is-text OP-TEXT OP-BINARY)
+           payload (if is-text (bytes data) data)
+           frame (encode-frame opcode payload :mask? conn:is-client?)]
+      (t-write conn:transport frame)
+      (t-flush conn:transport)))
+
+  (defn ws-recv [conn]
+    "Receive a complete WebSocket message. Returns {:type :data}."
+    (recv-message conn))
+
+  (defn ws-ping [conn]
+    "Send a ping frame."
+    (let [frame (encode-frame OP-PING (bytes) :mask? conn:is-client?)]
+      (t-write conn:transport frame)
+      (t-flush conn:transport)))
+
+  (defn ws-close [conn &named code reason]
+    "Close the WebSocket connection gracefully."
+    (let* [close-code (or code 1000)
+           close-reason (or reason "")
+           payload (concat (bytes (bit/and (bit/shr close-code 8) 0xFF)
+                                  (bit/and close-code 0xFF))
+                           (bytes close-reason))
+           frame (encode-frame OP-CLOSE payload :mask? conn:is-client?)]
+      (t-write conn:transport frame)
+      (t-flush conn:transport)
+      (let [[ok? _] (protect (recv-message conn))]
+        nil)
+      (let [[ok? _] (protect (t-close conn:transport))]
+        nil)))
+
+  ## ── Server API ──────────────────────────────────────────────────────
+
+  (defn ws-upgrade [req t]
+    "Upgrade an HTTP request to WebSocket. Returns a connection struct."
+    (let* [headers req:headers
+           key (get headers :sec-websocket-key)]
+      (when (nil? key)
+        (error {:error :ws-error :reason :missing-key
+                :message "missing Sec-WebSocket-Key header"}))
+      (let* [accept (compute-accept-key key)
+             response (string "HTTP/1.1 101 Switching Protocols\r\n"
+                             "Upgrade: websocket\r\n"
+                             "Connection: Upgrade\r\n"
+                             "Sec-WebSocket-Accept: " accept "\r\n"
+                             "\r\n")]
+        (t-write t response)
+        (t-flush t)
+        (make-conn t false))))
+
+  (defn ws-serve [listener handler]
+    "Accept WebSocket connections and handle them."
+    (forever
+      (let* [[ok? tcp-port] (protect (tcp/accept listener))]
+        (unless ok? (break nil))
+        (ev/spawn
+          (fn []
+            (let [t (tcp-transport tcp-port)]
+              (defer (protect (t-close t))
+                (let [req-line (t-read-line t)]
+                  (when (not (nil? req-line))
+                    (let [parts (string/split req-line " ")]
+                      (when (>= (length parts) 2)
+                        (def @headers @{})
+                        (forever
+                          (let [line (t-read-line t)]
+                            (when (or (nil? line) (empty? line) (= line "\r"))
+                              (break nil))
+                            (let [colon (string/find line ":")]
+                              (when colon
+                                (let [name (keyword (string/lowercase
+                                              (string/trim (slice line 0 colon))))
+                                      value (string/trim (slice line (+ colon 1)))]
+                                  (put headers name value))))))
+                        (let* [req {:method (get parts 0)
+                                    :path (get parts 1)
+                                    :headers (freeze headers)
+                                    :body nil}
+                               conn (ws-upgrade req t)]
+                          (let [[ok? _] (protect (handler conn))]
+                            nil)))))))))))))
+
+  ## ── Internal tests ──────────────────────────────────────────────────
+
+  (defn run-tests []
+
+    ## ── URL parsing ──
+    (let [p (ws-parse-url "ws://example.com/chat")]
+      (assert (= p:scheme "ws") "ws: scheme")
+      (assert (= p:host "example.com") "ws: host")
+      (assert (= p:port 80) "ws: default port")
+      (assert (= p:path "/chat") "ws: path"))
+
+    (let [p (ws-parse-url "wss://secure.io:9443/ws")]
+      (assert (= p:scheme "wss") "wss: scheme")
+      (assert (= p:host "secure.io") "wss: host")
+      (assert (= p:port 9443) "wss: port")
+      (assert (= p:path "/ws") "wss: path"))
+
+    (let [p (ws-parse-url "ws://localhost/")]
+      (assert (= p:port 80) "ws: default 80"))
+
+    (let [p (ws-parse-url "wss://example.com")]
+      (assert (= p:port 443) "wss: default 443")
+      (assert (= p:path "/") "wss: default path"))
+
+    (let [[ok? _] (protect (ws-parse-url "http://bad.com"))]
+      (assert (not ok?) "rejects http://"))
+
+    ## ── Accept key (RFC 6455 section 4.2.2 test vector) ──
+    (let [key "dGhlIHNhbXBsZSBub25jZQ=="
+          expected "NAwr/jm285Ly94AfF1mwjRaNwgQ="]
+      (assert (= (compute-accept-key key) expected) "accept key: RFC 6455 test vector"))
+
+    ## ── Masking ──
+    (let* [data (bytes 1 2 3 4 5)
+           mask (bytes 0xAA 0xBB 0xCC 0xDD)
+           masked (apply-mask data mask)
+           unmasked (apply-mask masked mask)]
+      (assert (= unmasked data) "mask roundtrip"))
+
+    (assert (= (apply-mask (bytes) (bytes 1 2 3 4)) (bytes)) "mask empty")
+
+    ## ── Frame codec ──
+    (let* [payload (bytes 72 101 108 108 111)
+           frame (encode-frame OP-TEXT payload)
+           byte0 (get frame 0)
+           byte1 (get frame 1)]
+      (assert (= byte0 0x81) "text frame: FIN + opcode 1")
+      (assert (= byte1 5) "text frame: payload len 5")
+      (assert (= (slice frame 2) payload) "text frame: payload matches"))
+
+    (let* [payload (apply bytes (map (fn [i] (% i 256)) (range 200)))
+           frame (encode-frame OP-BINARY payload)
+           byte1 (get frame 1)]
+      (assert (= (bit/and byte1 0x7F) 126) "medium frame: extended length marker")
+      (let [ext-len (bit/or (bit/shl (get frame 2) 8) (get frame 3))]
+        (assert (= ext-len 200) "medium frame: extended length value")))
+
+    (let* [frame (encode-frame OP-TEXT (bytes 65) :fin false)
+           byte0 (get frame 0)]
+      (assert (= (bit/and byte0 0x80) 0) "non-fin: FIN bit clear")
+      (assert (= (bit/and byte0 0x0F) OP-TEXT) "non-fin: opcode"))
+
+    true)
+
+  ## ── Exports ─────────────────────────────────────────────────────────
+
+  {:connect   ws-connect
+   :send      ws-send
+   :recv      ws-recv
+   :close     ws-close
+   :ping      ws-ping
+   :upgrade   ws-upgrade
+   :serve     ws-serve
+   :parse-url ws-parse-url
+   :test      run-tests})

--- a/src/port.rs
+++ b/src/port.rs
@@ -173,7 +173,9 @@ impl Port {
             fd: RefCell::new(Some(fd)),
             kind: PortKind::UnixStream,
             direction: Direction::ReadWrite,
-            encoding: Encoding::Text,
+            // Binary encoding: Unix streams are byte streams, same as TCP.
+            // port/read returns bytes for binary protocols (h2, gRPC, etc.).
+            encoding: Encoding::Binary,
             closed: Cell::new(false),
             path: Some(peer_path),
             timeout: Cell::new(None),
@@ -456,7 +458,7 @@ mod tests {
     fn test_new_unix_stream_kind() {
         let p = Port::new_unix_stream(devnull_fd(), "/tmp/test.sock".into());
         assert_eq!(p.kind(), PortKind::UnixStream);
-        assert_eq!(p.encoding(), Encoding::Text);
+        assert_eq!(p.encoding(), Encoding::Binary);
     }
 
     #[test]

--- a/src/primitives/math.rs
+++ b/src/primitives/math.rs
@@ -212,6 +212,33 @@ fn prim_nan(_args: &[Value]) -> (SignalBits, Value) {
 }
 
 // ---------------------------------------------------------------------------
+// IEEE 754 bitcast
+// ---------------------------------------------------------------------------
+
+fn prim_f32_bits(args: &[Value]) -> (SignalBits, Value) {
+    match require_number("math/f32-bits", &args[0]) {
+        Ok(f) => (SIG_OK, Value::int((f as f32).to_bits() as i64)),
+        Err(e) => e,
+    }
+}
+
+fn prim_f32_from_bits(args: &[Value]) -> (SignalBits, Value) {
+    match args[0].as_int() {
+        Some(i) => (SIG_OK, Value::float(f32::from_bits(i as u32) as f64)),
+        None => (
+            SIG_ERROR,
+            error_val(
+                "type-error",
+                format!(
+                    "math/f32-from-bits: expected int, got {}",
+                    args[0].type_name()
+                ),
+            ),
+        ),
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Registration table
 // ---------------------------------------------------------------------------
 
@@ -389,6 +416,18 @@ pub(crate) const PRIMITIVES: &[PrimitiveDef] = &[
         arity: Arity::Exact(0), doc: "Not-a-number (IEEE 754 NaN).",
         params: &[], category: "math", example: "(math/nan)",
         aliases: &["nan"],
+    },
+    PrimitiveDef {
+        name: "math/f32-bits", func: prim_f32_bits, signal: Signal::errors(),
+        arity: Arity::Exact(1), doc: "Return the IEEE 754 f32 bit pattern of a number as an integer.",
+        params: &["x"], category: "math", example: "(math/f32-bits 1.0)",
+        aliases: &[],
+    },
+    PrimitiveDef {
+        name: "math/f32-from-bits", func: prim_f32_from_bits, signal: Signal::errors(),
+        arity: Arity::Exact(1), doc: "Reinterpret an integer as an IEEE 754 f32 bit pattern.",
+        params: &["bits"], category: "math", example: "(math/f32-from-bits 1065353216)",
+        aliases: &[],
     },
 ];
 

--- a/tests/elle/grpc.lisp
+++ b/tests/elle/grpc.lisp
@@ -1,0 +1,55 @@
+## tests/elle/grpc.lisp — gRPC framing tests
+##
+## Tests the pure framing functions (encode/decode) without needing a
+## running gRPC server or the protobuf plugin.
+
+(elle/epoch 8)
+
+## ── Init with fake protobuf ──────────────────────────────────────
+
+(def fake-pb {:encode (fn [s t d] (bytes 1 2 3))
+              :decode (fn [s t b] {})})
+(def http2 ((import "std/http2")))
+(def grpc  ((import "std/grpc") :http2 http2 :protobuf fake-pb))
+
+## ── Encode: empty payload ────────────────────────────────────────
+
+(let [frame (grpc:encode (bytes))]
+  (assert (= frame (bytes 0 0 0 0 0)) "encode empty: 5-byte header, zero length"))
+
+## ── Encode/decode roundtrip: small payload ───────────────────────
+
+(let* [payload (bytes 10 20 30)
+       frame (grpc:encode payload)
+       decoded (grpc:decode frame)]
+  (assert (= decoded payload) "roundtrip small payload"))
+
+## ── Encode/decode roundtrip: multi-byte length ───────────────────
+
+(let* [payload (apply bytes (map (fn [i] (% i 256)) (range 300)))
+       frame (grpc:encode payload)
+       decoded (grpc:decode frame)]
+  (assert (= (length frame) (+ 5 300)) "multi-byte: frame length")
+  (assert (= decoded payload) "multi-byte: roundtrip"))
+
+## ── Decode nil → nil ─────────────────────────────────────────────
+
+(assert (nil? (grpc:decode nil)) "decode nil")
+
+## ── Decode truncated frame → nil ─────────────────────────────────
+
+(assert (nil? (grpc:decode (bytes 0 0 0))) "decode truncated: 3 bytes")
+(assert (nil? (grpc:decode (bytes 0 0 0 0))) "decode truncated: 4 bytes")
+
+## ── Decode length exceeding available bytes → nil ────────────────
+
+(let [frame (bytes 0 0 0 0 10 1 2 3)]  # claims 10 bytes, only 3 available
+  (assert (nil? (grpc:decode frame)) "decode: length exceeds data"))
+
+## ── Verify all export keys exist ─────────────────────────────────
+
+(each key in [:connect :call :call-decode :close :encode :decode]
+  (assert (not (nil? (get grpc key)))
+          (string "export key exists: " key)))
+
+(println "tests/elle/grpc.lisp: all tests passed")

--- a/tests/elle/websocket.lisp
+++ b/tests/elle/websocket.lisp
@@ -1,0 +1,108 @@
+## tests/elle/websocket.lisp — WebSocket module tests
+
+(elle/epoch 8)
+
+## ── Plugin availability check ────────────────────────────────────
+
+(let [[h-ok? _] (protect (import "plugin/hash"))
+      [r-ok? _] (protect (import "plugin/random"))]
+  (unless (and h-ok? r-ok?)
+    (println "SKIP: plugin/hash or plugin/random not available")
+    (exit 0)))
+
+## ── Init ─────────────────────────────────────────────────────────
+
+(def hash-plug (import "plugin/hash"))
+(def rand-plug (import "plugin/random"))
+(def ws ((import "std/websocket") :hash hash-plug :random rand-plug))
+
+## ── Internal pure tests ──────────────────────────────────────────
+
+(ws:test)
+
+## ── URL parsing ──────────────────────────────────────────────────
+
+(let [p (ws:parse-url "ws://localhost:9090/path")]
+  (assert (= p:scheme "ws") "url: ws scheme")
+  (assert (= p:host "localhost") "url: host")
+  (assert (= p:port 9090) "url: explicit port")
+  (assert (= p:path "/path") "url: path"))
+
+(let [p (ws:parse-url "ws://example.com")]
+  (assert (= p:port 80) "url: ws default 80"))
+
+(let [p (ws:parse-url "wss://example.com")]
+  (assert (= p:port 443) "url: wss default 443"))
+
+(let [[ok? _] (protect (ws:parse-url "http://example.com"))]
+  (assert (not ok?) "url: rejects http://"))
+
+## ── Loopback integration test ────────────────────────────────────
+
+(defn make-t [tcp]
+  "Transport wrapper for a raw TCP port."
+  (def @wbuf @[])
+  {:read      (fn [n] (port/read tcp n))
+   :read-line (fn [] (port/read-line tcp))
+   :write     (fn [data]
+                (let [d (if (bytes? data) data (bytes data))]
+                  (push wbuf d)))
+   :flush     (fn []
+                (when (> (length wbuf) 0)
+                  (let [combined (apply concat (freeze wbuf))]
+                    (port/write tcp combined)
+                    (assign wbuf @[]))))
+   :close     (fn [] (port/close tcp))})
+
+(let* [listener (tcp/listen "127.0.0.1" 0)
+       lpath (port/path listener)
+       lport (parse-int (slice lpath (+ 1 (string/find lpath ":"))))
+       _srv (ev/spawn (fn []
+         (let* [tcp (tcp/accept listener)
+                t (make-t tcp)]
+           (def line (t:read-line))
+           (def parts (string/split line " "))
+           (def @hdrs @{})
+           (forever
+             (let [h (t:read-line)]
+               (when (or (nil? h) (empty? h) (= h "\r")) (break nil))
+               (let [c (string/find h ":")]
+                 (when c
+                   (put hdrs (keyword (string/lowercase (string/trim (slice h 0 c))))
+                             (string/trim (slice h (+ c 1))))))))
+           (let* [req {:method (get parts 0) :path (get parts 1)
+                       :headers (freeze hdrs) :body nil}
+                  conn (ws:upgrade req t)]
+             ## Echo loop: text→text, binary→binary, close→close
+             (forever
+               (let [msg (ws:recv conn)]
+                 (cond
+                   ((= msg:type :close)
+                    (ws:close conn)
+                    (break nil))
+                   ((= msg:type :text)
+                    (ws:send conn (string msg:data)))
+                   ((= msg:type :binary)
+                    (ws:send conn msg:data)))))))))]
+  (let* [url (string "ws://127.0.0.1:" lport "/echo")
+         conn (ws:connect url)]
+    ## Text echo
+    (ws:send conn "hello websocket")
+    (let [msg (ws:recv conn)]
+      (assert (= msg:type :text) "loopback: text type")
+      (assert (= (string msg:data) "hello websocket") "loopback: text echo"))
+    ## Binary echo
+    (ws:send conn (bytes 1 2 3 4 5))
+    (let [msg (ws:recv conn)]
+      (assert (= msg:type :binary) "loopback: binary type")
+      (assert (= msg:data (bytes 1 2 3 4 5)) "loopback: binary echo"))
+    ## Close — server will echo close frame
+    (ws:close conn))
+  (port/close listener))
+
+## ── Error path: connection refused ───────────────────────────────
+
+(let [[ok? _] (protect (ws:connect "ws://127.0.0.1:1/nope"))]
+  (assert (not ok?) "connect refused on port 1"))
+
+(println "tests/elle/websocket.lisp: all tests passed")

--- a/tests/integration/elle_scripts.rs
+++ b/tests/integration/elle_scripts.rs
@@ -74,3 +74,13 @@ fn caps() {
 fn emit() {
     run_elle_script("emit");
 }
+
+#[test]
+fn grpc() {
+    run_elle_script("grpc");
+}
+
+#[test]
+fn websocket() {
+    run_elle_script("websocket");
+}


### PR DESCRIPTION
New modules:
- lib/websocket.lisp: RFC 6455 WebSocket client and server (parameterized with &named tls hash random)
- lib/grpc.lisp: gRPC client over HTTP/2 with length-prefixed framing (parameterized with &named http2 protobuf)

HTTP/2 enhancements (from Grace fork):
- 1MB initial window / 256KB max frame for large gRPC responses
- Connection-level WINDOW_UPDATE in client handshake
- h2-connect accepts :transport/:host for Unix sockets
- h2-send-raw returns stream for caller-collected responses
- unix-transport, scheme tracking

Runtime additions:
- src/port.rs: Unix stream binary encoding (Encoding::Binary)
- src/primitives/math.rs: math/f32-bits, math/f32-from-bits (IEEE 754 bitcast)

Fix gpu.lisp plugin import anti-pattern:
- lib/gpu.lisp accepts &named vulkan (was importing plugin/vulkan directly)
- demos/gpu/vecadd.lisp, demos/gpu/mandelbrot.lisp, demos/mandelbrot/mandelbrot.lisp updated to pass vulkan plugin

Tests:
- tests/elle/grpc.lisp: framing encode/decode roundtrip, edge cases
- tests/elle/websocket.lisp: URL parsing, accept key, frame codec, loopback echo
- tests/integration/elle_scripts.rs: registered grpc and websocket tests