### PR TITLE
add `elle fmt` subcommand: opinionated prettify

### DIFF
--- a/README.md
+++ b/README.md
@@ -872,6 +872,14 @@ See [docs/libraries.md](docs/libraries.md) for full documentation.
 
 - **Match exhaustiveness is checked at compile time.** The compiler warns when a match expression has patterns that can never be reached, and when the match may not cover all cases for a known type.
 
+- **Opinionated code formatter.** `elle fmt` formats Elle source to a single canonical style with zero configuration. Wadler-style pretty printing with column-aware alignment. Idempotent — formatting already-formatted code produces identical output. See [`docs/fmt.md`](docs/fmt.md) for the rule set and examples.
+
+  ```
+  elle fmt lib/*.lisp              # format in place
+  elle fmt --check lib/*.lisp      # CI: exit 1 if any file needs formatting
+  cat file.lisp | elle fmt         # stdin → stdout
+  ```
+
 - **Source-to-source rewriting tool.** The `rewrite` subcommand applies pattern-based rules to Elle source files for refactoring and code generation. Rules are pattern-action pairs that match syntax trees and produce transformed output.
 
 - **Compilation pipeline is fully documented.** See [`docs/pipeline.md`](docs/pipeline.md) for data flow across boundaries and [`AGENTS.md`](AGENTS.md) for architecture details.

--- a/docs/fmt.md
+++ b/docs/fmt.md
@@ -1,0 +1,260 @@
+# elle fmt
+
+Opinionated code formatter for Elle. One canonical style.
+
+## Usage
+
+```
+elle fmt [OPTIONS] <file...>     Format files in place
+elle fmt --check <file...>       Check mode (exit 1 if changes needed)
+elle fmt < input.lisp            Format stdin to stdout
+```
+
+### Options
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--check` | off | Don't write; list files that need formatting, enforce column limits |
+| `--line-length=N` | 80 | Target line width |
+| `--indent-width=N` | 2 | Spaces per indent level |
+
+### Column enforcement (--check only)
+
+- **Warning at column 60**: opening delimiter past column 60 suggests
+  lifting a lambda or refactoring.
+- **Error at column 80**: opening delimiter past column 80 means too
+  much nesting; `--check` exits 1.
+
+## Rule set
+
+### General principles
+
+- **Idempotent.** `format(format(x)) == format(x)`, always.
+- **2-space indent.** Every nesting level adds 2 spaces.
+- **Trailing newline.** Output always ends with `\n`.
+- **Shebang preserved.** `#!/usr/bin/env elle` stays on line 1.
+- **Comments preserved.** Inline comments stay inline; block comments
+  stay on their own line.
+
+### Definitions
+
+`defn`, `defmacro`: header on first line, body always breaks.
+
+```scheme
+(defn fib [n]
+  (if (< n 2) n (+ (fib (- n 1)) (fib (- n 2)))))
+```
+
+`def`: inline if fits, break with +2 if not.
+
+```scheme
+(def x 5)
+(def long-name
+  (compute-something))
+```
+
+### Bindings
+
+`let`, `let*`, `letrec`: one binding pair per line, names aligned to the
+column after `[`. Body indented +2.
+
+```scheme
+(let [x 5
+      y 10]
+  (+ x y))
+
+(let* [a (compute-a)
+       b (compute-b a)]
+  (combine a b))
+```
+
+### Conditionals
+
+`if`: trivial branches inline. Compound branches break with +2 indent,
+aligned relative to `(if`.
+
+```scheme
+(if (> x 0) x (- x))
+
+(if (> x 0)
+  (begin
+    (print x)
+    x)
+  (begin
+    (print "negative")
+    (- x)))
+```
+
+`cond`: flat alternating pairs. Trivial body stays with test;
+compound body breaks +2.
+
+```scheme
+(cond
+  (< x 0) "negative"
+  (= x 0) "zero"
+  true "positive")
+
+(cond
+  (< x 0)
+    (begin
+      (log "negative")
+      "negative")
+  true "non-negative")
+```
+
+`match`: flat alternating pairs after expr, same layout as cond.
+
+```scheme
+(match x
+  1 "one"
+  2 "two"
+  _ "other")
+```
+
+`case`: flat alternating pairs. Non-trivial results break +2.
+
+```scheme
+(case status
+  :ok (handle-ok)
+  :error
+    (begin
+      (log-error)
+      (retry)))
+```
+
+### Loops and control
+
+`when`, `unless`: test on first line, body +2.
+
+```scheme
+(when (> x 0)
+  (print "positive")
+  x)
+```
+
+`while`: single body inline, multi-body breaks.
+
+`each`: header (`each item [in] collection`) always on one line, body +2.
+The `in` keyword is optional.
+
+```scheme
+(each item in items
+  (print item))
+
+(each block (get cfg :blocks)
+  (process block))
+```
+
+`forever`: single body inline, multi-body breaks like begin.
+
+```scheme
+(forever (pump))
+
+(forever
+  (read-input)
+  (process)
+  (flush))
+```
+
+`begin`: always breaks, body +2.
+
+`block`: like begin, `:name` stays on the block line.
+
+```scheme
+(block :main
+  (setup)
+  (run))
+```
+
+### Functions
+
+`fn`: single body tries inline; multi-body breaks. Body aligns relative to
+`(fn`'s actual column (via `Align`), so lambdas inside bindings indent correctly.
+
+```scheme
+(fn [x] (+ x 1))
+
+(letrec [loop (fn (i)
+                (if (>= i n)
+                  result
+                  (loop (+ i 1))))]
+  (loop 0))
+```
+
+### Generic calls
+
+Short head (first-arg column <= line_length / 4): columnar alignment via
+`Align`. Args align to the first arg's column.
+
+```scheme
+(map (fn [x] (+ x 1))
+     items)
+```
+
+Long head: fall back to +2 indent.
+
+```scheme
+(some-very-long-function arg1
+  arg2
+  arg3)
+```
+
+### Logical operators
+
+`and`, `or`, `not`: columnar alignment like generic calls.
+
+```scheme
+(when (and (nil? first-error)
+           (or (= s :error) (not done?)))
+  (handle-error))
+```
+
+### Threading macros
+
+`->`, `->>`, `some->`, `some->>`: value on first line, steps aligned
+with value.
+
+```scheme
+(-> data
+    (transform)
+    (filter valid?)
+    (collect))
+
+(->> items
+     (map inc)
+     (filter even?)
+     (take 5))
+```
+
+### Parameterize
+
+Bindings each on a new line, aligned to column after `(parameterize (`.
+
+```scheme
+(parameterize ((*scheduler* sched)
+               (*spawn* (get sched :spawn))
+               (*shutdown* (get sched :shutdown)))
+  body)
+```
+
+### Collections
+
+Arrays, sets, structs: inline if fits; broken elements align to column
+after the opening delimiter.
+
+```scheme
+[1 2 3]
+
+{:error :type-error
+ :reason :not-a-sequence
+ :message "not a sequence"}
+```
+
+Structs group elements as key-value pairs.
+
+### Comments
+
+- Inline comments: 2 spaces before `#`, stay on the same line.
+- Block comments: own line, indented with surrounding code.
+- `CommentBreak` prevents double-newline when a trailing comment
+  precedes the inter-sibling line break.

--- a/src/formatter/AGENTS.md
+++ b/src/formatter/AGENTS.md
@@ -1,24 +1,71 @@
 # formatter
 
-Code formatting for Elle source. Pretty-prints code with consistent style.
+Opinionated code formatter for Elle source. Wadler-style pretty printing
+with column-aware alignment via `Align`. One canonical style. Zero
+configuration beyond line width and indent width.
 
 ## Responsibility
 
 - Format Elle source code
-- Apply configurable style rules
-- Preserve semantics while improving readability
+- Apply form-specific formatting rules (defn, let, if, cond, etc.)
+- Preserve comments and blank lines via trivia attachment
+- Produce idempotent output (format(format(x)) == format(x))
+- Column enforcement in `--check` mode (warn 60, error 80)
 
 Does NOT:
-- Parse code (uses `reader`)
+- Parse code (uses `reader` SyntaxReader)
 - Validate code (just formats)
 - Modify file system (caller handles I/O)
+
+## Architecture
+
+```
+Source → strip shebang → lex_for_format (separate tokens + comments)
+       → parse to Syntax → collect trivia → attach trivia
+       → generate Doc → render → strip leading newline
+       → prepend shebang + trailing newline
+```
+
+Five phases:
+1. **Lex with comments** (`comments.rs`): separates regular tokens from comment tokens
+2. **Parse** (`SyntaxReader`): regular tokens → Syntax tree
+3. **Trivia** (`trivia.rs`): merge comments + blank lines → attach to Syntax nodes
+4. **Doc generation** (`format.rs` + `forms.rs`): walk AnnotatedSyntax → Doc tree
+5. **Render** (`render.rs`): Doc tree → string with optimal line breaks
+
+## Doc algebra
+
+The formatter uses a Wadler-style document algebra extended with
+column-aware alignment:
+
+| Variant | Flat | Broken |
+|---------|------|--------|
+| `Empty` | nothing | nothing |
+| `Text(s)` | literal string | literal string |
+| `Concat(ds)` | sequence | sequence |
+| `Nest(n, d)` | no effect | indent += n * indent_width |
+| `Break` | space | newline + indent |
+| `Group(d)` | try flat; break if too wide | — |
+| `HardBreak` | newline (forces Group to break) | newline + indent |
+| `CommentBreak` | like HardBreak | absorbed by adjacent HardBreak/Break |
+| `Align(d)` | no effect | sets indent = current column |
+
+**Indent is tracked in absolute columns** (not indent levels).
+`Nest(n)` adds `n * indent_width` to the indent. `Align` sets indent
+to the current cursor column, enabling columnar alignment that works
+correctly for inline-nested forms.
+
+**CommentBreak** solves the double-newline idempotency problem: comments
+extend to end-of-line and need a newline after them, but the inter-sibling
+HardBreak also produces a newline. CommentBreak is absorbed by any
+adjacent newline-producing variant (HardBreak, Break, SoftBreak, BreakTo).
 
 ## Interface
 
 | Type | Purpose |
 |------|---------|
-| `FormatterConfig` | Style configuration |
-| `format_code(src, config)` | Format source string |
+| `FormatterConfig` | Style configuration (indent_width, line_length) |
+| `format_code(src, config)` | Format source string → `Result<String, String>` |
 
 ## Usage
 
@@ -26,18 +73,96 @@ Does NOT:
 use elle::formatter::{format_code, FormatterConfig};
 
 let config = FormatterConfig::default();
