### PR TITLE
progress-bar OSD demo; wayland plugin pin update

### DIFF
--- a/demos/progress-bar/AGENTS.md
+++ b/demos/progress-bar/AGENTS.md
@@ -1,0 +1,49 @@
+# demos/progress-bar
+
+OSD progress bar overlay for Wayland.
+
+## Architecture
+
+Two-fiber design:
+
+- **Stdin fiber** — reads lines from stdin, parses as integers, updates `@target-pct`
+- **Main loop** — eases `@display-pct` toward `@target-pct` at 15%/frame, renders bar, pumps wayland events
+
+Rendering uses the wayland plugin's geometric primitives (fill-rect, fill-circle)
+to draw a pill-shaped bar with rounded endcaps directly into an ARGB8888 SHM buffer.
+
+## Data flow
+
+```
+stdin → port/read-line → parse-int → @target-pct
+                                        ↓
+main loop: ease display toward target → render-bar → buffer-fill-circle/rect → wl/commit
+```
+
+## Wayland plugin requirements
+
+This demo uses primitives that were implemented alongside it:
+
+- `wl/layer-surface` — accepts options struct (`:layer`, `:anchor`, `:width`, `:height`, `:exclusive-zone`)
+- `wl/buffer-fill-rect` — fills a rectangular region
+- `wl/buffer-fill-circle` — fills a circular region (for pill endcaps)
+- `wl/dispatch` — does `prepare_read` + non-blocking `read` + `dispatch_pending`
+
+The event loop pattern is: `flush → ev/poll-fd → dispatch → poll-events`.
+This is required because `dispatch_pending` alone does not read from the wire;
+`ev/poll-fd` yields to the scheduler, and `dispatch` reads + dispatches.
+
+## Geometry
+
+- Full-screen transparent overlay (all anchors)
+- Bar: 50% screen width, centered, 25% from bottom, 3% screen height
+- Pill shape: two semicircular endcaps + rectangle middle
+- Fill animates from left with rounded leading edge
+
+## Colors (ARGB8888)
+
+| Element   | Color       | Description             |
+|-----------|-------------|-------------------------|
+| Track     | `0x55000000` | Transparent black       |
+| Fill      | `0xDD7EC8E3` | Light blue, ~87% alpha  |
+| Background| `0x00000000` | Fully transparent       |

--- a/demos/progress-bar/README.md
+++ b/demos/progress-bar/README.md
@@ -1,0 +1,39 @@
+# Progress Bar OSD
+
+Wayland overlay progress bar. Reads percentages (0–100) from stdin, one per
+line, and renders a pill-shaped bar with smooth ease-out transitions.
+
+## Usage
+
+```bash
+# Single value
+echo "50" | cargo run --release -- demos/progress-bar/progress-bar.lisp
+
+# Animated sequence
+seq 0 5 100 | cargo run --release -- demos/progress-bar/progress-bar.lisp
+
+# Pipe from a slow process
+(some-long-process) | cargo run --release -- demos/progress-bar/progress-bar.lisp
+
+# fish shell
+for i in (seq 0 5 100); echo $i; sleep 0.15; end | cargo run --release -- demos/progress-bar/progress-bar.lisp
+```
+
+## Dependencies
+
+- `plugin/wayland` — Wayland compositor interaction
+- `std/wayland` — Elle wrapper for the wayland plugin
+- A Wayland compositor with `wlr-layer-shell` support (Sway, Hyprland, River, etc.)
+
+## What it does
+
+1. Connects to the Wayland compositor
+2. Creates a full-screen transparent overlay at the top layer
+3. Waits for the compositor to configure the surface
+4. Creates an ARGB8888 SHM buffer
+5. Spawns a fiber to read stdin percentages
+6. Animates the bar toward each new value with ease-out interpolation
+7. Cleans up the overlay on EOF
+
+The bar is 50% of screen width, centered horizontally, positioned 25% up
+from the bottom edge, with height at 3% of screen height.

