### PR TITLE
fix LSP diagnostic underflow, add exit handling, add integration tests

### DIFF
--- a/src/lsp/run.rs
+++ b/src/lsp/run.rs
@@ -12,6 +12,7 @@ pub fn run() -> i32 {
     let stdin = std::io::stdin();
     let mut reader = BufReader::new(stdin.lock());
     let mut stdout = std::io::stdout();
+    let mut shutdown_received = false;
 
     loop {
         // Read headers until Content-Length
@@ -47,6 +48,7 @@ pub fn run() -> i32 {
 
         let message = String::from_utf8_lossy(&buf);
         if let Ok(request) = serde_json::from_str::<Value>(&message) {
+            let method = request.get("method").and_then(|v| v.as_str()).unwrap_or("");
             let (response, notifications) = handle_request(&request, &mut compiler_state);
 
             // Only send response for requests (not notifications)
@@ -62,10 +64,57 @@ pub fn run() -> i32 {
                 let _ = write!(stdout, "Content-Length: {}\r\n\r\n{}", body.len(), body);
                 let _ = stdout.flush();
             }
+
+            // LSP spec: exit notification causes the server to exit.
+            // Must check AFTER sending any pending response/notifications.
+            if method == "exit" {
+                return if shutdown_received { 0 } else { 1 };
+            }
+
+            if method == "shutdown" {
+                shutdown_received = true;
+            }
         }
     }
 
     0
+}
+
+/// Convert a `Diagnostic` to an LSP diagnostic JSON value.
+fn diagnostic_to_json(d: &crate::lint::diagnostics::Diagnostic) -> Value {
+    let (line, col) = match &d.location {
+        Some(loc) => (loc.line as u32, loc.col as u32),
+        None => (1, 1), // Default to (1,1) so subtracting 1 stays non-zero
+    };
+    json!({
+        "range": {
+            "start": { "line": line.saturating_sub(1), "character": col.saturating_sub(1) },
+            "end": { "line": line.saturating_sub(1), "character": col }
+        },
+        "severity": match d.severity {
+            crate::lint::diagnostics::Severity::Error => 1,
+            crate::lint::diagnostics::Severity::Warning => 2,
+            crate::lint::diagnostics::Severity::Info => 3,
+        },
+        "code": d.code,
+        "source": "elle-lint",
+        "message": d.message
+    })
+}
+
+/// Collect diagnostics from a compiled document and return a
+/// `textDocument/publishDiagnostics` notification.
+fn diagnostics_notification(uri: &str, compiler_state: &CompilerState) -> Option<Value> {
+    let doc = compiler_state.get_document(uri)?;
+    let diags: Vec<Value> = doc.diagnostics.iter().map(diagnostic_to_json).collect();
+    Some(json!({
+        "jsonrpc": "2.0",
+        "method": "textDocument/publishDiagnostics",
+        "params": {
+            "uri": uri,
+            "diagnostics": diags
+        }
+    }))
 }
 
 /// Extract the word/prefix at the given position
@@ -174,40 +223,8 @@ fn handle_request(request: &Value, compiler_state: &mut CompilerState) -> (Value
                         compiler_state.on_document_open(uri.to_string(), text.to_string());
                         compiler_state.compile_document(uri);
 
-                        if let Some(doc) = compiler_state.get_document(uri) {
-                            let diags: Vec<_> = doc
-                                .diagnostics
-                                .iter()
-                                .map(|d| {
-                                    let (line, col) = match &d.location {
-                                        Some(loc) => (loc.line as u32, loc.col as u32),
-                                        None => (0, 0),
-                                    };
-                                    json!({
-                                        "range": {
-                                            "start": { "line": line - 1, "character": col - 1 },
-                                            "end": { "line": line - 1, "character": col }
-                                        },
-                                        "severity": match d.severity {
-                                            crate::lint::diagnostics::Severity::Error => 1,
-                                            crate::lint::diagnostics::Severity::Warning => 2,
-                                            crate::lint::diagnostics::Severity::Info => 3,
-                                        },
-                                        "code": d.code,
-                                        "source": "elle-lint",
-                                        "message": d.message
-                                    })
-                                })
-                                .collect();
-
-                            notifications.push(json!({
-                                "jsonrpc": "2.0",
-                                "method": "textDocument/publishDiagnostics",
-                                "params": {
-                                    "uri": uri,
-                                    "diagnostics": diags
-                                }
-                            }));
+                        if let Some(notification) = diagnostics_notification(uri, compiler_state) {
+                            notifications.push(notification);
                         }
                     }
                 }
@@ -234,40 +251,10 @@ fn handle_request(request: &Value, compiler_state: &mut CompilerState) -> (Value
                             compiler_state.on_document_change(uri, text.to_string());
                             compiler_state.compile_document(uri);
 
-                            if let Some(doc) = compiler_state.get_document(uri) {
-                                let diags: Vec<_> = doc
-                                    .diagnostics
-                                    .iter()
-                                    .map(|d| {
-                                        let (line, col) = match &d.location {
-                                            Some(loc) => (loc.line as u32, loc.col as u32),
-                                            None => (0, 0),
-                                        };
-                                        json!({
-                                            "range": {
-                                                "start": { "line": line - 1, "character": col - 1 },
-                                                "end": { "line": line - 1, "character": col }
-                                            },
-                                        "severity": match d.severity {
-                                            crate::lint::diagnostics::Severity::Error => 1,
-                                            crate::lint::diagnostics::Severity::Warning => 2,
-                                            crate::lint::diagnostics::Severity::Info => 3,
-                                        },
-                                            "code": d.code,
-                                            "source": "elle-lint",
-                                            "message": d.message
-                                        })
-                                    })
-                                    .collect();
-
-                                notifications.push(json!({
-                                    "jsonrpc": "2.0",
-                                    "method": "textDocument/publishDiagnostics",
-                                    "params": {
-                                        "uri": uri,
-                                        "diagnostics": diags
-                                    }
-                                }));
+                            if let Some(notification) =
+                                diagnostics_notification(uri, compiler_state)
+                            {
+                                notifications.push(notification);
                             }
                         }
                     }

--- a/src/lsp/state.rs
+++ b/src/lsp/state.rs
@@ -7,10 +7,30 @@ use crate::context::set_symbol_table;
 use crate::hir::{extract_symbols_from_hir, HirLinter};
 use crate::lint::diagnostics::{Diagnostic, Severity};
 use crate::primitives::def::Doc;
+use crate::reader::SourceLoc;
 use crate::symbol::SymbolTable;
 use crate::symbols::SymbolIndex;
 use crate::{analyze_file, init_stdlib, register_primitives, VM};
 use std::collections::HashMap;
+
+/// Extract a `SourceLoc` from a reader/analyzer error string.
+///
+/// Reader and analyzer errors are formatted as `<file>:line:col: message`.
+/// This parses the prefix to recover the structured location.
+fn extract_location_from_error(msg: &str) -> Option<SourceLoc> {
+    // Format: "<file>:line:col: message"
+    let rest = msg.strip_prefix('<')?;
+    let bracket_end = rest.find('>')?;
+    let file = &rest[..bracket_end];
+    // After "<file>" comes ":line:col: message"
+    let tail = &rest[bracket_end + 1..]; // ":line:col: message"
+    let tail = tail.strip_prefix(':')?; // "line:col: message"
+    let (line_str, col_and_rest) = tail.split_once(':')?;
+    let (col_str, _) = col_and_rest.split_once(": ")?;
+    let line = line_str.parse::<usize>().ok()?;
+    let col = col_str.parse::<usize>().ok()?;
+    Some(SourceLoc::new(format!("<{}>", file), line, col))
+}
 
 /// Document state: source + diagnostics + symbol index
 pub(crate) struct DocumentState {
@@ -97,12 +117,13 @@ impl CompilerState {
             Ok(result) => result,
             Err(e) => {
                 // Analysis error - add as diagnostic
+                let location = extract_location_from_error(&e);
                 doc.diagnostics.push(Diagnostic::new(
                     Severity::Error,
                     "E0001",
                     "syntax-error",
                     e,
-                    None,
+                    location,
                 ));
                 return false;
             }
@@ -183,5 +204,48 @@ mod tests {
         state.on_document_open("file:///test.l".to_string(), "(+ 1 2)".to_string());
         let result = state.compile_document("file:///test.l");
         assert!(result);
+    }
+
+    #[test]
+    fn test_extract_location_from_error() {
+        // Standard reader error format
+        let loc = extract_location_from_error("<lsp>:1:4: unterminated list");
+        assert!(loc.is_some());
+        let loc = loc.unwrap();
+        assert_eq!(loc.file, "<lsp>");
+        assert_eq!(loc.line, 1);
+        assert_eq!(loc.col, 4);
+
+        // Multi-digit line/col
+        let loc = extract_location_from_error("<lsp>:12:34: some error");
+        assert!(loc.is_some());
+        let loc = loc.unwrap();
+        assert_eq!(loc.line, 12);
+        assert_eq!(loc.col, 34);
+    }
+
+    #[test]
+    fn test_extract_location_from_error_invalid() {
+        // No angle brackets
+        assert!(extract_location_from_error("something went wrong").is_none());
+        // Missing colon-separated parts
+        assert!(extract_location_from_error("<lsp>: message").is_none());
+    }
+
+    #[test]
+    fn test_compile_syntax_error_has_location() {
+        let mut state = CompilerState::new();
+        state.on_document_open("file:///test.l".to_string(), "((((".to_string());
+        state.compile_document("file:///test.l");
+        let doc = state.get_document("file:///test.l").unwrap();
+        assert!(!doc.diagnostics.is_empty());
+        let diag = &doc.diagnostics[0];
+        assert!(
+            diag.location.is_some(),
+            "parse error diagnostic should have a location"
+        );
+        let loc = diag.location.as_ref().unwrap();
+        assert_eq!(loc.line, 1);
+        assert_eq!(loc.col, 4);
     }
 }

--- a/tests/integration/lsp.rs
+++ b/tests/integration/lsp.rs
@@ -1,0 +1,369 @@
+// LSP server integration tests
+//
+// Spawns `elle lsp` as a subprocess and exercises the JSON-RPC protocol.
+
+use serde_json::{json, Value};
+use std::io::{BufRead, BufReader, Read, Write};
+use std::process::{Command, Stdio};
+
+fn get_elle_binary() -> &'static str {
+    env!("CARGO_BIN_EXE_elle")
+}
+
+/// Build a JSON-RPC message with Content-Length header.
+fn make_message(obj: Value) -> Vec<u8> {
+    let body = serde_json::to_string(&obj).unwrap();
+    let header = format!("Content-Length: {}\r\n\r\n", body.len());
+    let mut buf = header.into_bytes();
+    buf.extend_from_slice(body.as_bytes());
+    buf
+}
+
+/// Read one JSON-RPC response from the LSP server stdout.
+fn read_response(reader: &mut BufReader<std::process::ChildStdout>) -> Value {
+    let mut content_length: usize = 0;
+
+    // Read headers
+    loop {
+        let mut line = String::new();
+        let n = reader.read_line(&mut line).unwrap();
+        assert!(n > 0, "unexpected EOF reading headers");
+
+        if line == "\r\n" || line == "\n" {
+            break;
+        }
+
+        if let Some(rest) = line.strip_prefix("Content-Length:") {
+            content_length = rest.trim().parse::<usize>().unwrap();
+        }
+    }
+
+    assert!(content_length > 0, "missing Content-Length header");
+
+    let mut body_buf = vec![0u8; content_length];
+    reader.read_exact(&mut body_buf).unwrap();
+    let body_str = String::from_utf8(body_buf).unwrap();
+    serde_json::from_str(&body_str).expect("invalid JSON in response")
+}
+
+/// Send a message to the LSP server.
+fn send(stdin: &mut dyn Write, msg: Value) {
+    let data = make_message(msg);
+    stdin.write_all(&data).unwrap();
+    stdin.flush().unwrap();
+}
+
+/// Start the LSP server, returning (stdin, bufreader, child).
+fn start_lsp() -> (
+    std::process::ChildStdin,
+    BufReader<std::process::ChildStdout>,
+    std::process::Child,
+) {
+    let mut child = Command::new(get_elle_binary())
+        .arg("lsp")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to start elle lsp");
+
+    let stdin = child.stdin.take().expect("no stdin");
+    let stdout = child.stdout.take().expect("no stdout");
+    (stdin, BufReader::new(stdout), child)
+}
+
+/// Send initialize, return capabilities.
+fn init_lsp(stdin: &mut dyn Write, reader: &mut BufReader<std::process::ChildStdout>) -> Value {
+    send(
+        stdin,
+        json!({
+            "jsonrpc": "2.0", "id": 1, "method": "initialize",
+            "params": { "capabilities": {} }
+        }),
+    );
+    let resp = read_response(reader);
+    assert_eq!(resp["id"], 1);
+    resp["result"]["capabilities"].clone()
+}
+
+/// Send shutdown + exit, wait for clean exit.
+fn shutdown_lsp(
+    mut stdin: std::process::ChildStdin,
+    reader: &mut BufReader<std::process::ChildStdout>,
+    child: &mut std::process::Child,
+) {
+    send(
+        &mut stdin,
+        json!({
+            "jsonrpc": "2.0", "id": 999, "method": "shutdown", "params": null
+        }),
+    );
+    let resp = read_response(reader);
+    assert_eq!(resp["id"], 999);
+
+    send(
+        &mut stdin,
+        json!({
+            "jsonrpc": "2.0", "method": "exit", "params": null
+        }),
+    );
+
+    // Drop stdin to unblock server if exit handling fails
+    drop(stdin);
+    let status = child.wait().expect("child didn't exit");
+    assert!(
+        status.success(),
+        "LSP server should exit cleanly after shutdown"
+    );
+}
+
+/// Run the full initialize → shutdown → exit lifecycle.
+#[test]
+fn test_lsp_initialize_shutdown() {
+    let (mut stdin, mut reader, mut child) = start_lsp();
+
+    let caps = init_lsp(&mut stdin, &mut reader);
+    assert!(caps["hoverProvider"].is_boolean());
+    assert!(caps["completionProvider"].is_object());
+    assert_eq!(caps["completionProvider"]["triggerCharacters"][0], "(");
+
+    shutdown_lsp(stdin, &mut reader, &mut child);
+}
+
+/// Open a document, verify empty diagnostics, then close it.
+#[test]
+fn test_lsp_document_lifecycle() {
+    let (mut stdin, mut reader, mut child) = start_lsp();
+    let _ = init_lsp(&mut stdin, &mut reader);
+
+    send(
+        &mut stdin,
+        json!({
+            "jsonrpc": "2.0",
+            "method": "textDocument/didOpen",
+            "params": {
+                "textDocument": {
+                    "uri": "file:///test.lisp",
+                    "languageId": "elle",
+                    "version": 1,
+                    "text": "(+ 1 2)"
+                }
+            }
+        }),
+    );
+
+    let diag = read_response(&mut reader);
+    assert_eq!(diag["method"], "textDocument/publishDiagnostics");
+    assert_eq!(diag["params"]["uri"], "file:///test.lisp");
+    assert!(diag["params"]["diagnostics"].as_array().unwrap().is_empty());
+
+    shutdown_lsp(stdin, &mut reader, &mut child);
+}
+
+/// Open a document with a syntax error and verify the diagnostic has
+/// correct 0-based line/character values (not u32::MAX from underflow).
+#[test]
+fn test_lsp_syntax_error_diagnostic_location() {
+    let (mut stdin, mut reader, mut child) = start_lsp();
+    let _ = init_lsp(&mut stdin, &mut reader);
+
+    send(
+        &mut stdin,
+        json!({
+            "jsonrpc": "2.0",
+            "method": "textDocument/didOpen",
+            "params": {
+                "textDocument": {
+                    "uri": "file:///bad.lisp",
+                    "languageId": "elle",
+                    "version": 1,
+                    "text": "(((("
+                }
+            }
+        }),
+    );
+
+    let diag = read_response(&mut reader);
+    assert_eq!(diag["method"], "textDocument/publishDiagnostics");
+
+    let diags = diag["params"]["diagnostics"].as_array().unwrap();
+    assert!(!diags.is_empty(), "should have at least one diagnostic");
+
+    let d = &diags[0];
+    assert_eq!(d["code"], "E0001");
+
+    // Verify no u32::MAX (4294967295) from underflow
+    let start_line = d["range"]["start"]["line"].as_u64().unwrap();
+    let start_char = d["range"]["start"]["character"].as_u64().unwrap();
+    let end_line = d["range"]["end"]["line"].as_u64().unwrap();
+    let end_char = d["range"]["end"]["character"].as_u64().unwrap();
+
+    assert!(
+        start_line < 1000,
+        "start.line should be reasonable, got {}",
+        start_line
+    );
+    assert!(
+        start_char < 1000,
+        "start.character should be reasonable, got {}",
+        start_char
+    );
+    assert!(
+        end_line < 1000,
+        "end.line should be reasonable, got {}",
+        end_line
+    );
+    assert!(
+        end_char < 1000,
+        "end.character should be reasonable, got {}",
+        end_char
+    );
+    assert_eq!(start_line, 0, "error is on first line (0-based)");
+
+    shutdown_lsp(stdin, &mut reader, &mut child);
+}
+
+/// Verify hover returns information for a known symbol.
+#[test]
+fn test_lsp_hover() {
+    let (mut stdin, mut reader, mut child) = start_lsp();
+    let _ = init_lsp(&mut stdin, &mut reader);
+
+    send(
+        &mut stdin,
+        json!({
+            "jsonrpc": "2.0",
+            "method": "textDocument/didOpen",
+            "params": {
+                "textDocument": {
+                    "uri": "file:///hover.lisp",
+                    "languageId": "elle",
+                    "version": 1,
+                    "text": "(def foo 42)"
+                }
+            }
+        }),
+    );
+    let _ = read_response(&mut reader); // diagnostics
+
+    send(
+        &mut stdin,
+        json!({
+            "jsonrpc": "2.0", "id": 2,
+            "method": "textDocument/hover",
+            "params": {
+                "textDocument": { "uri": "file:///hover.lisp" },
+                "position": { "line": 0, "character": 5 }
+            }
+        }),
+    );
+
+    let resp = read_response(&mut reader);
+    assert_eq!(resp["id"], 2);
+    assert!(resp["result"].is_object(), "hover should return a result");
+
+    shutdown_lsp(stdin, &mut reader, &mut child);
+}
+
+/// Verify completion returns items including builtins.
+#[test]
+fn test_lsp_completion() {
+    let (mut stdin, mut reader, mut child) = start_lsp();
+    let _ = init_lsp(&mut stdin, &mut reader);
+
+    send(
+        &mut stdin,
+        json!({
+            "jsonrpc": "2.0",
+            "method": "textDocument/didOpen",
+            "params": {
+                "textDocument": {
+                    "uri": "file:///comp.lisp",
+                    "languageId": "elle",
+                    "version": 1,
+                    "text": "(+ 1 2)"
+                }
+            }
+        }),
+    );
+    let _ = read_response(&mut reader); // diagnostics
+
+    send(
+        &mut stdin,
+        json!({
+            "jsonrpc": "2.0", "id": 2,
+            "method": "textDocument/completion",
+            "params": {
+                "textDocument": { "uri": "file:///comp.lisp" },
+                "position": { "line": 0, "character": 1 }
+            }
+        }),
+    );
+
+    let resp = read_response(&mut reader);
+    assert_eq!(resp["id"], 2);
+    let items = resp["result"]["items"].as_array().unwrap();
+    assert!(!items.is_empty(), "completion should return items");
+
+    let labels: Vec<&str> = items
+        .iter()
+        .filter_map(|i| i.get("label").and_then(|l| l.as_str()))
+        .collect();
+    assert!(labels.contains(&"+"), "completion should include '+'");
+
+    shutdown_lsp(stdin, &mut reader, &mut child);
+}
+
+/// Verify didChange updates the document and produces new diagnostics.
+#[test]
+fn test_lsp_document_change() {
+    let (mut stdin, mut reader, mut child) = start_lsp();
+    let _ = init_lsp(&mut stdin, &mut reader);
+
+    // Open clean document
+    send(
+        &mut stdin,
+        json!({
+            "jsonrpc": "2.0",
+            "method": "textDocument/didOpen",
+            "params": {
+                "textDocument": {
+                    "uri": "file:///change.lisp",
+                    "languageId": "elle",
+                    "version": 1,
+                    "text": "(+ 1 2)"
+                }
+            }
+        }),
+    );
+    let _ = read_response(&mut reader); // empty diagnostics
+
+    // Change to broken content
+    send(
+        &mut stdin,
+        json!({
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange",
+            "params": {
+                "textDocument": { "uri": "file:///change.lisp", "version": 2 },
+                "contentChanges": [{ "text": "(((" }]
+            }
+        }),
+    );
+
+    let diag = read_response(&mut reader);
+    assert_eq!(diag["method"], "textDocument/publishDiagnostics");
+    let diags = diag["params"]["diagnostics"].as_array().unwrap();
+    assert!(!diags.is_empty(), "broken code should produce diagnostics");
+
+    // Verify no u32::MAX in range
+    let d = &diags[0];
+    let start_line = d["range"]["start"]["line"].as_u64().unwrap();
+    assert!(
+        start_line < 1000,
+        "line should be reasonable, got {}",
+        start_line
+    );
+
+    shutdown_lsp(stdin, &mut reader, &mut child);
+}

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -115,6 +115,9 @@ mod embedding {
 mod projection {
     include!("projection.rs");
 }
+mod lsp {
+    include!("lsp.rs");
+}
 
 // Temporarily disabled while sorting out compilation caching.
 // mod fn_flow {


### PR DESCRIPTION
- Fix u32 underflow in diagnostic range (line/col 0 - 1 wrapped to 4294967295). Use saturating_sub and default to (1,1) for missing locations so conversion to 0-based LSP coordinates stays valid.
- Extract SourceLoc from parse error strings so diagnostics carry structured location data instead of None.
- Handle LSP exit/shutdown lifecycle: server now terminates on exit notification, returning 0 if shutdown was received per spec.
- Deduplicate diagnostic-to-JSON code into helper functions.
- Add 6 integration tests that spawn `elle lsp` and exercise the JSON-RPC protocol: initialize/shutdown, document lifecycle, syntax error diagnostics, hover, completion, and didChange.