-let formatted = format_code(source, config)?;
+let formatted = format_code(source, &config)?;
 ```
+
+## Dispatch table
+
+The formatter dispatches on the head symbol of list forms:
+
+| Head | Handler | Behavior |
+|------|---------|----------|
+| `def` | `format_def` | Inline if fits |
+| `defn` | `format_defn` | Always break before body |
+| `fn` | `format_fn` | Single body: try inline; multi: break. Align-wrapped. |
+| `let`, `let*`, `letrec` | `format_let` | One binding pair per line, exact column alignment |
+| `if` | `format_if` | Trivial: inline. Compound: Align-wrapped, +2 body |
+| `cond` | `format_cond` | Flat pairs `(cond test body ...)` |
+| `match` | `format_match` | Flat pairs `(match expr pat body ...)` |
+| `case` | `format_case` | Flat pairs `(case expr key result ...)` |
+| `while` | `format_while` | Break if multi-expression body |
+| `defmacro` | `format_defmacro` → `format_defn` | Same as defn |
+| `begin` | `format_begin` | Always break, +2 body |
+| `forever` | `format_forever` | Single body: try inline. Multi: break like begin |
+| `block` | `format_block` | Like begin, `:name` stays on block line |
+| `parameterize` | `format_parameterize` | Bindings Align-wrapped, one per line |
+| `->`, `->>`, `some->`, `some->>` | `format_threading` | Always break |
+| `when`, `unless` | `format_when` | Trivial: group. Compound: +2 body |
+| `and`, `or`, `not`, `emit` | `format_generic_call` | Columnar via generic call |
+| `each` | `format_each` | Header on one line, `in` optional, body +2 |
+| `try`, `protect` | `format_try` | Always break (same as begin) |
+| `assign` | `format_assign` | Inline if fits |
+| *other* | `format_generic_call` | Short head: Align columnar. Long head: +2 fallback |
+
+## Alignment strategy
+
+Generic calls use two strategies based on head width:
+
+- **Short head** (`first_arg_col <= line_length / 4`): `Align` captures the
+  first arg's column. Subsequent args align to that column via `Break`.
+- **Long head**: fall back to `nest(1)` (+2 indent).
+
+Forms like `fn`, `if` (compound), and struct/collection literals use `Align`
+to ensure their content indents relative to the form's actual column position,
+not the Nest level. This is critical for forms nested inline inside bindings
+or arguments.
 
 ## Dependents
 
-- `lsp/formatting.rs` - document formatting
-- CLI - `elle fmt` command (if implemented)
+- `lsp/formatting.rs` — document formatting
+- CLI — `elle fmt` command
 
 ## Files
 
-| File | Lines | Content |
-|------|-------|---------|
-| `mod.rs` | 20 | Re-exports |
-| `config.rs` | ~50 | `FormatterConfig` |
-| `core.rs` | ~200 | Formatting logic |
+| File | Content |
+|------|---------|
+| `mod.rs` | Module declarations and re-exports |
+| `config.rs` | `FormatterConfig` with indent_width and line_length |
+| `core.rs` | Entry point `format_code()`, pipeline orchestration, idempotency tests |
+| `format.rs` | AnnotatedSyntax → Doc walk, trivia emission, collection/struct formatting |
+| `forms.rs` | Per-special-form formatting rules, generic call |
+| `doc.rs` | Doc algebra (Empty, Text, Concat, Nest, Break, Group, HardBreak, CommentBreak, Align) |
+| `render.rs` | Doc → String renderer with absolute-column indent tracking |
+| `comments.rs` | CommentMap, lex_for_format(), strip_shebang() |
+| `trivia.rs` | Trivia types, collection, attachment pass |
+| `run.rs` | CLI entry point for `elle fmt`, --check column enforcement |
+
+## Invariants
+
+1. **Trivia is pre-attached.** The attachment pass runs before the Doc walk.
+   The Doc generator is a pure function from AnnotatedSyntax → Doc with no
+   mutable state.
+
+2. **Trivia inside string spans is skipped.** Blank lines inside multi-line
+   string literals are not trivia. The attachment pass advances past them.
+
+3. **Shebang is stripped once.** `strip_shebang()` produces a single stripped
+   source that both the parser and trivia collector use, keeping byte offsets
+   consistent.
+
+4. **String literals are source-sliced.** `SyntaxKind::String(s)` stores the
+   unescaped value. The formatter slices `source[span.start..span.end]` to
+   preserve the raw literal including quotes and escapes.
+
+5. **Output always ends with `\n`.** The entry point enforces a trailing newline.
+
+6. **Formatting is idempotent.** `format(format(x)) == format(x)` is a
+   testable invariant with dedicated tests for every special form.
+
+7. **Indent is absolute columns.** The renderer tracks indent as a column
+   count (number of spaces), not as a multiple of indent_width. Nest adds
+   `n * indent_width`; Align sets indent to the current column.
+
+8. **CommentBreak absorption is symmetric.** Any newline-producing variant
+   (HardBreak, Break) absorbs a preceding CommentBreak. Both must be at the
+   same Nest level to avoid indent mismatch.

--- a/src/formatter/README.md
+++ b/src/formatter/README.md
@@ -1,34 +1,35 @@
 # Formatter
 
-The formatter pretty-prints Elle source code with consistent style.
+Opinionated pretty-printer for Elle source. One canonical style. Idempotent.
 
-## Usage
+## CLI
+
+```
+elle fmt [OPTIONS] <file...>     Format files in place
+elle fmt < file.lisp             Format stdin to stdout
+elle fmt --check lib/*.lisp      Check without writing (exit 1 if changes needed)
+```
+
+Options:
+- `--check` — report files that need formatting, enforce column limits
+- `--line-length=N` — target line width (default: 80)
+- `--indent-width=N` — spaces per indent level (default: 2)
+
+## API
 
 ```rust
 use elle::formatter::{format_code, FormatterConfig};
 
-let source = "(if(> x 0)(+ x 1)(- x 1))";
 let config = FormatterConfig::default();
-let formatted = format_code(source, config)?;
-// Result:
-// (if (> x 0)
-//     (+ x 1)
-//     (- x 1))
+let formatted = format_code(source, &config)?;
 ```
 
-## Configuration
+## Design
 
-`FormatterConfig` controls formatting behavior:
+Wadler-style document algebra with column-aware `Align`. The renderer
+tracks indent as absolute columns so forms nested inline (fn inside
+letrec bindings, and inside when, structs inside error calls) align
+relative to their actual position, not their Nest level.
 
-```rust
-pub struct FormatterConfig {
-    pub indent_width: usize,     // Spaces per indent level
-    pub max_line_length: usize,  // Wrap threshold
-    // ...
-}
-```
-
-## See Also
-
-- [AGENTS.md](AGENTS.md) - technical reference for LLM agents
-- `src/lsp/formatting.rs` - uses formatter for LSP document formatting
+See [AGENTS.md](AGENTS.md) for the full Doc algebra, dispatch table,
+and invariants.

--- a/src/formatter/comments.rs
+++ b/src/formatter/comments.rs
@@ -1,0 +1,288 @@
+//! Comment collection and attachment for the formatter.
+//!
+//! The lexer emits `Token::Comment(text)` tokens. The `SyntaxReader` skips
+//! them during parsing. This module collects those comment tokens with their
+//! source positions into a `CommentMap` that the formatter consults when
+//! emitting output — placing comments relative to the Syntax nodes they
+//! annotate.
+
+use crate::reader::{Lexer, OwnedToken, SourceLoc, Token};
+
+/// A source comment with its position and text.
+#[derive(Debug, Clone)]
+pub struct SourceComment {
+    /// The full comment text including the `#` prefix.
+    pub text: String,
+    /// Byte offset in the source where the comment starts.
+    pub byte_offset: usize,
+    /// 1-indexed line number.
+    pub line: u32,
+    /// 1-indexed column number.
+    pub col: u32,
+}
+
+/// A map of all comments in a source file, ordered by byte offset.
+#[derive(Debug, Clone)]
+pub struct CommentMap {
+    comments: Vec<SourceComment>,
+}
+
+impl CommentMap {
+    /// Build a CommentMap from a source string.
+    /// Lexes the source and collects all comment tokens.
+    pub fn collect(source: &str, source_name: &str) -> Result<Self, String> {
+        let mut lexer = Lexer::with_file(source, source_name);
+        let mut comments = Vec::new();
+
+        loop {
+            match lexer.next_token_with_loc() {
+                Ok(Some(twl)) => {
+                    if let Token::Comment(text) = &twl.token {
+                        // Strip trailing newline — the lexer includes it
+                        // but the formatter handles line breaks itself.
+                        let trimmed = text.trim_end_matches('\n').to_string();
+                        comments.push(SourceComment {
+                            text: trimmed,
+                            byte_offset: twl.byte_offset,
+                            line: twl.loc.line as u32,
+                            col: twl.loc.col as u32,
+                        });
+                    }
+                }
+                Ok(None) => break,
+                Err(e) => return Err(e),
+            }
+        }
+
+        Ok(CommentMap { comments })
+    }
+
+    /// An empty comment map.
+    pub fn empty() -> Self {
+        CommentMap {
+            comments: Vec::new(),
+        }
+    }
+
+    /// Get all comments.
+    pub fn comments(&self) -> &[SourceComment] {
+        &self.comments
+    }
+
+    /// Drain all comments with byte offset in the range [start, end).
+    /// Returns the comments and removes them from the map.
+    pub fn drain_range(&mut self, start: usize, end: usize) -> Vec<SourceComment> {
+        let mut result = Vec::new();
+        self.comments.retain(|c| {
+            if c.byte_offset >= start && c.byte_offset < end {
+                result.push(c.clone());
+                false
+            } else {
+                true
+            }
+        });
+        result
+    }
+
+    /// Get comments that appear before a given byte offset (leading comments).
+    /// These are comments whose byte offset is strictly before `offset`.
+    /// Consumes the returned comments from the map.
+    pub fn take_leading(&mut self, offset: usize) -> Vec<SourceComment> {
+        let mut result = Vec::new();
+        self.comments.retain(|c| {
+            if c.byte_offset < offset {
+                result.push(c.clone());
+                false
+            } else {
+                true
+            }
+        });
+        result
+    }
+
+    /// Get comments that appear on the same line as a given byte offset.
+    /// These are trailing comments (after code on the same line).
+    pub fn take_trailing(&mut self, line: u32) -> Vec<SourceComment> {
+        let mut result = Vec::new();
+        self.comments.retain(|c| {
+            if c.line == line {
+                result.push(c.clone());
+                false
+            } else {
+                true
+            }
+        });
+        result
+    }
+
+    /// Check if there are any remaining comments.
+    pub fn is_empty(&self) -> bool {
+        self.comments.is_empty()
+    }
+}
+
+/// Result of lexing source for the formatter.
+/// Contains both the regular tokens (for SyntaxReader) and the comment map.
+pub struct LexedForFormat {
+    pub tokens: Vec<OwnedToken>,
+    pub locations: Vec<SourceLoc>,
+    pub lengths: Vec<usize>,
+    pub byte_offsets: Vec<usize>,
+    pub comment_map: CommentMap,
+}
+
+/// Strip a shebang line from source if present.
+/// Returns (stripped_source, shebang_line).
+/// The shebang_line includes the trailing newline, or is empty if none.
+pub fn strip_shebang(source: &str) -> (&str, &str) {
+    if source.starts_with("#!") {
+        match source.find('\n') {
+            Some(pos) => (&source[pos + 1..], &source[..pos + 1]),
+            None => ("", source),
+        }
+    } else {
+        (source, "")
+    }
+}
+
+/// Lex source for formatting: produces regular tokens for the parser
+/// and collects comment tokens into a CommentMap.
+///
+/// IMPORTANT: `source` must already have its shebang stripped (if any).
+/// Use `strip_shebang()` before calling this function. This ensures
+/// byte offsets in the token stream agree with byte offsets in the
+/// source string passed to `collect_trivia`.
+pub fn lex_for_format(source: &str, source_name: &str) -> Result<LexedForFormat, String> {
+    let mut lexer = Lexer::with_file(source, source_name);
+    let mut tokens = Vec::new();
+    let mut locations = Vec::new();
+    let mut lengths = Vec::new();
+    let mut byte_offsets = Vec::new();
+    let mut comments = Vec::new();
+
+    loop {
+        match lexer.next_token_with_loc() {
+            Ok(Some(twl)) => match &twl.token {
+                Token::Comment(text) => {
+                    // Strip trailing newline — the lexer includes it
+                    // but the formatter handles line breaks itself.
+                    let trimmed = text.trim_end_matches('\n').to_string();
+                    comments.push(SourceComment {
+                        text: trimmed,
+                        byte_offset: twl.byte_offset,
+                        line: twl.loc.line as u32,
+                        col: twl.loc.col as u32,
+                    });
+                }
+                _ => {
+                    tokens.push(OwnedToken::from(twl.token));
+                    locations.push(twl.loc);
+                    lengths.push(twl.len);
+                    byte_offsets.push(twl.byte_offset);
+                }
+            },
+            Ok(None) => break,
+            Err(e) => return Err(e),
+        }
+    }
+
+    Ok(LexedForFormat {
+        tokens,
+        locations,
+        lengths,
+        byte_offsets,
+        comment_map: CommentMap { comments },
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_empty_source() {
+        let map = CommentMap::collect("", "<test>").unwrap();
+        assert!(map.is_empty());
+    }
+
+    #[test]
+    fn test_no_comments() {
+        let map = CommentMap::collect("(+ 1 2)", "<test>").unwrap();
+        assert!(map.is_empty());
+    }
+
+    #[test]
+    fn test_single_comment() {
+        let map = CommentMap::collect("# hello", "<test>").unwrap();
+        assert_eq!(map.comments().len(), 1);
+        assert_eq!(map.comments()[0].text, "# hello");
+        assert_eq!(map.comments()[0].line, 1);
+    }
+
+    #[test]
+    fn test_multiple_comments() {
+        let map = CommentMap::collect("# first\n# second\n(+ 1 2)", "<test>").unwrap();
+        assert_eq!(map.comments().len(), 2);
+        assert_eq!(map.comments()[0].text, "# first");
+        assert_eq!(map.comments()[1].text, "# second");
+    }
+
+    #[test]
+    fn test_doc_comment() {
+        let map = CommentMap::collect("## doc text", "<test>").unwrap();
+        assert_eq!(map.comments().len(), 1);
+        assert!(map.comments()[0].text.starts_with("##"));
+    }
+
+    #[test]
+    fn test_take_leading() {
+        let mut map = CommentMap::collect("# before\n42 # inline\n# after", "<test>").unwrap();
+        assert_eq!(map.comments().len(), 3);
+
+        let leading = map.take_leading(10); // byte offset of "42"
+        assert_eq!(leading.len(), 1);
+        assert_eq!(leading[0].text, "# before");
+        assert_eq!(map.comments().len(), 2);
+    }
+
+    #[test]
+    fn test_take_trailing() {
+        let mut map = CommentMap::collect("42 # inline\n# after", "<test>").unwrap();
+        let trailing = map.take_trailing(1);
+        assert_eq!(trailing.len(), 1);
+        assert_eq!(trailing[0].text, "# inline");
+        assert_eq!(map.comments().len(), 1);
+    }
+
+    #[test]
+    fn test_lex_for_format() {
+        let result = lex_for_format("# comment\n(+ 1 2)", "<test>").unwrap();
+        // Regular tokens: (, +, 1, 2, )
+        assert_eq!(result.tokens.len(), 5);
+        // Comment map has 1 comment
+        assert_eq!(result.comment_map.comments().len(), 1);
+    }
+
+    #[test]
+    fn test_strip_shebang() {
+        let (source, shebang) = strip_shebang("#!/usr/bin/env elle\n(+ 1 2)");
+        assert_eq!(shebang, "#!/usr/bin/env elle\n");
+        assert_eq!(source, "(+ 1 2)");
+    }
+
+    #[test]
+    fn test_strip_no_shebang() {
+        let (source, shebang) = strip_shebang("(+ 1 2)");
+        assert_eq!(shebang, "");
+        assert_eq!(source, "(+ 1 2)");
+    }
+
+    #[test]
+    fn test_lex_for_format_shebang() {
+        // lex_for_format receives already-stripped source
+        let (stripped, _shebang) = strip_shebang("#!/usr/bin/env elle\n(+ 1 2)");
+        let result = lex_for_format(stripped, "<test>").unwrap();
+        assert_eq!(result.tokens.len(), 5);
+        assert!(result.comment_map.is_empty());
+    }
+}

--- a/src/formatter/config.rs
+++ b/src/formatter/config.rs
@@ -31,6 +31,22 @@ impl FormatterConfig {
         self.line_length = length;
         self
     }
+
+    /// Set the line length if Some, otherwise keep default.
+    pub fn maybe_with_line_length(mut self, length: Option<usize>) -> Self {
+        if let Some(l) = length {
+            self.line_length = l;
+        }
+        self
+    }
+
+    /// Set the indent width if Some, otherwise keep default.
+    pub fn maybe_with_indent_width(mut self, width: Option<usize>) -> Self {
+        if let Some(w) = width {
+            self.indent_width = w;
+        }
+        self
+    }
 }
 
 impl Default for FormatterConfig {

--- a/src/formatter/core.rs
+++ b/src/formatter/core.rs
@@ -1,272 +1,77 @@
-//! Core formatting logic
+//! Core formatting entry point.
 //!
-//! Implements a recursive pretty-printer for s-expressions.
+//! Implements the full formatting pipeline:
+//!
+//! ```text
+//! Source → strip shebang → lex (separate tokens + comments)
+//!       → parse to Syntax → collect trivia → attach trivia
+//!       → generate Doc → render → prepend shebang + trailing newline
+//! ```
 
+use super::comments::{lex_for_format, strip_shebang};
 use super::config::FormatterConfig;
-use crate::reader::Lexer;
-use crate::symbol::SymbolTable;
-use crate::value::{SymbolId, Value};
-use crate::Reader;
+use super::format::format_forms;
+use super::render::render;
+use super::trivia::{collect_trivia, AnnotatedSyntax};
+use crate::reader::SyntaxReader;
 
-/// Format Elle code with the given configuration
+/// Format Elle source code with the given configuration.
 ///
-/// Parses the input code and returns a formatted version.
-/// Returns an error if parsing fails.
+/// Returns the formatted string, or an error if parsing fails.
 pub fn format_code(source: &str, config: &FormatterConfig) -> Result<String, String> {
-    // Parse the source code
-    let mut lexer = Lexer::new(source);
-    let mut tokens = Vec::new();
+    // 1. Strip shebang (single strip point for consistent byte offsets)
+    let (stripped, shebang) = strip_shebang(source);
 
-    loop {
-        match lexer.next_token() {
-            Ok(Some(token)) => {
-                tokens.push(crate::reader::OwnedToken::from(token));
-            }
-            Ok(None) => break,
-            Err(e) => return Err(format!("Lexer error: {}", e)),
-        }
-    }
+    // 2. Lex: separate regular tokens from comment tokens
+    let lexed = lex_for_format(stripped, "<format>")?;
 
-    let mut reader = Reader::new(tokens);
-    let mut symbol_table = SymbolTable::new();
-    let mut values = Vec::new();
+    // 3. Parse regular tokens to Syntax tree
+    let forms = if lexed.tokens.is_empty() {
+        Vec::new()
+    } else {
+        let mut parser = SyntaxReader::with_byte_offsets(
+            lexed.tokens,
+            lexed.locations,
+            lexed.lengths,
+            lexed.byte_offsets,
+        );
+        parser.read_all()?
+    };
 
-    while let Some(result) = reader.try_read(&mut symbol_table) {
-        match result {
-            Ok(value) => values.push(value),
-            Err(e) => return Err(format!("Reader error: {}", e)),
-        }
-    }
-
-    // Format each value
-    let mut formatted = Vec::new();
-    for value in values {
-        formatted.push(format_value(&value, 0, config, &symbol_table));
-    }
-
-    Ok(formatted.join("\n"))
-}
-
-/// Format a single Value into a string
-fn format_value(
-    value: &Value,
-    indent: usize,
-    config: &FormatterConfig,
-    symbol_table: &SymbolTable,
-) -> String {
-    use crate::value::heap::{deref, HeapObject};
-
-    if value.is_nil() {
-        return "nil".to_string();
-    }
-
-    if let Some(b) = value.as_bool() {
-        return if b { "true" } else { "false" }.to_string();
-    }
-
-    if let Some(n) = value.as_int() {
-        return n.to_string();
-    }
-
-    if let Some(n) = value.as_float() {
-        return n.to_string();
-    }
-
-    if let Some(id) = value.as_symbol() {
-        let sym_id = SymbolId(id);
-        return symbol_table
-            .name(sym_id)
-            .map(|s| s.to_string())
-            .unwrap_or_else(|| format!("#{}", id));
-    }
-
-    if let Some(name) = value.as_keyword_name() {
-        return format!(":{}", name);
-    }
-
-    // SSO or heap string
-    if value.is_string() {
-        return value
-            .with_string(|s| format!("\"{}\"", s.escape_default()))
-            .unwrap();
-    }
-
-    // Handle heap values
-    if let Some(_ptr) = value.as_heap_ptr() {
-        let obj = unsafe { deref(*value) };
-        match obj {
-            HeapObject::LArrayMut { data: v, .. } => {
-                if let Ok(elements) = v.try_borrow() {
-                    if elements.is_empty() {
-                        return "[]".to_string();
-                    } else {
-                        let items: Vec<String> = elements
-                            .iter()
-                            .map(|e| format_value(e, indent, config, symbol_table))
-                            .collect();
-                        return format!("[{}]", items.join(" "));
-                    }
-                }
-                return "[<borrowed>]".to_string();
-            }
-            HeapObject::Cons(cons) => {
-                return format_cons(&cons.first, &cons.rest, indent, config, symbol_table);
-            }
-            HeapObject::LStructMut { .. } => {
-                // For Phase 1, just return a placeholder
-                return "{{...}}".to_string();
-            }
-            HeapObject::LStruct { .. } => {
-                // For Phase 1, just return a placeholder
-                return "{{...}}".to_string();
-            }
-            HeapObject::Closure { .. } => return "#<closure>".to_string(),
-            HeapObject::NativeFn(_) => return "#<native-fn>".to_string(),
-            HeapObject::LibHandle(_) => return "#<lib-handle>".to_string(),
-            HeapObject::LArray {
-                elements: elems, ..
-            } => {
-                let items: Vec<String> = elems
-                    .iter()
-                    .map(|e| format_value(e, indent, config, symbol_table))
-                    .collect();
-                return format!("[{}]", items.join(" "));
-            }
-            HeapObject::ThreadHandle { .. } => return "#<thread-handle>".to_string(),
-            HeapObject::LBox { .. } => return "#<box>".to_string(),
-            HeapObject::CaptureCell { .. } => return "#<capture-cell>".to_string(),
-            HeapObject::Float(_) => return "#<float>".to_string(),
-            HeapObject::Fiber { .. } => return "#<fiber>".to_string(),
-            HeapObject::Syntax { syntax: s, .. } => return format!("#<syntax:{}>", s),
-            HeapObject::FFISignature(_, _) => return "<ffi-signature>".to_string(),
-            HeapObject::FFIType(_) => return "<ffi-type>".to_string(),
-            HeapObject::LStringMut { .. } => return "@\"...\"".to_string(),
-            HeapObject::LBytes { .. } => return "#bytes[...]".to_string(),
-            HeapObject::LBytesMut { .. } => return "#@bytes[...]".to_string(),
-            HeapObject::ManagedPointer { addr: cell, .. } => {
-                return match cell.get() {
-                    Some(addr) => format!("<pointer 0x{:x}>", addr),
-                    None => "<freed-pointer>".to_string(),
-                }
-            }
-            HeapObject::External { obj: ext, .. } => return format!("#<{}>", ext.type_name),
-            HeapObject::Parameter { id, .. } => return format!("<parameter:{}>", id),
-            HeapObject::LString { s, .. } => {
-                // SAFETY: LString bytes are always valid UTF-8 (enforced by constructors).
-                let as_str = unsafe { std::str::from_utf8_unchecked(s.as_slice()) };
-                return format!("\"{}\"", as_str.escape_default());
-            }
-            HeapObject::LSet { data: s, .. } => {
-                let items: Vec<String> = s
-                    .iter()
-                    .map(|e| format_value(e, indent, config, symbol_table))
-                    .collect();
-                return format!("|{}|", items.join(" "));
-            }
-            HeapObject::LSetMut { data: s_ref, .. } => {
-                if let Ok(s) = s_ref.try_borrow() {
-                    let items: Vec<String> = s
-                        .iter()
-                        .map(|e| format_value(e, indent, config, symbol_table))
-                        .collect();
-                    return format!("@|{}|", items.join(" "));
-                }
-                return "@|<borrowed>|".to_string();
-            }
-        }
-    }
-
-    // Fallback for unknown types
-    "#<unknown>".to_string()
-}
-
-/// Format a cons cell (list)
-fn format_cons(
-    head: &Value,
-    tail: &Value,
-    indent: usize,
-    config: &FormatterConfig,
-    symbol_table: &SymbolTable,
-) -> String {
-    use crate::value::heap::{deref, HeapObject};
-
-    // Collect all elements in the list
-    let mut elements = vec![head];
-    let mut current = tail;
-
-    loop {
-        if current.is_nil() || current.is_empty_list() {
-            break;
-        }
-
-        if let Some(_ptr) = current.as_heap_ptr() {
-            let obj = unsafe { deref(*current) };
-            if let HeapObject::Cons(cons) = obj {
-                elements.push(&cons.first);
-                current = &cons.rest;
-                continue;
-            }
-        }
-
-        // Improper list - not common in well-formed Elle code
-        elements.push(current);
-        break;
-    }
-
-    // Try to format on one line first
-    let one_line = format_list_inline(&elements, config, symbol_table);
-
-    if one_line.len() <= config.line_length - indent {
-        return one_line;
-    }
-
-    // Multi-line formatting
-    format_list_multiline(&elements, indent, config, symbol_table)
-}
-
-/// Format a list on a single line
-fn format_list_inline(
-    elements: &[&Value],
-    config: &FormatterConfig,
-    symbol_table: &SymbolTable,
-) -> String {
-    let formatted: Vec<String> = elements
+    // 4. Collect trivia: merge comments from lexer with blank lines from source
+    let comment_data: Vec<(String, usize, u32)> = lexed
+        .comment_map
+        .comments()
         .iter()
-        .map(|e| format_value(e, 0, config, symbol_table))
+        .map(|c| (c.text.clone(), c.byte_offset, c.line))
         .collect();
-    format!("({})", formatted.join(" "))
-}
+    let trivia = collect_trivia(stripped, &comment_data);
 
-/// Format a list across multiple lines
-fn format_list_multiline(
-    elements: &[&Value],
-    indent: usize,
-    config: &FormatterConfig,
-    symbol_table: &SymbolTable,
-) -> String {
-    if elements.is_empty() {
-        return "()".to_string();
+    // 5. Attach trivia to Syntax nodes
+    let (annotated, dangling) = AnnotatedSyntax::build_toplevel(forms, &trivia, stripped);
+
+    // 6. Generate Doc tree from annotated syntax
+    let doc = format_forms(&annotated, &dangling, stripped, config);
+
+    // 7. Render Doc to string
+    let rendered = render(&doc, config);
+
+    // 8. Assemble output: shebang + rendered + trailing newline
+    //    Strip leading newline from rendered output — format_annotated
+    //    emits HardBreak before leading comments, which produces a
+    //    spurious newline at the document start.
+    let rendered = rendered.trim_start_matches('\n');
+
+    let mut output = String::new();
+    if !shebang.is_empty() {
+        output.push_str(shebang);
+    }
+    output.push_str(rendered);
+    if !output.ends_with('\n') {
+        output.push('\n');
     }
 
-    let new_indent = indent + config.indent_width;
-    let indent_str = " ".repeat(new_indent);
-
-    let mut result = String::from("(");
-
-    // Format first element on the same line as opening paren if it's short
-    let first_formatted = format_value(elements[0], new_indent, config, symbol_table);
-    result.push_str(&first_formatted);
-
-    // Format remaining elements on new lines
-    for element in &elements[1..] {
-        result.push('\n');
-        result.push_str(&indent_str);
-        let formatted = format_value(element, new_indent, config, symbol_table);
-        result.push_str(&formatted);
-    }
-
-    result.push(')');
-    result
+    Ok(output)
 }
 
 #[cfg(test)]
@@ -277,14 +82,13 @@ mod tests {
     fn test_format_simple_number() {
         let config = FormatterConfig::default();
         let formatted = format_code("42", &config).unwrap();
-        assert_eq!(formatted, "42");
+        assert_eq!(formatted, "42\n");
     }
 
     #[test]
     fn test_format_simple_list() {
         let config = FormatterConfig::default();
         let formatted = format_code("(+ 1 2)", &config).unwrap();
-        // Should be formatted, may be on one or multiple lines
         assert!(formatted.contains('('));
         assert!(formatted.contains(')'));
     }
@@ -293,7 +97,7 @@ mod tests {
     fn test_format_nil() {
         let config = FormatterConfig::default();
         let formatted = format_code("nil", &config).unwrap();
-        assert_eq!(formatted, "nil");
+        assert_eq!(formatted, "nil\n");
     }
 
     #[test]
@@ -301,8 +105,8 @@ mod tests {
         let config = FormatterConfig::default();
         let formatted_true = format_code("true", &config).unwrap();
         let formatted_false = format_code("false", &config).unwrap();
-        assert_eq!(formatted_true, "true");
-        assert_eq!(formatted_false, "false");
+        assert_eq!(formatted_true, "true\n");
+        assert_eq!(formatted_false, "false\n");
     }
 
     #[test]
@@ -318,5 +122,426 @@ mod tests {
         let formatted = format_code("[1 2 3]", &config).unwrap();
         assert!(formatted.contains('['));
         assert!(formatted.contains(']'));
+    }
+
+    #[test]
+    fn test_trailing_newline() {
+        let config = FormatterConfig::default();
+        let formatted = format_code("(+ 1 2)", &config).unwrap();
+        assert!(formatted.ends_with('\n'), "must end with newline");
+    }
+
+    #[test]
+    fn test_empty_source() {
+        let config = FormatterConfig::default();
+        let formatted = format_code("", &config).unwrap();
+        assert_eq!(formatted, "\n");
+    }
+
+    #[test]
+    fn test_multiple_forms() {
+        let config = FormatterConfig::default();
+        let formatted = format_code("(def x 5)\n(+ x 1)", &config).unwrap();
+        let lines: Vec<&str> = formatted.trim_end().lines().collect();
+        assert!(lines.len() >= 2, "should have 2+ lines: {:?}", lines);
+    }
+
+    #[test]
+    fn test_idempotent_simple() {
+        let config = FormatterConfig::default();
+        let first = format_code("(+ 1 2)", &config).unwrap();
+        let second = format_code(&first, &config).unwrap();
+        assert_eq!(first, second, "formatter must be idempotent");
+    }
+
+    #[test]
+    fn test_idempotent_defn() {
+        let config = FormatterConfig::default();
+        let input = "(defn foo [x] (+ x 1))";
+        let first = format_code(input, &config).unwrap();
+        let second = format_code(&first, &config).unwrap();
+        assert_eq!(first, second, "defn formatting must be idempotent");
+    }
+
+    #[test]
+    fn test_idempotent_let() {
+        let config = FormatterConfig::default();
+        let input = "(let [x 5] (+ x 1))";
+        let first = format_code(input, &config).unwrap();
+        let second = format_code(&first, &config).unwrap();
+        assert_eq!(first, second, "let formatting must be idempotent");
+    }
+
+    #[test]
+    fn test_shebang_preserved() {
+        let config = FormatterConfig::default();
+        let input = "#!/usr/bin/env elle\n(+ 1 2)";
+        let formatted = format_code(input, &config).unwrap();
+        assert!(
+            formatted.starts_with("#!/usr/bin/env elle\n"),
+            "shebang must be preserved"
+        );
+    }
+
+    #[test]
+    fn test_keyword() {
+        let config = FormatterConfig::default();
+        let formatted = format_code(":hello", &config).unwrap();
+        assert_eq!(formatted, ":hello\n");
+    }
+
+    #[test]
+    fn test_set_literal() {
+        let config = FormatterConfig::default();
+        let formatted = format_code("|1 2 3|", &config).unwrap();
+        assert!(formatted.contains('|'));
+    }
+
+    #[test]
+    fn test_quote() {
+        let config = FormatterConfig::default();
+        let formatted = format_code("'foo", &config).unwrap();
+        assert_eq!(formatted, "'foo\n");
+    }
+
+    #[test]
+    fn test_nested_list() {
+        let config = FormatterConfig::default();
+        let formatted = format_code("(defn foo [x] (if (> x 0) x (- x)))", &config).unwrap();
+        let second = format_code(&formatted, &config).unwrap();
+        assert_eq!(formatted, second, "nested formatting must be idempotent");
+    }
+
+    #[test]
+    fn test_inspect_defn_output() {
+        let config = FormatterConfig::default();
+        let input = "(defn fib [n] (if (< n 2) n (+ (fib (- n 1)) (fib (- n 2)))))";
+        let formatted = format_code(input, &config).unwrap();
+        // defn always breaks before body
+        assert!(formatted.contains('\n'), "defn should break before body");
+        let lines: Vec<&str> = formatted.trim_end().lines().collect();
+        assert!(
+            lines[0].starts_with("(defn fib [n]"),
+            "first line: {:?}",
+            lines
+        );
+        let second = format_code(&formatted, &config).unwrap();
+        assert_eq!(formatted, second);
+    }
+
+    #[test]
+    fn test_inspect_let_output() {
+        let config = FormatterConfig::default();
+        let input = "(let [x 5 y 10] (+ x y))";
+        let formatted = format_code(input, &config).unwrap();
+        // let with multiple pairs breaks between pairs
+        assert!(
+            formatted.contains("[x 5\n"),
+            "let bindings should have pairs on separate lines: {:?}",
+            formatted
+        );
+        let second = format_code(&formatted, &config).unwrap();
+        assert_eq!(formatted, second, "let must be idempotent");
+    }
+
+    #[test]
+    fn test_inspect_full_file() {
+        let config = FormatterConfig::default();
+        let input = r#"(defn fib [n]
+  (if (< n 2) n (+ (fib (- n 1)) (fib (- n 2)))))
+
+(def x 5)
+
+(let [a 1 b 2 c 3]
+  (+ a b c))
+
+(begin
+  (print "hello")
+  (print "world"))
+
+(when (> x 0)
+  (print "positive")
+  x)
+
+(cond
+  (< n 0) "negative"
+  (= n 0) "zero"
+  true "positive")
+
+(match x
+  1 "one"
+  2 "two"
+  _ "other")
+
+(-> val
+  (f a)
+  (g b))
+
+(each item in items
+  (print item))
+
+(and a b c)
+
+'foo
+[1 2 3]
+|a b c|
+{:x 1 :y 2}
+"hello world"
+42
+true
+nil
+:keyword"#;
+        let formatted = format_code(input, &config).unwrap();
+        let second = format_code(&formatted, &config).unwrap();
+        assert_eq!(formatted, second, "full file must be idempotent");
+    }
+
+    // ── Idempotency tests for each special form ─────────────────
+
+    #[test]
+    fn test_idempotent_if_with_else() {
+        let config = FormatterConfig::default();
+        let input = "(if true 1 2)";
+        let first = format_code(input, &config).unwrap();
+        let second = format_code(&first, &config).unwrap();
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn test_idempotent_if_complex() {
+        let config = FormatterConfig::default();
+        let input = "(if (< x 10) (print x) (print (- x 10)))";
+        let first = format_code(input, &config).unwrap();
+        let second = format_code(&first, &config).unwrap();
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn test_idempotent_fn_single_body() {
+        let config = FormatterConfig::default();
+        let input = "(fn (x) (+ x 1))";
+        let first = format_code(input, &config).unwrap();
+        let second = format_code(&first, &config).unwrap();
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn test_idempotent_fn_multi_body() {
+        let config = FormatterConfig::default();
+        let input = "(fn (x) (print x) (+ x 1))";
+        let first = format_code(input, &config).unwrap();
+        let second = format_code(&first, &config).unwrap();
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn test_idempotent_begin() {
+        let config = FormatterConfig::default();
+        let input = "(begin (print 1) (print 2) (print 3))";
+        let first = format_code(input, &config).unwrap();
+        let second = format_code(&first, &config).unwrap();
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn test_idempotent_when() {
+        let config = FormatterConfig::default();
+        let input = "(when (> x 0) (print x) x)";
+        let first = format_code(input, &config).unwrap();
+        let second = format_code(&first, &config).unwrap();
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn test_idempotent_cond() {
+        let config = FormatterConfig::default();
+        let input = "(cond (< x 0) \"neg\" (= x 0) \"zero\" true \"pos\")";
+        let first = format_code(input, &config).unwrap();
+        let second = format_code(&first, &config).unwrap();
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn test_idempotent_match() {
+        let config = FormatterConfig::default();
+        let input = "(match x 1 \"one\" 2 \"two\" _ \"other\")";
+        let first = format_code(input, &config).unwrap();
+        let second = format_code(&first, &config).unwrap();
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn test_idempotent_threading() {
+        let config = FormatterConfig::default();
+        let input = "(-> x (f 1) (g 2) (h 3))";
+        let first = format_code(input, &config).unwrap();
+        let second = format_code(&first, &config).unwrap();
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn test_idempotent_each() {
+        let config = FormatterConfig::default();
+        let input = "(each item in items (print item))";
+        let first = format_code(input, &config).unwrap();
+        let second = format_code(&first, &config).unwrap();
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn test_idempotent_and_or() {
+        let config = FormatterConfig::default();
+        let first_and = format_code("(and a b c)", &config).unwrap();
+        let second_and = format_code(&first_and, &config).unwrap();
+        assert_eq!(first_and, second_and);
+
+        let first_or = format_code("(or x y z)", &config).unwrap();
+        let second_or = format_code(&first_or, &config).unwrap();
+        assert_eq!(first_or, second_or);
+    }
+
+    #[test]
+    fn test_idempotent_defmacro() {
+        let config = FormatterConfig::default();
+        let input = "(defmacro swap (a b) `(let [tmp ,a] (assign ,a ,b) (assign ,b tmp)))";
+        let first = format_code(input, &config).unwrap();
+        let second = format_code(&first, &config).unwrap();
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn test_idempotent_assign() {
+        let config = FormatterConfig::default();
+        let input = "(assign x 42)";
+        let first = format_code(input, &config).unwrap();
+        let second = format_code(&first, &config).unwrap();
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn test_idempotent_def() {
+        let config = FormatterConfig::default();
+        let input = "(def my-fn (fn (x) (+ x 1)))";
+        let first = format_code(input, &config).unwrap();
+        let second = format_code(&first, &config).unwrap();
+        assert_eq!(first, second);
+    }
+
+    // ── Collection type tests ──────────────────────────────────
+
+    #[test]
+    fn test_format_array() {
+        let config = FormatterConfig::default();
+        let formatted = format_code("[1 2 3]", &config).unwrap();
+        assert_eq!(formatted, "[1 2 3]\n");
+    }
+
+    #[test]
+    fn test_format_set() {
+        let config = FormatterConfig::default();
+        let formatted = format_code("|a b c|", &config).unwrap();
+        assert_eq!(formatted, "|a b c|\n");
+    }
+
+    #[test]
+    fn test_format_struct() {
+        let config = FormatterConfig::default();
+        let formatted = format_code("{:x 1 :y 2}", &config).unwrap();
+        assert_eq!(formatted, "{:x 1 :y 2}\n");
+    }
+
+    #[test]
+    fn test_format_nested_quote() {
+        let config = FormatterConfig::default();
+        assert_eq!(format_code("'foo", &config).unwrap(), "'foo\n");
+        assert_eq!(format_code("'(1 2 3)", &config).unwrap(), "'(1 2 3)\n");
+    }
+
+    #[test]
+    fn test_format_quasiquote() {
+        let config = FormatterConfig::default();
+        let formatted = format_code("`(foo ,bar ;baz)", &config).unwrap();
+        let second = format_code(&formatted, &config).unwrap();
+        assert_eq!(formatted, second);
+    }
+
+    // ── CommentBreak idempotency tests ──────────────────────────
+
+    fn assert_idempotent(input: &str) {
+        let config = FormatterConfig::default();
+        let first = format_code(input, &config).unwrap();
+        let second = format_code(&first, &config).unwrap();
+        assert_eq!(
+            first, second,
+            "not idempotent:\n--- first ---\n{}\n--- second ---\n{}",
+            first, second
+        );
+    }
+
+    #[test]
+    fn test_idempotent_trailing_comment_non_last() {
+        assert_idempotent("(begin\n  (foo)  # comment\n  (bar))");
+    }
+
+    #[test]
+    fn test_idempotent_trailing_comment_last() {
+        assert_idempotent("(begin\n  (foo)  # comment\n)");
+    }
+
+    #[test]
+    fn test_idempotent_block_comment_between() {
+        assert_idempotent("(begin\n  (foo)\n  # between\n  (bar))");
+    }
+
+    #[test]
+    fn test_idempotent_block_comment_before_close() {
+        assert_idempotent("(defn f [x]\n  # before close\n  x)");
+    }
+
+    #[test]
+    fn test_idempotent_inline_comment_blank_line_next() {
+        assert_idempotent("(foo)  # comment\n\n(bar)");
+    }
+
+    #[test]
+    fn test_idempotent_nested_comments_multi_level() {
+        assert_idempotent("(defn outer [x]\n  (let [a 1]  # bind\n    (inner a)))  # done");
+    }
+
+    #[test]
+    fn test_idempotent_cond_trivial_and_compound() {
+        assert_idempotent(
+            "(cond (< x 0) \"neg\" (= x 0) (begin (print \"zero\") \"zero\") true \"pos\")",
+        );
+    }
+
+    #[test]
+    fn test_idempotent_case_trivial_and_compound() {
+        assert_idempotent("(case x :a 1 :b (begin (print \"b\") 2) :c 3)");
+    }
+
+    #[test]
+    fn test_idempotent_let_star() {
+        assert_idempotent("(let* [x 5 y (+ x 1)] (+ x y))");
+    }
+
+    #[test]
+    fn test_idempotent_when_with_comment() {
+        assert_idempotent("(when (> x 0)  # guard\n  (print x))");
+    }
+
+    #[test]
+    fn test_idempotent_defn_with_comments() {
+        assert_idempotent("(defn foo [x]  # params\n  # body comment\n  (+ x 1))");
+    }
+
+    #[test]
+    fn test_idempotent_generic_call_long_head() {
+        assert_idempotent("(some-very-long-function-name arg1 arg2 arg3 arg4)");
+    }
+
+    #[test]
+    fn test_idempotent_generic_call_short_head() {
+        assert_idempotent("(f arg1 arg2 arg3)");
     }
 }

--- a/src/formatter/doc.rs
+++ b/src/formatter/doc.rs
@@ -1,0 +1,210 @@
+//! Wadler-style document algebra for pretty printing.
+//!
+//! Based on "A Prettier Printer" (Wadler, 2003). The core idea:
+//! build a Doc tree that describes layout *choices* (flat vs broken),
+//! then a separate renderer evaluates the tree within a line-width
+//! budget and picks the optimal layout.
+//!
+//! ## Core primitives
+//!
+//! - `Empty`        — nothing
+//! - `Text(s)`      — literal string
+//! - `Concat(ds)`   — sequence of docs
+//! - `Nest(n, d)`   — increase indentation by n levels when breaking
+//! - `Break`        — space if flat, newline + indent if broken
+//! - `Group(d)`     — try flat; break inner if doesn't fit
+//! - `HardBreak`    — unconditional newline (never flat)
+//! - `CommentBreak` — like HardBreak, absorbed by adjacent HardBreak
+//! - `Align(d)`     — set indent to current column
+
+/// A document describing layout choices for a pretty printer.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Doc {
+    /// Empty document — produces no output.
+    Empty,
+
+    /// Literal text string.
+    Text(String),
+
+    /// Concatenation of documents in sequence.
+    Concat(Vec<Doc>),
+
+    /// Increase indentation level by `n` when breaking within this doc.
+    /// The actual indent width is `n * indent_width` from the config.
+    Nest(usize, Box<Doc>),
+
+    /// A break point. Space if the enclosing Group stays flat,
+    /// newline + current indentation if broken.
+    Break,
+
+    /// Try to lay out the inner doc on one line. If it doesn't fit
+    /// within the page width, break it (inner Breaks become newlines).
+    Group(Box<Doc>),
+
+    /// Unconditional line break. Always produces a newline regardless
+    /// of whether the enclosing Group is flat or broken.
+    HardBreak,
+
+    /// Like HardBreak but absorbed by an adjacent HardBreak.
+    /// Used after trailing comments to prevent double-newline when
+    /// the inter-sibling HardBreak follows.
+    CommentBreak,
+
+    /// Align inner content to the current column.
+    /// Sets the indent reference to the current column position so that
+    /// Breaks inside `inner` align to where Align was entered.
+    Align(Box<Doc>),
+}
+
+impl Doc {
+    /// Create an empty document.
+    pub fn empty() -> Self {
+        Doc::Empty
+    }
+
+    /// Create a text document.
+    pub fn text(s: impl Into<String>) -> Self {
+        Doc::Text(s.into())
+    }
+
+    /// Create a newline (hard break).
+    pub fn hardbreak() -> Self {
+        Doc::HardBreak
+    }
+
+    /// Create a comment break (absorbed by adjacent HardBreak).
+    pub fn comment_break() -> Self {
+        Doc::CommentBreak
+    }
+
+    /// Align inner content to the current column position.
+    pub fn align(inner: Doc) -> Self {
+        Doc::Align(Box::new(inner))
+    }
+
+    /// Concatenate multiple docs.
+    pub fn concat(docs: impl IntoIterator<Item = Doc>) -> Self {
+        let docs: Vec<Doc> = docs.into_iter().collect();
+        if docs.is_empty() {
+            Doc::Empty
+        } else if docs.len() == 1 {
+            docs.into_iter().next().unwrap()
+        } else {
+            Doc::Concat(docs)
+        }
+    }
+
+    /// Concatenate docs with a separator between each pair.
+    /// The separator is a Break (space if flat, newline if broken).
+    pub fn intersperse(docs: impl IntoIterator<Item = Doc>) -> Self {
+        let docs: Vec<Doc> = docs.into_iter().collect();
+        if docs.is_empty() {
+            return Doc::Empty;
+        }
+        if docs.len() == 1 {
+            return docs.into_iter().next().unwrap();
+        }
+        let mut result = Vec::with_capacity(docs.len() * 2 - 1);
+        for (i, doc) in docs.into_iter().enumerate() {
+            if i > 0 {
+                result.push(Doc::Break);
+            }
+            result.push(doc);
+        }
+        Doc::Concat(result)
+    }
+
+    /// Concatenate docs with a hard break between each.
+    pub fn join_hardbreak(docs: impl IntoIterator<Item = Doc>) -> Self {
+        let docs: Vec<Doc> = docs.into_iter().collect();
+        if docs.is_empty() {
+            return Doc::Empty;
+        }
+        let mut result = Vec::with_capacity(docs.len() * 2 - 1);
+        for (i, doc) in docs.into_iter().enumerate() {
+            if i > 0 {
+                result.push(Doc::HardBreak);
+            }
+            result.push(doc);
+        }
+        Doc::Concat(result)
+    }
+
+    /// Increase indentation by `n` levels.
+    pub fn nest(self, n: usize) -> Self {
+        if matches!(self, Doc::Empty) {
+            return self;
+        }
+        Doc::Nest(n, Box::new(self))
+    }
+
+    /// Try to lay out flat; break if doesn't fit.
+    pub fn group(self) -> Self {
+        if matches!(self, Doc::Empty) {
+            return self;
+        }
+        Doc::Group(Box::new(self))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_empty_doc() {
+        let doc = Doc::empty();
+        assert!(matches!(doc, Doc::Empty));
+    }
+
+    #[test]
+    fn test_text_doc() {
+        let doc = Doc::text("hello");
+        assert!(matches!(doc, Doc::Text(s) if s == "hello"));
+    }
+
+    #[test]
+    fn test_concat_flatten_single() {
+        let doc = Doc::concat(vec![Doc::text("x")]);
+        // Single-element concat is unwrapped
+        assert!(matches!(doc, Doc::Text(s) if s == "x"));
+    }
+
+    #[test]
+    fn test_concat_empty() {
+        let doc = Doc::concat(vec![]);
+        assert!(matches!(doc, Doc::Empty));
+    }
+
+    #[test]
+    fn test_nest_empty() {
+        let doc = Doc::empty().nest(2);
+        // Nesting empty is still empty
+        assert!(matches!(doc, Doc::Empty));
+    }
+
+    #[test]
+    fn test_group_empty() {
+        let doc = Doc::empty().group();
+        // Grouping empty is still empty
+        assert!(matches!(doc, Doc::Empty));
+    }
+
+    #[test]
+    fn test_intersperse_empty() {
+        let doc = Doc::intersperse(vec![]);
+        assert!(matches!(doc, Doc::Empty));
+    }
+
+    #[test]
+    fn test_intersperse_single() {
+        let doc = Doc::intersperse(vec![Doc::text("x")]);
+        assert!(matches!(doc, Doc::Text(s) if s == "x"));
+    }
+
+    #[test]
+    fn test_builder_chaining() {
+        let doc = Doc::concat([Doc::text("hello"), Doc::text(" "), Doc::text("world")]).group();
+        assert!(matches!(doc, Doc::Group(_)));
+    }
+}

--- a/src/formatter/format.rs
+++ b/src/formatter/format.rs
@@ -1,0 +1,359 @@
+//! Doc generator: walks AnnotatedSyntax trees, produces Doc trees.
+//!
+//! This is the formatter's brain. It takes the annotated syntax tree
+//! (where trivia is pre-attached to every node) and produces a Wadler
+//! Doc tree. The Doc tree is then rendered to a string by `render.rs`.
+//!
+//! ## Design
+//!
+//! The walk is a pure function `AnnotatedSyntax → Doc` with no mutable
+//! state. Trivia (comments, blank lines) is emitted from the annotated
+//! tree — no separate CommentMap is consulted during the walk.
+//!
+//! For list forms, the generator dispatches on the head symbol to apply
+//! form-specific rules from `forms.rs`. Unknown forms fall through to
+//! generic call formatting.
+
+use super::config::FormatterConfig;
+use super::doc::Doc;
+use super::trivia::{AnnotatedSyntax, Trivia};
+use crate::syntax::SyntaxKind;
+
+// ── Public entry point ─────────────────────────────────────────
+
+/// Format a list of top-level forms into a single Doc.
+///
+/// Forms are separated by HardBreaks. Leading and trailing trivia
+/// (comments, blank lines) are emitted around each form.
+/// Dangling trivia (comments after the last form) is emitted at the end.
+pub fn format_forms(
+    forms: &[AnnotatedSyntax],
+    dangling: &[Trivia],
+    source: &str,
+    config: &FormatterConfig,
+) -> Doc {
+    let mut all_docs: Vec<Doc> = Vec::new();
+
+    // Format all forms. Between forms, add a HardBreak only if the
+    // next form has no leading trivia (which provides its own spacing).
+    for (i, form) in forms.iter().enumerate() {
+        if i > 0 && form.leading.is_empty() {
+            all_docs.push(Doc::hardbreak());
+        }
+        all_docs.push(format_annotated(form, source, config));
+    }
+
+    // Emit dangling trivia (comments after the last form) without extra spacing
+    let mut has_dangling_comments = false;
+    for t in dangling {
+        if let Trivia::Comment { .. } = t {
+            has_dangling_comments = true;
+            break;
+        }
+    }
+
+    if has_dangling_comments {
+        // If we have forms, add a hardbreak before the first dangling trivia
+        if !all_docs.is_empty() {
+            all_docs.push(Doc::hardbreak());
+        }
+
+        for t in dangling {
+            if let Trivia::Comment { text, .. } = t {
+                all_docs.push(Doc::text(text));
+                all_docs.push(Doc::hardbreak());
+            }
+            // Note: BlankLines trivia in dangling is ignored.
+            // The formatter ensures comments are consecutive without blank lines.
+        }
+    }
+
+    if all_docs.is_empty() {
+        Doc::empty()
+    } else {
+        Doc::concat(all_docs)
+    }
+}
+
+// ── Core recursive walk ────────────────────────────────────────
+
+/// Format a node with its leading and trailing trivia.
+///
+/// Every AnnotatedSyntax passes through here to ensure trivia is
+/// never lost. The trivia is emitted around the node's own Doc.
+pub(super) fn format_annotated(
+    node: &AnnotatedSyntax,
+    source: &str,
+    config: &FormatterConfig,
+) -> Doc {
+    let mut parts = Vec::new();
+
+    // Leading trivia: comments and blank lines before this node.
+    //
+    // The inter-form HardBreak from format_forms provides the newline
+    // that ends the previous form's line. Leading trivia adds to that:
+    // - BlankLines(n): emit n HardBreaks (n blank lines in output)
+    // - Comment: emit HardBreak + text (comment on its own line)
+    //
+    // After all trivia, one final HardBreak separates the last trivia
+    // from the form itself.
+    if !node.leading.is_empty() {
+        for t in &node.leading {
+            match t {
+                Trivia::Comment { text, .. } => {
+                    parts.push(Doc::hardbreak());
+                    parts.push(Doc::text(text));
+                }
+                Trivia::BlankLines { count, .. } => {
+                    for _ in 0..(*count).min(2) {
+                        parts.push(Doc::hardbreak());
+                    }
+                }
+            }
+        }
+        // Separate from the form
+        parts.push(Doc::hardbreak());
+    }
+
+    // The node itself
+    parts.push(format_syntax(node, source, config));
+
+    // Trailing trivia: inline comments and blank lines after this node.
+    //
+    // Comments extend to end-of-line, so they MUST be followed by a
+    // newline — otherwise the next token gets eaten by the comment.
+    //
+    // BlankLines in trailing trivia are only emitted when followed by
+    // a comment — they provide block-vs-inline context. Otherwise,
+    // inter-sibling spacing is handled by the form formatters' own
+    // HardBreaks, and trailing blank lines before close parens must
+    // be stripped to maintain idempotency.
+    let has_trailing_comments = node
+        .trailing
+        .iter()
+        .any(|t| matches!(t, Trivia::Comment { .. }));
+    let mut seen_break = false;
+    let mut inline_done = false;
+    for t in &node.trailing {
+        match t {
+            Trivia::Comment { text, .. } => {
+                if !seen_break && !inline_done {
+                    // Inline: same line as the form
+                    parts.push(Doc::text("  "));
+                    parts.push(Doc::text(text));
+                    inline_done = true;
+                } else {
+                    // Block: own line
+                    parts.push(Doc::hardbreak());
+                    parts.push(Doc::text(text));
+                }
+            }
+            Trivia::BlankLines { count, .. } => {
+                seen_break = true;
+                if has_trailing_comments {
+                    for _ in 0..(*count).min(2) {
+                        parts.push(Doc::hardbreak());
+                    }
+                }
+            }
+        }
+    }
+
+    // Comments extend to end-of-line, so they MUST be followed by a
+    // newline. CommentBreak renders like HardBreak but is absorbed by
+    // an adjacent HardBreak, preventing double-newline between siblings.
+    if node
+        .trailing
+        .iter()
+        .any(|t| matches!(t, Trivia::Comment { .. }))
+    {
+        parts.push(Doc::comment_break());
+    }
+
+    Doc::concat(parts)
+}
+
+/// Format a single Syntax node (no trivia).
+///
+/// Dispatches on SyntaxKind. For lists, checks the head symbol for
+/// special-form dispatch.
+fn format_syntax(node: &AnnotatedSyntax, source: &str, config: &FormatterConfig) -> Doc {
+    match &node.syntax.kind {
+        // ── Atoms ────────────────────────────────────────────
+        SyntaxKind::Nil => Doc::text("nil"),
+        SyntaxKind::Bool(b) => Doc::text(if *b { "true" } else { "false" }),
+        SyntaxKind::Int(n) => Doc::text(n.to_string()),
+        SyntaxKind::Float(f) => Doc::text(f.to_string()),
+        SyntaxKind::Symbol(s) => Doc::text(s.clone()),
+        SyntaxKind::Keyword(s) => Doc::text(format!(":{}", s)),
+        SyntaxKind::String(_) => {
+            // Slice from source to preserve the raw literal (escapes, quotes).
+            // SyntaxKind::String stores the unescaped value, not the source text.
+            let span = &node.syntax.span;
+            if span.start < source.len() && span.end <= source.len() {
+                Doc::text(&source[span.start..span.end])
+            } else {
+                // Synthetic or detached span — fall back to escaped display
+                match &node.syntax.kind {
+                    SyntaxKind::String(s) => Doc::text(format!("\"{}\"", s.escape_default())),
+                    _ => Doc::text("#<bad-string>"),
+                }
+            }
+        }
+
+        // ── Compound collections ─────────────────────────────
+        SyntaxKind::List(_) => format_list(node, source, config),
+        SyntaxKind::Array(_) => format_collection(node, "[", "]", source, config),
+        SyntaxKind::ArrayMut(_) => format_collection(node, "@[", "]", source, config),
+        SyntaxKind::Struct(_) => format_pairs(node, "{", "}", source, config),
+        SyntaxKind::StructMut(_) => format_pairs(node, "@{", "}", source, config),
+        SyntaxKind::Set(_) => format_collection(node, "|", "|", source, config),
+        SyntaxKind::SetMut(_) => format_collection(node, "@|", "|", source, config),
+        SyntaxKind::Bytes(_) => format_collection(node, "b[", "]", source, config),
+        SyntaxKind::BytesMut(_) => format_collection(node, "@b[", "]", source, config),
+
+        // ── Reader macros ────────────────────────────────────
+        SyntaxKind::Quote(_) => format_reader_macro("'", node, source, config),
+        SyntaxKind::Quasiquote(_) => format_reader_macro("`", node, source, config),
+        SyntaxKind::Unquote(_) => format_reader_macro(",", node, source, config),
+        SyntaxKind::UnquoteSplicing(_) => format_reader_macro(",;", node, source, config),
+        SyntaxKind::Splice(_) => format_reader_macro(";", node, source, config),
+
+        // ── Internal (should never appear in formatter input) ──
+        SyntaxKind::SyntaxLiteral(_) => Doc::text("#<syntax-literal>"),
+    }
+}
+
+// ── List dispatch ──────────────────────────────────────────────
+
+/// Format a list form, dispatching on the head symbol.
+fn format_list(node: &AnnotatedSyntax, source: &str, config: &FormatterConfig) -> Doc {
+    let children = &node.children;
+
+    if children.is_empty() {
+        return Doc::text("()");
+    }
+
+    // Dispatch on the head symbol
+    if let Some(sym) = children[0].syntax.as_symbol() {
+        match sym {
+            "def" | "defn" => return super::forms::format_def(children, source, config),
+            "fn" => return super::forms::format_fn(children, source, config),
+            "let" | "let*" | "letrec" => return super::forms::format_let(children, source, config),
+            "if" => return super::forms::format_if(children, source, config),
+            "cond" => return super::forms::format_cond(children, source, config),
+            "match" => return super::forms::format_match(children, source, config),
+            "while" => return super::forms::format_while(children, source, config),
+            "defmacro" => return super::forms::format_defmacro(children, source, config),
+            "begin" => return super::forms::format_begin(children, source, config),
+            "forever" => return super::forms::format_forever(children, source, config),
+            "block" => return super::forms::format_block(children, source, config),
+            "parameterize" => return super::forms::format_parameterize(children, source, config),
+            "->" | "->>" | "some->" | "some->>" => {
+                return super::forms::format_threading(children, source, config)
+            }
+            "when" | "unless" => return super::forms::format_when(children, source, config),
+            "and" | "or" | "not" | "emit" => {
+                return super::forms::format_generic_call(children, source, config)
+            }
+            "each" => return super::forms::format_each(children, source, config),
+            "case" => return super::forms::format_case(children, source, config),
+            "try" | "protect" => return super::forms::format_try(children, source, config),
+            "assign" => return super::forms::format_assign(children, source, config),
+            _ => {}
+        }
+    }
+
+    // Default: generic call
+    super::forms::format_generic_call(children, source, config)
+}
+
+// ── Generic collection ─────────────────────────────────────────
+
+/// Format a generic collection with delimiters.
+///
+/// Elements are separated by Break (space if flat, newline if broken).
+/// The whole body is grouped — if it fits on one line, it stays flat.
+fn format_collection(
+    node: &AnnotatedSyntax,
+    open: &str,
+    close: &str,
+    source: &str,
+    config: &FormatterConfig,
+) -> Doc {
+    if node.children.is_empty() {
+        return Doc::text(format!("{}{}", open, close));
+    }
+
+    let elems: Vec<Doc> = node
+        .children
+        .iter()
+        .map(|c| format_annotated(c, source, config))
+        .collect();
+
+    Doc::concat([
+        Doc::text(open),
+        Doc::align(Doc::intersperse(elems).group()),
+        Doc::text(close),
+    ])
+}
+
+// ── Pair-wise collection (structs) ─────────────────────────────
+
+/// Format a key-value collection (structs). Elements are grouped in pairs.
+/// Flat: `{:a 1 :b 2}`. Broken: one pair per line, +2 indent.
+fn format_pairs(
+    node: &AnnotatedSyntax,
+    open: &str,
+    close: &str,
+    source: &str,
+    config: &FormatterConfig,
+) -> Doc {
+    if node.children.is_empty() {
+        return Doc::text(format!("{}{}", open, close));
+    }
+
+    let children = &node.children;
+
+    // Build pair docs: each pair is "key value" joined by a space
+    let mut pair_docs: Vec<Doc> = Vec::new();
+    let mut i = 0;
+    while i < children.len() {
+        let key = format_annotated(&children[i], source, config);
+        i += 1;
+        if i < children.len() {
+            let val = format_annotated(&children[i], source, config);
+            i += 1;
+            pair_docs.push(Doc::concat([key, Doc::text(" "), val]));
+        } else {
+            pair_docs.push(key);
+        }
+    }
+
+    Doc::concat([
+        Doc::text(open),
+        Doc::align(Doc::intersperse(pair_docs).group()),
+        Doc::text(close),
+    ])
+}
+
+// ── Reader macros ──────────────────────────────────────────────
+
+/// Format a reader macro: `'x`, `` `x ``, `,x`, `;x`.
+///
+/// The prefix is prepended to the formatted inner form.
+/// If the inner form breaks, the prefix stays on the same line
+/// as the first element.
+fn format_reader_macro(
+    prefix: &str,
+    node: &AnnotatedSyntax,
+    source: &str,
+    config: &FormatterConfig,
+) -> Doc {
+    if node.children.is_empty() {
+        return Doc::text(prefix);
+    }
+
+    let inner = format_annotated(&node.children[0], source, config);
+    Doc::concat([Doc::text(prefix), inner])
+}

--- a/src/formatter/forms.rs
+++ b/src/formatter/forms.rs
@@ -1,0 +1,975 @@
+//! Per-special-form formatting rules.
+//!
+//! Each public function receives the children of a list form (including
+//! the head symbol as `children[0]`) and returns a Doc for the entire
+//! form including parentheses.
+//!
+//! ## Convention
+//!
+//! Children are positional — the handler knows which child is the name,
+//! params, body, etc. Each child is formatted via `format_annotated`
+//! which preserves its attached trivia (comments, blank lines).
+
+use super::config::FormatterConfig;
+use super::doc::Doc;
+use super::format::format_annotated;
+use super::render::measure_flat;
+use super::trivia::AnnotatedSyntax;
+use crate::syntax::SyntaxKind;
+
+// ── Helpers ────────────────────────────────────────────────────
+
+/// Check if a node is a string literal (for docstring detection).
+fn is_string_literal(node: &AnnotatedSyntax) -> bool {
+    matches!(node.syntax.kind, SyntaxKind::String(_))
+}
+
+/// Check if a node is a collection type (List, Array, etc.).
+fn is_collection(node: &AnnotatedSyntax) -> bool {
+    matches!(
+        node.syntax.kind,
+        SyntaxKind::List(_)
+            | SyntaxKind::Array(_)
+            | SyntaxKind::ArrayMut(_)
+            | SyntaxKind::Struct(_)
+            | SyntaxKind::StructMut(_)
+            | SyntaxKind::Set(_)
+            | SyntaxKind::SetMut(_)
+    )
+}
+
+/// Body-form head symbols that introduce nesting/control flow.
+const BODY_FORMS: &[&str] = &[
+    "def", "defn", "defmacro", "fn", "let", "let*", "letrec", "if", "when", "unless", "while",
+    "each", "begin", "cond", "match", "case", "try", "protect", "->", "->>", "some->", "some->>",
+];
+
+/// A node is "trivial" if it is structurally simple — no nested body forms.
+/// Trivial nodes get columnar alignment; compound nodes get +2 body indent.
+fn is_trivial(node: &AnnotatedSyntax) -> bool {
+    match &node.syntax.kind {
+        // Atoms are always trivial
+        SyntaxKind::Nil
+        | SyntaxKind::Bool(_)
+        | SyntaxKind::Int(_)
+        | SyntaxKind::Float(_)
+        | SyntaxKind::Symbol(_)
+        | SyntaxKind::Keyword(_)
+        | SyntaxKind::String(_) => true,
+
+        // A list is trivial if its head is NOT a body form
+        // and all children are trivial
+        SyntaxKind::List(_) => {
+            if let Some(sym) = node.children.first().and_then(|c| c.syntax.as_symbol()) {
+                if BODY_FORMS.contains(&sym) {
+                    return false;
+                }
+            }
+            node.children.iter().all(is_trivial)
+        }
+
+        // Collections are trivial if all elements are trivial
+        SyntaxKind::Array(_)
+        | SyntaxKind::ArrayMut(_)
+        | SyntaxKind::Struct(_)
+        | SyntaxKind::StructMut(_)
+        | SyntaxKind::Set(_)
+        | SyntaxKind::SetMut(_)
+        | SyntaxKind::Bytes(_)
+        | SyntaxKind::BytesMut(_) => node.children.iter().all(is_trivial),
+
+        // Reader macros: trivial if inner is trivial
+        SyntaxKind::Quote(_)
+        | SyntaxKind::Quasiquote(_)
+        | SyntaxKind::Unquote(_)
+        | SyntaxKind::UnquoteSplicing(_)
+        | SyntaxKind::Splice(_) => node.children.first().is_none_or(is_trivial),
+
+        SyntaxKind::SyntaxLiteral(_) => true,
+    }
+}
+
+/// Format a sequence of body expressions separated by HardBreaks.
+///
+/// CommentBreak (emitted after trailing comments by format_annotated)
+/// is absorbed by the inter-sibling HardBreak, so no special-casing needed.
+fn format_body(children: &[AnnotatedSyntax], source: &str, config: &FormatterConfig) -> Doc {
+    if children.is_empty() {
+        return Doc::empty();
+    }
+    let mut parts = Vec::new();
+    for (i, child) in children.iter().enumerate() {
+        if i > 0 {
+            parts.push(Doc::HardBreak);
+        }
+        parts.push(format_annotated(child, source, config));
+    }
+    Doc::concat(parts)
+}
+
+// ── def / defn ─────────────────────────────────────────────────
+
+/// Format `(def name value)` or `(defn name [params] body...)`.
+pub(super) fn format_def(
+    children: &[AnnotatedSyntax],
+    source: &str,
+    config: &FormatterConfig,
+) -> Doc {
+    if children.len() >= 4 && is_collection(&children[2]) {
+        format_defn(children, source, config)
+    } else {
+        format_def_simple(children, source, config)
+    }
+}
+
+/// `(def name value)` — name on same line as def, value breaks with +2 if needed.
+fn format_def_simple(children: &[AnnotatedSyntax], source: &str, config: &FormatterConfig) -> Doc {
+    if children.len() < 3 {
+        return format_generic_call(children, source, config);
+    }
+
+    let head = format_annotated(&children[0], source, config);
+    let name = format_annotated(&children[1], source, config);
+    let value = format_annotated(&children[2], source, config);
+
+    // (def name value) inline if fits, else (def name\n  value)
+    Doc::concat([
+        Doc::text("("),
+        head,
+        Doc::text(" "),
+        name,
+        Doc::concat([Doc::Break, value]).nest(1).group(),
+        Doc::text(")"),
+    ])
+}
+
+/// `(defn name [params] body...)` — always break before body.
+///
+/// ```lisp
+/// (defn name [params]
+///   body)
+/// ```
+fn format_defn(children: &[AnnotatedSyntax], source: &str, config: &FormatterConfig) -> Doc {
+    // children: [defn, name, [params], body...]
+    // or:       [defn, name, [params], "docstring", body...]
+    if children.len() < 4 {
+        return format_generic_call(children, source, config);
+    }
+
+    let head = format_annotated(&children[0], source, config);
+    let name = format_annotated(&children[1], source, config);
+    let params = format_annotated(&children[2], source, config);
+
+    // Header: (defn name [params])
+    let header = Doc::concat([head, Doc::Break, name, Doc::Break, params]);
+
+    // Check for docstring (first body element is a string literal)
+    let (docstring, body_start) = if children.len() > 3 && is_string_literal(&children[3]) {
+        (Some(&children[3]), 4)
+    } else {
+        (None, 3)
+    };
+
+    // Build body: docstring (if present) + body expressions, all separated by HardBreaks
+    let body = if let Some(ds_node) = docstring {
+        let ds = format_annotated(ds_node, source, config);
+        let rest = format_body(&children[body_start..], source, config);
+        if children[body_start..].is_empty() {
+            ds
+        } else {
+            Doc::concat([ds, Doc::HardBreak, rest])
+        }
+    } else {
+        format_body(&children[body_start..], source, config)
+    };
+
+    Doc::concat([
+        Doc::text("("),
+        Doc::concat([header.group(), Doc::HardBreak, body]).nest(1),
+        Doc::text(")"),
+    ])
+}
+
+// ── fn / λ ─────────────────────────────────────────────────────
+
+/// `(fn [params] body...)` or `(fn name [params] body...)`.
+///
+/// Inline if single short body expression; break otherwise.
+pub(super) fn format_fn(
+    children: &[AnnotatedSyntax],
+    source: &str,
+    config: &FormatterConfig,
+) -> Doc {
+    if children.len() < 3 {
+        return format_generic_call(children, source, config);
+    }
+
+    // fn can have an optional name: (fn name [params] body) or (fn [params] body)
+    let has_name = !is_collection(&children[1]);
+    let params_idx = if has_name { 2 } else { 1 };
+    let body_start = params_idx + 1;
+
+    if children.len() < body_start {
+        return format_generic_call(children, source, config);
+    }
+
+    let head = format_annotated(&children[0], source, config);
+    let params = format_annotated(&children[params_idx], source, config);
+
+    // Header: (fn name? [params])
+    let mut header_parts = vec![head];
+    if has_name {
+        header_parts.push(Doc::Break);
+        header_parts.push(format_annotated(&children[1], source, config));
+    }
+    header_parts.push(Doc::Break);
+    header_parts.push(params);
+    let header = Doc::concat(header_parts);
+
+    let body_children = &children[body_start..];
+
+    if body_children.is_empty() {
+        // No body — just header
+        Doc::concat([Doc::text("("), header.group(), Doc::text(")")])
+    } else if body_children.len() == 1 {
+        // Single body: try inline, break if needed.
+        // Align so the body indents relative to (fn's column, not Nest level.
+        let body_doc = format_annotated(&body_children[0], source, config);
+        Doc::align(Doc::concat([
+            Doc::text("("),
+            header.group(),
+            Doc::concat([Doc::Break, body_doc]).nest(1).group(),
+            Doc::text(")"),
+        ]))
+    } else {
+        // Multiple body expressions: always break.
+        // Align so body indents relative to (fn's column.
+        let body = format_body(body_children, source, config);
+        Doc::align(Doc::concat([
+            Doc::text("("),
+            Doc::concat([header.group(), Doc::HardBreak, body]).nest(1),
+            Doc::text(")"),
+        ]))
+    }
+}
+
+// ── let / letrec ───────────────────────────────────────────────
+
+/// `(let [bindings...] body...)` — one binding pair per line, always.
+///
+/// ```lisp
+/// (let [x 5
+///       y 10]
+///   body)
+/// ```
+pub(super) fn format_let(
+    children: &[AnnotatedSyntax],
+    source: &str,
+    config: &FormatterConfig,
+) -> Doc {
+    if children.len() < 3 {
+        return format_generic_call(children, source, config);
+    }
+
+    let head = format_annotated(&children[0], source, config);
+
+    // Column of first binding name relative to the "(": "(let* [" = 1 + 4 + 1 + 1 = 7
+    let head_width = measure_flat(&head).unwrap_or(0);
+    let binding_col = 1 + head_width + 1 + 1; // "(head ["
+
+    let bindings_doc = format_bindings(&children[1], source, config, binding_col);
+
+    // Header: (let [...])
+    let header = Doc::concat([head, Doc::text(" "), bindings_doc]);
+
+    // Body: +2 indent
+    let body = format_body(&children[2..], source, config);
+
+    Doc::concat([
+        Doc::text("("),
+        Doc::concat([header, Doc::HardBreak, body]).nest(1),
+        Doc::text(")"),
+    ])
+}
+
+/// Format binding vector: one pair per line, always.
+///
+/// Uses HardBreak between pairs with exact column alignment via
+/// Nest + padding. `binding_col` is the column of the first binding
+/// name relative to the enclosing `(`.
+fn format_bindings(
+    bindings_node: &AnnotatedSyntax,
+    source: &str,
+    config: &FormatterConfig,
+    binding_col: usize,
+) -> Doc {
+    let items = &bindings_node.children;
+
+    if items.is_empty() {
+        return Doc::text("[]");
+    }
+
+    // Nest handles the bulk of alignment; padding covers the remainder
+    // (e.g. let* needs 7 spaces = nest(3)*2 + 1 pad)
+    let binding_nest = binding_col / config.indent_width;
+    let padding = binding_col % config.indent_width;
+
+    let mut pair_parts = Vec::new();
+    let mut i = 0;
+    let mut first = true;
+    while i < items.len() {
+        if !first {
+            pair_parts.push(Doc::HardBreak);
+            if padding > 0 {
+                pair_parts.push(Doc::text(" ".repeat(padding)));
+            }
+        }
+        first = false;
+
+        // Name
+        pair_parts.push(format_annotated(&items[i], source, config));
+        i += 1;
+
+        // Value (if present) — always a space, never a Break
+        if i < items.len() {
+            pair_parts.push(Doc::text(" "));
+            pair_parts.push(format_annotated(&items[i], source, config));
+            i += 1;
+        }
+    }
+
+    Doc::concat([
+        Doc::text("["),
+        Doc::concat(pair_parts).nest(binding_nest),
+        Doc::text("]"),
+    ])
+}
+
+// ── if ─────────────────────────────────────────────────────────
+
+/// `(if test then else?)`.
+///
+/// Inline if fits. When breaking:
+/// - Trivial branches: columnar (align to first arg).
+/// - Compound branches: +2 body indent.
+pub(super) fn format_if(
+    children: &[AnnotatedSyntax],
+    source: &str,
+    config: &FormatterConfig,
+) -> Doc {
+    if children.len() < 3 {
+        return format_generic_call(children, source, config);
+    }
+
+    let head = format_annotated(&children[0], source, config);
+    let test = format_annotated(&children[1], source, config);
+    let then = format_annotated(&children[2], source, config);
+
+    let branches = &children[2..];
+    let trivial = branches.iter().all(is_trivial);
+
+    if children.len() <= 3 {
+        // (if test then) — same as when
+        if trivial {
+            let header = Doc::concat([head, Doc::text(" "), test]);
+            Doc::concat([
+                Doc::text("("),
+                Doc::concat([header, Doc::Break, then]).nest(1).group(),
+                Doc::text(")"),
+            ])
+        } else {
+            Doc::align(Doc::concat([
+                Doc::text("("),
+                head,
+                Doc::text(" "),
+                test,
+                Doc::concat([Doc::HardBreak, then]).nest(1),
+                Doc::text(")"),
+            ]))
+        }
+    } else {
+        let else_ = format_annotated(&children[3], source, config);
+
+        if trivial {
+            // Trivial branches: test stays with head, branches break to +2
+            let header = Doc::concat([head, Doc::text(" "), test]);
+            Doc::concat([
+                Doc::text("("),
+                Doc::concat([header, Doc::Break, then, Doc::Break, else_])
+                    .nest(1)
+                    .group(),
+                Doc::text(")"),
+            ])
+        } else {
+            // Compound branches: always break, +2 indent relative to (if.
+            // head+test inside Nest so CommentBreak absorption uses correct indent.
+            Doc::align(Doc::concat([
+                Doc::text("("),
+                Doc::concat([
+                    head,
+                    Doc::text(" "),
+                    test,
+                    Doc::HardBreak,
+                    then,
+                    Doc::HardBreak,
+                    else_,
+                ])
+                .nest(1),
+                Doc::text(")"),
+            ]))
+        }
+    }
+}
+
+// ── cond ───────────────────────────────────────────────────────
+
+/// `(cond test1 body1 test2 body2 default)` — flat pairs.
+///
+/// Always break. Each test-body pair on its own line. Trivial body stays
+/// with test; compound body breaks +2. Odd trailing element is the default.
+pub(super) fn format_cond(
+    children: &[AnnotatedSyntax],
+    source: &str,
+    config: &FormatterConfig,
+) -> Doc {
+    if children.len() < 2 {
+        return format_generic_call(children, source, config);
+    }
+
+    let head = format_annotated(&children[0], source, config);
+    let pairs = format_flat_pairs(&children[1..], source, config);
+    let clauses = Doc::join_hardbreak(pairs);
+
+    Doc::concat([
+        Doc::text("("),
+        Doc::concat([head, Doc::HardBreak, clauses]).nest(1),
+        Doc::text(")"),
+    ])
+}
+
+// ── match ──────────────────────────────────────────────────────
+
+/// `(match expr pat1 body1 pat2 body2 default)` — flat pairs after expr.
+pub(super) fn format_match(
+    children: &[AnnotatedSyntax],
+    source: &str,
+    config: &FormatterConfig,
+) -> Doc {
+    if children.len() < 3 {
+        return format_generic_call(children, source, config);
+    }
+
+    let head = format_annotated(&children[0], source, config);
+    let expr = format_annotated(&children[1], source, config);
+    let pairs = format_flat_pairs(&children[2..], source, config);
+    let clauses = Doc::join_hardbreak(pairs);
+
+    Doc::concat([
+        Doc::text("("),
+        Doc::concat([head, Doc::text(" "), expr, Doc::HardBreak, clauses]).nest(1),
+        Doc::text(")"),
+    ])
+}
+
+// ── while ──────────────────────────────────────────────────────
+
+/// `(while test body...)` — break if body has >1 expression.
+pub(super) fn format_while(
+    children: &[AnnotatedSyntax],
+    source: &str,
+    config: &FormatterConfig,
+) -> Doc {
+    if children.len() < 3 {
+        return format_generic_call(children, source, config);
+    }
+
+    let head = format_annotated(&children[0], source, config);
+    let test = format_annotated(&children[1], source, config);
+    let body_children = &children[2..];
+
+    if body_children.len() == 1 {
+        // Single body: try inline
+        let body = format_annotated(&body_children[0], source, config);
+        let cp = Doc::text(")");
+        Doc::concat([
+            Doc::text("("),
+            Doc::intersperse([head, test, body]).nest(1).group(),
+            cp,
+        ])
+    } else {
+        // Multiple body expressions: always break
+        let body = format_body(body_children, source, config);
+        Doc::concat([
+            Doc::text("("),
+            Doc::concat([
+                Doc::concat([head, Doc::Break, test]).group(),
+                Doc::HardBreak,
+                body,
+            ])
+            .nest(1),
+            Doc::text(")"),
+        ])
+    }
+}
+
+// ── defmacro ───────────────────────────────────────────────────
+
+/// `(defmacro name [params] body...)` — same layout as defn.
+pub(super) fn format_defmacro(
+    children: &[AnnotatedSyntax],
+    source: &str,
+    config: &FormatterConfig,
+) -> Doc {
+    format_defn(children, source, config)
+}
+
+// ── begin ──────────────────────────────────────────────────────
+
+/// `(begin body...)` — always break. Each expression on its own line, +2 indent.
+pub(super) fn format_begin(
+    children: &[AnnotatedSyntax],
+    source: &str,
+    config: &FormatterConfig,
+) -> Doc {
+    if children.len() < 2 {
+        return format_generic_call(children, source, config);
+    }
+
+    let head = format_annotated(&children[0], source, config);
+    let body = format_body(&children[1..], source, config);
+
+    Doc::concat([
+        Doc::text("("),
+        Doc::concat([head, Doc::HardBreak, body]).nest(1),
+        Doc::text(")"),
+    ])
+}
+
+// ── forever ────────────────────────────────────────────────────
+
+/// `(forever body...)` — infinite loop. Single body: try inline. Multi: break like begin.
+pub(super) fn format_forever(
+    children: &[AnnotatedSyntax],
+    source: &str,
+    config: &FormatterConfig,
+) -> Doc {
+    if children.len() < 2 {
+        return format_generic_call(children, source, config);
+    }
+
+    let head = format_annotated(&children[0], source, config);
+    let body_children = &children[1..];
+
+    if body_children.len() == 1 {
+        let body = format_annotated(&body_children[0], source, config);
+        Doc::concat([
+            Doc::text("("),
+            Doc::concat([head, Doc::Break, body]).nest(1).group(),
+            Doc::text(")"),
+        ])
+    } else {
+        let body = format_body(body_children, source, config);
+        Doc::concat([
+            Doc::text("("),
+            Doc::concat([head, Doc::HardBreak, body]).nest(1),
+            Doc::text(")"),
+        ])
+    }
+}
+
+// ── block ──────────────────────────────────────────────────────
+
+/// `(block :name body...)` — like begin, with :name on same line as block.
+pub(super) fn format_block(
+    children: &[AnnotatedSyntax],
+    source: &str,
+    config: &FormatterConfig,
+) -> Doc {
+    if children.len() < 3 {
+        return format_generic_call(children, source, config);
+    }
+
+    let head = format_annotated(&children[0], source, config);
+    let name = format_annotated(&children[1], source, config);
+    let body = format_body(&children[2..], source, config);
+
+    Doc::concat([
+        Doc::text("("),
+        Doc::concat([head, Doc::text(" "), name, Doc::HardBreak, body]).nest(1),
+        Doc::text(")"),
+    ])
+}
+
+// ── parameterize ──────────────────────────────────────────────
+
+/// `(parameterize ((var val) ...) body...)` — bindings each on a new line,
+/// aligned to the first binding via Align.
+pub(super) fn format_parameterize(
+    children: &[AnnotatedSyntax],
+    source: &str,
+    config: &FormatterConfig,
+) -> Doc {
+    if children.len() < 3 {
+        return format_generic_call(children, source, config);
+    }
+
+    let head = format_annotated(&children[0], source, config);
+
+    // children[1] is the bindings list ((var val) ...)
+    let bindings_node = &children[1];
+    let binding_docs: Vec<Doc> = bindings_node
+        .children
+        .iter()
+        .map(|c| format_annotated(c, source, config))
+        .collect();
+
+    let bindings = if binding_docs.is_empty() {
+        Doc::text("()")
+    } else {
+        // Align binding entries to the column after "(parameterize ("
+        Doc::concat([
+            Doc::text("("),
+            Doc::align(Doc::join_hardbreak(binding_docs)),
+            Doc::text(")"),
+        ])
+    };
+
+    let body = format_body(&children[2..], source, config);
+
+    Doc::concat([
+        Doc::text("("),
+        Doc::concat([head, Doc::text(" "), bindings, Doc::HardBreak, body]).nest(1),
+        Doc::text(")"),
+    ])
+}
+
+// ── Threading macros ─────────────────────────────────────────
+
+/// `(-> val step...)` — always break. Steps align with value.
+pub(super) fn format_threading(
+    children: &[AnnotatedSyntax],
+    source: &str,
+    config: &FormatterConfig,
+) -> Doc {
+    if children.len() < 3 {
+        return format_generic_call(children, source, config);
+    }
+
+    let head = format_annotated(&children[0], source, config);
+    let val = format_annotated(&children[1], source, config);
+    let steps: Vec<Doc> = children[2..]
+        .iter()
+        .map(|c| format_annotated(c, source, config))
+        .collect();
+
+    // Align val and all steps to the column after "(-> "
+    let mut all = Vec::with_capacity(steps.len() + 1);
+    all.push(val);
+    all.extend(steps);
+
+    Doc::concat([
+        Doc::text("("),
+        head,
+        Doc::text(" "),
+        Doc::align(Doc::join_hardbreak(all)),
+        Doc::text(")"),
+    ])
+}
+
+// ── when / unless ──────────────────────────────────────────────
+
+/// `(when test body...)` or `(unless test body...)`.
+///
+/// Trivial body (single, no nested body forms): columnar alignment.
+/// Compound body: +2 indent.
+pub(super) fn format_when(
+    children: &[AnnotatedSyntax],
+    source: &str,
+    config: &FormatterConfig,
+) -> Doc {
+    if children.len() < 3 {
+        return format_generic_call(children, source, config);
+    }
+
+    let head = format_annotated(&children[0], source, config);
+    let test = format_annotated(&children[1], source, config);
+    let body_children = &children[2..];
+    let body = format_body(body_children, source, config);
+
+    let trivial = body_children.len() == 1 && is_trivial(&body_children[0]);
+
+    if trivial {
+        Doc::concat([
+            Doc::text("("),
+            Doc::concat([head, Doc::text(" "), test, Doc::Break, body])
+                .nest(1)
+                .group(),
+            Doc::text(")"),
+        ])
+    } else {
+        Doc::concat([
+            Doc::text("("),
+            Doc::concat([head, Doc::text(" "), test, Doc::HardBreak, body]).nest(1),
+            Doc::text(")"),
+        ])
+    }
+}
+
+// ── each ───────────────────────────────────────────────────────
+
+/// `(each item in collection body...)`.
+///
+/// ```lisp
+/// (each item in collection
+///   body)
+/// ```
+pub(super) fn format_each(
+    children: &[AnnotatedSyntax],
+    source: &str,
+    config: &FormatterConfig,
+) -> Doc {
+    // Two forms: (each item in collection body...) or (each item collection body...)
+    let has_in = children.get(2).and_then(|c| c.syntax.as_symbol()) == Some("in");
+
+    let (coll_idx, body_start) = if has_in { (3, 4) } else { (2, 3) };
+
+    if children.len() <= body_start {
+        return format_generic_call(children, source, config);
+    }
+
+    let head = format_annotated(&children[0], source, config);
+    let item = format_annotated(&children[1], source, config);
+    let coll = format_annotated(&children[coll_idx], source, config);
+    let body = format_body(&children[body_start..], source, config);
+
+    // Header: each item [in] collection — always on one line
+    let header = if has_in {
+        let in_kw = format_annotated(&children[2], source, config);
+        Doc::concat([
+            head,
+            Doc::text(" "),
+            item,
+            Doc::text(" "),
+            in_kw,
+            Doc::text(" "),
+            coll,
+        ])
+    } else {
+        Doc::concat([head, Doc::text(" "), item, Doc::text(" "), coll])
+    };
+
+    Doc::concat([
+        Doc::text("("),
+        Doc::concat([header, Doc::HardBreak, body]).nest(1),
+        Doc::text(")"),
+    ])
+}
+
+// ── case ───────────────────────────────────────────────────────
+
+/// `(case expr key result ...)` — always break. Flat alternating pairs.
+pub(super) fn format_case(
+    children: &[AnnotatedSyntax],
+    source: &str,
+    config: &FormatterConfig,
+) -> Doc {
+    if children.len() < 3 {
+        return format_generic_call(children, source, config);
+    }
+
+    let head = format_annotated(&children[0], source, config);
+    let expr = format_annotated(&children[1], source, config);
+    let pairs = format_flat_pairs(&children[2..], source, config);
+    let clauses = Doc::join_hardbreak(pairs);
+
+    Doc::concat([
+        Doc::text("("),
+        Doc::concat([
+            Doc::concat([head, Doc::Break, expr]).group(),
+            Doc::HardBreak,
+            clauses,
+        ])
+        .nest(1),
+        Doc::text(")"),
+    ])
+}
+
+/// Format flat alternating test/body pairs.
+///
+/// Trivial body stays on the same line as test. Compound body breaks +2.
+/// An odd trailing element (default clause) stands alone.
+fn format_flat_pairs(
+    children: &[AnnotatedSyntax],
+    source: &str,
+    config: &FormatterConfig,
+) -> Vec<Doc> {
+    let mut pair_docs = Vec::new();
+    let mut i = 0;
+    while i < children.len() {
+        let test = format_annotated(&children[i], source, config);
+        i += 1;
+        if i < children.len() {
+            let result = format_annotated(&children[i], source, config);
+            if is_trivial(&children[i]) {
+                pair_docs.push(Doc::concat([test, Doc::text(" "), result]));
+            } else {
+                pair_docs.push(Doc::concat([
+                    test,
+                    Doc::concat([Doc::HardBreak, result]).nest(1),
+                ]));
+            }
+            i += 1;
+        } else {
+            pair_docs.push(test);
+        }
+    }
+    pair_docs
+}
+
+// ── try / protect ──────────────────────────────────────────────
+
+/// `(try body (catch pattern handler))` or `(protect body (finally cleanup))`.
+///
+/// Single short body: try inline. Multiple or long body: break.
+pub(super) fn format_try(
+    children: &[AnnotatedSyntax],
+    source: &str,
+    config: &FormatterConfig,
+) -> Doc {
+    if children.len() < 3 {
+        return format_generic_call(children, source, config);
+    }
+
+    let head = format_annotated(&children[0], source, config);
+    let body_children = &children[1..];
+
+    if body_children.len() == 1 {
+        // Single body: try inline
+        let body = format_annotated(&body_children[0], source, config);
+        Doc::concat([
+            Doc::text("("),
+            Doc::intersperse([head, body]).nest(1).group(),
+            Doc::text(")"),
+        ])
+    } else {
+        // Multiple sub-forms (e.g. body + catch/finally): break
+        let body = format_body(body_children, source, config);
+        Doc::concat([
+            Doc::text("("),
+            Doc::concat([head, Doc::HardBreak, body]).nest(1),
+            Doc::text(")"),
+        ])
+    }
+}
+
+// ── assign ─────────────────────────────────────────────────────
+
+/// `(assign name value)` — inline if fits.
+pub(super) fn format_assign(
+    children: &[AnnotatedSyntax],
+    source: &str,
+    config: &FormatterConfig,
+) -> Doc {
+    if children.len() < 3 {
+        return format_generic_call(children, source, config);
+    }
+
+    let elems: Vec<Doc> = children
+        .iter()
+        .map(|c| format_annotated(c, source, config))
+        .collect();
+
+    Doc::concat([
+        Doc::text("("),
+        Doc::intersperse(elems).nest(1).group(),
+        Doc::text(")"),
+    ])
+}
+
+// ── Generic call (default) ────────────────────────────────────
+
+/// Generic function call: try inline; break with args aligned to first arg.
+///
+/// Head and first arg stay on the same line. When breaking, subsequent
+/// args align to the first arg's column (approximated via Nest levels).
+///
+/// ```lisp
+/// (f a b c)          # fits on one line
+/// (f a               # doesn't fit — first arg stays with head
+///   b                #   remaining args align to first arg
+///   c)
+/// ```
+pub(super) fn format_generic_call(
+    children: &[AnnotatedSyntax],
+    source: &str,
+    config: &FormatterConfig,
+) -> Doc {
+    if children.is_empty() {
+        return Doc::text("()");
+    }
+
+    let elems: Vec<Doc> = children
+        .iter()
+        .map(|c| format_annotated(c, source, config))
+        .collect();
+
+    if elems.len() == 1 {
+        // Head only
+        return Doc::concat([
+            Doc::text("("),
+            elems.into_iter().next().unwrap(),
+            Doc::text(")"),
+        ]);
+    }
+
+    if elems.len() == 2 {
+        // Head + one arg: Align so arg indents to first-arg column
+        let head = elems[0].clone();
+        let arg = elems[1].clone();
+        return Doc::concat([
+            Doc::text("("),
+            head,
+            Doc::text(" "),
+            Doc::align(Doc::concat([arg]).group()),
+            Doc::text(")"),
+        ]);
+    }
+
+    // Head + first arg stay together; remaining args align to first arg column
+    let head = elems[0].clone();
+    let rest_args: Vec<Doc> = elems[2..].to_vec();
+
+    // First arg column relative to the "(": 1 + head_width + 1
+    let head_width = measure_flat(&head).unwrap_or(0);
+    let first_arg_col = 1 + head_width + 1;
+
+    // Columnar alignment if head is short enough, otherwise fall back to +2 indent
+    if first_arg_col <= config.line_length / 4 {
+        // Columnar: Align captures the first arg's column; Break inside
+        // aligns subsequent args to that column.
+        let all_args: Vec<Doc> = elems[1..].to_vec();
+        Doc::concat([
+            Doc::text("("),
+            head,
+            Doc::text(" "),
+            Doc::align(Doc::intersperse(all_args)).group(),
+            Doc::text(")"),
+        ])
+    } else {
+        // Fallback: +2 indent for long heads
+        let first_arg = elems[1].clone();
+        let header = Doc::concat([head, Doc::text(" "), first_arg]);
+        let mut all_parts: Vec<Doc> = Vec::new();
+        all_parts.push(header);
+        for arg in &rest_args {
+            all_parts.push(Doc::Break);
+            all_parts.push(arg.clone());
+        }
+
+        Doc::concat([
+            Doc::text("("),
+            Doc::concat(all_parts).nest(1).group(),
+            Doc::text(")"),
+        ])
+    }
+}

--- a/src/formatter/mod.rs
+++ b/src/formatter/mod.rs
@@ -1,19 +1,41 @@
 //! Code formatter for Elle Lisp
 //!
-//! Provides pretty-printing and formatting functionality for Elle source code.
+//! Opinionated formatter using Wadler-style pretty printing.
+//! One canonical style. Zero configuration beyond line width and indent width.
 //!
-//! # Examples
+//! # Architecture
+//!
+//! ```text
+//! Source → Lexer (with comments) → Syntax tree + CommentMap
+//!                                      ↓
+//!                               Doc generator
+//!                                      ↓
+//!                               Doc tree (Wadler algebra)
+//!                                      ↓
+//!                               Renderer (best(w, k, doc))
+//!                                      ↓
+//!                               Formatted string
+//! ```
+//!
+//! # Usage
 //!
 //! ```ignore
 //! use elle::formatter::{format_code, FormatterConfig};
 //!
 //! let config = FormatterConfig::default();
-//! let formatted = format_code("(+ 1 2)", config)?;
+//! let formatted = format_code("(+ 1 2)", &config)?;
 //! println!("{}", formatted);
 //! ```
 
+pub mod comments;
 pub mod config;
 pub mod core;
+pub mod doc;
+pub mod format;
+pub mod forms;
+pub mod render;
+pub mod run;
+pub mod trivia;
 
 pub use config::FormatterConfig;
 pub use core::format_code;

--- a/src/formatter/render.rs
+++ b/src/formatter/render.rs
@@ -1,0 +1,401 @@
+//! Doc renderer — evaluates a Doc tree within a line-width budget.
+//!
+//! Implements a simplified version of Wadler's `best(w, k, doc)` algorithm.
+//! At each `Group`, tries flat layout first; if it exceeds page width,
+//! falls back to broken layout (Breaks become newlines with indentation).
+//!
+//! The renderer tracks the current column position as a running counter
+//! (O(1) per step) rather than re-scanning the output string.
+//!
+//! Indent is tracked in absolute columns (number of spaces), not indent
+//! levels. Nest(n) adds n * indent_width to the indent; Align sets indent
+//! to the current column.
+
+use super::config::FormatterConfig;
+use super::doc::Doc;
+
+/// Render a Doc tree to a string with the given configuration.
+pub fn render(doc: &Doc, config: &FormatterConfig) -> String {
+    let mut out = String::new();
+    let ctx = LayoutCtx {
+        indent_width: config.indent_width,
+        line_width: config.line_length,
+    };
+    let mut last_cb = false;
+    ctx.layout(doc, 0, 0, false, &mut last_cb, &mut out);
+    out
+}
+
+/// Layout context carrying configuration.
+struct LayoutCtx {
+    indent_width: usize,
+    line_width: usize,
+}
+
+impl LayoutCtx {
+    /// Recursively layout a Doc.
+    ///
+    /// Returns the column position after laying out the doc.
+    ///
+    /// - `col`: current column position
+    /// - `indent`: current indentation in absolute columns (not levels)
+    /// - `broken`: true if we're in a broken (newline) context from an enclosing Group
+    /// - `out`: output string
+    fn layout(
+        &self,
+        doc: &Doc,
+        col: usize,
+        indent: usize,
+        broken: bool,
+        last_cb: &mut bool,
+        out: &mut String,
+    ) -> usize {
+        match doc {
+            Doc::Empty => col,
+
+            Doc::Text(s) => {
+                *last_cb = false;
+                out.push_str(s);
+                col + s.len()
+            }
+
+            Doc::Concat(docs) => {
+                let mut current_col = col;
+                for d in docs {
+                    current_col = self.layout(d, current_col, indent, broken, last_cb, out);
+                }
+                current_col
+            }
+
+            Doc::Nest(n, inner) => self.layout(
+                inner,
+                col,
+                indent + n * self.indent_width,
+                broken,
+                last_cb,
+                out,
+            ),
+
+            Doc::Break => {
+                if broken {
+                    if *last_cb {
+                        *last_cb = false;
+                        col
+                    } else {
+                        self.emit_newline(indent, out)
+                    }
+                } else {
+                    *last_cb = false;
+                    out.push(' ');
+                    col + 1
+                }
+            }
+
+            Doc::Group(inner) => match measure_flat(inner) {
+                Some(flat_width) if col + flat_width <= self.line_width => {
+                    self.layout(inner, col, indent, false, last_cb, out)
+                }
+                _ => self.layout(inner, col, indent, true, last_cb, out),
+            },
+
+            Doc::HardBreak => {
+                if *last_cb {
+                    *last_cb = false;
+                    col
+                } else {
+                    self.emit_newline(indent, out)
+                }
+            }
+
+            Doc::CommentBreak => {
+                if *last_cb {
+                    col
+                } else {
+                    *last_cb = true;
+                    self.emit_newline(indent, out)
+                }
+            }
+
+            Doc::Align(inner) => self.layout(inner, col, col, broken, last_cb, out),
+        }
+    }
+
+    /// Emit newline + indent spaces. Returns the new column.
+    fn emit_newline(&self, indent: usize, out: &mut String) -> usize {
+        out.push('\n');
+        let spaces = " ".repeat(indent);
+        out.push_str(&spaces);
+        indent
+    }
+}
+
+/// Measure the width of a doc when laid out flat (no breaks).
+///
+/// Returns `Some(width)` if the doc can be laid out flat, `None` if it
+/// contains a HardBreak (which can never be flat).
+pub(super) fn measure_flat(doc: &Doc) -> Option<usize> {
+    match doc {
+        Doc::Empty => Some(0),
+        Doc::Text(s) => Some(s.len()),
+        Doc::Concat(docs) => {
+            let mut total: usize = 0;
+            for d in docs {
+                total = total.checked_add(measure_flat(d)?)?;
+            }
+            Some(total)
+        }
+        Doc::Nest(_, inner) => measure_flat(inner),
+        Doc::Break => Some(1),
+        Doc::Group(inner) => measure_flat(inner),
+        Doc::HardBreak => None,
+        Doc::CommentBreak => None,
+        Doc::Align(inner) => measure_flat(inner),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn default_config() -> FormatterConfig {
+        FormatterConfig::default()
+    }
+
+    #[test]
+    fn test_empty() {
+        assert_eq!(render(&Doc::empty(), &default_config()), "");
+    }
+
+    #[test]
+    fn test_text() {
+        assert_eq!(render(&Doc::text("hello"), &default_config()), "hello");
+    }
+
+    #[test]
+    fn test_concat_texts() {
+        let doc = Doc::concat([Doc::text("hello"), Doc::text(" world")]);
+        assert_eq!(render(&doc, &default_config()), "hello world");
+    }
+
+    #[test]
+    fn test_group_fits() {
+        let doc = Doc::concat([
+            Doc::text("("),
+            Doc::concat([Doc::text("a"), Doc::Break, Doc::text("b")]).group(),
+            Doc::text(")"),
+        ]);
+        assert_eq!(render(&doc, &default_config()), "(a b)");
+    }
+
+    #[test]
+    fn test_group_breaks() {
+        let config = FormatterConfig::new().with_line_length(10);
+        let doc = Doc::concat([
+            Doc::text("("),
+            Doc::concat([Doc::text("hello"), Doc::Break, Doc::text("world")])
+                .nest(1)
+                .group(),
+            Doc::text(")"),
+        ]);
+        let result = render(&doc, &config);
+        assert!(result.contains('\n'), "should break: got {:?}", result);
+        let lines: Vec<&str> = result.lines().collect();
+        assert!(
+            lines[1].starts_with("  "),
+            "second line should be indented: {:?}",
+            lines
+        );
+        assert!(
+            lines[1].contains("world"),
+            "second line should contain 'world': {:?}",
+            lines
+        );
+    }
+
+    #[test]
+    fn test_nest_indentation_with_leading_break() {
+        let config = FormatterConfig::new()
+            .with_line_length(10)
+            .with_indent_width(2);
+        let doc = Doc::concat([
+            Doc::text("("),
+            Doc::concat([
+                Doc::HardBreak,
+                Doc::text("a"),
+                Doc::HardBreak,
+                Doc::text("b"),
+            ])
+            .nest(1),
+            Doc::HardBreak,
+            Doc::text(")"),
+        ]);
+        let result = render(&doc, &config);
+        assert_eq!(result, "(\n  a\n  b\n)", "got: {:?}", result);
+    }
+
+    #[test]
+    fn test_nest_indentation_same_line() {
+        let config = FormatterConfig::new()
+            .with_line_length(10)
+            .with_indent_width(2);
+        let doc = Doc::concat([
+            Doc::text("("),
+            Doc::concat([Doc::text("a"), Doc::HardBreak, Doc::text("b")]).nest(1),
+            Doc::HardBreak,
+            Doc::text(")"),
+        ]);
+        let result = render(&doc, &config);
+        assert_eq!(result, "(a\n  b\n)", "got: {:?}", result);
+    }
+
+    #[test]
+    fn test_hardbreak_alone() {
+        let doc = Doc::concat([Doc::text("a"), Doc::HardBreak, Doc::text("b")]);
+        assert_eq!(render(&doc, &default_config()), "a\nb");
+    }
+
+    #[test]
+    fn test_hardbreak_forces_group_break() {
+        let doc = Doc::concat([Doc::text("a"), Doc::HardBreak, Doc::text("b")]).group();
+        let result = render(&doc, &default_config());
+        assert_eq!(result, "a\nb", "got: {:?}", result);
+    }
+
+    #[test]
+    fn test_nested_group_outer_fits_inner_also_fits() {
+        let config = FormatterConfig::new().with_line_length(40);
+        let doc = Doc::concat([
+            Doc::text("outer-start "),
+            Doc::concat([Doc::text("inner-a"), Doc::Break, Doc::text("inner-b")]).group(),
+        ])
+        .group();
+        let result = render(&doc, &config);
+        assert_eq!(result, "outer-start inner-a inner-b");
+    }
+
+    #[test]
+    fn test_nested_group_outer_breaks_inner_also_breaks() {
+        let config = FormatterConfig::new().with_line_length(10);
+        let doc = Doc::concat([
+            Doc::text("start"),
+            Doc::Break,
+            Doc::concat([Doc::text("inner-a"), Doc::Break, Doc::text("inner-b")])
+                .nest(1)
+                .group(),
+        ])
+        .nest(1)
+        .group();
+        let result = render(&doc, &config);
+        assert!(result.contains('\n'), "should break: got {:?}", result);
+    }
+
+    #[test]
+    fn test_list_formatting_short() {
+        let doc = Doc::concat([
+            Doc::text("("),
+            Doc::intersperse([Doc::text("a"), Doc::text("b"), Doc::text("c")]).group(),
+            Doc::text(")"),
+        ]);
+        assert_eq!(render(&doc, &default_config()), "(a b c)");
+    }
+
+    #[test]
+    fn test_list_formatting_long() {
+        let config = FormatterConfig::new().with_line_length(20);
+        let doc = Doc::concat([
+            Doc::text("("),
+            Doc::intersperse([Doc::text("long-argument-1"), Doc::text("long-argument-2")])
+                .nest(1)
+                .group(),
+            Doc::text(")"),
+        ]);
+        let result = render(&doc, &config);
+        assert!(result.contains('\n'), "should break: got {:?}", result);
+        let lines: Vec<&str> = result.lines().collect();
+        assert!(lines.len() >= 2, "expected 2+ lines, got: {:?}", lines);
+        assert!(
+            lines[0].starts_with("(long-argument-1"),
+            "first line should start with (long-argument-1: {:?}",
+            lines
+        );
+        assert!(
+            lines[1].starts_with("  long-argument-2"),
+            "second line should be indented: {:?}",
+            lines
+        );
+    }
+
+    #[test]
+    fn test_measure_flat_values() {
+        assert_eq!(measure_flat(&Doc::empty()), Some(0));
+        assert_eq!(measure_flat(&Doc::text("hello")), Some(5));
+        assert_eq!(measure_flat(&Doc::Break), Some(1));
+        assert_eq!(measure_flat(&Doc::HardBreak), None);
+        assert_eq!(
+            measure_flat(&Doc::concat([Doc::text("ab"), Doc::Break, Doc::text("cd")])),
+            Some(5)
+        );
+        assert_eq!(
+            measure_flat(&Doc::concat([
+                Doc::text("a"),
+                Doc::HardBreak,
+                Doc::text("b")
+            ])),
+            None
+        );
+    }
+
+    #[test]
+    fn test_deeply_nested_indentation() {
+        let config = FormatterConfig::new().with_indent_width(2);
+        let doc = Doc::concat([
+            Doc::text("outer"),
+            Doc::concat([
+                Doc::HardBreak,
+                Doc::text("mid"),
+                Doc::concat([Doc::HardBreak, Doc::text("inner")]).nest(1),
+            ])
+            .nest(1),
+        ]);
+        let result = render(&doc, &config);
+        let expected = "outer\n  mid\n    inner";
+        assert_eq!(result, expected, "got: {:?}", result);
+    }
+
+    #[test]
+    fn test_nest_only_affects_breaks() {
+        let config = FormatterConfig::new().with_indent_width(2);
+        let doc = Doc::concat([
+            Doc::text("a"),
+            Doc::concat([Doc::text("b"), Doc::HardBreak, Doc::text("c")]).nest(1),
+        ]);
+        let result = render(&doc, &config);
+        assert_eq!(result, "ab\n  c", "got: {:?}", result);
+    }
+
+    #[test]
+    fn test_align() {
+        let config = FormatterConfig::new().with_line_length(15);
+        let doc = Doc::concat([
+            Doc::text("(foo "),
+            Doc::align(
+                Doc::concat([
+                    Doc::text("long-a"),
+                    Doc::Break,
+                    Doc::text("long-b"),
+                    Doc::Break,
+                    Doc::text("long-c"),
+                ])
+                .group(),
+            ),
+            Doc::text(")"),
+        ]);
+        let result = render(&doc, &config);
+        // When broken, long-b and long-c align to column 5 (after "(foo ")
+        assert_eq!(
+            result, "(foo long-a\n     long-b\n     long-c)",
+            "got: {:?}",
+            result
+        );
+    }
+}

--- a/src/formatter/run.rs
+++ b/src/formatter/run.rs
@@ -1,0 +1,275 @@
+//! CLI entry point for `elle fmt`.
+
+use crate::formatter::{format_code, FormatterConfig};
+use crate::rewrite::run::rewrite_file;
+use std::io::IsTerminal;
+
+/// Run epoch rewrite on source, then format.
+/// Returns the formatted string with epoch migrations applied.
+fn rewrite_and_format(
+    source: &str,
+    file_path: &str,
+    config: &FormatterConfig,
+) -> Result<String, String> {
+    let rewritten = match rewrite_file(source, file_path)? {
+        Some((new_source, _)) => new_source,
+        None => source.to_string(),
+    };
+    format_code(&rewritten, config)
+}
+
+/// Run the formatter tool. Returns exit code.
+///
+/// Exit codes:
+/// - 0 = success (all files formatted, or no changes needed in --check)
+/// - 1 = error, or changes needed in --check mode
+pub fn run(args: &[String]) -> i32 {
+    let mut check = false;
+    let mut line_length: Option<usize> = None;
+    let mut indent_width: Option<usize> = None;
+    let mut files = Vec::new();
+
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--check" => check = true,
+            "--help" | "-h" => {
+                print_help();
+                return 0;
+            }
+            opt if opt.starts_with("--line-length=") => {
+                if let Some(val) = opt.strip_prefix("--line-length=") {
+                    match val.parse::<usize>() {
+                        Ok(n) => line_length = Some(n),
+                        Err(_) => {
+                            eprintln!("Error: --line-length expects a number, got {:?}", val);
+                            return 1;
+                        }
+                    }
+                }
+            }
+            opt if opt.starts_with("--indent-width=") => {
+                if let Some(val) = opt.strip_prefix("--indent-width=") {
+                    match val.parse::<usize>() {
+                        Ok(n) => indent_width = Some(n),
+                        Err(_) => {
+                            eprintln!("Error: --indent-width expects a number, got {:?}", val);
+                            return 1;
+                        }
+                    }
+                }
+            }
+            other => {
+                if !other.starts_with('-') {
+                    files.push(other.to_string());
+                } else {
+                    eprintln!("Unknown option: {}", other);
+                    return 1;
+                }
+            }
+        }
+        i += 1;
+    }
+
+    let config = FormatterConfig::new()
+        .maybe_with_line_length(line_length)
+        .maybe_with_indent_width(indent_width);
+
+    // No files given: if stdin is piped, format it; otherwise show help.
+    if files.is_empty() {
+        if std::io::stdin().is_terminal() {
+            eprintln!("Error: no files specified");
+            print_help();
+            return 1;
+        }
+        return run_stdin(check, &config);
+    }
+
+    let mut any_changed = false;
+    let mut had_errors = false;
+
+    for file_path in &files {
+        let source = match std::fs::read_to_string(file_path) {
+            Ok(s) => s,
+            Err(e) => {
+                eprintln!("Error reading {}: {}", file_path, e);
+                had_errors = true;
+                continue;
+            }
+        };
+
+        match rewrite_and_format(&source, file_path, &config) {
+            Ok(formatted) => {
+                if check {
+                    if let Some(exit) = check_columns(file_path, &formatted) {
+                        had_errors = exit != 0;
+                    }
+                }
+                if formatted == source {
+                    // No changes needed
+                } else if check {
+                    println!("{}", file_path);
+                    any_changed = true;
+                } else if let Err(e) = std::fs::write(file_path, &formatted) {
+                    eprintln!("Error writing {}: {}", file_path, e);
+                    had_errors = true;
+                }
+            }
+            Err(e) => {
+                eprintln!("Error formatting {}: {}", file_path, e);
+                had_errors = true;
+            }
+        }
+    }
+
+    if had_errors {
+        return 1;
+    }
+
+    if check && any_changed {
+        return 1;
+    }
+
+    0
+}
+
+/// Format stdin, write to stdout.
+fn run_stdin(check: bool, config: &FormatterConfig) -> i32 {
+    let mut source = String::new();
+    if let Err(e) = std::io::Read::read_to_string(&mut std::io::stdin(), &mut source) {
+        eprintln!("Error reading stdin: {}", e);
+        return 1;
+    }
+
+    let formatted = match rewrite_and_format(&source, "<stdin>", config) {
+        Ok(f) => f,
+        Err(e) => {
+            eprintln!("Error formatting stdin: {}", e);
+            return 1;
+        }
+    };
+
+    if check {
+        if formatted != source {
+            return 1;
+        }
+        return 0;
+    }
+
+    print!("{}", formatted);
+    0
+}
+
+/// Check for lines with opening delimiters past column thresholds.
+/// Returns Some(exit_code) if violations found, None if clean.
+fn check_columns(file_path: &str, formatted: &str) -> Option<i32> {
+    let mut has_warning = false;
+    let mut has_error = false;
+    let openers = ['(', '[', '{'];
+
+    for (line_num, line) in formatted.lines().enumerate() {
+        for (col, ch) in line.chars().enumerate() {
+            if openers.contains(&ch) {
+                if col >= 80 {
+                    eprintln!(
+                        "error: {}:{}:{}: opening delimiter past column 80",
+                        file_path,
+                        line_num + 1,
+                        col + 1
+                    );
+                    has_error = true;
+                } else if col >= 60 {
+                    eprintln!(
+                        "warning: {}:{}:{}: opening delimiter past column 60, consider refactoring",
+                        file_path,
+                        line_num + 1,
+                        col + 1
+                    );
+                    has_warning = true;
+                }
+            }
+        }
+    }
+
+    if has_error {
+        Some(1)
+    } else if has_warning {
+        Some(0)
+    } else {
+        None
+    }
+}
+
+fn print_help() {
+    println!("elle fmt - Opinionated code formatter");
+    println!();
+    println!("Formats Elle source files in place. One canonical style.");
+    println!("No configuration beyond line width and indent width.");
+    println!();
+    println!("Usage: elle fmt [OPTIONS] <file...>");
+    println!("       elle fmt < file.lisp");
+    println!();
+    println!("Options:");
+    println!("  --check                   Check if files need formatting (exit 1 if yes)");
+    println!("  --line-length=N           Target line length (default: 80)");
+    println!("  --indent-width=N          Spaces per indent level (default: 2)");
+    println!("  --help                    Show this help message");
+    println!();
+    println!("Examples:");
+    println!("  elle fmt src/*.lisp");
+    println!("  elle fmt --check lib/*.lisp");
+    println!("  elle fmt --line-length=120 src/*.lisp");
+    println!("  cat file.lisp | elle fmt");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::epoch::CURRENT_EPOCH;
+
+    #[test]
+    fn test_fmt_upgrades_epoch() {
+        let config = FormatterConfig::default();
+        let input = "(elle/epoch 0)\n(assert-true x \"test\")\n";
+        let result = rewrite_and_format(input, "<test>", &config).unwrap();
+        assert!(
+            result.contains(&format!("(elle/epoch {})", CURRENT_EPOCH)),
+            "should upgrade epoch tag, got: {:?}",
+            result
+        );
+        assert!(
+            !result.contains("assert-true"),
+            "old symbol should be rewritten, got: {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_fmt_current_epoch_unchanged() {
+        let config = FormatterConfig::default();
+        let input = format!("(elle/epoch {})\n(println \"hello\")\n", CURRENT_EPOCH);
+        let result = rewrite_and_format(&input, "<test>", &config).unwrap();
+        assert_eq!(result, input, "current-epoch file should be unchanged");
+    }
+
+    #[test]
+    fn test_fmt_no_epoch_gets_one() {
+        let config = FormatterConfig::default();
+        let input = "(println \"hello\")\n";
+        let result = rewrite_and_format(input, "<test>", &config).unwrap();
+        assert!(
+            result.contains(&format!("(elle/epoch {})", CURRENT_EPOCH)),
+            "should inject epoch tag, got: {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_fmt_epoch_upgrade_idempotent() {
+        let config = FormatterConfig::default();
+        let input = "(elle/epoch 0)\n(assert-true x \"test\")\n";
+        let first = rewrite_and_format(input, "<test>", &config).unwrap();
+        let second = rewrite_and_format(&first, "<test>", &config).unwrap();
+        assert_eq!(first, second, "rewrite+format must be idempotent");
+    }
+}

--- a/src/formatter/trivia.rs
+++ b/src/formatter/trivia.rs
@@ -1,0 +1,460 @@
+//! Trivia layer: comment and blank-line attachment to Syntax nodes.
+//!
+//! The formatter operates on an `AnnotatedSyntax` tree — a Syntax tree where
+//! every node has its leading and trailing trivia (comments, blank lines)
+//! pre-attached. This is produced by a single upfront pass that maps trivia
+//! items to Syntax nodes by byte-offset comparison.
+//!
+//! ## Why this exists
+//!
+//! The Syntax tree is designed for compilation — it intentionally discards
+//! comments and blank lines. The formatter needs this information. Rather
+//! than consulting a separate map during the Doc walk (which creates ordering
+//! dependencies and loses dangling trivia), we attach everything upfront in
+//! a single pass. The Doc generator then walks the annotated tree as a pure
+//! function with no mutable state.
+//!
+//! ## Data flow
+//!
+//! ```text
+//! Source string ──┬──► Lexer ──► Comment tokens (byte offsets)
+//!                 └──► Blank-line scanner ──► Blank-line ranges (byte offsets)
+//!                              │
+//!                              ▼
+//!                      Merge → Vec<Trivia> (sorted by byte offset)
+//!                              │
+//! Syntax tree ────────────────►│
+//!                              ▼
+//!                      Attachment pass
+//!                      (compare trivia byte offsets with Syntax span ranges)
+//!                              │
+//!                              ▼
+//!                      Vec<AnnotatedSyntax>
+//! ```
+
+use crate::syntax::{Span, Syntax, SyntaxKind};
+
+// ── Trivia types ──────────────────────────────────────────────
+
+/// A piece of source trivia — a comment or blank lines.
+/// Positioned by byte offset for attachment to Syntax nodes.
+#[derive(Debug, Clone)]
+pub enum Trivia {
+    /// A line comment: `# text` or `## doc text`.
+    /// `text` includes the `#` prefix, with trailing newline stripped.
+    Comment {
+        text: String,
+        byte_offset: usize,
+        line: u32,
+    },
+    /// One or more consecutive blank lines.
+    BlankLines {
+        count: u32,
+        byte_offset: usize,
+        /// Line number of the first blank line.
+        line: u32,
+    },
+}
+
+impl Trivia {
+    /// Byte offset where this trivia starts in the source.
+    pub fn byte_offset(&self) -> usize {
+        match self {
+            Trivia::Comment { byte_offset, .. } => *byte_offset,
+            Trivia::BlankLines { byte_offset, .. } => *byte_offset,
+        }
+    }
+
+    /// Line number of this trivia.
+    pub fn line(&self) -> u32 {
+        match self {
+            Trivia::Comment { line, .. } => *line,
+            Trivia::BlankLines { line, .. } => *line,
+        }
+    }
+}
+
+// ── Annotated syntax tree ─────────────────────────────────────
+
+/// A Syntax node with its attached trivia and annotated children.
+#[derive(Debug, Clone)]
+pub struct AnnotatedSyntax {
+    /// The underlying Syntax node.
+    pub syntax: Syntax,
+    /// Trivia that appears before this node, on lines strictly above
+    /// the node's start line. Emitted as HardBreak + comment text
+    /// before the node's Doc.
+    pub leading: Vec<Trivia>,
+    /// Trivia that appears after this node on the same line
+    /// (trailing inline comments). Emitted after the node's Doc.
+    pub trailing: Vec<Trivia>,
+    /// Annotated children for compound nodes.
+    pub children: Vec<AnnotatedSyntax>,
+}
+
+impl AnnotatedSyntax {
+    /// Build annotated trees for a list of top-level forms, consuming
+    /// trivia from the list by attaching each trivia item to the
+    /// nearest Syntax node based on byte offsets.
+    /// Returns both the annotated forms and any dangling trivia (trivia after the last form).
+    pub fn build_toplevel(
+        forms: Vec<Syntax>,
+        trivia: &[Trivia],
+        source: &str,
+    ) -> (Vec<Self>, Vec<Trivia>) {
+        attach_trivia_to_forms(forms, trivia, source)
+    }
+
+    /// Get the span of the underlying Syntax node.
+    pub fn span(&self) -> &Span {
+        &self.syntax.span
+    }
+
+    /// Get the kind of the underlying Syntax node.
+    pub fn kind(&self) -> &SyntaxKind {
+        &self.syntax.kind
+    }
+}
+
+// ── Trivia collection ─────────────────────────────────────────
+
+/// Collect trivia (comments + blank lines) from source text.
+///
+/// Comments come from the lexer's `CommentMap` (which has accurate
+/// byte offsets). Blank lines are scanned from the source directly.
+/// This function merges both sources into a single sorted list.
+pub fn collect_trivia(
+    source: &str,
+    comments: &[(String, usize, u32)], // (text, byte_offset, line)
+) -> Vec<Trivia> {
+    let mut trivia: Vec<Trivia> = Vec::new();
+
+    // Add comments from the lexer
+    for (text, byte_offset, line) in comments {
+        trivia.push(Trivia::Comment {
+            text: text.clone(),
+            byte_offset: *byte_offset,
+            line: *line,
+        });
+    }
+
+    // Scan for blank lines
+    let mut offset = 0usize;
+    let mut blank_start: Option<(usize, u32)> = None;
+    let mut blank_count: u32 = 0;
+
+    for (current_line, raw_line) in (1_u32..).zip(source.lines()) {
+        let line_len = raw_line.len();
+        if raw_line.trim().is_empty() {
+            if blank_start.is_none() {
+                blank_start = Some((offset, current_line));
+                blank_count = 1;
+            } else {
+                blank_count += 1;
+            }
+        } else {
+            if let Some((boff, line)) = blank_start.take() {
+                if blank_count > 0 {
+                    trivia.push(Trivia::BlankLines {
+                        count: blank_count,
+                        byte_offset: boff,
+                        line,
+                    });
+                }
+                blank_count = 0;
+            }
+        }
+        offset += line_len + 1; // +1 for the newline character
+    }
+
+    // Flush trailing blank lines
+    if let Some((boff, line)) = blank_start.take() {
+        trivia.push(Trivia::BlankLines {
+            count: blank_count,
+            byte_offset: boff,
+            line,
+        });
+    }
+
+    // Sort by byte offset
+    trivia.sort_by_key(|t| t.byte_offset());
+    trivia
+}
+
+// ── Attachment pass ───────────────────────────────────────────
+
+/// Attach trivia to top-level Syntax forms.
+///
+/// The algorithm:
+/// 1. For each Syntax node, compute its span range [start, end).
+/// 2. Leading trivia: items with byte_offset < node.span.start and
+///    line < node.span.line.
+/// 3. Trailing trivia: items between this form and the next form (if any).
+///    For the last form, no trailing trivia is attached — it remains dangling.
+/// 4. Recurse into children with remaining trivia.
+/// 5. Any leftover trivia after the last form is "dangling".
+fn attach_trivia_to_forms(
+    forms: Vec<Syntax>,
+    trivia: &[Trivia],
+    source: &str,
+) -> (Vec<AnnotatedSyntax>, Vec<Trivia>) {
+    if forms.is_empty() {
+        // All trivia is dangling if there are no forms
+        return (Vec::new(), trivia.to_vec());
+    }
+
+    // Helper to calculate line number from byte offset
+    let line_at_offset = |offset: usize| -> u32 {
+        let mut line: u32 = 1;
+        for (i, ch) in source.chars().enumerate() {
+            if i >= offset {
+                break;
+            }
+            if ch == '\n' {
+                line += 1;
+            }
+        }
+        line
+    };
+
+    // Pre-compute span starts for looking ahead to next form
+    let form_spans: Vec<(usize, usize)> =
+        forms.iter().map(|f| (f.span.start, f.span.end)).collect();
+
+    let mut all_attached = Vec::new();
+    let mut trivia_idx: usize = 0;
+
+    for (form_idx, form) in forms.into_iter().enumerate() {
+        let span = form.span.clone();
+
+        // Collect leading trivia: items before this form's span start
+        let mut leading = Vec::new();
+        while trivia_idx < trivia.len() {
+            let t = &trivia[trivia_idx];
+            if t.byte_offset() >= span.start {
+                break;
+            }
+            leading.push(t.clone());
+            trivia_idx += 1;
+        }
+
+        // Build children (recursively attach trivia within this form)
+        let children = attach_to_children(&form, trivia, &mut trivia_idx);
+
+        // Collect trailing trivia: comments on the same line as this form's end.
+        // Blank lines and comments on later lines are left for the next form.
+        // For the last form, don't attach trailing trivia (leave it dangling).
+        let mut trailing = Vec::new();
+        let is_last_form = form_idx + 1 >= form_spans.len();
+        if !is_last_form {
+            let form_end_line = line_at_offset(span.end);
+            let next_start = form_spans
+                .get(form_idx + 1)
+                .map(|(s, _)| *s)
+                .unwrap_or(usize::MAX);
+
+            // Collect only comments on the same line as the form ends
+            while trivia_idx < trivia.len() {
+                let t = &trivia[trivia_idx];
+                if t.byte_offset() >= next_start {
+                    break;
+                }
+                // Only trailing comments on the same line; leave other trivia for next form
+                match t {
+                    Trivia::Comment { line, .. } if *line == form_end_line => {
+                        trailing.push(t.clone());
+                        trivia_idx += 1;
+                    }
+                    _ => {
+                        // Blank lines and comments on later lines stay for the next form
+                        break;
+                    }
+                }
+            }
+        }
+
+        all_attached.push(AnnotatedSyntax {
+            syntax: form,
+            leading,
+            trailing,
+            children,
+        });
+    }
+
+    // Collect any remaining trivia as dangling
+    let mut dangling = Vec::new();
+    while trivia_idx < trivia.len() {
+        dangling.push(trivia[trivia_idx].clone());
+        trivia_idx += 1;
+    }
+
+    (all_attached, dangling)
+}
+
+/// Recursively attach trivia to children of a compound node.
+fn attach_to_children(
+    parent: &Syntax,
+    trivia: &[Trivia],
+    trivia_idx: &mut usize,
+) -> Vec<AnnotatedSyntax> {
+    let children: Vec<&Syntax> = match &parent.kind {
+        SyntaxKind::List(cs)
+        | SyntaxKind::Array(cs)
+        | SyntaxKind::ArrayMut(cs)
+        | SyntaxKind::Struct(cs)
+        | SyntaxKind::StructMut(cs)
+        | SyntaxKind::Set(cs)
+        | SyntaxKind::SetMut(cs)
+        | SyntaxKind::Bytes(cs)
+        | SyntaxKind::BytesMut(cs) => cs.iter().collect(),
+        SyntaxKind::Quote(inner)
+        | SyntaxKind::Quasiquote(inner)
+        | SyntaxKind::Unquote(inner)
+        | SyntaxKind::UnquoteSplicing(inner)
+        | SyntaxKind::Splice(inner) => vec![inner],
+        _ => return Vec::new(),
+    };
+
+    let mut annotated = Vec::with_capacity(children.len());
+
+    for (i, child) in children.iter().enumerate() {
+        let span = &child.span;
+
+        // Leading trivia: before this child's span
+        let mut leading = Vec::new();
+        while *trivia_idx < trivia.len() {
+            let t = &trivia[*trivia_idx];
+            if t.byte_offset() >= span.start {
+                break;
+            }
+            leading.push(t.clone());
+            *trivia_idx += 1;
+        }
+
+        // Recurse into grandchildren
+        let grandchildren = attach_to_children(child, trivia, trivia_idx);
+
+        // Skip trivia items that fall inside this child's span but were
+        // not consumed by grandchildren (e.g. blank lines inside strings).
+        while *trivia_idx < trivia.len() && trivia[*trivia_idx].byte_offset() < span.end {
+            *trivia_idx += 1;
+        }
+
+        // Trailing trivia: after this child but before next child (or parent end)
+        let next_start = children
+            .get(i + 1)
+            .map(|c| c.span.start)
+            .unwrap_or(parent.span.end);
+        let mut trailing = Vec::new();
+        while *trivia_idx < trivia.len() {
+            let t = &trivia[*trivia_idx];
+            if t.byte_offset() >= next_start {
+                break;
+            }
+            trailing.push(t.clone());
+            *trivia_idx += 1;
+        }
+
+        annotated.push(AnnotatedSyntax {
+            syntax: (*child).clone(),
+            leading,
+            trailing,
+            children: grandchildren,
+        });
+    }
+
+    annotated
+}
+
+// ── Tests ─────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_collect_trivia_empty() {
+        let trivia = collect_trivia("", &[]);
+        assert!(trivia.is_empty());
+    }
+
+    #[test]
+    fn test_collect_trivia_no_trivia() {
+        let trivia = collect_trivia("(+ 1 2)", &[]);
+        assert!(trivia.is_empty());
+    }
+
+    #[test]
+    fn test_collect_trivia_comment() {
+        let comments = vec![("# hello".to_string(), 0, 1)];
+        let trivia = collect_trivia("# hello\n(+ 1 2)", &comments);
+        assert_eq!(trivia.len(), 1);
+        assert!(matches!(&trivia[0], Trivia::Comment { text, .. } if text == "# hello"));
+    }
+
+    #[test]
+    fn test_collect_trivia_blank_lines() {
+        let trivia = collect_trivia("a\n\n\nb", &[]);
+        assert_eq!(trivia.len(), 1);
+        assert!(matches!(&trivia[0], Trivia::BlankLines { count: 2, .. }));
+    }
+
+    #[test]
+    fn test_collect_trivia_sorted() {
+        let comments = vec![("# second".to_string(), 5, 2)];
+        let source = "# first\n# second\n42";
+        let mut trivia = collect_trivia(source, &comments);
+        // Add first comment manually (it's not in comments because it would
+        // be at byte offset 0)
+        trivia.push(Trivia::Comment {
+            text: "# first".to_string(),
+            byte_offset: 0,
+            line: 1,
+        });
+        trivia.sort_by_key(|t| t.byte_offset());
+        assert!(trivia[0].byte_offset() < trivia[1].byte_offset());
+    }
+
+    #[test]
+    fn test_annotated_atom() {
+        let syntax = Syntax::new(SyntaxKind::Int(42), Span::new(0, 2, 1, 1));
+        let (annotated, dangling) = AnnotatedSyntax::build_toplevel(vec![syntax], &[], "42");
+        assert_eq!(annotated.len(), 1);
+        assert!(matches!(annotated[0].kind(), SyntaxKind::Int(42)));
+        assert!(annotated[0].leading.is_empty());
+        assert!(annotated[0].children.is_empty());
+        assert!(dangling.is_empty());
+    }
+
+    #[test]
+    fn test_annotated_with_leading_comment() {
+        let syntax = Syntax::new(SyntaxKind::Int(42), Span::new(9, 11, 2, 1));
+        let trivia = vec![Trivia::Comment {
+            text: "# before".to_string(),
+            byte_offset: 0,
+            line: 1,
+        }];
+        let (annotated, dangling) =
+            AnnotatedSyntax::build_toplevel(vec![syntax], &trivia, "# before\n42");
+        assert_eq!(annotated.len(), 1);
+        assert_eq!(annotated[0].leading.len(), 1);
+        assert!(
+            matches!(&annotated[0].leading[0], Trivia::Comment { text, .. } if text == "# before")
+        );
+        assert!(dangling.is_empty());
+    }
+
+    #[test]
+    fn test_annotated_list_children() {
+        let syntax = Syntax::new(
+            SyntaxKind::List(vec![
+                Syntax::new(SyntaxKind::Symbol("+".into()), Span::new(1, 2, 1, 2)),
+                Syntax::new(SyntaxKind::Int(1), Span::new(3, 4, 1, 4)),
+                Syntax::new(SyntaxKind::Int(2), Span::new(5, 6, 1, 6)),
+            ]),
+            Span::new(0, 7, 1, 1),
+        );
+        let (annotated, _dangling) = AnnotatedSyntax::build_toplevel(vec![syntax], &[], "(+ 1 2)");
+        assert_eq!(annotated[0].children.len(), 3);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ use std::io::{self, Read};
 fn print_help() {
     println!("Elle v1.0.0\n");
     println!("Usage: elle [file...] [-- args...]       Run files or start REPL");
+    println!("       elle fmt [options] <file...>       Format source files");
     println!("       elle lint [options] <file|dir>... Static analysis");
     println!("       elle lsp                          Start language server");
     println!("       elle rewrite [options] <file...>  Source-to-source rewriting\n");
@@ -532,6 +533,11 @@ fn main() {
 
     // Subcommand dispatch — no VM setup needed for these
     match args.get(1).map(|s| s.as_str()) {
+        Some("fmt") => {
+            let sub_args: Vec<String> = args[2..].to_vec();
+            let exit_code = elle::formatter::run::run(&sub_args);
+            std::process::exit(exit_code);
+        }
         Some("lint") => {
             let sub_args: Vec<String> = args[2..].to_vec();
             let exit_code = elle::lint::run::run(&sub_args);

--- a/src/reader/AGENTS.md
+++ b/src/reader/AGENTS.md
@@ -82,7 +82,7 @@ The lexer recognizes these delimiters (characters that cannot appear in symbol n
 | `;` | `Splice` | Splice reader macro |
 | `:` | `Colon` | Keyword prefix; also `:@name` for mutable type keywords |
 | `@` | `At` | Mutable collection prefix (when not followed by `[`, `{`, or `\|`) |
-| `#` | Comment | Line comment (not a token) |
+| `#` | `Comment` | Line comment (now emitted as a token) |
 
 ## Keyword syntax
 
@@ -125,6 +125,11 @@ The `@` in `:@name` is consumed by the lexer and prepended to the keyword name.
 
 7. **`:@name` keywords are valid.** The lexer recognizes `:@` as a keyword
    prefix variant. The `@` is consumed and prepended to the keyword name.
+
+8. **Comments are tokens.** `#` line comments are emitted as `Token::Comment(String)`
+   by the lexer. Both `SyntaxReader` and `Reader` skip comment tokens during
+   parsing — they do not appear in the output tree. The formatter collects
+   them separately via `lex_with_comments()` for comment preservation.
 
 ## Files
 

--- a/src/reader/lexer.rs
+++ b/src/reader/lexer.rs
@@ -103,17 +103,25 @@ impl<'a> Lexer<'a> {
         while let Some(c) = self.current() {
             if c.is_whitespace() {
                 self.advance();
-            } else if c == '#' {
-                // Skip comment until newline
-                while let Some(c) = self.advance() {
-                    if c == '\n' {
-                        break;
-                    }
-                }
             } else {
                 break;
             }
         }
+    }
+
+    /// Read a comment starting at the current `#` character.
+    /// Returns the full comment text including the `#` prefix.
+    /// Leaves the lexer positioned after the newline (or at EOF).
+    fn read_comment(&mut self) -> String {
+        let mut text = String::new();
+        // The caller guarantees current() == Some('#')
+        while let Some(c) = self.advance() {
+            text.push(c);
+            if c == '\n' {
+                break;
+            }
+        }
+        text
     }
 
     fn read_string(&mut self) -> Result<String, String> {
@@ -179,6 +187,16 @@ impl<'a> Lexer<'a> {
 
         match self.current() {
             None => Ok(None),
+            Some('#') => {
+                let text = self.read_comment();
+                let len = self.pos - start_pos;
+                Ok(Some(TokenWithLoc {
+                    token: Token::Comment(text),
+                    loc,
+                    len,
+                    byte_offset: start_pos,
+                }))
+            }
             Some('(') => {
                 self.advance();
                 Ok(Some(TokenWithLoc {
@@ -509,5 +527,52 @@ mod tests {
     #[test]
     fn truetrue_is_symbol() {
         assert!(matches!(lex_single("truetrue"), Token::Symbol("truetrue")));
+    }
+
+    #[test]
+    fn comment_is_token() {
+        let mut lexer = Lexer::new("# hello");
+        let tok = lexer.next_token().unwrap().unwrap();
+        assert!(matches!(tok, Token::Comment(s) if s == "# hello"));
+    }
+
+    #[test]
+    fn doc_comment_is_token() {
+        let mut lexer = Lexer::new("## doc text");
+        let tok = lexer.next_token().unwrap().unwrap();
+        assert!(matches!(tok, Token::Comment(s) if s == "## doc text"));
+    }
+
+    #[test]
+    fn comment_before_code() {
+        let mut lexer = Lexer::new("# comment\n42");
+        let first = lexer.next_token().unwrap().unwrap();
+        assert!(matches!(first, Token::Comment(_)));
+        let second = lexer.next_token().unwrap().unwrap();
+        assert!(matches!(second, Token::Integer(42)));
+    }
+
+    #[test]
+    fn comment_after_code() {
+        let mut lexer = Lexer::new("42 # inline comment");
+        let first = lexer.next_token().unwrap().unwrap();
+        assert!(matches!(first, Token::Integer(42)));
+        let second = lexer.next_token().unwrap().unwrap();
+        assert!(matches!(second, Token::Comment(s) if s.contains("inline comment")));
+    }
+
+    #[test]
+    fn comment_at_eof() {
+        let mut lexer = Lexer::new("# trailing");
+        let tok = lexer.next_token().unwrap().unwrap();
+        assert!(matches!(tok, Token::Comment(s) if s == "# trailing"));
+        assert!(lexer.next_token().unwrap().is_none());
+    }
+
+    #[test]
+    fn comment_with_special_chars() {
+        let mut lexer = Lexer::new("# (parens) [brackets] 'quote");
+        let tok = lexer.next_token().unwrap().unwrap();
+        assert!(matches!(tok, Token::Comment(s) if s.contains("(parens)")));
     }
 }

--- a/src/reader/parser.rs
+++ b/src/reader/parser.rs
@@ -55,6 +55,10 @@ impl Reader {
     /// Try to read a single value from the token stream.
     /// Returns None if at EOF (not an error), Some(Err(_)) if there's a parse error.
     pub fn try_read(&mut self, symbols: &mut SymbolTable) -> Option<Result<Value, String>> {
+        // Skip comment tokens
+        while matches!(self.current(), Some(OwnedToken::Comment(_))) {
+            self.advance();
+        }
         let token = self.current().cloned()?;
         Some(self.read_one(symbols, &token))
     }
@@ -62,6 +66,12 @@ impl Reader {
     /// Read a single token/form and return result
     fn read_one(&mut self, symbols: &mut SymbolTable, token: &OwnedToken) -> Result<Value, String> {
         match token {
+            // Skip comment tokens — they are handled before reaching here by try_read,
+            // but may appear in recursive read() calls inside compound forms.
+            OwnedToken::Comment(_) => {
+                self.advance();
+                self.read(symbols)
+            }
             OwnedToken::LeftParen => self.read_list(symbols),
             OwnedToken::LeftBracket => self.read_array(symbols),
             OwnedToken::LeftBrace => self.read_struct(symbols),
@@ -91,6 +101,10 @@ impl Reader {
                                     .rev()
                                     .fold(Value::EMPTY_LIST, |acc, v| Value::cons(v, acc));
                                 return Ok(Value::cons(list_sym, result));
+                            }
+                            Some(OwnedToken::Comment(_)) => {
+                                self.advance();
+                                continue;
                             }
                             _ => elements.push(self.read(symbols)?),
                         }
@@ -253,6 +267,10 @@ impl Reader {
                         .rev()
                         .fold(Value::EMPTY_LIST, |acc, v| Value::cons(v, acc)));
                 }
+                Some(OwnedToken::Comment(_)) => {
+                    self.advance();
+                    continue;
+                }
                 _ => elements.push(self.read(symbols)?),
             }
         }
@@ -274,6 +292,10 @@ impl Reader {
                 Some(OwnedToken::RightBracket) => {
                     self.advance();
                     return Ok(Value::array_mut(elements));
+                }
+                Some(OwnedToken::Comment(_)) => {
+                    self.advance();
+                    continue;
                 }
                 _ => elements.push(self.read(symbols)?),
             }
@@ -303,6 +325,10 @@ impl Reader {
                         .fold(Value::EMPTY_LIST, |acc, v| Value::cons(v, acc));
                     return Ok(Value::cons(struct_sym, result));
                 }
+                Some(OwnedToken::Comment(_)) => {
+                    self.advance();
+                    continue;
+                }
                 _ => elements.push(self.read(symbols)?),
             }
         }
@@ -324,6 +350,10 @@ impl Reader {
                         .rev()
                         .fold(Value::EMPTY_LIST, |acc, v| Value::cons(v, acc));
                     return Ok(Value::cons(table_sym, result));
+                }
+                Some(OwnedToken::Comment(_)) => {
+                    self.advance();
+                    continue;
                 }
                 _ => elements.push(self.read(symbols)?),
             }

--- a/src/reader/syntax.rs
+++ b/src/reader/syntax.rs
@@ -96,6 +96,10 @@ impl SyntaxReader {
 
     /// Try to read a single syntax form. Returns None at EOF.
     pub fn try_read(&mut self) -> Option<Result<Syntax, String>> {
+        // Skip any leading comment tokens
+        while matches!(self.current(), Some(OwnedToken::Comment(_))) {
+            self.advance();
+        }
         let token = self.current().cloned()?;
         let loc = self.current_location();
         let boff = self.current_byte_offset();
@@ -116,8 +120,8 @@ impl SyntaxReader {
     /// Read all remaining forms
     pub fn read_all(&mut self) -> Result<Vec<Syntax>, String> {
         let mut results = Vec::new();
-        while self.current().is_some() {
-            results.push(self.read()?);
+        while let Some(result) = self.try_read() {
+            results.push(result?);
         }
         Ok(results)
     }
@@ -129,6 +133,11 @@ impl SyntaxReader {
         boff: usize,
     ) -> Result<Syntax, String> {
         match token {
+            // Skip comment tokens inside compound forms
+            OwnedToken::Comment(_) => {
+                self.advance();
+                self.read()
+            }
             OwnedToken::LeftParen => self.read_list(loc, boff),
             OwnedToken::LeftBracket => self.read_array(loc, boff),
             OwnedToken::LeftBrace => self.read_struct(loc, boff),
@@ -237,6 +246,10 @@ impl SyntaxReader {
                     let span = self.make_span(start_boff, end, start_loc);
                     return Ok(Syntax::new(SyntaxKind::Set(elements), span));
                 }
+                Some(OwnedToken::Comment(_)) => {
+                    self.advance();
+                    continue;
+                }
                 _ => elements.push(self.read()?),
             }
         }
@@ -260,6 +273,10 @@ impl SyntaxReader {
                     let span = self.make_span(start_boff, end, start_loc);
                     return Ok(Syntax::new(SyntaxKind::SetMut(elements), span));
                 }
+                Some(OwnedToken::Comment(_)) => {
+                    self.advance();
+                    continue;
+                }
                 _ => elements.push(self.read()?),
             }
         }
@@ -281,6 +298,10 @@ impl SyntaxReader {
                     self.advance();
                     let span = self.make_span(start_boff, end, start_loc);
                     return Ok(Syntax::new(SyntaxKind::Bytes(elements), span));
+                }
+                Some(OwnedToken::Comment(_)) => {
+                    self.advance();
+                    continue;
                 }
                 _ => elements.push(self.read()?),
             }
@@ -307,6 +328,10 @@ impl SyntaxReader {
                     self.advance();
                     let span = self.make_span(start_boff, end, start_loc);
                     return Ok(Syntax::new(SyntaxKind::BytesMut(elements), span));
+                }
+                Some(OwnedToken::Comment(_)) => {
+                    self.advance();
+                    continue;
                 }
                 _ => elements.push(self.read()?),
             }
@@ -342,6 +367,10 @@ impl SyntaxReader {
                     let span = self.make_span(start_boff, end, start_loc);
                     return Ok(Syntax::new(SyntaxKind::List(elements), span));
                 }
+                Some(OwnedToken::Comment(_)) => {
+                    self.advance();
+                    continue;
+                }
                 Some(OwnedToken::Pipe) => {
                     let set_loc = self.current_location();
                     let set_boff = self.current_byte_offset();
@@ -376,6 +405,10 @@ impl SyntaxReader {
                     let span = self.make_span(start_boff, end, start_loc);
                     return Ok(Syntax::new(SyntaxKind::Array(elements), span));
                 }
+                Some(OwnedToken::Comment(_)) => {
+                    self.advance();
+                    continue;
+                }
                 Some(OwnedToken::Pipe) => {
                     let set_loc = self.current_location();
                     let set_boff = self.current_byte_offset();
@@ -404,6 +437,10 @@ impl SyntaxReader {
                     self.advance();
                     let span = self.make_span(start_boff, end, start_loc);
                     return Ok(Syntax::new(SyntaxKind::Struct(elements), span));
+                }
+                Some(OwnedToken::Comment(_)) => {
+                    self.advance();
+                    continue;
                 }
                 Some(OwnedToken::Pipe) => {
                     let set_loc = self.current_location();
@@ -443,6 +480,10 @@ impl SyntaxReader {
                             let span = self.make_span(start_boff, end, start_loc);
                             return Ok(Syntax::new(SyntaxKind::ArrayMut(elements), span));
                         }
+                        Some(OwnedToken::Comment(_)) => {
+                            self.advance();
+                            continue;
+                        }
                         _ => elements.push(self.read()?),
                     }
                 }
@@ -466,6 +507,10 @@ impl SyntaxReader {
                             let span = self.make_span(start_boff, end, start_loc);
                             return Ok(Syntax::new(SyntaxKind::StructMut(elements), span));
                         }
+                        Some(OwnedToken::Comment(_)) => {
+                            self.advance();
+                            continue;
+                        }
                         _ => elements.push(self.read()?),
                     }
                 }
@@ -473,12 +518,18 @@ impl SyntaxReader {
             Some(OwnedToken::String(s)) => {
                 // @"..." is sugar for (thaw "...")
                 let string_val = s.clone();
-                let end = self.current_byte_offset() + self.current_length();
+                let str_boff = self.current_byte_offset();
+                let end = str_boff + self.current_length();
                 self.advance(); // skip the string token
-                let span = self.make_span(start_boff, end, start_loc);
-                let sym = Syntax::new(SyntaxKind::Symbol("thaw".to_string()), span.clone());
-                let str_lit = Syntax::new(SyntaxKind::String(string_val), span.clone());
-                Ok(Syntax::new(SyntaxKind::List(vec![sym, str_lit]), span))
+                let outer_span = self.make_span(start_boff, end, start_loc);
+                let sym_span = self.make_span(start_boff, start_boff + 1, start_loc);
+                let str_span = self.make_span(str_boff, end, start_loc);
+                let sym = Syntax::new(SyntaxKind::Symbol("thaw".to_string()), sym_span);
+                let str_lit = Syntax::new(SyntaxKind::String(string_val), str_span);
+                Ok(Syntax::new(
+                    SyntaxKind::List(vec![sym, str_lit]),
+                    outer_span,
+                ))
             }
             _ => Err(format!(
                 "{}: @ must be followed by [...], {{...}}, |...|, or \"...\"",

--- a/src/reader/syntax_tests.rs
+++ b/src/reader/syntax_tests.rs
@@ -533,3 +533,48 @@ fn test_parse_hex_with_underscore() {
     let result = lex_and_parse("0xFF_FF").unwrap();
     assert!(matches!(result.kind, SyntaxKind::Int(0xFFFF)));
 }
+
+#[test]
+fn test_comment_skipped_before_form() {
+    let result = lex_and_parse_all("# comment\n42").unwrap();
+    assert_eq!(result.len(), 1);
+    assert!(matches!(result[0].kind, SyntaxKind::Int(42)));
+}
+
+#[test]
+fn test_comment_skipped_after_form() {
+    let result = lex_and_parse_all("42 # inline").unwrap();
+    assert_eq!(result.len(), 1);
+    assert!(matches!(result[0].kind, SyntaxKind::Int(42)));
+}
+
+#[test]
+fn test_comment_between_forms() {
+    let result = lex_and_parse_all("1 # mid\n2").unwrap();
+    assert_eq!(result.len(), 2);
+    assert!(matches!(result[0].kind, SyntaxKind::Int(1)));
+    assert!(matches!(result[1].kind, SyntaxKind::Int(2)));
+}
+
+#[test]
+fn test_comment_inside_list() {
+    let result = lex_and_parse_all("(1 # comment\n2)").unwrap();
+    assert_eq!(result.len(), 1);
+    match &result[0].kind {
+        SyntaxKind::List(elems) => assert_eq!(elems.len(), 2),
+        other => panic!("expected List, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_file_ends_with_comment() {
+    let result = lex_and_parse_all("42 # trailing").unwrap();
+    assert_eq!(result.len(), 1);
+    assert!(matches!(result[0].kind, SyntaxKind::Int(42)));
+}
+
+#[test]
+fn test_only_comment_produces_empty() {
+    let result = lex_and_parse_all("# just a comment").unwrap();
+    assert_eq!(result.len(), 0);
+}

--- a/src/reader/token.rs
+++ b/src/reader/token.rs
@@ -96,6 +96,7 @@ pub enum Token<'a> {
     String(String),
     Bool(bool),
     Nil,
+    Comment(String),
 }
 
 /// Owned token variant for storage in Reader
@@ -124,6 +125,7 @@ pub enum OwnedToken {
     String(String),
     Bool(bool),
     Nil,
+    Comment(String),
 }
 
 impl<'a> From<Token<'a>> for OwnedToken {
@@ -152,6 +154,7 @@ impl<'a> From<Token<'a>> for OwnedToken {
             Token::String(s) => OwnedToken::String(s),
             Token::Bool(b) => OwnedToken::Bool(b),
             Token::Nil => OwnedToken::Nil,
+            Token::Comment(s) => OwnedToken::Comment(s),
         }
     }
 }

--- a/src/rewrite/engine.rs
+++ b/src/rewrite/engine.rs
@@ -55,8 +55,8 @@ mod tests {
 
     #[test]
     fn test_preserves_comments() {
-        // Comments are not tokens — lexer skips them.
-        // So they must survive untouched.
+        // Comments are now tokens but no rewrite rule matches them,
+        // so comment text survives untouched in the source string.
         let source = "# this is a comment\n(path/join a b)";
         let mut renames = HashMap::new();
         renames.insert("path/join".to_string(), "path-join".to_string());

--- a/src/rewrite/run.rs
+++ b/src/rewrite/run.rs
@@ -11,6 +11,27 @@ use crate::epoch::rules::{
 use crate::reader::{Lexer, Token};
 use std::collections::HashMap;
 
+/// Lex source into tokens, filtering out comment tokens.
+/// The rewrite engine uses positional token matching that assumes
+/// no comment tokens in the stream (they were invisible before the
+/// formatter needed them).
+fn lex_tokens_no_comments(source: &str) -> Result<Vec<(Token<'_>, usize, usize)>, String> {
+    let mut lexer = Lexer::new(source);
+    let mut tokens = Vec::new();
+    loop {
+        match lexer.next_token_with_loc() {
+            Ok(Some(t)) => {
+                if !matches!(t.token, Token::Comment(_)) {
+                    tokens.push((t.token, t.byte_offset, t.len));
+                }
+            }
+            Ok(None) => break,
+            Err(e) => return Err(e.to_string()),
+        }
+    }
+    Ok(tokens)
+}
+
 /// Run the rewrite tool. Returns exit code.
 /// Exit codes: 0 = success (or no changes in --check mode), 1 = changes needed (--check) or error.
 pub fn run(args: &[String]) -> i32 {
@@ -137,7 +158,12 @@ pub fn run(args: &[String]) -> i32 {
 
 /// Rewrite a single file's source. Returns `Ok(None)` if no changes needed,
 /// `Ok(Some((new_source, edit_count)))` if changes were made.
-fn rewrite_file(source: &str, file_path: &str) -> Result<Option<(String, usize)>, String> {
+///
+/// `file_path` is used only for error messages.
+pub(crate) fn rewrite_file(
+    source: &str,
+    file_path: &str,
+) -> Result<Option<(String, usize)>, String> {
     // Detect epoch
     let epoch_info = detect_epoch_in_source(source)?;
 
@@ -291,22 +317,14 @@ fn check_removals(
     removals: &HashMap<&str, &str>,
     file_path: &str,
 ) -> Result<(), String> {
-    use crate::reader::{Lexer, Token};
+    let tokens = lex_tokens_no_comments(source)?;
 
-    let mut lexer = Lexer::new(source);
     let mut errors = Vec::new();
-
-    loop {
-        match lexer.next_token_with_loc() {
-            Ok(Some(token)) => {
-                if let Token::Symbol(name) = &token.token {
-                    if let Some(msg) = removals.get(*name) {
-                        errors.push(format!("  `{}` has been removed — {}", name, msg));
-                    }
-                }
+    for (token, _, _) in &tokens {
+        if let Token::Symbol(name) = token {
+            if let Some(msg) = removals.get(*name) {
+                errors.push(format!("  `{}` has been removed — {}", name, msg));
             }
-            Ok(None) => break,
-            Err(e) => return Err(e.to_string()),
         }
     }
 
@@ -329,15 +347,7 @@ fn collect_unwrap_edits(
     unwraps: &HashMap<&str, &str>,
     file_path: &str,
 ) -> Result<Vec<Edit>, String> {
-    let mut lexer = Lexer::new(source);
-    let mut tokens: Vec<(Token<'_>, usize, usize)> = Vec::new();
-    loop {
-        match lexer.next_token_with_loc() {
-            Ok(Some(t)) => tokens.push((t.token, t.byte_offset, t.len)),
-            Ok(None) => break,
-            Err(e) => return Err(e.to_string()),
-        }
-    }
+    let tokens = lex_tokens_no_comments(source)?;
 
     let mut edits = Vec::new();
     let mut i = 0;
@@ -452,15 +462,7 @@ fn collect_replace_edits(
     source: &str,
     replaces: &[(&str, usize, &str)],
 ) -> Result<Vec<Edit>, String> {
-    let mut lexer = Lexer::new(source);
-    let mut tokens: Vec<(Token<'_>, usize, usize)> = Vec::new(); // (token, byte_offset, len)
-    loop {
-        match lexer.next_token_with_loc() {
-            Ok(Some(t)) => tokens.push((t.token, t.byte_offset, t.len)),
-            Ok(None) => break,
-            Err(e) => return Err(e.to_string()),
-        }
-    }
+    let tokens = lex_tokens_no_comments(source)?;
 
     let mut edits = Vec::new();
     let mut i = 0;
@@ -594,15 +596,7 @@ fn skip_pipe_form(tokens: &[(Token<'_>, usize, usize)], start: usize) -> usize {
 /// Matches `( let|letrec [ [p1 v1] [p2 v2] ... ] body... )` and deletes
 /// the inner `[`/`]` (or `(`/`)`) delimiters, leaving the contents flat.
 fn collect_flatten_edits(source: &str, flatten_syms: &[&str]) -> Result<Vec<Edit>, String> {
-    let mut lexer = Lexer::new(source);
-    let mut tokens: Vec<(Token<'_>, usize, usize)> = Vec::new();
-    loop {
-        match lexer.next_token_with_loc() {
-            Ok(Some(t)) => tokens.push((t.token, t.byte_offset, t.len)),
-            Ok(None) => break,
-            Err(e) => return Err(e.to_string()),
-        }
-    }
+    let tokens = lex_tokens_no_comments(source)?;
 
     let mut edits = Vec::new();
     let mut i = 0;
@@ -728,15 +722,7 @@ fn try_match_flatten(
 /// Matches `(let|letrec|let*|if-let|when-let|when-ok (bindings...) body...)`
 /// where the bindings container uses `(...)` and replaces with `[...]`.
 fn collect_bracket_edits(source: &str, binding_forms: &[&str]) -> Result<Vec<Edit>, String> {
-    let mut lexer = Lexer::new(source);
-    let mut tokens: Vec<(Token<'_>, usize, usize)> = Vec::new();
-    loop {
-        match lexer.next_token_with_loc() {
-            Ok(Some(t)) => tokens.push((t.token, t.byte_offset, t.len)),
-            Ok(None) => break,
-            Err(e) => return Err(e.to_string()),
-        }
-    }
+    let tokens = lex_tokens_no_comments(source)?;
 
     let mut edits = Vec::new();
     let mut i = 0;


### PR DESCRIPTION
- Remove dead Doc variants (SoftBreak, ColumnIndent, BreakTo) and unused constructors (space, break_, softbreak, column_indent, break_to, surround)
- Deduplicate measure_flat: pub(super) in render.rs, import in forms.rs
- Inline trivial delegations: format_and_or, format_emit removed; dispatch calls format_generic_call directly for and/or/not/emit
- Fix cross-Nest CommentBreak absorption for defn, fn (multi), let, while (multi), block, parameterize, case, try (multi) — move boundary elements inside Nest so CommentBreak and HardBreak share indent context
- Deduplicate format_defmacro: delegates to format_defn
- elle fmt now runs epoch rewrite before formatting, implicitly upgrading files to the current epoch
- Adapt cond/match to epoch 9 flat-pair syntax: remove format_clause, extract format_flat_pairs shared by cond/match/case
- Fix pre-existing doctest failure in docs/fmt.md (scheme fence tag)
- Fix pre-existing clippy warnings in forms.rs (redundant closures, map_or)
- Update doc.rs module comment and AGENTS.md for current variants