### PR TITLE
Fix call_stack leak in JIT dispatch path

### DIFF
--- a/src/vm/call.rs
+++ b/src/vm/call.rs
@@ -289,6 +289,7 @@ impl VM {
             if closure.template.lir_function.is_some() {
                 if let Some(bits) = self.try_jit_call(closure, &args, func) {
                     self.fiber.call_depth -= 1;
+                    self.fiber.call_stack.pop();
                     match bits {
                         Some(sig) if !sig.contains(SIG_ERROR) && !sig.contains(SIG_HALT) => {
                             // JIT function suspended — any bits except SIG_ERROR/SIG_HALT


### PR DESCRIPTION
The interpreter's handle_call pushes a CallFrame at line 225 for stack traces. The WASM and MLIR dispatch paths pop it on return, but the JIT path at line 290 only decremented call_depth without popping call_stack.

Every JIT-dispatched closure call leaked one CallFrame (~64 bytes). For nqueens N=12 with ~14M safe?/check-safe JIT calls, this accumulated ~900 MB of leaked CallFrames — explaining the 1 GB RSS with JIT vs 172 MB without.

Fix: add call_stack.pop() to the JIT dispatch path, matching WASM/MLIR.

Result: nqueens N=12 RSS with JIT drops from 1055 MB to 176 MB.