### PR TITLE
fmt: Align fixes, trailing-ws strip, depth-limited trivial, --no-epoch, --plm

### DIFF
--- a/src/formatter/core.rs
+++ b/src/formatter/core.rs
@@ -67,6 +67,18 @@ pub fn format_code(source: &str, config: &FormatterConfig) -> Result<String, Str
         output.push_str(shebang);
     }
     output.push_str(rendered);
+
+    // 9. Strip trailing whitespace from every line. The renderer emits
+    //    indent spaces before HardBreaks (blank separator lines), producing
+    //    lines with only whitespace. Strip these so editors and linters
+    //    don't complain.
+    let output: String = output
+        .lines()
+        .map(|line| line.trim_end())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let mut output = output;
     if !output.ends_with('\n') {
         output.push('\n');
     }
@@ -543,5 +555,94 @@ nil
     #[test]
     fn test_idempotent_generic_call_short_head() {
         assert_idempotent("(f arg1 arg2 arg3)");
+    }
+
+    // ── Trailing trivia on params must not split header ──────────
+
+    #[test]
+    fn test_fn_header_not_split_by_trailing_comment() {
+        let config = FormatterConfig::default();
+        let input = "(fn [x y]\n\n  ## doc comment\n  (+ x y))";
+        let formatted = format_code(input, &config).unwrap();
+        assert!(
+            formatted.starts_with("(fn [x y]"),
+            "fn header should stay on one line, got:\n{}",
+            formatted
+        );
+        let second = format_code(&formatted, &config).unwrap();
+        assert_eq!(formatted, second, "must be idempotent");
+    }
+
+    #[test]
+    fn test_defn_header_not_split_by_trailing_comment() {
+        let config = FormatterConfig::default();
+        let input = "(defn foo [x y]\n\n  ## doc comment\n  (+ x y))";
+        let formatted = format_code(input, &config).unwrap();
+        assert!(
+            formatted.starts_with("(defn foo [x y]"),
+            "defn header should stay on one line, got:\n{}",
+            formatted
+        );
+        let second = format_code(&formatted, &config).unwrap();
+        assert_eq!(formatted, second, "must be idempotent");
+    }
+
+    #[test]
+    fn test_no_trailing_whitespace() {
+        let config = FormatterConfig::default();
+        let input = "(fn [x]\n\n  ## comment\n  (+ x 1))";
+        let formatted = format_code(input, &config).unwrap();
+        for (i, line) in formatted.lines().enumerate() {
+            assert!(
+                line == line.trim_end(),
+                "line {} has trailing whitespace: {:?}",
+                i + 1,
+                line
+            );
+        }
+    }
+
+    #[test]
+    fn test_if_branches_align_in_let_binding() {
+        let config = FormatterConfig::default();
+        // When (if ...) is a value in a let binding and breaks, branches
+        // must align relative to the (if column, not the ambient nest.
+        let input = "(let [port (if (nil? colon) info:default-port (parse-int (slice auth (inc colon))))] port)";
+        let formatted = format_code(input, &config).unwrap();
+        let second = format_code(&formatted, &config).unwrap();
+        assert_eq!(formatted, second, "must be idempotent");
+        // The branches should be indented relative to the ( of (if,
+        // not at some unrelated nest level.
+        let lines: Vec<&str> = formatted.lines().collect();
+        // Find the line with (if
+        let if_line_idx = lines.iter().position(|l| l.contains("(if")).unwrap();
+        let if_col = lines[if_line_idx].find("(if").unwrap();
+        // Branch lines should be at if_col + 2 (standard body indent from "(")
+        if if_line_idx + 1 < lines.len() {
+            let branch_line = lines[if_line_idx + 1];
+            let branch_col = branch_line.len() - branch_line.trim_start().len();
+            assert_eq!(
+                branch_col,
+                if_col + 2,
+                "branch should indent +2 from (if at col {}, got col {}\nformatted:\n{}",
+                if_col,
+                branch_col,
+                formatted
+            );
+        }
+    }
+
+    #[test]
+    fn test_fn_named_args_header_not_split() {
+        let config = FormatterConfig::default();
+        let input = "(fn [&named tls compress]\n\n  ## comment block\n  (def x 1)\n  (def y 2))";
+        let formatted = format_code(input, &config).unwrap();
+        assert!(
+            formatted.starts_with("(fn [&named tls compress]"),
+            "fn &named header should stay on one line, got:\n{}",
+            formatted
+        );
+        let second = format_code(&formatted, &config).unwrap();
+        assert_eq!(formatted, second, "must be idempotent");
     }
 }

--- a/src/formatter/format.rs
+++ b/src/formatter/format.rs
@@ -173,6 +173,88 @@ pub(super) fn format_annotated(
     Doc::concat(parts)
 }
 
