### PR TITLE
Use plugin/ prefix for all plugin imports

### DIFF
--- a/demos/egui/counter.lisp
+++ b/demos/egui/counter.lisp
@@ -1,7 +1,7 @@
 (elle/epoch 8)
 ## examples/egui-counter.lisp — minimal egui counter app
 
-(def egui-plugin (import "egui"))
+(def egui-plugin (import "plugin/egui"))
 (def ui ((import "std/egui") egui-plugin))
 
 (def @count 0)

--- a/demos/egui/smoke.lisp
+++ b/demos/egui/smoke.lisp
@@ -1,7 +1,7 @@
 (elle/epoch 8)
 ## demos/egui/smoke.lisp — headless smoke test for egui plugin
 
-(def egui-plugin (import "egui"))
+(def egui-plugin (import "plugin/egui"))
 (def ui ((import "std/egui") egui-plugin))
 
 (def win (ui:open :title "Smoke Test"))

--- a/tools/add-epoch.lisp
+++ b/tools/add-epoch.lisp
@@ -10,7 +10,7 @@
 
 (def epoch (parse-int (first args)))
 
-(def glob-plugin (import "glob"))
+(def glob-plugin (import "plugin/glob"))
 (def do-glob (get glob-plugin :glob))
 
 (def files (append

--- a/tools/q.lisp
+++ b/tools/q.lisp
@@ -1,5 +1,5 @@
 (elle/epoch 8)
-(def ox (import "oxigraph"))
+(def ox (import "plugin/oxigraph"))
 (def store (ox:store-open ".elle-mcp/store"))
 
 (def args (drop 1 (sys/args)))

--- a/tools/query.lisp
+++ b/tools/query.lisp
@@ -2,7 +2,7 @@
 ## query.lisp — run a SPARQL query against the store
 ## Usage: tools/run-elle.sh tools/query.lisp -- 'SELECT ...'
 
-(def ox (import "oxigraph"))
+(def ox (import "plugin/oxigraph"))
 (def store (ox:store-open ".elle-mcp/store"))
 
 (def args (drop 1 (sys/args)))


### PR DESCRIPTION
Adopts the (import "plugin/foo") convention instead of bare (import "foo") for egui, oxigraph, syn, and glob plugin imports across demos/, tools/, and the mcp submodule.

toh to redditor chemical-vacation-25 ;-)