### PR TITLE
h2: fix stream leak; add grpc streaming

### DIFF
--- a/lib/grpc.lisp
+++ b/lib/grpc.lisp
@@ -102,6 +102,69 @@
         {}
         (protobuf:decode schema response-type raw))))
 
+  ## ── Server-streaming RPC ──────────────────────────────────────────
+
+  (defn grpc-call-stream [session schema method request-type request-struct response-type]
+    "Open a server-streaming gRPC call. Returns a reader function.
+     Call (reader) repeatedly; returns the next decoded message, or nil
+     at end-of-stream. Each call blocks until a message is available.
+     gRPC frames may span h2 DATA boundaries — the reader buffers and
+     splits on the 5-byte length-prefixed frame headers."
+    (def body (grpc-encode (protobuf:encode schema request-type request-struct)))
+    (def s (http2:send-raw session "POST" method
+              :body body
+              :headers [["content-type" "application/grpc"]
+                        ["te" "trailers"]]))
+    (def @buf (bytes))
+    (def @done false)
+
+    ## Return reader closure
+    (fn []
+      ## Try to extract a complete gRPC frame from buf
+      (def @result nil)
+      (when (>= (length buf) 5)
+        (let [len (bit/or (bit/shl (get buf 1) 24)
+                          (bit/shl (get buf 2) 16)
+                          (bit/shl (get buf 3) 8)
+                          (get buf 4))
+              frame-end (+ 5 len)]
+          (when (>= (length buf) frame-end)
+            (let [payload (slice buf 5 frame-end)]
+              (assign buf (slice buf frame-end))
+              (assign result (protobuf:decode schema response-type payload))))))
+
+      ## If nothing in buffer, read h2 frames until we get a complete message
+      (while (and (nil? result) (not done))
+        (let [msg (s:data-queue:take)]
+          (cond
+            ((= msg:type :headers)
+             (let [status-pair (first (filter (fn [h] (= (get h 0) "grpc-status")) msg:headers))]
+               (when (and status-pair (not (= (get status-pair 1) "0")))
+                 (let [msg-pair (first (filter (fn [h] (= (get h 0) "grpc-message")) msg:headers))]
+                   (error {:error :grpc-error
+                           :code (parse-int (get status-pair 1))
+                           :message (if msg-pair (get msg-pair 1) "unknown error")}))))
+             (when msg:end-stream (assign done true)))
+            ((= msg:type :data)
+             (assign buf (concat buf msg:data))
+             (when msg:end-stream (assign done true))
+             ## Try to extract after each data frame
+             (when (and (nil? result) (>= (length buf) 5))
+               (let [len (bit/or (bit/shl (get buf 1) 24)
+                                 (bit/shl (get buf 2) 16)
+                                 (bit/shl (get buf 3) 8)
+                                 (get buf 4))
+                     frame-end (+ 5 len)]
+                 (when (>= (length buf) frame-end)
+                   (let [payload (slice buf 5 frame-end)]
+                     (assign buf (slice buf frame-end))
+                     (assign result (protobuf:decode schema response-type payload)))))))
+            ((= msg:type :rst)
+             (error {:error :grpc-error :reason :stream-reset
+                     :code msg:code}))
+            (true (assign done true)))))
+      result))
+
   ## ── Close ──────────────────────────────────────────────────────────
 
   (defn grpc-close [session]
@@ -110,9 +173,10 @@
 
   ## ── Exports ────────────────────────────────────────────────────────
 
-  {:connect    grpc-connect
-   :call       grpc-call
-   :call-decode grpc-call-decode
-   :close      grpc-close
-   :encode     grpc-encode
-   :decode     grpc-decode})
+  {:connect      grpc-connect
+   :call         grpc-call
+   :call-decode  grpc-call-decode
+   :call-stream  grpc-call-stream
+   :close        grpc-close
+   :encode       grpc-encode
+   :decode       grpc-decode})

