### PR TITLE
Make let sequential (Clojure-style), 86 parallel let (#765)

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -15,8 +15,8 @@ Read these first — they cause the most bugs.
 - **Only `nil` and `false` are falsy** — `0`, `""`, and `()` are truthy.
 - **Bare = immutable; `@` = mutable** — `[1 2]` is immutable, `@[1 2]`
   is mutable.
-- **`let` is parallel; `let*` is sequential** — bindings are flat pairs
-  `[a 1 b 2]`. Use `let*` when a binding depends on a previous one.
+- **`let` is sequential** (Clojure-style) — bindings are flat pairs
+  `[a 1 b 2]`; each binding sees all previous ones. `let*` is an alias.
 
 ## Running
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -34,7 +34,7 @@ make smoke                 # run all tests (~30s)
 |------|---------|
 | [syntax](docs/syntax.md) | Literals, comments, splice, quoting, collection literals |
 | [types](docs/types.md) | Type predicates, conversions, truthiness, equality |
-| [bindings](docs/bindings.md) | def, var, let, let*, letrec, assign, scope rules |
+| [bindings](docs/bindings.md) | def, var, let, letrec, assign, scope rules |
 | [destructuring](docs/destructuring.md) | List, array, struct patterns |
 | [destructuring-advanced](docs/destructuring-advanced.md) | Rest, wildcard, nested, match integration |
 | [functions](docs/functions.md) | fn, defn, closures, higher-order, sorting |

--- a/docs/bindings.md
+++ b/docs/bindings.md
@@ -44,19 +44,18 @@ counter              # => 1
 **`assign` is not `set`.** `set` creates a set collection. `assign` mutates
 a binding.
 
-## let — parallel bindings
+## let — sequential bindings
 
-All right-hand sides are evaluated in the outer scope. No binding sees
-any other binding in the same `let`. Bindings are flat pairs inside a
-single bracket form: `[name1 value1 name2 value2 ...]`.
+Each binding sees all previous bindings (Clojure-style). Bindings are
+flat pairs inside a single bracket form: `[name1 value1 name2 value2 ...]`.
 
 Bindings are immutable unless prefixed with `@`.
 
 ```lisp
-(def outer-a 100)
-(let [a 1
-      b (+ outer-a 1)]   # b sees outer-a (100), not a
-  b)                       # => 101
+(let [x 5
+      y (* x 2)          # y sees x
+      z (+ x y)]         # z sees both x and y
+  z)                       # => 15
 ```
 
 ```lisp
@@ -65,17 +64,7 @@ Bindings are immutable unless prefixed with `@`.
   x)                      # => 10
 ```
 
-## let* — sequential bindings
-
-Each binding sees all previous bindings. Use this when later bindings
-depend on earlier ones. Bindings are immutable unless prefixed with `@`.
-
-```lisp
-(let* [x 5
-       y (* x 2)         # y sees x
-       z (+ x y)]        # z sees both x and y
-  z)                       # => 15
-```
+`let*` is kept as an alias for `let`.
 
 ## letrec — recursive bindings
 

--- a/docs/cookbook/prelude-macros.md
+++ b/docs/cookbook/prelude-macros.md
@@ -56,7 +56,7 @@ That's it. No Rust changes needed.
 | Macro | Expansion |
 |-------|-----------|
 | `defn` | `(def name (fn params body...))` |
-| `let*` | Nested `let` (one binding per level) |
+| `let*` | Alias for `let` (retained for Scheme familiarity) |
 | `->` | Thread-first |
 | `->>` | Thread-last |
 | `when` | `(if test (begin body...) nil)` |

--- a/docs/destructuring.md
+++ b/docs/destructuring.md
@@ -1,7 +1,7 @@
 # Destructuring
 
 Destructuring unpacks collections into bindings. It works in `def`, `var`,
-`let`, `let*`, `fn`, `defn`, and `match`.
+`let`, `fn`, `defn`, and `match`.
 
 Destructuring is strict — missing elements or keys signal an error.
 Extra elements are silently ignored.
@@ -93,15 +93,15 @@ target    # => :target
 (magnitude {:x 3 :y 4})   # => 7
 ```
 
-## In let / let*
+## In let
 
 ```lisp
 (let [(a b) (list 10 20)]
   (+ a b))                 # => 30
 
-# let* — sequential: second binding depends on first
-(let* [(a b) (list 3 4)
-       total (+ a b)]
+# let is sequential: second binding depends on first
+(let [(a b) (list 3 4)
+      total (+ a b)]
   total)                    # => 7
 ```
 
@@ -134,6 +134,6 @@ q     # => 2
 ## See also
 
 - [destructuring-advanced.md](destructuring-advanced.md) — guards, match patterns
-- [bindings.md](bindings.md) — def, var, let, let*, scope rules
+- [bindings.md](bindings.md) — def, var, let, letrec, scope rules
 - [match.md](match.md) — pattern matching with dispatch
 - [functions.md](functions.md) — destructuring in function params

--- a/docs/stdlib.md
+++ b/docs/stdlib.md
@@ -39,7 +39,7 @@ Macros loaded before user code. These define fundamental control flow:
 
 ```text
 defn        function definition sugar
-let*        sequential bindings
+let*        alias for let (sequential bindings)
 ->          thread-first
 ->>         thread-last
 when        one-armed conditional

--- a/prelude.lisp
+++ b/prelude.lisp
@@ -10,8 +10,8 @@
 (defmacro defn (name params & body)
   `(def ,name (fn ,params ,;body)))
 
-## let* - sequential bindings (flat pairs)
-## (let* [a 1 b a] body...) => (let [a 1] (let [b a] (begin body...)))
+## let* - alias for let (retained for Scheme familiarity)
+## let is already sequential; let* expands to nested single-binding lets
 (defmacro let* (bindings & body)
   (if (empty? bindings)
     `(begin ,;body)

--- a/src/hir/AGENTS.md
+++ b/src/hir/AGENTS.md
@@ -111,12 +111,13 @@ Lowerer (&BindingArena) — read-only access to binding metadata
    etc. The type system enforces this: the analyzer holds `&mut BindingArena`,
    the lowerer holds `&BindingArena`.
 
-10. **`Destructure` decomposes values into pattern bindings.** 
+10. **`Destructure` decomposes values into pattern bindings.**
     `HirKind::Destructure { pattern: HirPattern, value: Box<Hir> }` is
     produced by the analyzer for `def`, `var`, `let`, and `fn` parameter
     destructuring. The pattern's leaf `Var` bindings are created in the
-    current scope. `let*` is desugared to nested `let` in the expander,
-    so the analyzer never sees `let*`.
+    current scope. `let` is sequential (Clojure-style): multi-binding lets
+    are desugared to nested single-binding lets by the analyzer.
+    `let*` is a prelude macro alias that also desugars to nested `let`.
 
 11. **Destructured bindings use silent nil semantics.** Missing list/@array/@struct
      elements produce `nil`, not errors. Wrong-type values produce `nil`

--- a/src/hir/analyze/binding.rs
+++ b/src/hir/analyze/binding.rs
@@ -24,20 +24,9 @@ impl<'a> Analyzer<'a> {
             }
         })?;
 
-        // Phase 1: Analyze all value expressions in the OUTER scope.
-        // For destructuring bindings, we record the pattern syntax for Phase 2.
-        // Bindings are flat pairs: [name1 value1 name2 value2 ...]
-        struct TransientState {
-            import_projection: Option<HashMap<String, Signal>>,
-            squelch_signal: Option<Signal>,
-        }
-        enum LetBinding<'s> {
-            Simple(&'s str, Vec<ScopeId>, Hir, TransientState),
-            Destructure(&'s Syntax, Hir),
-        }
-        let mut analyzed = Vec::new();
-        let mut signal = Signal::silent();
-
+        // Sequential bindings (Clojure-style): each binding sees all
+        // previous bindings. Implemented by nesting single-binding lets.
+        // (let [a 1 b (+ a 1)] body) → (let [a 1] (let [b (+ a 1)] body))
         if bindings_syntax.len() % 2 != 0 {
             return Err(format!(
                 "{}: let bindings must have an even number of forms (name/value pairs)",
@@ -45,129 +34,103 @@ impl<'a> Analyzer<'a> {
             ));
         }
 
-        let mut i = 0;
-        while i < bindings_syntax.len() {
-            let name_syn = &bindings_syntax[i];
-            let value_syn = &bindings_syntax[i + 1];
+        self.analyze_sequential_let(bindings_syntax, &items[2..], span)
+    }
 
-            let value = self.analyze_expr(value_syn)?;
-            signal = signal.combine(value.signal);
-
-            // Capture transient state set during analyze_expr
-            let transient = TransientState {
-                import_projection: self.last_import_projection.take(),
-                squelch_signal: self.last_squelch_signal.take(),
-            };
-
-            if let Some(name) = name_syn.as_symbol() {
-                analyzed.push(LetBinding::Simple(
-                    name,
-                    name_syn.scopes.clone(),
-                    value,
-                    transient,
-                ));
-            } else if Self::is_destructure_pattern(name_syn) {
-                analyzed.push(LetBinding::Destructure(name_syn, value));
+    /// Recursively build nested single-binding lets for sequential semantics.
+    /// Each binding pair becomes its own Let scope so the next pair sees it.
+    fn analyze_sequential_let(
+        &mut self,
+        bindings: &[Syntax],
+        body_items: &[Syntax],
+        span: Span,
+    ) -> Result<Hir, String> {
+        if bindings.is_empty() {
+            // Base case: no more bindings — analyze body
+            return if body_items.is_empty() {
+                Ok(Hir::silent(HirKind::Nil, span))
             } else {
-                return Err(format!(
-                    "{}: let binding name must be a symbol, list, or array",
-                    span
-                ));
-            }
-            i += 2;
+                self.analyze_body(body_items, span)
+            };
         }
 
-        // Phase 2: Push scope and create all bindings
+        let name_syn = &bindings[0];
+        let value_syn = &bindings[1];
+        let rest = &bindings[2..];
+
+        // Analyze this single binding using the original (non-sequential)
+        // let machinery: push scope, analyze value in outer scope, create
+        // binding, then analyze inner body (which is the rest of the chain).
         self.push_scope(false);
 
-        let mut bindings = Vec::new();
-        let mut destructures = Vec::new();
+        let value = self.analyze_expr(value_syn)?;
+        let mut signal = value.signal;
 
-        for item in analyzed {
-            match item {
-                LetBinding::Simple(name, name_scopes, value, transient) => {
-                    let (actual_name, is_mutable) = super::strip_at_prefix(name);
-                    let binding = self.bind(actual_name, &name_scopes, BindingScope::Local);
-                    if self.immutable_by_default && !is_mutable {
-                        self.arena.get_mut(binding).is_immutable = true;
-                    }
-                    // Track signal and arity for interprocedural analysis
-                    if let HirKind::Lambda {
-                        params: lambda_params,
-                        num_required,
-                        rest_param,
-                        inferred_signals,
-                        ..
-                    } = &value.kind
-                    {
-                        self.signal_env.insert(binding, *inferred_signals);
-                        let arity = Arity::for_lambda(
-                            rest_param.is_some(),
-                            *num_required,
-                            lambda_params.len(),
-                        );
-                        self.arity_env.insert(binding, arity);
-                    }
-                    // Apply import projection and squelch signal
-                    if let Some(proj) = transient.import_projection {
-                        self.projection_env.insert(binding, proj);
-                    }
-                    if let Some(sig) = transient.squelch_signal {
-                        self.signal_env.insert(binding, sig);
-                    }
-                    bindings.push((binding, value));
-                }
-                LetBinding::Destructure(pattern_syntax, value) => {
-                    // Create a temp binding for the value
-                    let tmp = self.bind("__destructure_tmp", &[], BindingScope::Local);
-                    bindings.push((tmp, value));
-                    // Analyze the pattern (creates leaf bindings in this scope)
-                    // Immutable by default; individual leaves with @ opt into mutability
-                    let pattern = self.analyze_destructure_pattern(
-                        pattern_syntax,
-                        BindingScope::Local,
-                        self.immutable_by_default,
-                        &span,
-                    )?;
-                    destructures.push((pattern, tmp));
-                }
+        let mut let_bindings = Vec::new();
+        let mut destructure = None;
+
+        if let Some(name) = name_syn.as_symbol() {
+            let (actual_name, is_mutable) = super::strip_at_prefix(name);
+            let binding = self.bind(actual_name, &name_syn.scopes, BindingScope::Local);
+            if self.immutable_by_default && !is_mutable {
+                self.arena.get_mut(binding).is_immutable = true;
             }
+            if let HirKind::Lambda {
+                params: lambda_params,
+                num_required,
+                rest_param,
+                inferred_signals,
+                ..
+            } = &value.kind
+            {
+                self.signal_env.insert(binding, *inferred_signals);
+                let arity =
+                    Arity::for_lambda(rest_param.is_some(), *num_required, lambda_params.len());
+                self.arity_env.insert(binding, arity);
+            }
+            self.apply_transient_binding_state(binding);
+            let_bindings.push((binding, value));
+        } else if Self::is_destructure_pattern(name_syn) {
+            let tmp = self.bind("__destructure_tmp", &[], BindingScope::Local);
+            let_bindings.push((tmp, value));
+            let pattern = self.analyze_destructure_pattern(
+                name_syn,
+                BindingScope::Local,
+                self.immutable_by_default,
+                &span,
+            )?;
+            destructure = Some((pattern, tmp));
+        } else {
+            return Err(format!(
+                "{}: let binding name must be a symbol, list, or array",
+                span
+            ));
         }
 
-        // Analyze body expressions (empty body returns nil)
-        let body = if items.len() > 2 {
-            self.analyze_body(&items[2..], span.clone())?
-        } else {
-            Hir::silent(HirKind::Nil, span.clone())
-        };
-        signal = signal.combine(body.signal);
+        // Recursively analyze remaining bindings + body as the inner expression
+        let inner = self.analyze_sequential_let(rest, body_items, span.clone())?;
+        signal = signal.combine(inner.signal);
 
         self.pop_scope();
 
-        // If there are destructures, wrap the body with Destructure nodes
-        let final_body = if destructures.is_empty() {
-            body
+        // Wrap with destructure if needed
+        let final_body = if let Some((pattern, tmp)) = destructure {
+            let destr = Hir::silent(
+                HirKind::Destructure {
+                    pattern,
+                    value: Box::new(Hir::silent(HirKind::Var(tmp), span.clone())),
+                    strict: true,
+                },
+                span.clone(),
+            );
+            Hir::new(HirKind::Begin(vec![destr, inner]), span.clone(), signal)
         } else {
-            let mut exprs: Vec<Hir> = destructures
-                .into_iter()
-                .map(|(pattern, tmp)| {
-                    Hir::silent(
-                        HirKind::Destructure {
-                            pattern,
-                            value: Box::new(Hir::silent(HirKind::Var(tmp), span.clone())),
-                            strict: true,
-                        },
-                        span.clone(),
-                    )
-                })
-                .collect();
-            exprs.push(body);
-            Hir::new(HirKind::Begin(exprs), span.clone(), signal)
+            inner
         };
 
         Ok(Hir::new(
             HirKind::Let {
-                bindings,
+                bindings: let_bindings,
                 body: Box::new(final_body),
             },
             span,

--- a/src/syntax/expand/AGENTS.md
+++ b/src/syntax/expand/AGENTS.md
@@ -6,7 +6,7 @@ Hygienic macro expansion: macro definition, macro calls, quasiquote, and introsp
 
 - Expand macros with hygiene (scope sets prevent accidental capture)
 - Handle `defmacro` definitions
-- Desugar `let*` to nested `let`
+- Expand `let*` (alias for `let`, defined in prelude)
 - Desugar `defn` to `(def name (fn ...))`
 - Expand quasiquote to runtime list construction
 - Provide `macro?` and `expand-macro` introspection
@@ -35,7 +35,7 @@ Syntax (from reader)
 Expander
     ├─► load prelude macros (when, unless, try, protect, defer, with, etc.)
     ├─► desugar defn to (def name (fn params body...))
-    ├─► desugar let* to nested let (one binding at a time)
+    ├─► expand let* (prelude alias for let)
     ├─► check for macro calls
     ├─► compile & eval macro body in VM via pipeline::eval_syntax()
     ├─► convert result Value back to Syntax via from_value()
@@ -119,7 +119,7 @@ The `Expander` maintains:
 
 The standard prelude (`prelude.lisp`) defines:
 - `defn` — shorthand for `(def name (fn ...))`
-- `let*` — sequential let bindings (desugared to nested `let`)
+- `let*` — alias for `let` (retained for Scheme familiarity)
 - `->` — thread-first macro
 - `->>` — thread-last macro
 - `as->` — thread with explicit binding name: `(as-> val x (f x) (g x))`

--- a/src/syntax/expand/README.md
+++ b/src/syntax/expand/README.md
@@ -14,7 +14,7 @@ The macro expansion module transforms macro calls into their expanded forms usin
 The expander loads prelude macros before user code:
 
 - `defn` — Define a function (desugars to `def` + `fn`)
-- `let*` — Sequential let bindings (desugars to nested `let`)
+- `let*` — Alias for `let` (retained for Scheme familiarity)
 - `when` — Conditional without else (desugars to `if`)
 - `unless` — Conditional with inverted test (desugars to `if`)
 - `try`/`catch` — Exception handling

--- a/tests/elle/flatlet.lisp
+++ b/tests/elle/flatlet.lisp
@@ -1,28 +1,41 @@
 (elle/epoch 8)
-## Epoch 7: flat let bindings
+## Flat let bindings
 ##
-## Exercises flat (Clojure-style) binding syntax for let, let*, letrec,
+## Exercises flat (Clojure-style) binding syntax for let, letrec,
 ## if-let, and when-let. All binding pairs are laid out flat inside a
 ## single bracket form: [name1 value1 name2 value2 ...].
+##
+## let is sequential (like Clojure): each binding sees previous ones.
+## let* is kept as an alias.
 
 ## ── single binding ──────────────────────────────────────────────────
 (assert (= (let [x 1] x) 1) "flat let single binding")
 
-## ── multiple bindings ────────────────────��──────────────────────────
+## ── multiple bindings ───────────────────────────────────────────────
 (assert (= (let [a 1 b 2] (+ a b)) 3) "flat let multi binding")
 
-## ── destructuring ────────────────────────��──────────────────────────
+## ── destructuring ───────────────────────────────────────────────────
 (assert (= (let [[x y] [3 4]] (+ x y)) 7) "flat let destructuring")
 
-## ── let* sequential ─────────────────���───────────────────────────────
-(assert (= (let* [a 1 b (+ a 1)] b) 2) "flat let* sequential")
+## ── let is sequential (Clojure-style) ───────────────────────────────
+(assert (= (let [a 1 b (+ a 1)] b) 2) "let sequential pair")
 
-(assert (= (let* [x 5
-                   y (* x 2)
-                   z (+ x y)]
+(assert (= (let [x 5
+                  y (* x 2)
+                  z (+ x y)]
              z)
            15)
-  "flat let* triple")
+  "let sequential triple")
+
+## ── let with destructuring + sequential ─────────────────────────────
+(assert (= (let [[a b] [10 20]
+                 c (+ a b)]
+             c)
+           30)
+  "let destructure + sequential binding")
+
+## ── let* still works (alias) ────────────────────────────────────────
+(assert (= (let* [a 1 b (+ a 1)] b) 2) "let* still works")
 
 ## ── letrec mutual recursion ────────────────────────────────────────
 (letrec [is-even (fn [n]
@@ -32,22 +45,15 @@
   (assert (is-even 4) "flat letrec mutual recursion even")
   (assert (not (is-even 3)) "flat letrec mutual recursion odd"))
 
-## ── if-let ─────────────────────────���────────────────────────────────
+## ── if-let ──────────────────────────────────────────────────────────
 (assert (= (if-let [x 42] x :nope) 42) "flat if-let truthy")
 (assert (= (if-let [x nil] x :nope) :nope) "flat if-let falsy")
 
-## ── when-let ────────────��────────────────────────────��──────────────
+## ── when-let ────────────────────────────────────────────────────────
 (assert (= (when-let [x 10] (+ x 1)) 11) "flat when-let truthy")
 (assert (nil? (when-let [x nil] (+ x 1))) "flat when-let falsy")
 
-## ── let with destructuring + extra bindings ──────────────────��──────
-(assert (= (let* [[a b] [10 20]
-                  c (+ a b)]
-             c)
-           30)
-  "flat let* destructure + extra binding")
-
-## ── nested let ──────────────────────────────────────────────────��───
+## ── nested let ──────────────────────────────────────────────────────
 (assert (= (let [x 1]
              (let [y (+ x 1)]
                (+ x y)))

--- a/tests/elle/pipeline.lisp
+++ b/tests/elle/pipeline.lisp
@@ -121,9 +121,9 @@
 
 ## === Let Binding Semantics ===
 
-(assert (= (let [x 10 y 20] (+ x y)) 30) "let parallel binding")
+(assert (= (let [x 10 y 20] (+ x y)) 30) "let independent bindings")
 
-(assert (= (begin (def @x 999) (let [x 10 y x] y)) 999) "let parallel binding shadowing")
+(assert (= (begin (def @x 999) (let [x 10 y x] y)) 10) "let sequential binding sees previous")
 
 (assert (= (begin (def @x 999) (let* [x 10 y x] y)) 10) "let* sequential binding")
 


### PR DESCRIPTION
let now binds sequentially: each binding sees all previous ones. Implemented by desugaring multi-binding lets into nested single-binding lets in the analyzer. let* kept as a prelude macro alias.