### PR TITLE
fix mlir capture lowering: separate env_vals from regs map

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ docgen: elle  ## Generate documentation site (Rust docs + Elle site)
 # jit-rejections    — requires JIT active (tests rejection tracking)
 ELLE_SKIP_VM  := -e jit-rejections.lisp
 ELLE_SKIP_JIT := -e NOMATCH_PLACEHOLDER
-ELLE_SKIP_MLIR := -e core.lisp -e lexical-scope.lisp -e concurrency.lisp
+ELLE_SKIP_MLIR := -e core.lisp -e concurrency.lisp
 
 # FFI skip list: tests requiring libffi (skipped when built --no-default-features)
 ELLE_SKIP_FFI := -e ffi.lisp -e compress.lisp -e sqlite.lisp -e zmq.lisp -e git.lisp -e http.lisp

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ docgen: elle  ## Generate documentation site (Rust docs + Elle site)
 # jit-rejections    — requires JIT active (tests rejection tracking)
 ELLE_SKIP_VM  := -e jit-rejections.lisp
 ELLE_SKIP_JIT := -e NOMATCH_PLACEHOLDER
-ELLE_SKIP_MLIR := -e core.lisp -e concurrency.lisp
+ELLE_SKIP_MLIR := -e NOMATCH_PLACEHOLDER
 
 # FFI skip list: tests requiring libffi (skipped when built --no-default-features)
 ELLE_SKIP_FFI := -e ffi.lisp -e compress.lisp -e sqlite.lisp -e zmq.lisp -e git.lisp -e http.lisp

--- a/src/mlir/lower.rs
+++ b/src/mlir/lower.rs
@@ -237,6 +237,10 @@ pub fn lower_to_module<'c>(
     let mut regs: HashMap<u32, Value> = HashMap::new();
     // Type map: LIR Reg → ScalarType (Int or Float)
     let mut types: HashMap<u32, ScalarType> = HashMap::new();
+    // Environment values: env index → (MLIR Value, ScalarType).
+    // Separate from `regs` so LoadCapture lookups are never clobbered by
+    // destination register writes (LIR reg indices can collide with env indices).
+    let mut env_vals: HashMap<u32, (Value, ScalarType)> = HashMap::new();
     // Local slot types: slot index → ScalarType
     let mut slot_types: HashMap<u32, ScalarType> = HashMap::new();
     // Return type: determined from Return terminators
@@ -251,18 +255,16 @@ pub fn lower_to_module<'c>(
     if !blocks.is_empty() {
         let entry = &blocks[0];
 
-        // Pre-populate regs with entry block arguments.
+        // Pre-populate env_vals with entry block arguments.
         // MLIR signature: [captures..., params...], all i64.
         // Captures marked as Float in capture_types get bitcast i64→f64.
         for i in 0..num_captures as usize {
             let raw: Value = entry.argument(i).unwrap().into();
             if capture_types & (1u64 << i) != 0 {
                 let bc = entry.append_operation(arith::bitcast(raw, f64_type, location));
-                regs.insert(i as u32, bc.result(0).unwrap().into());
-                types.insert(i as u32, ScalarType::Float);
+                env_vals.insert(i as u32, (bc.result(0).unwrap().into(), ScalarType::Float));
             } else {
-                regs.insert(i as u32, raw);
-                types.insert(i as u32, ScalarType::Int);
+                env_vals.insert(i as u32, (raw, ScalarType::Int));
             }
         }
         // Params follow captures in the MLIR argument list.
@@ -271,11 +273,12 @@ pub fn lower_to_module<'c>(
             let raw: Value = entry.argument(arg_idx).unwrap().into();
             if param_types & (1u64 << i) != 0 {
                 let bc = entry.append_operation(arith::bitcast(raw, f64_type, location));
-                regs.insert(arg_idx as u32, bc.result(0).unwrap().into());
-                types.insert(arg_idx as u32, ScalarType::Float);
+                env_vals.insert(
+                    arg_idx as u32,
+                    (bc.result(0).unwrap().into(), ScalarType::Float),
+                );
             } else {
-                regs.insert(arg_idx as u32, raw);
-                types.insert(arg_idx as u32, ScalarType::Int);
+                env_vals.insert(arg_idx as u32, (raw, ScalarType::Int));
             }
         }
 
@@ -305,20 +308,16 @@ pub fn lower_to_module<'c>(
                     // to the MLIR block argument index.
                     let idx = *index as usize;
                     if idx < total_args {
-                        let t = if idx < num_captures as usize {
-                            // Capture — type already set during entry setup
-                            types.get(&(idx as u32)).copied().unwrap_or(ScalarType::Int)
-                        } else {
-                            // Parameter — type already set during entry setup
-                            types.get(&(idx as u32)).copied().unwrap_or(ScalarType::Int)
-                        };
-                        // Use the pre-computed (possibly bitcast) value from regs
-                        if let Some(&val) = regs.get(&(idx as u32)) {
+                        // Use env_vals (never clobbered by dst writes) to look
+                        // up the (possibly bitcast) MLIR value and its type.
+                        if let Some(&(val, t)) = env_vals.get(&(idx as u32)) {
                             regs.insert(dst.0, val);
+                            types.insert(dst.0, t);
                         } else {
+                            // Fallback: shouldn't happen if env_vals was populated
                             regs.insert(dst.0, blocks[0].argument(idx).unwrap().into());
+                            types.insert(dst.0, ScalarType::Int);
                         }
-                        types.insert(dst.0, t);
                     }
                 }
                 LirInstr::Const { dst, value } => match value {

--- a/src/mlir/mod.rs
+++ b/src/mlir/mod.rs
@@ -956,4 +956,103 @@ mod tests {
             "error should mention captures"
         );
     }