+/// Format a node with leading trivia + syntax, but WITHOUT trailing trivia.
+///
+/// Used for header elements (like params) whose trailing trivia (comments,
+/// blank lines before the body) would poison `measure_flat` inside a Group,
+/// forcing the header to break unnecessarily.
+pub(super) fn format_without_trailing(
+    node: &AnnotatedSyntax,
+    source: &str,
+    config: &FormatterConfig,
+) -> Doc {
+    let mut parts = Vec::new();
+
+    // Leading trivia (same as format_annotated)
+    if !node.leading.is_empty() {
+        for t in &node.leading {
+            match t {
+                Trivia::Comment { text, .. } => {
+                    parts.push(Doc::hardbreak());
+                    parts.push(Doc::text(text));
+                }
+                Trivia::BlankLines { count, .. } => {
+                    for _ in 0..(*count).min(2) {
+                        parts.push(Doc::hardbreak());
+                    }
+                }
+            }
+        }
+        parts.push(Doc::hardbreak());
+    }
+
+    // The node itself — no trailing trivia
+    parts.push(format_syntax(node, source, config));
+    Doc::concat(parts)
+}
+
+/// Format only the trailing trivia of a node.
+///
+/// Companion to `format_without_trailing`. Emit this after the header
+/// group so trivia appears between header and body without affecting
+/// the header's flat-width measurement.
+pub(super) fn format_trailing_trivia(node: &AnnotatedSyntax) -> Doc {
+    if node.trailing.is_empty() {
+        return Doc::empty();
+    }
+
+    let mut parts = Vec::new();
+    let has_trailing_comments = node
+        .trailing
+        .iter()
+        .any(|t| matches!(t, Trivia::Comment { .. }));
+    let mut seen_break = false;
+    let mut inline_done = false;
+    for t in &node.trailing {
+        match t {
+            Trivia::Comment { text, .. } => {
+                if !seen_break && !inline_done {
+                    parts.push(Doc::text("  "));
+                    parts.push(Doc::text(text));
+                    inline_done = true;
+                } else {
+                    parts.push(Doc::hardbreak());
+                    parts.push(Doc::text(text));
+                }
+            }
+            Trivia::BlankLines { count, .. } => {
+                seen_break = true;
+                if has_trailing_comments {
+                    for _ in 0..(*count).min(2) {
+                        parts.push(Doc::hardbreak());
+                    }
+                }
+            }
+        }
+    }
+
+    if has_trailing_comments {
+        parts.push(Doc::comment_break());
+    }
+
+    Doc::concat(parts)
+}
+
 /// Format a single Syntax node (no trivia).
 ///
 /// Dispatches on SyntaxKind. For lists, checks the head symbol for

--- a/src/formatter/forms.rs
+++ b/src/formatter/forms.rs
@@ -12,7 +12,7 @@
 
 use super::config::FormatterConfig;
 use super::doc::Doc;
-use super::format::format_annotated;
+use super::format::{format_annotated, format_trailing_trivia, format_without_trailing};
 use super::render::measure_flat;
 use super::trivia::AnnotatedSyntax;
 use crate::syntax::SyntaxKind;
@@ -38,17 +38,23 @@ fn is_collection(node: &AnnotatedSyntax) -> bool {
     )
 }
 
