### PR TITLE
standardize module headers: import-file → import

### DIFF
--- a/lib/aws.lisp
+++ b/lib/aws.lisp
@@ -1,5 +1,13 @@
 (elle/epoch 9)
 ## lib/aws.lisp — Elle-native AWS client
+##
+## Usage:
+##   (def crypto (import "plugin/crypto"))
+##   (def jiff   (import "plugin/jiff"))
+##   (def tls-plug (import "plugin/tls"))
+##   (def tls ((import "std/tls") tls-plug))
+##   (def aws ((import "std/aws") :crypto crypto :jiff jiff :tls tls))
+##   (aws:request "s3" "GET" "/" :region "us-east-1")
 
 (def @sigv4-mod nil)
 
@@ -106,9 +114,8 @@
 
 ## ── Entry point ──────────────────────────────────────────────────────
 
-(fn [crypto jiff tls-module]
-  (def tls tls-module)
-  (assign sigv4-mod ((import-file "lib/aws/sigv4.lisp") crypto jiff))
+(fn [&named crypto jiff tls]
+  (assign sigv4-mod ((import "std/aws/sigv4") crypto jiff))
 
   {:request (fn [service method path & args]
     (aws-request-impl tls service method path (or (get args 0) {})))})

--- a/lib/aws/sigv4.lisp
+++ b/lib/aws/sigv4.lisp
@@ -4,9 +4,9 @@
 ## Pure Elle. Receives crypto and jiff functions as arguments.
 ##
 ## Usage:
-##   (def crypto (import-file "target/debug/libelle_crypto.so"))
-##   (def jiff   (import-file "target/debug/libelle_jiff.so"))
-##   (def sigv4 ((import-file "lib/aws/sigv4.lisp") crypto jiff))
+##   (def crypto (import "plugin/crypto"))
+##   (def jiff   (import "plugin/jiff"))
+##   (def sigv4 ((import "std/aws/sigv4") crypto jiff))
 ##   (sigv4:sign "GET" "/" nil nil "s3.us-east-1.amazonaws.com" creds "us-east-1" "s3")
 
 (fn [crypto jiff]

--- a/lib/contract.lisp
+++ b/lib/contract.lisp
@@ -2,7 +2,7 @@
 ## lib/contract.lisp — Compositional validation system for function boundaries.
 ##
 ## Loaded via:
-##   (def cv ((import-file "lib/contract.lisp")))
+##   (def cv ((import "std/contract")))
 ##   (def compile-validator (get cv :compile-validator))
 ##   ...
 ##

--- a/lib/dns.lisp
+++ b/lib/dns.lisp
@@ -1,7 +1,7 @@
 (elle/epoch 9)
 ## lib/dns.lisp — Pure Elle DNS client (RFC 1035)
 ##
-## Loaded via: (def dns ((import-file "lib/dns.lisp")))
+## Loaded via: (def dns ((import "std/dns")))
 ## Usage:      (dns:resolve "example.com")
 ##
 ## Async/uring-first: all I/O goes through udp/send-to and udp/recv-from,

--- a/lib/egui.lisp
+++ b/lib/egui.lisp
@@ -6,11 +6,11 @@
 ## the plugin is a thin wrapper with zero async knowledge.
 ##
 ## Dependencies:
-##   - elle-egui plugin loaded via (import "target/release/libelle_egui.so")
+##   - elle-egui plugin loaded via (import "plugin/egui")
 ##   - ev/poll-fd from stdlib (fiber scheduler)
 ##
 ## Usage:
-##   (def egui-plugin (import "target/release/libelle_egui.so"))
+##   (def egui-plugin (import "plugin/egui"))
 ##   (def ui ((import "std/egui") egui-plugin))
 ##
 ##   (var count 0)

--- a/lib/hash.lisp
+++ b/lib/hash.lisp
@@ -5,12 +5,12 @@
 ## and files using the elle-hash plugin's incremental API.
 ##
 ## Dependencies:
-##   - elle-hash plugin loaded via (import-file "path/to/libelle_hash.so")
+##   - elle-hash plugin loaded via (import "plugin/hash")
 ##   - port/chunks, stream/fold from stdlib
 ##
 ## Usage:
-##   (def hash-plugin (import-file "target/release/libelle_hash.so"))
-##   (def h ((import-file "lib/hash.lisp") hash-plugin))
+##   (def hash-plugin (import "plugin/hash"))
+##   (def h ((import "std/hash") hash-plugin))
 ##
 ##   (bytes->hex (h:file :sha256 "bigfile.bin"))
 ##   (bytes->hex (h:digest :blake3 port))

--- a/lib/http.lisp
+++ b/lib/http.lisp
@@ -5,7 +5,7 @@
 ##   (def http ((import "std/http")))
 ##
 ## HTTPS client support requires a TLS plugin passed as :tls:
-##   (def tls-plug ((import "plugin/tls")))
+##   (def tls-plug (import "plugin/tls"))
 ##   (def http ((import "std/http") :tls tls-plug))
 ##
 ## Usage: (http:get "http://example.com/")   (http:get "https://...")

--- a/lib/http2.lisp
+++ b/lib/http2.lisp
@@ -5,7 +5,7 @@
 ##   (def http2 ((import "std/http2")))
 ##
 ## h2 over TLS (requires TLS plugin):
-##   (def tls-plug ((import "plugin/tls")))
+##   (def tls-plug (import "plugin/tls"))
 ##   (def tls ((import "std/tls") tls-plug))
 ##   (def http2 ((import "std/http2") :tls tls))
 ##

--- a/lib/mqtt.lisp
+++ b/lib/mqtt.lisp
@@ -5,12 +5,12 @@
 ## All TCP I/O is async via native TCP ports and the fiber scheduler.
 ##
 ## Dependencies:
-##   - elle-mqtt plugin loaded via (import-file "path/to/libelle_mqtt.so")
+##   - elle-mqtt plugin loaded via (import "plugin/mqtt")
 ##   - tcp/connect, port/read, port/write, port/close
 ##
 ## Usage:
-##   (def mqtt-plugin (import-file "target/release/libelle_mqtt.so"))
-##   (def mqtt ((import-file "lib/mqtt.lisp") mqtt-plugin))
+##   (def mqtt-plugin (import "plugin/mqtt"))
+##   (def mqtt ((import "std/mqtt") mqtt-plugin))
 ##   (let* [[conn (mqtt:connect "broker.example.com" 1883
 ##                              :client-id "elle-client")]
 ##          [_ (mqtt:subscribe conn [["test/#" 0]])]

--- a/lib/process.lisp
+++ b/lib/process.lisp
@@ -1,7 +1,7 @@
 (elle/epoch 9)
 ## lib/process.lisp — Erlang-inspired process module
 ##
-## Loaded via: (def process ((import-file "lib/process.lisp")))
+## Loaded via: (def process ((import "std/process")))
 ## Usage:      (process:start (fn () (send (self) :hello) (recv)))
 ##
 ## Processes are fibers driven by a cooperative scheduler with fuel-based

--- a/lib/redis.lisp
+++ b/lib/redis.lisp
@@ -1,7 +1,7 @@
 (elle/epoch 9)
 ## lib/redis.lisp — Pure Elle Redis client (RESP2)
 ##
-## Loaded via: (def redis ((import-file "lib/redis.lisp")))
+## Loaded via: (def redis ((import "std/redis")))
 ## Usage:      (redis:set "key" "value")
 ##             (redis:get "key")
 ##

--- a/lib/sync.lisp
+++ b/lib/sync.lisp
@@ -1,7 +1,7 @@
 (elle/epoch 9)
 ## lib/sync.lisp — Concurrency primitives built on futex (park/notify)
 ##
-## Loaded via: (def sync ((import-file "lib/sync.lisp")))
+## Loaded via: (def sync ((import "std/sync")))
 ## Usage:      (def lock (sync:make-lock))
 ##             (lock:acquire)
 ##             (lock:release)

--- a/lib/telemetry.lisp
+++ b/lib/telemetry.lisp
@@ -1,7 +1,7 @@
 (elle/epoch 9)
 ## lib/telemetry.lisp — OpenTelemetry metrics (OTLP/HTTP JSON export)
 ##
-## Loaded via: (def telemetry ((import-file "lib/telemetry.lisp")))
+## Loaded via: (def telemetry ((import "std/telemetry")))
 ## Usage:
 ##   (def meter (telemetry:meter "my-service" :endpoint "http://localhost:9090/api/v1/otlp/v1/metrics"))
 ##   (def reqs  (telemetry:counter meter "http.requests" :unit "1" :description "Total HTTP requests"))
@@ -19,7 +19,7 @@
 ## histogram bucket counts).  Export snapshots and clears in one cooperative
 ## step — no races between background and manual flushes.
 
-(def http ((import-file "lib/http.lisp")))
+(def http ((import "std/http")))
 
 (def *telemetry-version* "0.2.0")
 

--- a/lib/tls.lisp
+++ b/lib/tls.lisp
@@ -5,7 +5,7 @@
 ## All socket I/O is async via native TCP ports and the fiber scheduler.
 ##
 ## Dependencies:
-##   - elle-tls plugin loaded via (import-file "path/to/libelle_tls.so")
+##   - elle-tls plugin loaded via (import "plugin/tls")
 ##   - tcp/connect, tcp/accept from net primitives
 ##   - port/read, port/write from stream primitives  (port/read returns
 ##     bytes for TCP ports — TCP streams use binary encoding in this runtime)
@@ -14,8 +14,8 @@
 ##   - subprocess/system for hostname resolution (getent fallback)
 ##
 ## Usage:
-##   (def tls-plugin (import-file "target/release/libelle_tls.so"))
-##   (def tls ((import-file "lib/tls.lisp") tls-plugin))
+##   (def tls-plugin (import "plugin/tls"))
+##   (def tls ((import "std/tls") tls-plugin))
 ##   (let [[conn (tls:connect "example.com" 443)]]
 ##     (defer (tls:close conn) ...))
 ##
@@ -24,7 +24,7 @@
 ## functions can call plugin primitives without naming them globally.
 ##
 ## API change from spec: the entry point takes the plugin struct as argument.
-## Load with: (def tls ((import-file "lib/tls.lisp") tls-plugin))
+## Load with: (def tls ((import "std/tls") tls-plugin))
 ##
 ## tls-conn shape:
 ##   {:tcp port :tls tls-state}
@@ -58,7 +58,7 @@
 ##
 ## The file's last expression is a function that accepts the plugin struct
 ## and returns the public API. Call it like:
-##   (def tls ((import-file "lib/tls.lisp") tls-plugin))
+##   (def tls ((import "std/tls") tls-plugin))
 
 (fn [plugin]
   ## Extract plugin primitives from the struct so they can be called

--- a/lib/websocket.lisp
+++ b/lib/websocket.lisp
@@ -7,7 +7,7 @@
 ##   (def ws   ((import "std/websocket") :hash hash :random rand))
 ##
 ## With TLS (for wss://):
-##   (def tls-plug ((import "plugin/tls")))
+##   (def tls-plug (import "plugin/tls"))
 ##   (def tls ((import "std/tls") tls-plug))
 ##   (def ws  ((import "std/websocket") :hash hash :random rand :tls tls))
 ##

--- a/lib/zmq.lisp
+++ b/lib/zmq.lisp
@@ -8,7 +8,7 @@
 ##   - ffi primitives (ffi/native, ffi/defbind, ffi/malloc, etc.)
 ##
 ## Usage:
-##   (def zmq (import-file "lib/zmq.lisp"))
+##   (def zmq ((import "std/zmq")))
 ##   (def ctx (zmq:context))
 ##   (def sock (zmq:socket ctx :req))
 ##   (zmq:connect sock "tcp://localhost:5555")
@@ -227,6 +227,7 @@
 
 # ── Export ─────────────────────────────────────────────────────────────
 
+(fn []
 {:context        zmq/context
  :term           zmq/term
  :socket         zmq/socket
@@ -244,4 +245,4 @@
  :get-option     zmq/get-option
  :has-more?      zmq/has-more?
  :send-multipart zmq/send-multipart
- :recv-multipart zmq/recv-multipart}
+ :recv-multipart zmq/recv-multipart})

--- a/tests/elle/zmq.lisp
+++ b/tests/elle/zmq.lisp
@@ -11,7 +11,7 @@
     (println "zmq tests skipped: libzmq.so not found")
     (sys/exit 0)))
 
-(def zmq (import-file "lib/zmq.lisp"))
+(def zmq ((import-file "lib/zmq.lisp")))
 
 ## ── Context creation ─────────────────────────────────────────────
 


### PR DESCRIPTION
Replace import-file paths with (import "std/...") and (import "plugin/...") in all lib/ header comments. Fix double-paren plugin imports (plugins return structs, not closures). Wrap zmq.lisp bare struct in closure-as-module. Convert aws.lisp entry point from positional to &named args.