### PR TITLE
Fix h2 writer shutdown race; add list_to_array plugin ABI

### DIFF
--- a/elle-plugin/src/lib.rs
+++ b/elle-plugin/src/lib.rs
@@ -204,6 +204,9 @@ elle_api! {
     fn array_len(ElleValue) -> isize;
     fn array_get(ElleValue, usize) -> ElleValue;
 
+    // ── List → array ──────────────────────────────────────────────
+    fn list_to_array(ElleValue) -> ElleValue;
+
     // ── Equality ──────────────────────────────────────────────────
     fn value_eq(ElleValue, ElleValue) -> bool;
 
@@ -400,6 +403,17 @@ impl Api {
 
     pub fn get_array_item(&self, v: ElleValue, idx: usize) -> ElleValue {
         (self.array_get)(v, idx)
+    }
+
+    /// Convert a proper list (cons chain) to an immutable array.
+    /// Returns `None` if the value is not a proper list.
+    pub fn list_to_array(&self, v: ElleValue) -> Option<ElleValue> {
+        let result = (self.list_to_array)(v);
+        if self.check_nil(result) {
+            None
+        } else {
+            Some(result)
+        }
     }
 
     pub fn get_struct_field(&self, v: ElleValue, key: &str) -> ElleValue {

--- a/lib/http2.lisp
+++ b/lib/http2.lisp
@@ -154,17 +154,20 @@
       (forever
         (let [item (q:take)]
           (when (= item :shutdown) (break nil))
-          (let [[ok? _] (protect
-            (begin
-              (let [[ftype flags sid payload] item]
-                (frame:write-frame t ftype flags sid payload))
-              (while (> (q:size) 0)
-                (let [next (q:take)]
-                  (when (= next :shutdown) (break nil))
-                  (let [[ftype flags sid payload] next]
-                    (frame:write-frame t ftype flags sid payload))))
-              (t:flush)))]
-            (unless ok? (break nil)))))))
+          (let [@shutting-down false
+                [ok? _] (protect
+                  (begin
+                    (let [[ftype flags sid payload] item]
+                      (frame:write-frame t ftype flags sid payload))
+                    (while (> (q:size) 0)
+                      (let [next (q:take)]
+                        (when (= next :shutdown)
+                          (assign shutting-down true)
+                          (break nil))
+                        (let [[ftype flags sid payload] next]
+                          (frame:write-frame t ftype flags sid payload))))
+                    (t:flush)))]
+            (when (or (not ok?) shutting-down) (break nil)))))))
 
   ## ── Send helpers ───────────────────────────────────────────────────────
 

--- a/src/plugin_api.rs
+++ b/src/plugin_api.rs
@@ -132,6 +132,7 @@ extern "C" fn api_resolve(name_ptr: *const u8, name_len: usize) -> *const c_void
         struct_value,
         array_len,
         array_get,
+        list_to_array,
         value_eq,
         make_poll_fd,
         intern_keyword,
@@ -588,6 +589,18 @@ extern "C" fn array_get(val: [u64; 2], idx: usize) -> [u64; 2] {
             }
             _ => from_value(Value::NIL),
         }
+    }
+}
+
+// ── List → array conversion ───────────────────────────────────────────
+
+/// Convert a proper list (cons chain) to an immutable array.
+/// Returns nil if the value is not a proper list.
+extern "C" fn list_to_array(val: [u64; 2]) -> [u64; 2] {
+    let v = unsafe { to_value(val) };
+    match v.list_to_vec() {
+        Ok(items) => from_value(Value::array(items)),
+        Err(_) => from_value(Value::NIL),
     }
 }
 


### PR DESCRIPTION

Two fixes for gRPC hangs when encoding lists:

1. h2 writer-loop: :shutdown arriving during the inner batch-drain
   while loop only broke the inner loop. Track @shutting-down flag
   to break the outer forever loop too.

2. Add list_to_array to the plugin ABI so plugins can accept lists
   (cons chains) wherever they accept arrays. The protobuf plugin's
   encode_repeated now uses this to handle repeated fields from
   ->list without hanging.