-/// Body-form head symbols that introduce nesting/control flow.
-const BODY_FORMS: &[&str] = &[
-    "def", "defn", "defmacro", "fn", "let", "let*", "letrec", "if", "when", "unless", "while",
-    "each", "begin", "cond", "match", "case", "try", "protect", "->", "->>", "some->", "some->>",
-];
-
-/// A node is "trivial" if it is structurally simple — no nested body forms.
-/// Trivial nodes get columnar alignment; compound nodes get +2 body indent.
+/// A node is "trivial" if it is structurally shallow — at most 2 levels
+/// of nested lists. Trivial nodes stay on the same line in cond/match
+/// pairs and get columnar alignment in if/when; deeply nested nodes break.
+///
+/// Depth budget: each compound node (list, collection) costs 1 level.
+/// Atoms are free. Budget of 3 allows e.g. `(if (nil? x) a b)` (2 levels)
+/// but rejects `(each x in xs (unless (nil? x) (push ...)))` (3+ levels).
 fn is_trivial(node: &AnnotatedSyntax) -> bool {
+    is_trivial_depth(node, 3)
+}
+
+fn is_trivial_depth(node: &AnnotatedSyntax, budget: usize) -> bool {
+    if budget == 0 {
+        return false;
+    }
     match &node.syntax.kind {
-        // Atoms are always trivial
+        // Atoms are always trivial (no depth cost)
         SyntaxKind::Nil
         | SyntaxKind::Bool(_)
         | SyntaxKind::Int(_)
@@ -57,18 +63,13 @@ fn is_trivial(node: &AnnotatedSyntax) -> bool {
         | SyntaxKind::Keyword(_)
         | SyntaxKind::String(_) => true,
 
-        // A list is trivial if its head is NOT a body form
-        // and all children are trivial
-        SyntaxKind::List(_) => {
-            if let Some(sym) = node.children.first().and_then(|c| c.syntax.as_symbol()) {
-                if BODY_FORMS.contains(&sym) {
-                    return false;
-                }
-            }
-            node.children.iter().all(is_trivial)
-        }
+        // A list costs 1 depth level
+        SyntaxKind::List(_) => node
+            .children
+            .iter()
+            .all(|c| is_trivial_depth(c, budget - 1)),
 
-        // Collections are trivial if all elements are trivial
+        // Collections cost 1 depth level
         SyntaxKind::Array(_)
         | SyntaxKind::ArrayMut(_)
         | SyntaxKind::Struct(_)
@@ -76,14 +77,20 @@ fn is_trivial(node: &AnnotatedSyntax) -> bool {
         | SyntaxKind::Set(_)
         | SyntaxKind::SetMut(_)
         | SyntaxKind::Bytes(_)
-        | SyntaxKind::BytesMut(_) => node.children.iter().all(is_trivial),
+        | SyntaxKind::BytesMut(_) => node
+            .children
+            .iter()
+            .all(|c| is_trivial_depth(c, budget - 1)),
 
-        // Reader macros: trivial if inner is trivial
+        // Reader macros cost 1 depth level
         SyntaxKind::Quote(_)
         | SyntaxKind::Quasiquote(_)
         | SyntaxKind::Unquote(_)
         | SyntaxKind::UnquoteSplicing(_)
-        | SyntaxKind::Splice(_) => node.children.first().is_none_or(is_trivial),
+        | SyntaxKind::Splice(_) => node
+            .children
+            .first()
+            .is_none_or(|c| is_trivial_depth(c, budget - 1)),
 
         SyntaxKind::SyntaxLiteral(_) => true,
     }
@@ -158,7 +165,10 @@ fn format_defn(children: &[AnnotatedSyntax], source: &str, config: &FormatterCon
 
     let head = format_annotated(&children[0], source, config);
     let name = format_annotated(&children[1], source, config);
-    let params = format_annotated(&children[2], source, config);
+    // Format params without trailing trivia so comments/blank-lines between
+    // params and body don't poison the header group's measure_flat.
+    let params = format_without_trailing(&children[2], source, config);
+    let params_trivia = format_trailing_trivia(&children[2]);
 
     // Header: (defn name [params])
     let header = Doc::concat([head, Doc::Break, name, Doc::Break, params]);
@@ -185,7 +195,7 @@ fn format_defn(children: &[AnnotatedSyntax], source: &str, config: &FormatterCon
 
     Doc::concat([
         Doc::text("("),
-        Doc::concat([header.group(), Doc::HardBreak, body]).nest(1),
+        Doc::concat([header.group(), params_trivia, Doc::HardBreak, body]).nest(1),
         Doc::text(")"),
     ])
 }
@@ -214,7 +224,10 @@ pub(super) fn format_fn(
     }
 
     let head = format_annotated(&children[0], source, config);
-    let params = format_annotated(&children[params_idx], source, config);
+    // Format params without trailing trivia so comments/blank-lines between
+    // params and body don't poison the header group's measure_flat.
+    let params = format_without_trailing(&children[params_idx], source, config);
+    let params_trivia = format_trailing_trivia(&children[params_idx]);
 
     // Header: (fn name? [params])
     let mut header_parts = vec![head];
@@ -238,6 +251,7 @@ pub(super) fn format_fn(
         Doc::align(Doc::concat([
             Doc::text("("),
             header.group(),
+            params_trivia,
             Doc::concat([Doc::Break, body_doc]).nest(1).group(),
             Doc::text(")"),
         ]))
@@ -247,7 +261,7 @@ pub(super) fn format_fn(
         let body = format_body(body_children, source, config);
         Doc::align(Doc::concat([
             Doc::text("("),
-            Doc::concat([header.group(), Doc::HardBreak, body]).nest(1),
+            Doc::concat([header.group(), params_trivia, Doc::HardBreak, body]).nest(1),
             Doc::text(")"),
         ]))
     }
@@ -272,12 +286,7 @@ pub(super) fn format_let(
     }
 
     let head = format_annotated(&children[0], source, config);
-
-    // Column of first binding name relative to the "(": "(let* [" = 1 + 4 + 1 + 1 = 7
-    let head_width = measure_flat(&head).unwrap_or(0);
-    let binding_col = 1 + head_width + 1 + 1; // "(head ["
-
-    let bindings_doc = format_bindings(&children[1], source, config, binding_col);
+    let bindings_doc = format_bindings(&children[1], source, config);
 
     // Header: (let [...])
     let header = Doc::concat([head, Doc::text(" "), bindings_doc]);
@@ -285,34 +294,23 @@ pub(super) fn format_let(
     // Body: +2 indent
     let body = format_body(&children[2..], source, config);
 
-    Doc::concat([
+    Doc::align(Doc::concat([
         Doc::text("("),
         Doc::concat([header, Doc::HardBreak, body]).nest(1),
         Doc::text(")"),
-    ])
+    ]))
 }
 
 /// Format binding vector: one pair per line, always.
 ///
-/// Uses HardBreak between pairs with exact column alignment via
-/// Nest + padding. `binding_col` is the column of the first binding
-/// name relative to the enclosing `(`.
-fn format_bindings(
-    bindings_node: &AnnotatedSyntax,
-    source: &str,
-    config: &FormatterConfig,
-    binding_col: usize,
-) -> Doc {
+/// Uses Align after `[` so that subsequent binding names line up with
+/// the first binding name regardless of nesting depth.
+fn format_bindings(bindings_node: &AnnotatedSyntax, source: &str, config: &FormatterConfig) -> Doc {
     let items = &bindings_node.children;
 
     if items.is_empty() {
         return Doc::text("[]");
     }
-
-    // Nest handles the bulk of alignment; padding covers the remainder
-    // (e.g. let* needs 7 spaces = nest(3)*2 + 1 pad)
-    let binding_nest = binding_col / config.indent_width;
-    let padding = binding_col % config.indent_width;
 
     let mut pair_parts = Vec::new();
     let mut i = 0;
@@ -320,9 +318,6 @@ fn format_bindings(
     while i < items.len() {
         if !first {
             pair_parts.push(Doc::HardBreak);
-            if padding > 0 {
-                pair_parts.push(Doc::text(" ".repeat(padding)));
-            }
         }
         first = false;
 
@@ -340,7 +335,7 @@ fn format_bindings(
 
     Doc::concat([
         Doc::text("["),
-        Doc::concat(pair_parts).nest(binding_nest),
+        Doc::align(Doc::concat(pair_parts)),
         Doc::text("]"),
     ])
 }
@@ -372,11 +367,11 @@ pub(super) fn format_if(
         // (if test then) — same as when
         if trivial {
             let header = Doc::concat([head, Doc::text(" "), test]);
-            Doc::concat([
+            Doc::align(Doc::concat([
                 Doc::text("("),
                 Doc::concat([header, Doc::Break, then]).nest(1).group(),
                 Doc::text(")"),
-            ])
+            ]))
         } else {
             Doc::align(Doc::concat([
                 Doc::text("("),
@@ -393,13 +388,13 @@ pub(super) fn format_if(
         if trivial {
             // Trivial branches: test stays with head, branches break to +2
             let header = Doc::concat([head, Doc::text(" "), test]);
-            Doc::concat([
+            Doc::align(Doc::concat([
                 Doc::text("("),
                 Doc::concat([header, Doc::Break, then, Doc::Break, else_])
                     .nest(1)
                     .group(),
                 Doc::text(")"),
-            ])
+            ]))
         } else {
             // Compound branches: always break, +2 indent relative to (if.
             // head+test inside Nest so CommentBreak absorption uses correct indent.
@@ -440,11 +435,11 @@ pub(super) fn format_cond(
     let pairs = format_flat_pairs(&children[1..], source, config);
     let clauses = Doc::join_hardbreak(pairs);
 
-    Doc::concat([
+    Doc::align(Doc::concat([
         Doc::text("("),
         Doc::concat([head, Doc::HardBreak, clauses]).nest(1),
         Doc::text(")"),
-    ])
+    ]))
 }
 
 // ── match ──────────────────────────────────────────────────────
@@ -464,11 +459,11 @@ pub(super) fn format_match(
     let pairs = format_flat_pairs(&children[2..], source, config);
     let clauses = Doc::join_hardbreak(pairs);
 
-    Doc::concat([
+    Doc::align(Doc::concat([
         Doc::text("("),
         Doc::concat([head, Doc::text(" "), expr, Doc::HardBreak, clauses]).nest(1),
         Doc::text(")"),
-    ])
+    ]))
 }
 
 // ── while ──────────────────────────────────────────────────────
@@ -487,28 +482,25 @@ pub(super) fn format_while(
     let test = format_annotated(&children[1], source, config);
     let body_children = &children[2..];
 
+    let body = format_body(body_children, source, config);
+
     if body_children.len() == 1 {
-        // Single body: try inline
-        let body = format_annotated(&body_children[0], source, config);
-        let cp = Doc::text(")");
-        Doc::concat([
+        // Single body: try inline, break before body if needed.
+        // Test always stays with head.
+        let header = Doc::concat([head, Doc::text(" "), test]);
+        Doc::align(Doc::concat([
             Doc::text("("),
-            Doc::intersperse([head, test, body]).nest(1).group(),
-            cp,
-        ])
-    } else {
-        // Multiple body expressions: always break
-        let body = format_body(body_children, source, config);
-        Doc::concat([
-            Doc::text("("),
-            Doc::concat([
-                Doc::concat([head, Doc::Break, test]).group(),
-                Doc::HardBreak,
-                body,
-            ])
-            .nest(1),
+            Doc::concat([header, Doc::Break, body]).nest(1).group(),
             Doc::text(")"),
-        ])
+        ]))
+    } else {
+        // Multiple body expressions: always break.
+        // Test always stays with head.
+        Doc::align(Doc::concat([
+            Doc::text("("),
+            Doc::concat([head, Doc::text(" "), test, Doc::HardBreak, body]).nest(1),
+            Doc::text(")"),
+        ]))
     }
 }
 
@@ -538,11 +530,11 @@ pub(super) fn format_begin(
     let head = format_annotated(&children[0], source, config);
     let body = format_body(&children[1..], source, config);
 
-    Doc::concat([
+    Doc::align(Doc::concat([
         Doc::text("("),
         Doc::concat([head, Doc::HardBreak, body]).nest(1),
         Doc::text(")"),
-    ])
+    ]))
 }
 
 // ── forever ────────────────────────────────────────────────────
@@ -562,18 +554,18 @@ pub(super) fn format_forever(
 
     if body_children.len() == 1 {
         let body = format_annotated(&body_children[0], source, config);
-        Doc::concat([
+        Doc::align(Doc::concat([
             Doc::text("("),
             Doc::concat([head, Doc::Break, body]).nest(1).group(),
             Doc::text(")"),
-        ])
+        ]))
     } else {
         let body = format_body(body_children, source, config);
-        Doc::concat([
+        Doc::align(Doc::concat([
             Doc::text("("),
             Doc::concat([head, Doc::HardBreak, body]).nest(1),
             Doc::text(")"),
-        ])
+        ]))
     }
 }
 
@@ -593,11 +585,11 @@ pub(super) fn format_block(
     let name = format_annotated(&children[1], source, config);
     let body = format_body(&children[2..], source, config);
 
-    Doc::concat([
+    Doc::align(Doc::concat([
         Doc::text("("),
         Doc::concat([head, Doc::text(" "), name, Doc::HardBreak, body]).nest(1),
         Doc::text(")"),
-    ])
+    ]))
 }
 
 // ── parameterize ──────────────────────────────────────────────
@@ -636,11 +628,11 @@ pub(super) fn format_parameterize(
 
     let body = format_body(&children[2..], source, config);
 
-    Doc::concat([
+    Doc::align(Doc::concat([
         Doc::text("("),
         Doc::concat([head, Doc::text(" "), bindings, Doc::HardBreak, body]).nest(1),
         Doc::text(")"),
-    ])
+    ]))
 }
 
 // ── Threading macros ─────────────────────────────────────────
@@ -699,19 +691,19 @@ pub(super) fn format_when(
     let trivial = body_children.len() == 1 && is_trivial(&body_children[0]);
 
     if trivial {
-        Doc::concat([
+        Doc::align(Doc::concat([
             Doc::text("("),
             Doc::concat([head, Doc::text(" "), test, Doc::Break, body])
                 .nest(1)
                 .group(),
             Doc::text(")"),
-        ])
+        ]))
     } else {
-        Doc::concat([
+        Doc::align(Doc::concat([
             Doc::text("("),
             Doc::concat([head, Doc::text(" "), test, Doc::HardBreak, body]).nest(1),
             Doc::text(")"),
-        ])
+        ]))
     }
 }
 
@@ -758,11 +750,11 @@ pub(super) fn format_each(
         Doc::concat([head, Doc::text(" "), item, Doc::text(" "), coll])
     };
 
-    Doc::concat([
+    Doc::align(Doc::concat([
         Doc::text("("),
         Doc::concat([header, Doc::HardBreak, body]).nest(1),
         Doc::text(")"),
-    ])
+    ]))
 }
 
 // ── case ───────────────────────────────────────────────────────
@@ -782,7 +774,7 @@ pub(super) fn format_case(
     let pairs = format_flat_pairs(&children[2..], source, config);
     let clauses = Doc::join_hardbreak(pairs);
 
-    Doc::concat([
+    Doc::align(Doc::concat([
         Doc::text("("),
         Doc::concat([
             Doc::concat([head, Doc::Break, expr]).group(),
@@ -791,7 +783,7 @@ pub(super) fn format_case(
         ])
         .nest(1),
         Doc::text(")"),
-    ])
+    ]))
 }
 
 /// Format flat alternating test/body pairs.
@@ -846,19 +838,19 @@ pub(super) fn format_try(
     if body_children.len() == 1 {
         // Single body: try inline
         let body = format_annotated(&body_children[0], source, config);
-        Doc::concat([
+        Doc::align(Doc::concat([
             Doc::text("("),
             Doc::intersperse([head, body]).nest(1).group(),
             Doc::text(")"),
-        ])
+        ]))
     } else {
         // Multiple sub-forms (e.g. body + catch/finally): break
         let body = format_body(body_children, source, config);
-        Doc::concat([
+        Doc::align(Doc::concat([
             Doc::text("("),
             Doc::concat([head, Doc::HardBreak, body]).nest(1),
             Doc::text(")"),
-        ])
+        ]))
     }
 }
 
@@ -891,13 +883,14 @@ pub(super) fn format_assign(
 /// Generic function call: try inline; break with args aligned to first arg.
 ///
 /// Head and first arg stay on the same line. When breaking, subsequent
-/// args align to the first arg's column (approximated via Nest levels).
+/// args align to the first arg's column. Keyword-value pairs (`:key val`)
+/// are kept together as units so they break as one.
 ///
 /// ```lisp
 /// (f a b c)          # fits on one line
 /// (f a               # doesn't fit — first arg stays with head
-///   b                #   remaining args align to first arg
-///   c)
+///    b               #   remaining args align to first arg
+///    c)
 /// ```
 pub(super) fn format_generic_call(
     children: &[AnnotatedSyntax],
@@ -908,24 +901,19 @@ pub(super) fn format_generic_call(
         return Doc::text("()");
     }
 
-    let elems: Vec<Doc> = children
-        .iter()
-        .map(|c| format_annotated(c, source, config))
-        .collect();
-
-    if elems.len() == 1 {
+    if children.len() == 1 {
         // Head only
         return Doc::concat([
             Doc::text("("),
-            elems.into_iter().next().unwrap(),
+            format_annotated(&children[0], source, config),
             Doc::text(")"),
         ]);
     }
 
-    if elems.len() == 2 {
+    if children.len() == 2 {
         // Head + one arg: Align so arg indents to first-arg column
-        let head = elems[0].clone();
-        let arg = elems[1].clone();
+        let head = format_annotated(&children[0], source, config);
+        let arg = format_annotated(&children[1], source, config);
         return Doc::concat([
             Doc::text("("),
             head,
@@ -935,9 +923,11 @@ pub(super) fn format_generic_call(
         ]);
     }
 
-    // Head + first arg stay together; remaining args align to first arg column
-    let head = elems[0].clone();
-    let rest_args: Vec<Doc> = elems[2..].to_vec();
+    let head = format_annotated(&children[0], source, config);
+
+    // Build arg units: keyword-value pairs are joined with a space,
+    // positional args stand alone.
+    let arg_units = build_arg_units(&children[1..], source, config);
 
     // First arg column relative to the "(": 1 + head_width + 1
     let head_width = measure_flat(&head).unwrap_or(0);
@@ -947,21 +937,18 @@ pub(super) fn format_generic_call(
     if first_arg_col <= config.line_length / 4 {
         // Columnar: Align captures the first arg's column; Break inside
         // aligns subsequent args to that column.
-        let all_args: Vec<Doc> = elems[1..].to_vec();
         Doc::concat([
             Doc::text("("),
             head,
             Doc::text(" "),
-            Doc::align(Doc::intersperse(all_args)).group(),
+            Doc::align(Doc::intersperse(arg_units)).group(),
             Doc::text(")"),
         ])
     } else {
         // Fallback: +2 indent for long heads
-        let first_arg = elems[1].clone();
-        let header = Doc::concat([head, Doc::text(" "), first_arg]);
         let mut all_parts: Vec<Doc> = Vec::new();
-        all_parts.push(header);
-        for arg in &rest_args {
+        all_parts.push(Doc::concat([head, Doc::text(" "), arg_units[0].clone()]));
+        for arg in &arg_units[1..] {
             all_parts.push(Doc::Break);
             all_parts.push(arg.clone());
         }
@@ -972,4 +959,28 @@ pub(super) fn format_generic_call(
             Doc::text(")"),
         ])
     }
+}
+
+/// Build argument units for generic calls, grouping `:keyword value` pairs.
+///
+/// A keyword followed by a non-keyword argument forms a single doc unit
+/// joined by a space. Consecutive keywords or trailing keywords stand alone.
+fn build_arg_units(args: &[AnnotatedSyntax], source: &str, config: &FormatterConfig) -> Vec<Doc> {
+    let mut units = Vec::new();
+    let mut i = 0;
+    while i < args.len() {
+        let doc = format_annotated(&args[i], source, config);
+        if matches!(args[i].syntax.kind, SyntaxKind::Keyword(_)) {
+            // Keyword — pair with next arg if it's not also a keyword
+            if i + 1 < args.len() && !matches!(args[i + 1].syntax.kind, SyntaxKind::Keyword(_)) {
+                let val = format_annotated(&args[i + 1], source, config);
+                units.push(Doc::concat([doc, Doc::text(" "), val]));
+                i += 2;
+                continue;
+            }
+        }
+        units.push(doc);
+        i += 1;
+    }
+    units
 }

--- a/src/formatter/render.rs
+++ b/src/formatter/render.rs
@@ -116,7 +116,18 @@ impl LayoutCtx {
                 }
             }
 
-            Doc::Align(inner) => self.layout(inner, col, col, broken, last_cb, out),
+            Doc::Align(inner) => {
+                // Cap alignment: if we're past half the line width, don't
+                // create a new alignment point — keep the enclosing indent.
+                // This prevents cascading Aligns from pushing deeply nested
+                // code off the right edge.
+                let new_indent = if col <= self.line_width / 2 {
+                    col
+                } else {
+                    indent
+                };
+                self.layout(inner, col, new_indent, broken, last_cb, out)
+            }
         }
     }
 

--- a/src/formatter/run.rs
+++ b/src/formatter/run.rs
@@ -4,6 +4,38 @@ use crate::formatter::{format_code, FormatterConfig};
 use crate::rewrite::run::rewrite_file;
 use std::io::IsTerminal;
 
+/// Options for fragment formatting.
+struct FmtOpts {
+    no_epoch: bool,
+    preserve_margin: bool,
+}
+
+/// Top-level format dispatch: handles --no-epoch and --plm.
+fn do_format(
+    source: &str,
+    file_path: &str,
+    config: &FormatterConfig,
+    opts: &FmtOpts,
+) -> Result<String, String> {
+    let (input, margin) = if opts.preserve_margin {
+        strip_left_margin(source)
+    } else {
+        (source.to_string(), String::new())
+    };
+
+    let formatted = if opts.no_epoch {
+        format_only(&input, config)?
+    } else {
+        rewrite_and_format(&input, file_path, config)?
+    };
+
+    Ok(if opts.preserve_margin {
+        apply_left_margin(&formatted, &margin)
+    } else {
+        formatted
+    })
+}
+
 /// Run epoch rewrite on source, then format.
 /// Returns the formatted string with epoch migrations applied.
 fn rewrite_and_format(
@@ -18,6 +50,67 @@ fn rewrite_and_format(
     format_code(&rewritten, config)
 }
 
+/// Format-only (no epoch rewrite). Used by --no-epoch.
+fn format_only(source: &str, config: &FormatterConfig) -> Result<String, String> {
+    format_code(source, config)
+}
+
+/// Detect and strip a common left margin from every non-blank line.
+/// Returns (stripped_source, margin_string).
+fn strip_left_margin(source: &str) -> (String, String) {
+    let min_indent = source
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .map(|l| l.len() - l.trim_start().len())
+        .min()
+        .unwrap_or(0);
+
+    if min_indent == 0 {
+        return (source.to_string(), String::new());
+    }
+
+    let margin: String = " ".repeat(min_indent);
+    let stripped: String = source
+        .lines()
+        .map(|l| {
+            if l.trim().is_empty() {
+                ""
+            } else {
+                &l[min_indent..]
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    // Preserve trailing newline
+    let stripped = if source.ends_with('\n') && !stripped.ends_with('\n') {
+        stripped + "\n"
+    } else {
+        stripped
+    };
+
+    (stripped, margin)
+}
+
+/// Re-apply a left margin to every non-blank line.
+fn apply_left_margin(source: &str, margin: &str) -> String {
+    if margin.is_empty() {
+        return source.to_string();
+    }
+    source
+        .lines()
+        .map(|l| {
+            if l.trim().is_empty() {
+                l.to_string()
+            } else {
+                format!("{}{}", margin, l)
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+        + if source.ends_with('\n') { "\n" } else { "" }
+}
+
 /// Run the formatter tool. Returns exit code.
 ///
 /// Exit codes:
@@ -25,6 +118,8 @@ fn rewrite_and_format(
 /// - 1 = error, or changes needed in --check mode
 pub fn run(args: &[String]) -> i32 {
     let mut check = false;
+    let mut no_epoch = false;
+    let mut preserve_margin = false;
     let mut line_length: Option<usize> = None;
     let mut indent_width: Option<usize> = None;
     let mut files = Vec::new();
@@ -33,6 +128,8 @@ pub fn run(args: &[String]) -> i32 {
     while i < args.len() {
         match args[i].as_str() {
             "--check" => check = true,
+            "--no-epoch" => no_epoch = true,
+            "--plm" | "--preserve-left-margin" => preserve_margin = true,
             "--help" | "-h" => {
                 print_help();
                 return 0;
@@ -75,6 +172,11 @@ pub fn run(args: &[String]) -> i32 {
         .maybe_with_line_length(line_length)
         .maybe_with_indent_width(indent_width);
 
+    let opts = FmtOpts {
+        no_epoch,
+        preserve_margin,
+    };
+
     // No files given: if stdin is piped, format it; otherwise show help.
     if files.is_empty() {
         if std::io::stdin().is_terminal() {
@@ -82,7 +184,7 @@ pub fn run(args: &[String]) -> i32 {
             print_help();
             return 1;
         }
-        return run_stdin(check, &config);
+        return run_stdin(check, &config, &opts);
     }
 
     let mut any_changed = false;
@@ -98,7 +200,7 @@ pub fn run(args: &[String]) -> i32 {
             }
         };
 
-        match rewrite_and_format(&source, file_path, &config) {
+        match do_format(&source, file_path, &config, &opts) {
             Ok(formatted) => {
                 if check {
                     if let Some(exit) = check_columns(file_path, &formatted) {
@@ -134,14 +236,14 @@ pub fn run(args: &[String]) -> i32 {
 }
 
 /// Format stdin, write to stdout.
-fn run_stdin(check: bool, config: &FormatterConfig) -> i32 {
+fn run_stdin(check: bool, config: &FormatterConfig, opts: &FmtOpts) -> i32 {
     let mut source = String::new();
     if let Err(e) = std::io::Read::read_to_string(&mut std::io::stdin(), &mut source) {
         eprintln!("Error reading stdin: {}", e);
         return 1;
     }
 
-    let formatted = match rewrite_and_format(&source, "<stdin>", config) {
+    let formatted = match do_format(&source, "<stdin>", config, opts) {
         Ok(f) => f,
         Err(e) => {
             eprintln!("Error formatting stdin: {}", e);
@@ -211,6 +313,8 @@ fn print_help() {
     println!();
     println!("Options:");
     println!("  --check                   Check if files need formatting (exit 1 if yes)");
+    println!("  --no-epoch                Skip epoch tag injection/upgrade (for fragments)");
+    println!("  --plm                     Preserve left margin (auto-detect + re-apply indent)");
     println!("  --line-length=N           Target line length (default: 80)");
     println!("  --indent-width=N          Spaces per indent level (default: 2)");
     println!("  --help                    Show this help message");
@@ -219,6 +323,7 @@ fn print_help() {
     println!("  elle fmt src/*.lisp");
     println!("  elle fmt --check lib/*.lisp");
     println!("  elle fmt --line-length=120 src/*.lisp");
+    println!("  elle fmt --no-epoch --plm fragment.lisp");
     println!("  cat file.lisp | elle fmt");
 }
 
@@ -271,5 +376,78 @@ mod tests {
         let first = rewrite_and_format(input, "<test>", &config).unwrap();
         let second = rewrite_and_format(&first, "<test>", &config).unwrap();
         assert_eq!(first, second, "rewrite+format must be idempotent");
+    }
+
+    #[test]
+    fn test_no_epoch_skips_injection() {
+        let config = FormatterConfig::default();
+        let opts = FmtOpts {
+            no_epoch: true,
+            preserve_margin: false,
+        };
+        let input = "(defn foo [x]\n  (+ x 1))\n";
+        let result = do_format(input, "<test>", &config, &opts).unwrap();
+        assert!(
+            !result.contains("elle/epoch"),
+            "--no-epoch should not inject epoch, got: {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_preserve_left_margin() {
+        let config = FormatterConfig::default();
+        let opts = FmtOpts {
+            no_epoch: true,
+            preserve_margin: true,
+        };
+        let input = "    (defn foo [x]\n      (+ x 1))\n";
+        let result = do_format(input, "<test>", &config, &opts).unwrap();
+        assert!(
+            result.starts_with("    (defn foo [x]"),
+            "should preserve 4-space margin, got: {:?}",
+            result
+        );
+        // Body should be margin + 2 indent = 6 spaces
+        let lines: Vec<&str> = result.lines().collect();
+        assert!(
+            lines[1].starts_with("      "),
+            "body should be at margin+2, got: {:?}",
+            lines[1]
+        );
+    }
+
+    #[test]
+    fn test_preserve_left_margin_idempotent() {
+        let config = FormatterConfig::default();
+        let opts = FmtOpts {
+            no_epoch: true,
+            preserve_margin: true,
+        };
+        let input = "        (defn foo [x]\n          (+ x 1))\n";
+        let first = do_format(input, "<test>", &config, &opts).unwrap();
+        let second = do_format(&first, "<test>", &config, &opts).unwrap();
+        assert_eq!(first, second, "plm must be idempotent");
+    }
+
+    #[test]
+    fn test_strip_left_margin_basic() {
+        let (stripped, margin) = strip_left_margin("    (foo)\n      (bar)\n");
+        assert_eq!(margin, "    ");
+        assert_eq!(stripped, "(foo)\n  (bar)\n");
+    }
+
+    #[test]
+    fn test_strip_left_margin_zero() {
+        let (stripped, margin) = strip_left_margin("(foo)\n  (bar)\n");
+        assert_eq!(margin, "");
+        assert_eq!(stripped, "(foo)\n  (bar)\n");
+    }
+
+    #[test]
+    fn test_strip_left_margin_blank_lines() {
+        let (stripped, margin) = strip_left_margin("    (foo)\n\n    (bar)\n");
+        assert_eq!(margin, "    ");
+        assert!(stripped.contains("\n\n"), "blank lines should be preserved");
     }
 }


### PR DESCRIPTION
- fix fn/defn header split: trailing trivia on params poisoned measure_flat inside header group; split into format_without_trailing + format_trailing_trivia
- strip trailing whitespace from all output lines
- let* binding alignment: replace Nest+arithmetic with Align after [
- add Align to all breaking forms (cond, match, case, begin, while, each, when/unless, try/protect, forever, block, parameterize, let) so nested forms indent relative to their column, not the ambient nest depth
- trivial-if branches: wrap with Align (compound cases already had it)
- depth-limited is_trivial (budget=3): shallow body forms like (if v "true" "false") stay inline in cond pairs; deeply nested forms break
- while: test always stays on same line as head
- generic calls: group :keyword value pairs so they break as a unit
- cap Align at line_width/2 to prevent cascading rightward drift in deeply nested code
- --no-epoch: skip epoch injection (for editor fragment formatting)
- --plm/--preserve-left-margin: auto-detect and re-apply leading indent