+
+    // ── Capture index collision regression ──────────────────────────
+
+    /// Build LIR that reproduces the env-index vs dst-reg collision bug.
+    ///
+    /// The LIR mimics what the lowerer produces for:
+    ///   (fn (y) (+ x y))   where x is a capture
+    ///
+    /// Env layout: [cap0=x, param0=y] — indices 0 and 1.
+    /// The lowerer copies param from env to a local slot, then loads
+    /// the capture and the local into registers. If the MLIR lowerer
+    /// uses a single `regs` map for both block-argument lookups and
+    /// destination-register writes, the first LoadCaptureRaw (dst=r0,
+    /// index=1) clobbers regs[0], causing the second LoadCaptureRaw
+    /// (dst=r1, index=0) to read the wrong value.
+    fn make_capture_param_collision() -> LirFunction {
+        let mut func = LirFunction::new(Arity::Exact(1));
+        func.name = Some("cap_param_collision".to_string());
+        func.signal = Signal::errors();
+        func.num_captures = 1;
+        func.num_locals = 1; // one local slot for param copy
+
+        let mut block = BasicBlock::new(Label(0));
+        // Copy param from env index 1 to local slot 0
+        block.instructions.push(SpannedInstr::new(
+            LirInstr::LoadCaptureRaw {
+                dst: Reg(0),
+                index: 1, // param y
+            },
+            s(),
+        ));
+        block.instructions.push(SpannedInstr::new(
+            LirInstr::StoreLocal {
+                slot: 0,
+                src: Reg(0),
+            },
+            s(),
+        ));
+        // Load capture from env index 0
+        block.instructions.push(SpannedInstr::new(
+            LirInstr::LoadCaptureRaw {
+                dst: Reg(1),
+                index: 0, // capture x
+            },
+            s(),
+        ));
+        // Load param from local slot
+        block.instructions.push(SpannedInstr::new(
+            LirInstr::LoadLocal {
+                dst: Reg(2),
+                slot: 0,
+            },
+            s(),
+        ));
+        // x + y
+        block.instructions.push(SpannedInstr::new(
+            LirInstr::BinOp {
+                dst: Reg(3),
+                op: BinOp::Add,
+                lhs: Reg(1),
+                rhs: Reg(2),
+            },
+            s(),
+        ));
+        block.terminator = SpannedTerminator::new(Terminator::Return(Reg(3)), s());
+        func.blocks.push(block);
+        func.num_regs = 4;
+        func
+    }
+
+    #[test]
+    fn test_capture_param_collision() {
+        let func = make_capture_param_collision();
+        let context = lower::create_context();
+        // num_captures=1, capture_types=0 (int), param_types=0 (int)
+        let (mut module, _) =
+            lower::lower_to_module(&context, &func, 1, 0, 0).expect("lowering should succeed");
+        let pm = melior::pass::PassManager::new(&context);
+        pm.add_pass(melior::pass::conversion::create_to_llvm());
+        pm.run(&mut module).expect("LLVM conversion should succeed");
+        let engine = melior::ExecutionEngine::new(&module, 2, &[], false, false);
+        // capture(x)=10, param(y)=5 → should return 15
+        let mut cap: i64 = 10;
+        let mut arg: i64 = 5;
+        let mut result: i64 = 0;
+        unsafe {
+            engine
+                .invoke_packed(
+                    "cap_param_collision",
+                    &mut [
+                        &mut cap as *mut i64 as *mut (),
+                        &mut arg as *mut i64 as *mut (),
+                        &mut result as *mut i64 as *mut (),
+                    ],
+                )
+                .unwrap();
+        }
+        assert_eq!(result, 15, "capture(10) + param(5) should be 15");
+    }
 }


### PR DESCRIPTION
The MLIR lowerer stored block arguments (captures + params) and LIR destination register values in the same `regs` HashMap.  When a LoadCaptureRaw instruction had a destination register whose index collided with an earlier argument index, the lookup value was clobbered.  For example in `(fn (y) (+ x y))` where x is a capture:

  LoadCaptureRaw dst=r0, index=1   ->  regs[0] = regs[1]  (clobbers capture x)
  LoadCaptureRaw dst=r1, index=0   ->  regs[1] = regs[0]  (reads wrong value)

Fix: introduce `env_vals` map for the initial argument values, which is never written by destination registers.  LoadCapture/LoadCaptureRaw lookups now use `env_vals` exclusively.

Un-skip lexical-scope.lisp from the MLIR skip list (287-line closure and capture test suite now passes).  Add regression test test_capture_param_collision that constructs the exact LIR pattern that triggered the bug.