--- a/demos/progress-bar/progress-bar.lisp
+++ b/demos/progress-bar/progress-bar.lisp
@@ -1,0 +1,126 @@
+(elle/epoch 9)
+## demos/progress-bar/progress-bar.lisp — OSD progress bar overlay
+##
+## Reads percentages (0–100) from stdin, one per line.
+## Renders a progress bar as a Wayland overlay (layer-shell).
+##
+## Usage:
+##   echo "50" | cargo run --release -- demos/progress-bar/progress-bar.lisp
+##   seq 0 5 100 | cargo run --release -- demos/progress-bar/progress-bar.lisp
+##   (some-long-process) | tee >(cut -f2 | cargo run --release -- demos/progress-bar/progress-bar.lisp)
+
+(def wl-plugin (import "plugin/wayland"))
+(def wl ((import "std/wayland") wl-plugin))
+
+## ── Colors (ARGB8888) ──────────────────────────────────────────────────
+
+(def fill-color 0xDD7EC8E3)   # light blue, slightly transparent
+(def track-color 0x55000000) # transparent black
+
+## ── Connect and create full-screen overlay ──────────────────────────────
+
+(def conn (wl:connect))
+(def fd (wl:fd conn))
+
+(def surf-id (wl:layer-surface conn
+  :layer :overlay
+  :anchor [:top :bottom :left :right]
+  :height 0
+  :exclusive-zone 0))
+
+## ── Wait for the initial configure event ────────────────────────────────
+
+(def @configured false)
+(def @screen-w 0)
+(def @screen-h 0)
+
+(while (not configured)
+  (wl:flush conn)
+  (ev/poll-fd fd :read 0.1)
+  (wl:dispatch conn)
+  (each ev in (wl:poll-events conn)
+    (when (and (= ev:type :configure) (= ev:surface-id surf-id))
+      (assign configured true)
+      (assign screen-w ev:width)
+      (assign screen-h ev:height))))
+
+## ── Compute bar geometry ───────────────────────────────────────────────
+## Bar is 50% of screen width, centered horizontally,
+## positioned 25% up from the bottom edge.
+## Height is 2% of screen height.
+
+(def bar-height (max 1 (int (* screen-h 0.03))))
+
+(def bar-w  (int (/ screen-w 2)))
+(def bar-x  (int (/ (- screen-w bar-w) 2)))
+(def bar-y  (- screen-h (int (/ screen-h 4)) (int (/ bar-height 2))))
+
+## ── Create SHM buffer (full screen, mostly transparent) ────────────────
+
+(def buf-id (wl:shm-buffer conn screen-w screen-h))
+
+## ── Rendering ──────────────────────────────────────────────────────────
+
+(defn render-bar [pct]
+  "Fill buffer: clear to transparent, draw pill-shaped bar with rounded endcaps."
+  (wl:buffer-fill conn buf-id 0x00000000)
+  (def r (int (/ bar-height 2)))
+  # bar track — transparent black pill
+  (wl:buffer-fill-circle conn buf-id (+ bar-x r) (+ bar-y r) r track-color)
+  (wl:buffer-fill-circle conn buf-id (+ bar-x bar-w (- r)) (+ bar-y r) r track-color)
+  (wl:buffer-fill-rect conn buf-id (+ bar-x r) bar-y (- bar-w (* 2 r)) bar-height track-color)
+  # progress fill — light blue pill (clipped to fill width)
+  (def fill-w (int (* bar-w (/ (max 0 (min 100 pct)) 100.0))))
+  (when (> fill-w 0)
+    (cond
+      # fill is smaller than one diameter — just a circle
+      (<= fill-w (* 2 r))
+        (wl:buffer-fill-circle conn buf-id (+ bar-x r) (+ bar-y r) r fill-color)
+      # fill spans past one diameter — left cap + rect + right cap
+      true
+        (begin
+          (wl:buffer-fill-circle conn buf-id (+ bar-x r) (+ bar-y r) r fill-color)
+          (wl:buffer-fill-rect conn buf-id (+ bar-x r) bar-y (- fill-w (* 2 r)) bar-height fill-color)
+          (wl:buffer-fill-circle conn buf-id (+ bar-x fill-w (- r)) (+ bar-y r) r fill-color))))
+  (wl:attach conn surf-id buf-id)
+  (wl:damage conn surf-id 0 0 screen-w screen-h)
+  (wl:commit conn surf-id))
+
+## ── Initial render at 0% ───────────────────────────────────────────────
+
+(render-bar 0)
+
+## ── Main loop ──────────────────────────────────────────────────────────
+##
+## Two fibers: stdin reader updates @target-pct, main loop animates toward it.
+
+(def @target-pct 0.0)
+(def @display-pct 0.0)
+(def @done false)
+
+(ev/spawn (fn []
+  (forever
+    (def line (port/read-line (*stdin*)))
+    (when (nil? line)
+      (assign done true)
+      (break))
+    (assign target-pct (float (parse-int line))))))
+
+(def anim-step 0.15)   # ease-out fraction per frame
+
+(while (not done)
+  # ease toward target
+  (when (not (= display-pct target-pct))
+    (assign display-pct (+ display-pct (* (- target-pct display-pct) anim-step)))
+    (when (< (abs (- display-pct target-pct)) 0.5)
+      (assign display-pct target-pct)))
+  (render-bar display-pct)
+  (wl:flush conn)
+  (ev/poll-fd fd :read 0.033)
+  (wl:dispatch conn)
+  (each _ev in (wl:poll-events conn) nil))
+
+## ── Cleanup ────────────────────────────────────────────────────────────
+
+(wl:layer-destroy conn surf-id)
+(wl:disconnect conn)

