### PR TITLE
Call-scoped arena reclamation for backtracking patterns (#765)

### DIFF
--- a/src/lir/lower/AGENTS.md
+++ b/src/lir/lower/AGENTS.md
@@ -113,6 +113,26 @@ For `block`: conditions 1-4 plus all break values targeting this block are safe 
 
 **Compile-time scope stats** (`ScopeStats`): The lowerer counts how many scopes were analyzed, how many qualified for scope allocation, and the first-failing condition for each rejected scope (captured, suspends, unsafe-result, outward-set, break). Access via `lowerer.scope_stats()` after `lower()` completes. Pass `--stats` to the elle CLI to print the aggregated stats to stderr on program exit (alongside JIT stats).
 
+**`callee_return_safe` fixpoint analysis:**
+
+`precompute_return_safe()` determines whether each function's return value is
+provably non-heap-allocated (returns immediates, Vars, or results of other
+return-safe calls). Uses `result_is_safe_extended()` — identical to
+`result_is_safe()` but additionally trusts calls to functions already proven
+return-safe. This enables `tail_arg_is_safe_extended()` to see through call
+boundaries that `call_result_is_safe()` conservatively rejects (e.g.
+letrec-bound functions). Critical for backtracking patterns like nqueens where
+a non-tail call to a return-safe function appears inside an `if` in a
+tail-call argument.
+
+**`tail_arg_is_safe_extended`:**
+
+Extended version of `tail_arg_is_safe` that recurses into control flow (If,
+Cond, Begin, And, Or, Let, Letrec, Block, Match, While, Parameterize) and
+checks `callee_result_immediate` or `callee_return_safe` for Call expressions
+at any depth. Used by `body_escapes_heap_values` (rotation safety) when the
+standard flat check fails.
+
 **Known limitations and why they exist:**
 
 - **`suspends` (condition 2)**: Any let body that calls a polymorphic-signal
@@ -122,8 +142,9 @@ For `block`: conditions 1-4 plus all break values targeting this block are safe 
 
 - **`unsafe-result` (condition 3)**: Calls to user-defined functions fail
   `result_is_safe` because we don't know their return type at the call site.
-  Fixing this requires return-type inference or a return-type annotation system.
-  The whitelist in `IMMEDIATE_PRIMITIVES` covers built-in primitives only.
+  `callee_return_safe` partially mitigates this for rotation-safety analysis
+  and call-scoped reclamation, but `result_is_safe` remains conservative for
+  let-scope allocation decisions.
 
 These are accepted limitations. The analysis is maximally conservative to
 avoid use-after-free. False negatives (missed optimizations) are preferable

--- a/src/lir/lower/escape.rs
+++ b/src/lir/lower/escape.rs
@@ -57,6 +57,26 @@ impl<'a> Lowerer<'a> {
     /// Returns `false` for anything that might produce a heap-allocated
     /// value: non-intrinsic calls, lambdas, strings, quotes, etc.
     pub(super) fn result_is_safe(&self, hir: &Hir, scope_bindings: &[(Binding, &Hir)]) -> bool {
+        self.result_is_safe_impl(hir, scope_bindings, false)
+    }
+
+    /// Extended version that also trusts calls to `callee_return_safe`
+    /// functions. Used only by `precompute_return_safe` for fixpoint
+    /// iteration — not for general scope allocation decisions.
+    pub(super) fn result_is_safe_extended(
+        &self,
+        hir: &Hir,
+        scope_bindings: &[(Binding, &Hir)],
+    ) -> bool {
+        self.result_is_safe_impl(hir, scope_bindings, true)
+    }
+
+    fn result_is_safe_impl(
+        &self,
+        hir: &Hir,
+        scope_bindings: &[(Binding, &Hir)],
+        trust_return_safe: bool,
+    ) -> bool {
         match &hir.kind {
             // Literals: all immediates
             HirKind::Int(_)
@@ -72,7 +92,9 @@ impl<'a> Lowerer<'a> {
             HirKind::Var(binding) => {
                 match scope_bindings.iter().find(|(b, _)| b == binding) {
                     None => true, // outer binding — safe
-                    Some((_, init)) => self.result_is_safe(init, scope_bindings),
+                    Some((_, init)) => {
+                        self.result_is_safe_impl(init, scope_bindings, trust_return_safe)
+                    }
                 }
             }
 
@@ -82,8 +104,8 @@ impl<'a> Lowerer<'a> {
                 else_branch,
                 ..
             } => {
-                self.result_is_safe(then_branch, scope_bindings)
-                    && self.result_is_safe(else_branch, scope_bindings)
+                self.result_is_safe_impl(then_branch, scope_bindings, trust_return_safe)
+                    && self.result_is_safe_impl(else_branch, scope_bindings, trust_return_safe)
             }
 
             HirKind::Begin(exprs) => {
@@ -123,7 +145,7 @@ impl<'a> Lowerer<'a> {
                         _ => {}
                     }
                 }
-                self.result_is_safe(last, &extended)
+                self.result_is_safe_impl(last, &extended, trust_return_safe)
             }
 
             HirKind::Cond {
@@ -131,12 +153,14 @@ impl<'a> Lowerer<'a> {
                 else_branch,
             } => {
                 // All clause bodies must be safe
-                let clauses_safe = clauses
-                    .iter()
-                    .all(|(_, body)| self.result_is_safe(body, scope_bindings));
+                let clauses_safe = clauses.iter().all(|(_, body)| {
+                    self.result_is_safe_impl(body, scope_bindings, trust_return_safe)
+                });
                 // Missing else produces nil (safe); present else must be safe
                 let else_safe = match else_branch {
-                    Some(branch) => self.result_is_safe(branch, scope_bindings),
+                    Some(branch) => {
+                        self.result_is_safe_impl(branch, scope_bindings, trust_return_safe)
+                    }
                     None => true,
                 };
                 clauses_safe && else_safe
@@ -144,7 +168,9 @@ impl<'a> Lowerer<'a> {
 
             HirKind::And(exprs) | HirKind::Or(exprs) => {
                 // Short-circuit: any sub-expression could be the result
-                exprs.iter().all(|e| self.result_is_safe(e, scope_bindings))
+                exprs
+                    .iter()
+                    .all(|e| self.result_is_safe_impl(e, scope_bindings, trust_return_safe))
             }
 
             // Tail call: replaces the frame, so the scope's allocations are
@@ -157,14 +183,34 @@ impl<'a> Lowerer<'a> {
                 func,
                 args,
             } => {
-                self.result_is_safe(func, scope_bindings)
-                    && args
-                        .iter()
-                        .all(|a| self.result_is_safe(&a.expr, scope_bindings))
+                self.result_is_safe_impl(func, scope_bindings, trust_return_safe)
+                    && args.iter().all(|a| {
+                        self.result_is_safe_impl(&a.expr, scope_bindings, trust_return_safe)
+                    })
             }
 
             // Non-tail calls that return immediates
-            HirKind::Call { func, args, .. } => self.call_result_is_safe(func, args),
+            HirKind::Call { func, args, .. } => {
+                if self.call_result_is_safe(func, args) {
+                    return true;
+                }
+                // Extended mode: also trust calls to callee_return_safe functions.
+                // These are user functions proven (by fixpoint) to never return
+                // freshly heap-allocated values.
+                if trust_return_safe {
+                    if let HirKind::Var(binding) = &func.kind {
+                        if self
+                            .callee_return_safe
+                            .get(binding)
+                            .copied()
+                            .unwrap_or(false)
+                        {
+                            return true;
+                        }
+                    }
+                }
+                false
+            }
 
             // Nested let/letrec: the result is the body's result.
             // Extend scope_bindings with the inner let's bindings so that
@@ -174,7 +220,7 @@ impl<'a> Lowerer<'a> {
             HirKind::Let { bindings, body } | HirKind::Letrec { bindings, body } => {
                 let mut extended: Vec<(Binding, &Hir)> = scope_bindings.to_vec();
                 extended.extend(bindings.iter().map(|(b, init)| (*b, init)));
-                self.result_is_safe(body, &extended)
+                self.result_is_safe_impl(body, &extended, trust_return_safe)
             }
 
             // Nested block: the result is either the last expression or a
@@ -182,7 +228,7 @@ impl<'a> Lowerer<'a> {
             // Blocks introduce no bindings, so scope_bindings is unchanged.
             HirKind::Block { block_id, body, .. } => {
                 let last_safe = match body.last() {
-                    Some(last) => self.result_is_safe(last, scope_bindings),
+                    Some(last) => self.result_is_safe_impl(last, scope_bindings, trust_return_safe),
                     None => true, // empty block → nil → safe
                 };
                 last_safe && self.all_break_values_safe(body, *block_id, scope_bindings)
@@ -190,9 +236,9 @@ impl<'a> Lowerer<'a> {
 
             // Match: all arm bodies must produce safe results.
             // Exactly one arm executes, analogous to If/Cond.
-            HirKind::Match { arms, .. } => arms
-                .iter()
-                .all(|(_, _, body)| self.result_is_safe(body, scope_bindings)),
+            HirKind::Match { arms, .. } => arms.iter().all(|(_, _, body)| {
+                self.result_is_safe_impl(body, scope_bindings, trust_return_safe)
+            }),
 
             // While always returns nil (an immediate).
             HirKind::While { .. } => true,
@@ -209,7 +255,9 @@ impl<'a> Lowerer<'a> {
             HirKind::Break { .. } => true,
 
             // Parameterize: result is the body's result
-            HirKind::Parameterize { body, .. } => self.result_is_safe(body, scope_bindings),
+            HirKind::Parameterize { body, .. } => {
+                self.result_is_safe_impl(body, scope_bindings, trust_return_safe)
+            }
 
             // String constants live in the constant pool (LoadConst),
             // not on the fiber heap. Safe to return from a scope.
@@ -246,7 +294,102 @@ impl<'a> Lowerer<'a> {
                 }
             }
         }
-        false
+        // Fall back to extended check: recurse into control flow and
+        // trust callee_return_safe for Call nodes at any depth.
+        self.tail_arg_is_safe_extended(hir)
+    }
+
+    /// Extended tail-arg safety check that recurses into control flow
+    /// (If, Cond, Begin, And, Or, Let, Letrec, Block, Match, While,
+    /// Parameterize) and checks `callee_result_immediate` or
+    /// `callee_return_safe` for Call expressions at any depth.
+    ///
+    /// This handles the nqueens pattern where a tail-call argument is
+    /// `(if cond (search ...) count)` — the If wraps a Call that returns
+    /// an immediate, but `result_is_safe` can't see through the Call
+    /// boundary for letrec-bound callees.
+    fn tail_arg_is_safe_extended(&self, hir: &Hir) -> bool {
+        match &hir.kind {
+            // Literals: always safe
+            HirKind::Int(_)
+            | HirKind::Float(_)
+            | HirKind::Bool(_)
+            | HirKind::Nil
+            | HirKind::Keyword(_)
+            | HirKind::EmptyList
+            | HirKind::String(_) => true,
+
+            // Var: safe (pre-existing value, not freshly allocated)
+            HirKind::Var(_) => true,
+
+            // Control flow: recurse into all result positions
+            HirKind::If {
+                then_branch,
+                else_branch,
+                ..
+            } => {
+                self.tail_arg_is_safe_extended(then_branch)
+                    && self.tail_arg_is_safe_extended(else_branch)
+            }
+            HirKind::Cond {
+                clauses,
+                else_branch,
+            } => {
+                clauses
+                    .iter()
+                    .all(|(_, body)| self.tail_arg_is_safe_extended(body))
+                    && else_branch
+                        .as_ref()
+                        .is_none_or(|b| self.tail_arg_is_safe_extended(b))
+            }
+            HirKind::Begin(exprs) => exprs
+                .last()
+                .is_some_and(|e| self.tail_arg_is_safe_extended(e)),
+            HirKind::And(exprs) | HirKind::Or(exprs) => {
+                exprs.iter().all(|e| self.tail_arg_is_safe_extended(e))
+            }
+            HirKind::Let { body, .. } | HirKind::Letrec { body, .. } => {
+                self.tail_arg_is_safe_extended(body)
+            }
+            HirKind::Block { body, .. } => body
+                .last()
+                .is_some_and(|e| self.tail_arg_is_safe_extended(e)),
+            HirKind::Match { arms, .. } => arms
+                .iter()
+                .all(|(_, _, body)| self.tail_arg_is_safe_extended(body)),
+            HirKind::While { .. } | HirKind::Destructure { .. } => true, // returns nil
+            HirKind::Parameterize { body, .. } => self.tail_arg_is_safe_extended(body),
+
+            // Call: check callee_result_immediate OR callee_return_safe
+            HirKind::Call { func, args, .. } => {
+                // Intrinsics and whitelisted primitives
+                if self.call_result_is_safe(func, args) {
+                    return true;
+                }
+                if let HirKind::Var(binding) = &func.kind {
+                    if self
+                        .callee_result_immediate
+                        .get(binding)
+                        .copied()
+                        .unwrap_or(false)
+                    {
+                        return true;
+                    }
+                    if self
+                        .callee_return_safe
+                        .get(binding)
+                        .copied()
+                        .unwrap_or(false)
+                    {
+                        return true;
+                    }
+                }
+                false
+            }
+
+            // Everything else: conservatively unsafe
+            _ => false,
+        }
     }
 
     pub(super) fn call_result_is_safe(&self, func: &Hir, args: &[CallArg]) -> bool {

--- a/src/lir/lower/mod.rs
+++ b/src/lir/lower/mod.rs
@@ -238,6 +238,14 @@ pub struct Lowerer<'a> {
     /// lowering so that `body_escapes_heap_values` can check callees
     /// transitively: a call to a rotation-safe function doesn't escape.
     callee_rotation_safe: HashMap<Binding, bool>,
+    /// Binding → return_safe for function definitions.
+    /// A function is return-safe if its body never returns a freshly
+    /// heap-allocated value (returns immediates, Vars, or results of
+    /// other return-safe calls). Precomputed via fixpoint iteration.
+    /// Used by `tail_arg_is_safe_extended` and `result_is_safe_extended`
+    /// to see through call boundaries that `call_result_is_safe` rejects
+    /// (e.g. letrec-bound functions).
+    callee_return_safe: HashMap<Binding, bool>,
     /// Binding → result_is_immediate for function definitions.
     /// Precomputed via fixpoint iteration so that `call_result_is_safe`
     /// can identify user functions that always return immediates.
@@ -300,6 +308,7 @@ impl<'a> Lowerer<'a> {
             immediate_primitives: FxHashSet::default(),
             mutating_primitives: FxHashSet::default(),
             callee_rotation_safe: HashMap::new(),
+            callee_return_safe: HashMap::new(),
             callee_result_immediate: HashMap::new(),
             callee_return_params: HashMap::new(),
             callee_rest_index: HashMap::new(),
@@ -371,12 +380,13 @@ impl<'a> Lowerer<'a> {
 
         // Precompute callee properties for scope allocation decisions.
         // These scan the HIR for lambda defs and record per-binding
-        // properties (result_is_immediate, return_params, rotation_safe)
-        // which checks callee_result_immediate; rotation_safety depends on
-        // the callee having been lowered, so it reads from closures[].
+        // properties (result_is_immediate, return_params, return_safe,
+        // rotation_safe). Order matters: return_safe depends on nothing;
+        // rotation_safety depends on return_safe (via tail_arg_is_safe_extended).
         self.precompute_result_immediate(hir);
         self.precompute_return_params(hir);
         self.precompute_rest_index(hir);
+        self.precompute_return_safe(hir);
         self.precompute_rotation_safety(hir);
 
         let result_reg = self.lower_expr(hir)?;
@@ -821,6 +831,46 @@ impl<'a> Lowerer<'a> {
                 let was_imm = self.callee_result_immediate[&binding];
                 if was_imm && !is_imm {
                     self.callee_result_immediate.insert(binding, false);
+                    changed = true;
+                }
+            }
+            if !changed {
+                break;
+            }
+        }
+    }
+
+    /// Precompute `callee_return_safe` for all function definitions.
+    ///
+    /// A function is return-safe if its body's result is provably non-heap-
+    /// allocated, considering calls to other return-safe functions as safe.
+    /// Uses `result_is_safe_extended` (which trusts `callee_return_safe`)
+    /// in a fixpoint iteration: seed all functions as return-safe, then
+    /// iterate until stable. Only transitions safe→unsafe (monotone).
+    ///
+    /// This enables `tail_arg_is_safe_extended` to see through call
+    /// boundaries that `call_result_is_safe` conservatively rejects
+    /// (e.g. letrec-bound functions like nqueens' `search`).
+    fn precompute_return_safe(&mut self, hir: &Hir) {
+        let mut defs: Vec<(Binding, &Hir)> = Vec::new();
+        Self::collect_lambda_defs(hir, &mut defs);
+        if defs.is_empty() {
+            return;
+        }
+
+        // Seed: all functions optimistically return-safe.
+        for &(binding, _) in &defs {
+            self.callee_return_safe.insert(binding, true);
+        }
+
+        // Iterate until stable.
+        loop {
+            let mut changed = false;
+            for &(binding, body) in &defs {
+                let is_safe = self.result_is_safe_extended(body, &[]);
+                let was_safe = self.callee_return_safe[&binding];
+                if was_safe && !is_safe {
+                    self.callee_return_safe.insert(binding, false);
                     changed = true;
                 }
             }

--- a/tests/integration/escape.rs
+++ b/tests/integration/escape.rs
@@ -1865,4 +1865,63 @@ fn call_scoped_does_not_wrap_intrinsics() {
     assert!(!closure_has_region(source));
 }
 
+// ── callee_return_safe / tail_arg_is_safe_extended ──────────────────────────
+
+#[test]
+fn call_scoped_nqueens_search_gets_region() {
+    // Simplified nqueens pattern: try-col self-tail-calls with arg 4
+    // being (if cond (search ... (cons ...) ...) count). The search call
+    // is non-tail inside an If — before callee_return_safe analysis,
+    // tail_arg_is_safe can't see through the If to prove the arg safe,
+    // so try-col is NOT rotation-safe, and search's call doesn't get
+    // call-scoped reclamation.
+    //
+    // After the fix: callee_return_safe[search] = true (search returns
+    // immediates or tail-calls try-col with Var args), tail_arg_is_safe_extended
+    // recurses into the If and trusts callee_return_safe, try-col becomes
+    // rotation-safe, and the (search ... (cons col queens) ...) call
+    // gets RegionEnter/RegionExitCall.
+    let source = r#"(letrec
+        [search (fn [n row queens count]
+          (if (= row n) (+ count 1)
+            (try-col n 0 queens row count)))
+         try-col (fn [n col queens row count]
+          (if (= col n) count
+            (try-col n (+ col 1) queens row
+              (if (< col row)
+                (search n (+ row 1) (cons col queens) count)
+                count))))]
+        (search 5 0 (list) 0))
+    "#;
+    assert!(
+        closure_bytecode_contains(source, "RegionExitCall"),
+        "search call with heap arg (cons col queens) should get call-scoped reclamation"
+    );
+}
+
+#[test]
+fn return_safe_mutual_recursion_enables_rotation_safety() {
+    // f and g are mutually recursive. Both return immediates (ints).
+    // g calls f non-tail inside an If in a self-tail-call argument.
+    // callee_return_safe should prove both return-safe, enabling
+    // rotation safety for g, which enables call-scoped reclamation
+    // for the (f (cons ...)) call.
+    //
+    // Key: g's self-tail-call args are (x, <if>). x is a Var (safe).
+    // The If wraps a call to f which is return-safe — tail_arg_is_safe_extended
+    // recurses into the If and trusts callee_return_safe[f].
+    let source = r#"(letrec
+        [f (fn [x count]
+          (if (empty? x) count
+            (g x count)))
+         g (fn [x count]
+          (g x (if true (f (cons 1 x) (+ count 1)) count)))]
+        (g (list 1 2 3) 0))
+    "#;
+    assert!(
+        closure_bytecode_contains(source, "RegionExitCall"),
+        "f call with heap arg should get call-scoped reclamation after return-safe analysis"
+    );
+}
+
 


### PR DESCRIPTION
Add callee_return_safe fixpoint analysis and tail_arg_is_safe_extended to enable RegionEnter/RegionExitCall emission around non-tail calls to return-safe functions inside control flow in tail-call arguments.

The nqueens demo allocates ~13.7M cons cells via (cons col queens) in try-col's self-tail-call argument.  Before this change, the compiler cannot prove search is return-safe (letrec binding fails call_result_is_safe), so try-col is not rotation-safe, and the search call never gets call-scoped reclamation.

Three changes:

1. precompute_return_safe() — fixpoint over result_is_safe_extended() which trusts callee_return_safe entries for non-tail Call arms.

2. result_is_safe refactored to result_is_safe_impl(trust_return_safe) so the extended mode threads through all recursive positions.

3. tail_arg_is_safe_extended() — recurses into If/Cond/Begin/Match/etc checking callee_result_immediate OR callee_return_safe for Call nodes at any depth, enabling rotation-safety for try-col.

Result: N=12 nqueens RSS drops from ~1 GB to 172 MB (--jit=off). 856K RegionExitCall instructions execute per run.