--- a/lib/http2.lisp
+++ b/lib/http2.lisp
@@ -292,34 +292,37 @@
                    (stream:transition s :recv-rst)
                    (let [err-code (frame:read-u32 payload 0)]
                      (put s :error-code err-code)
-                     (s:data-queue:put {:type :rst :code err-code})))))
+                     (s:data-queue:put {:type :rst :code err-code}))
+                   (del session:streams sid))))
 
               ## ── HEADERS ──
               ((= ftype C:type-headers)
                (let [s (get-stream session sid)]
                  (when (= s:state :idle)
                    (stream:transition s :recv-headers))
-                 (let [headers (hpack:decode session:hpack-decoder payload)]
+                 (let [headers (hpack:decode session:hpack-decoder payload)
+                       end? (has-flag? flags C:flag-end-stream)]
                    (put s :headers headers)
-                   (when (has-flag? flags C:flag-end-stream)
-                     (stream:transition s :recv-end-stream))
+                   (when end? (stream:transition s :recv-end-stream))
                    (s:data-queue:put {:type :headers
                                       :headers headers
-                                      :end-stream (has-flag? flags C:flag-end-stream)}))))
+                                      :end-stream end?})
+                   (when end? (del session:streams sid)))))
 
               ## ── DATA ──
               ((= ftype C:type-data)
                (let [s (get session:streams sid)]
                  (when s
-                   (s:data-queue:put {:type :data :data payload
-                                      :end-stream (has-flag? flags C:flag-end-stream)})
-                   (when (has-flag? flags C:flag-end-stream)
-                     (stream:transition s :recv-end-stream))
-                   # Auto WINDOW_UPDATE for connection + stream
-                   (let [len (length payload)]
-                     (when (> len 0)
-                       (send-window-update session 0 len)
-                       (send-window-update session sid len))))))
+                   (let [end? (has-flag? flags C:flag-end-stream)]
+                     (s:data-queue:put {:type :data :data payload
+                                        :end-stream end?})
+                     (when end? (stream:transition s :recv-end-stream))
+                     # Auto WINDOW_UPDATE for connection + stream
+                     (let [len (length payload)]
+                       (when (> len 0)
+                         (send-window-update session 0 len)
+                         (send-window-update session sid len)))
+                     (when end? (del session:streams sid))))))
 
               ## ── PUSH_PROMISE — reject ──
               ((= ftype C:type-push-promise)
@@ -672,20 +675,22 @@
               ((= ftype C:type-data)
                (let [s (get session:streams sid)]
                  (when s
-                   (s:data-queue:put {:type :data :data payload
-                                      :end-stream (has-flag? flags C:flag-end-stream)})
-                   (when (has-flag? flags C:flag-end-stream)
-                     (stream:transition s :recv-end-stream))
-                   (let [len (length payload)]
-                     (when (> len 0)
-                       (send-window-update session 0 len)
-                       (send-window-update session sid len))))))
+                   (let [end? (has-flag? flags C:flag-end-stream)]
+                     (s:data-queue:put {:type :data :data payload
+                                        :end-stream end?})
+                     (when end? (stream:transition s :recv-end-stream))
+                     (let [len (length payload)]
+                       (when (> len 0)
+                         (send-window-update session 0 len)
+                         (send-window-update session sid len)))
+                     (when end? (del session:streams sid))))))
 
               ((= ftype C:type-rst-stream)
                (let [s (get session:streams sid)]
                  (when s
                    (stream:transition s :recv-rst)
-                   (s:data-queue:put {:type :rst :code (frame:read-u32 payload 0)}))))
+                   (s:data-queue:put {:type :rst :code (frame:read-u32 payload 0)})
+                   (del session:streams sid))))
 
               (true nil)))))))
 
@@ -775,6 +780,9 @@
         (let [resp (h2-send session "GET" "/test")]
           (assert (= resp:status 200) "loopback: status 200")
           (assert (= (string resp:body) "hello /test") "loopback: body"))
+        # Stream leak regression: completed streams must be removed
+        (assert (= (length (keys session:streams)) 0)
+                "loopback: stream removed after response")
         (h2-close session)))
 
     true)


### PR DESCRIPTION
Remove completed streams from session:streams in the reader loop after delivering end-stream DATA, end-stream HEADERS, or RST_STREAM. Consumers hold a direct reference to the stream object so enqueued messages are still readable, but the session map no longer grows unboundedly over the lifetime of a connection.

Without this, every unary gRPC call leaked its stream — the bounded data-queue (capacity 64) could eventually block the reader-loop fiber on put, deadlocking the connection.

Also adds grpc:call-stream for server-streaming RPCs and a loopback regression test asserting the stream map is empty after a response.