--- a/lib/wayland.lisp
+++ b/lib/wayland.lisp
@@ -47,14 +47,14 @@
     (plugin:poll-events conn))
 
   (defn wayland/event-loop [conn handler]
-    "Run an event loop: poll fd, dispatch, drain events, call handler.
+    "Run an event loop: flush, poll fd, dispatch, drain events, call handler.
      Handler receives each event struct. Loop until handler returns :stop."
-    (let [[fd (wayland/fd conn)]]
+    (let [fd (wayland/fd conn)]
       (forever
-        (ev/poll-fd fd 1)  ## POLLIN
-        (wayland/dispatch conn)
         (wayland/flush conn)
-        (for-each [ev (wayland/poll-events conn)]
+        (ev/poll-fd fd :read 0.033)
+        (wayland/dispatch conn)
+        (each ev in (wayland/poll-events conn)
           (when (= (handler ev) :stop)
             (break nil))))))
 
@@ -70,9 +70,21 @@
 
   ## ── Layer shell ─────────────────────────────────────────────────────
 
-  (defn wayland/layer-surface [conn &named width height anchor layer namespace]
-    "Create a layer-shell surface."
-    (plugin:layer-surface conn))
+  (defn wayland/layer-surface [conn &named @width @height @anchor @layer @namespace @exclusive-zone]
+    "Create a layer-shell surface.
+     :layer      — :background, :bottom, :top, :overlay (default :overlay)
+     :anchor     — array of :top, :bottom, :left, :right (default [:top :left :right])
+     :width      — int (default 0 = compositor decides from anchors)
+     :height     — int (default 50)
+     :exclusive-zone — int (default 0)
+     :namespace  — string (default \"elle\")"
+    (default layer :overlay)
+    (default anchor [:top :left :right])
+    (default height 50)
+    (default exclusive-zone 0)
+    (default namespace "elle")
+    (plugin:layer-surface conn {:layer layer :anchor anchor :width width :height height
+                                :exclusive-zone exclusive-zone :namespace namespace}))
 
   (defn wayland/layer-configure [conn surface-id]
     "Acknowledge a layer surface configure."
@@ -109,6 +121,18 @@
   (defn wayland/buffer-fill [conn buffer-id color]
     "Fill an SHM buffer with an ARGB color."
     (plugin:buffer-fill conn buffer-id color))
+
+  (defn wayland/buffer-fill-rect [conn buffer-id x y width height color]
+    "Fill a rectangular region of an SHM buffer with an ARGB color."
+    (plugin:buffer-fill-rect conn buffer-id x y width height color))
+
+  (defn wayland/buffer-fill-circle [conn buffer-id cx cy r color]
+    "Fill a circle region of an SHM buffer with an ARGB color."
+    (plugin:buffer-fill-circle conn buffer-id cx cy r color))
+
+  (defn wayland/buffer-fill-triangle [conn buffer-id x1 y1 x2 y2 x3 y3 color]
+    "Fill a triangle region of an SHM buffer with an ARGB color."
+    (plugin:buffer-fill-triangle conn buffer-id x1 y1 x2 y2 x3 y3 color))
 
   (defn wayland/buffer-destroy [conn buffer-id]
     "Destroy an SHM buffer."
@@ -162,6 +186,9 @@
    :shm-buffer wayland/shm-buffer
    :buffer-write wayland/buffer-write
    :buffer-fill wayland/buffer-fill
+   :buffer-fill-rect wayland/buffer-fill-rect
+   :buffer-fill-circle wayland/buffer-fill-circle
+   :buffer-fill-triangle wayland/buffer-fill-triangle
    :buffer-destroy wayland/buffer-destroy
    :screencopy wayland/screencopy
    :screencopy-destroy wayland/screencopy-destroy


### PR DESCRIPTION
Add demos/progress-bar/ — a Wayland overlay progress bar that reads percentages from stdin and renders a pill-shaped bar with smooth ease-out transitions. Uses layer-shell for the overlay and geometric fill primitives (circle, rect) for rendering.

Update lib/wayland.lisp to pass layer-surface options through to the plugin, add buffer-fill-rect/circle/triangle wrappers, and fix the event-loop to use the correct flush → poll → dispatch pattern.

Pin plugins submodule to include wayland plugin implementation.