### PR TITLE
Widen jump offsets from i16 to i32 to fix silent truncation

### DIFF
--- a/src/compiler/bytecode.rs
+++ b/src/compiler/bytecode.rs
@@ -43,13 +43,13 @@ pub enum Instruction {
     /// Return from function
     Return,
 
-    /// Jump unconditionally (offset i16)
+    /// Jump unconditionally (offset i32)
     Jump,
 
-    /// Jump if false (offset i16)
+    /// Jump if false (offset i32)
     JumpIfFalse,
 
-    /// Jump if true (offset i16)
+    /// Jump if true (offset i32)
     JumpIfTrue,
 
     /// Create closure (const_idx, num_upvalues)
@@ -364,15 +364,27 @@ impl Bytecode {
         self.emit_u16(value as u16);
     }
 
+    /// Emit an i32 (big-endian)
+    pub fn emit_i32(&mut self, value: i32) {
+        let bytes = value.to_be_bytes();
+        self.instructions.push(bytes[0]);
+        self.instructions.push(bytes[1]);
+        self.instructions.push(bytes[2]);
+        self.instructions.push(bytes[3]);
+    }
+
     /// Get current position for jump patching
     pub fn current_pos(&self) -> usize {
         self.instructions.len()
     }
 
-    /// Patch a jump instruction at a given position
-    pub fn patch_jump(&mut self, pos: usize, offset: i16) {
-        self.instructions[pos] = (offset >> 8) as u8;
-        self.instructions[pos + 1] = (offset & 0xff) as u8;
+    /// Patch a jump instruction at a given position (i32 big-endian)
+    pub fn patch_jump(&mut self, pos: usize, offset: i32) {
+        let bytes = offset.to_be_bytes();
+        self.instructions[pos] = bytes[0];
+        self.instructions[pos + 1] = bytes[1];
+        self.instructions[pos + 2] = bytes[2];
+        self.instructions[pos + 3] = bytes[3];
     }
 
     pub fn patch_u16(&mut self, pos: usize, value: u16) {
@@ -407,14 +419,17 @@ pub fn disassemble_lines(instructions: &[u8]) -> Vec<String> {
                 i += 2;
             }
             Instruction::Jump | Instruction::JumpIfFalse | Instruction::JumpIfTrue
-                if i + 1 < instructions.len() =>
+                if i + 3 < instructions.len() =>
             {
-                let high = instructions[i] as i8 as i16;
-                let low = instructions[i + 1] as i16;
-                let offset = (high << 8) | (low & 0xFF);
-                let target = (i + 2) as i32 + offset as i32;
+                let offset = i32::from_be_bytes([
+                    instructions[i],
+                    instructions[i + 1],
+                    instructions[i + 2],
+                    instructions[i + 3],
+                ]);
+                let target = (i + 4) as i64 + offset as i64;
                 line.push_str(&format!(" (offset={}, target={})", offset, target));
-                i += 2;
+                i += 4;
             }
             Instruction::LoadLocal | Instruction::StoreLocal if i + 1 < instructions.len() => {
                 let index = ((instructions[i] as u16) << 8) | (instructions[i + 1] as u16);

--- a/src/lir/emit/mod.rs
+++ b/src/lir/emit/mod.rs
@@ -206,10 +206,10 @@ impl Emitter {
             self.emit_block(block, func);
         }
 
-        // Patch jumps (relative offsets)
+        // Patch jumps (relative i32 offsets)
         for (pos, label) in &self.pending_jumps {
             if let Some(&target) = self.label_offsets.get(label) {
-                let offset = (target as i32 - *pos as i32 - 2) as i16;
+                let offset = target as i32 - *pos as i32 - 4;
                 self.bytecode.patch_jump(*pos, offset);
             }
         }
@@ -980,7 +980,7 @@ impl Emitter {
 
                 self.bytecode.emit(Instruction::Jump);
                 let pos = self.bytecode.current_pos();
-                self.bytecode.emit_i16(0); // placeholder
+                self.bytecode.emit_i32(0); // placeholder
                 self.pending_jumps.push((pos, *label));
             }
 
@@ -1010,13 +1010,13 @@ impl Emitter {
                 // JumpIfFalse to else_label
                 self.bytecode.emit(Instruction::JumpIfFalse);
                 let else_pos = self.bytecode.current_pos();
-                self.bytecode.emit_i16(0); // placeholder
+                self.bytecode.emit_i32(0); // placeholder
                 self.pending_jumps.push((else_pos, *else_label));
 
                 // Fall through or jump to then_label
                 self.bytecode.emit(Instruction::Jump);
                 let then_pos = self.bytecode.current_pos();
-                self.bytecode.emit_i16(0); // placeholder
+                self.bytecode.emit_i32(0); // placeholder
                 self.pending_jumps.push((then_pos, *then_label));
             }
 
@@ -1049,7 +1049,7 @@ impl Emitter {
 
                 self.bytecode.emit(Instruction::Jump);
                 let pos = self.bytecode.current_pos();
-                self.bytecode.emit_i16(0);
+                self.bytecode.emit_i32(0); // placeholder
                 self.pending_jumps.push((pos, *resume_label));
             }
 

--- a/src/vm/control.rs
+++ b/src/vm/control.rs
@@ -2,31 +2,31 @@ use super::core::VM;
 use crate::value::Value;
 
 pub(crate) fn handle_jump(bytecode: &[u8], ip: &mut usize, vm: &VM) {
-    let offset = vm.read_i16(bytecode, ip);
-    *ip = ((*ip as i32) + (offset as i32)) as usize;
+    let offset = vm.read_i32(bytecode, ip);
+    *ip = ((*ip as i64) + (offset as i64)) as usize;
 }
 
 pub(crate) fn handle_jump_if_false(bytecode: &[u8], ip: &mut usize, vm: &mut VM) {
-    let offset = vm.read_i16(bytecode, ip);
+    let offset = vm.read_i32(bytecode, ip);
     let val = vm
         .fiber
         .stack
         .pop()
         .expect("VM bug: Stack underflow on JumpIfFalse");
     if !val.is_truthy() {
-        *ip = ((*ip as i32) + (offset as i32)) as usize;
+        *ip = ((*ip as i64) + (offset as i64)) as usize;
     }
 }
 
 pub(crate) fn handle_jump_if_true(bytecode: &[u8], ip: &mut usize, vm: &mut VM) {
-    let offset = vm.read_i16(bytecode, ip);
+    let offset = vm.read_i32(bytecode, ip);
     let val = vm
         .fiber
         .stack
         .pop()
         .expect("VM bug: Stack underflow on JumpIfTrue");
     if val.is_truthy() {
-        *ip = ((*ip as i32) + (offset as i32)) as usize;
+        *ip = ((*ip as i64) + (offset as i64)) as usize;
     }
 }
 

--- a/src/vm/core.rs
+++ b/src/vm/core.rs
@@ -469,6 +469,16 @@ impl VM {
         self.read_u16(bytecode, ip) as i16
     }
 
+    #[inline(always)]
+    pub fn read_i32(&self, bytecode: &[u8], ip: &mut usize) -> i32 {
+        let b0 = bytecode[*ip] as u32;
+        let b1 = bytecode[*ip + 1] as u32;
+        let b2 = bytecode[*ip + 2] as u32;
+        let b3 = bytecode[*ip + 3] as u32;
+        *ip += 4;
+        ((b0 << 24) | (b1 << 16) | (b2 << 8) | b3) as i32
+    }
+
     pub(crate) fn ffi(&self) -> &FFISubsystem {
         &self.ffi
     }

--- a/src/vm/dispatch.rs
+++ b/src/vm/dispatch.rs
@@ -142,9 +142,9 @@ impl VM {
 
                 // Control flow
                 Instruction::Jump => {
-                    // Peek offset (big-endian i16, matching read_i16) to determine
+                    // Peek offset (big-endian i32, matching read_i32) to determine
                     // direction WITHOUT consuming bytes — handle_jump re-reads them.
-                    let offset = i16::from_be_bytes([bc[ip], bc[ip + 1]]);
+                    let offset = i32::from_be_bytes([bc[ip], bc[ip + 1], bc[ip + 2], bc[ip + 3]]);
                     if offset < 0 {
                         check_fuel!(self, instr_ip);
                     }


### PR DESCRIPTION

The bytecode emitter patched jump offsets with `as i16`, silently
truncating offsets that exceeded 32KB. Large compiled functions
(e.g. `each` over a ~100-line body with nested loops) could produce
match-arm exit jumps exceeding i16 range, wrapping to negative
offsets and landing on invalid bytecode — manifesting as spurious
upvalue panics or other corruption at runtime.

Widen Jump/JumpIfFalse/JumpIfTrue operands from i16 to i32:
- Bytecode: emit_i32/patch_jump take i32, disassembler reads 4 bytes
- Emitter: placeholders and patch calculation use i32 without truncation
- VM: read_i32 for jump handlers, 4-byte peek for fuel check