### PR TITLE
escape-analysis-gated FlipSwap at while-loop back-edges

### DIFF
--- a/src/lir/lower/escape.rs
+++ b/src/lir/lower/escape.rs
@@ -1406,4 +1406,25 @@ impl<'a> Lowerer<'a> {
             _ => false,
         }
     }
+
+    /// Determine whether a while loop's body is safe for FlipSwap injection.
+    ///
+    /// Two conditions must hold:
+    /// 1. No dangerous outward set — body doesn't write heap values to
+    ///    bindings defined outside the loop.
+    /// 2. All break values are safe immediates — breaks don't carry heap
+    ///    pointers past FlipExit.
+    ///
+    /// Suspension is NOT a rejection condition. The runtime's
+    /// `rotate_pools` returns early when `shared_alloc` is non-null,
+    /// so FlipSwap on shared-alloc fibers is a safe no-op.
+    pub(super) fn can_flip_while_loop(&self, body: &Hir) -> bool {
+        if self.body_contains_dangerous_outward_set(body, &[]) {
+            return false;
+        }
+        if !self.all_breaks_have_safe_values(body) {
+            return false;
+        }
+        true
+    }
 }

--- a/src/lir/lower/expr.rs
+++ b/src/lir/lower/expr.rs
@@ -285,6 +285,7 @@ impl<'a> Lowerer<'a> {
             result_slot: block_result_slot,
             exit_label,
             region_depth_at_entry: depth_before,
+            flip_depth_at_entry: self.flip_depth,
         });
 
         // Lower body (same as lower_begin but simpler — body is typically a single Begin node)
@@ -335,6 +336,7 @@ impl<'a> Lowerer<'a> {
         let target_result_slot = target.result_slot;
         let target_exit_label = target.exit_label;
         let target_region_depth = target.region_depth_at_entry;
+        let target_flip_depth = target.flip_depth_at_entry;
 
         // Lower the value expression
         let value_reg = self.lower_expr(value)?;
@@ -344,6 +346,13 @@ impl<'a> Lowerer<'a> {
             slot: target_result_slot,
             src: value_reg,
         });
+
+        // Emit compensating FlipExit for each while-loop flip frame
+        // entered since the target block was opened.
+        let compensating_flips = self.flip_depth - target_flip_depth;
+        for _ in 0..compensating_flips {
+            self.emit(LirInstr::FlipExit);
+        }
 
         // Emit compensating RegionExit for each region entered since the
         // target block was opened. This ensures scope marks are popped
@@ -370,10 +379,14 @@ impl<'a> Lowerer<'a> {
 
     fn lower_while(&mut self, cond: &Hir, body: &Hir) -> Result<Reg, String> {
         let result_reg = self.fresh_reg();
+        let flip_eligible = self.can_flip_while_loop(body);
 
         let cond_label = self.fresh_label();
         let body_label = self.fresh_label();
         let done_label = self.fresh_label();
+
+        // The entry block is the current block before we jump to cond.
+        let entry_label = self.current_block.label;
 
         // Jump to condition check
         self.terminate(Terminator::Jump(cond_label));
@@ -389,11 +402,27 @@ impl<'a> Lowerer<'a> {
         });
         self.finish_block();
 
-        // Body block
+        // Body block — track flip_depth so breaks can compensate
+        if flip_eligible {
+            self.flip_depth += 1;
+        }
         self.current_block = BasicBlock::new(body_label);
         let _body_reg = self.lower_expr(body)?;
+        // The back-edge block is whatever block we're in after lowering
+        // the body (body lowering may have created intermediate blocks).
+        let back_edge_label = self.current_block.label;
         self.terminate(Terminator::Jump(cond_label));
         self.finish_block();
+        if flip_eligible {
+            self.flip_depth -= 1;
+        }
+
+        // Record the loop triple for inject_flip to use later.
+        if flip_eligible {
+            self.current_func
+                .while_loops
+                .push((entry_label, back_edge_label, done_label));
+        }
 
         // Done block — emit nil result here so it's tracked in this block
         self.current_block = BasicBlock::new(done_label);

--- a/src/lir/lower/lambda.rs
+++ b/src/lir/lower/lambda.rs
@@ -163,6 +163,7 @@ impl<'a> Lowerer<'a> {
         let saved_discard_slot = self.discard_slot;
         let saved_pending_region_exits = self.pending_region_exits;
         let saved_region_depth = self.region_depth;
+        let saved_flip_depth = self.flip_depth;
         // Save function context. It's set by the caller (lower_letrec,
         // lower_define) before lower_expr so escape analysis can detect
         // self-tail-calls. We save it here and restore it for the
@@ -183,6 +184,7 @@ impl<'a> Lowerer<'a> {
         self.discard_slot = None;
         self.pending_region_exits = 0;
         self.region_depth = 0;
+        self.flip_depth = 0;
         self.current_func.doc = doc;
         self.current_func.syntax = syntax;
         self.current_func.vararg_kind = vararg_kind.clone();
@@ -307,6 +309,7 @@ impl<'a> Lowerer<'a> {
         self.discard_slot = saved_discard_slot;
         self.pending_region_exits = saved_pending_region_exits;
         self.region_depth = saved_region_depth;
+        self.flip_depth = saved_flip_depth;
 
         Ok(func)
     }

--- a/src/lir/lower/mod.rs
+++ b/src/lir/lower/mod.rs
@@ -92,6 +92,38 @@ fn inject_flip(func: &mut LirFunction) {
                 .push(SpannedInstr::new(LirInstr::FlipExit, Span::synthetic()));
         }
     }
+
+    // While-loop flip frames: detect back-edges from the CFG and inject
+    // FlipEnter/FlipSwap/FlipExit around each loop so per-iteration
+    // allocations are reclaimed.
+    //
+    // Pattern: entry→Jump(cond), cond→Branch{body,done}, back_edge→Jump(cond).
+    // Detect Branch blocks with exactly two Jump predecessors (forward entry +
+    // backward back-edge), distinguished by block order.
+    inject_flip_while_loops(func);
+}
+
+/// Inject per-loop FlipEnter/FlipSwap/FlipExit using the
+/// `while_loops` metadata recorded during lowering. Each triple
+/// `(entry, back_edge, done)` has already passed escape analysis.
+fn inject_flip_while_loops(func: &mut LirFunction) {
+    for &(entry_label, back_edge_label, done_label) in &func.while_loops.clone() {
+        if let Some(block) = func.blocks.iter_mut().find(|b| b.label == entry_label) {
+            block
+                .instructions
+                .push(SpannedInstr::new(LirInstr::FlipEnter, Span::synthetic()));
+        }
+        if let Some(block) = func.blocks.iter_mut().find(|b| b.label == back_edge_label) {
+            block
+                .instructions
+                .push(SpannedInstr::new(LirInstr::FlipSwap, Span::synthetic()));
+        }
+        if let Some(block) = func.blocks.iter_mut().find(|b| b.label == done_label) {
+            block
+                .instructions
+                .insert(0, SpannedInstr::new(LirInstr::FlipExit, Span::synthetic()));
+        }
+    }
 }
 
 /// Compile-time scope allocation statistics.
@@ -199,6 +231,10 @@ struct BlockLowerContext {
     /// `break` emits `(current_region_depth - region_depth_at_entry)`
     /// compensating `RegionExit` instructions before jumping to the exit.
     region_depth_at_entry: u32,
+    /// The `flip_depth` at the time this block was entered.
+    /// `break` emits compensating `FlipExit` instructions for each
+    /// flip frame entered since the block was opened.
+    flip_depth_at_entry: u32,
 }
 
 /// Lowers HIR to LIR
@@ -269,6 +305,11 @@ pub struct Lowerer<'a> {
     /// Incremented on `RegionEnter`, decremented on `RegionExit`.
     /// Used by `lower_break` to emit compensating `RegionExit`s.
     region_depth: u32,
+    /// Current nesting depth of while-loop flip frames.
+    /// Incremented when entering a flip-eligible while loop,
+    /// decremented when leaving. Used by `lower_break` to emit
+    /// compensating `FlipExit` instructions.
+    flip_depth: u32,
     pending_region_exits: u32,
     /// Compile-time scope allocation statistics.
     scope_stats: ScopeStats,
@@ -315,6 +356,7 @@ impl<'a> Lowerer<'a> {
             immutable_values: HashMap::new(),
             block_lower_contexts: Vec::new(),
             region_depth: 0,
+            flip_depth: 0,
             pending_region_exits: 0,
             scope_stats: ScopeStats::default(),
             discard_slot: None,

--- a/src/lir/types.rs
+++ b/src/lir/types.rs
@@ -124,6 +124,10 @@ pub struct LirFunction {
     pub has_outward_heap_set: bool,
     /// True when the function body is safe for tail-call pool rotation.
     pub rotation_safe: bool,
+    /// While-loop triples `(entry, back_edge, done)` that passed escape
+    /// analysis during lowering. `inject_flip` uses these to insert
+    /// FlipEnter/FlipSwap/FlipExit without CFG heuristics.
+    pub while_loops: Vec<(Label, Label, Label)>,
 }
 
 /// Metadata about a yield point, collected during bytecode emission.
@@ -195,6 +199,7 @@ impl LirFunction {
             result_is_immediate: false,
             has_outward_heap_set: false,
             rotation_safe: false,
+            while_loops: Vec::new(),
         }
     }
 

--- a/src/value/fiberheap/mod.rs
+++ b/src/value/fiberheap/mod.rs
@@ -603,30 +603,32 @@ impl FiberHeap {
         }
 
         let base_allocs = base.heap_mark.root_allocs_len();
-        let base_dtors = base.heap_mark.dtor_len();
+        let _base_dtors = base.heap_mark.dtor_len();
         let base_count = base.heap_mark.position();
 
         // 1. Teardown the swap pool (iteration N-2's allocations are dead).
+        //    Only dealloc slots — dtors are NOT in the swap pool (see step 2).
         if let Some(old) = self.swap_pool.take() {
-            for i in (0..old.dtors.len()).rev() {
-                unsafe { std::ptr::drop_in_place(old.dtors[i]) };
-            }
             for &ptr in old.root_allocs.iter().rev() {
                 unsafe { self.pool.dealloc_slot(ptr) };
             }
             self.rotation_freed += old.root_allocs.len();
         }
 
-        // 2. Move current iteration's objects (after base_mark) to swap.
+        // 2. Move current iteration's non-dtor objects to swap.
+        //    Dtor-bearing objects (Closures, Fibers, etc.) stay in the main
+        //    pool because they may be reachable via Rc references held in
+        //    arrays/maps that survive rotation. Dropping them would free the
+        //    Rc inner data (Fiber, ClosureTemplate) while still referenced.
+        //    They are cleaned up only on pool teardown (fiber exit).
         let iter_allocs = self.pool.allocs.split_off(base_allocs);
-        let iter_dtors = self.pool.dtors.split_off(base_dtors);
 
         self.swap_pool = if iter_allocs.is_empty() {
             None
         } else {
             Some(SwapPool {
                 root_allocs: iter_allocs,
-                dtors: iter_dtors,
+                dtors: Vec::new(),
             })
         };
 
@@ -679,9 +681,6 @@ impl FiberHeap {
         // `rotate_pools` — those slab slots were held "live for one
         // iteration" but the function is exiting, so they're dead now.
         if let Some(old) = self.swap_pool.take() {
-            for i in (0..old.dtors.len()).rev() {
-                unsafe { std::ptr::drop_in_place(old.dtors[i]) };
-            }
             for &ptr in old.root_allocs.iter().rev() {
                 unsafe { self.pool.dealloc_slot(ptr) };
             }

--- a/tests/integration/flip_cli.rs
+++ b/tests/integration/flip_cli.rs
@@ -90,6 +90,115 @@ fn flip_on_runs_a_tail_loop_correctly() {
 }
 
 #[test]
+fn flip_on_injects_at_while_back_edge() {
+    let (out, _, status) = run(
+        &["--flip=on", "--dump=lir"],
+        "(defn f [] (def @i 0) (while (< i 10) (assign i (+ i 1))))",
+    );
+    assert!(status.success(), "compile failed with --flip=on");
+    let flip_enter_count = out.matches("flip-enter").count();
+    assert!(
+        flip_enter_count >= 2,
+        "expected at least 2 flip-enter (function + while), got {}:\n{}",
+        flip_enter_count,
+        out
+    );
+    assert!(
+        out.matches("flip-swap").count() >= 1,
+        "missing flip-swap for while back-edge:\n{}",
+        out
+    );
+}
+
+#[test]
+fn flip_on_while_loop_correct() {
+    let (out, err, status) = run(
+        &["--flip=on", "--jit=0"],
+        "(defn f [] \
+           (def @i 0) \
+           (def @sum 0) \
+           (while (< i 10000) \
+             (assign sum (+ sum i)) \
+             (assign i (+ i 1))) \
+           sum) \
+         (println (f))",
+    );
+    assert!(
+        status.success(),
+        "elle exited non-zero:\nstdout: {}\nstderr: {}",
+        out,
+        err
+    );
+    assert!(out.contains("49995000"), "expected 49995000, got: {}", out);
+}
+
+#[test]
+fn flip_on_nested_while_correct() {
+    let (out, err, status) = run(
+        &["--flip=on", "--jit=0"],
+        "(defn f [] \
+           (def @total 0) \
+           (def @i 0) \
+           (while (< i 100) \
+             (def @j 0) \
+             (while (< j 100) \
+               (assign total (+ total 1)) \
+               (assign j (+ j 1))) \
+             (assign i (+ i 1))) \
+           total) \
+         (println (f))",
+    );
+    assert!(
+        status.success(),
+        "elle exited non-zero:\nstdout: {}\nstderr: {}",
+        out,
+        err
+    );
+    assert!(out.contains("10000"), "expected 10000, got: {}", out);
+}
+
+#[test]
+fn flip_on_break_from_while() {
+    let (out, err, status) = run(
+        &["--flip=on", "--jit=0"],
+        "(println (block :x (while true (break :x 42))))",
+    );
+    assert!(
+        status.success(),
+        "elle exited non-zero:\nstdout: {}\nstderr: {}",
+        out,
+        err
+    );
+    assert!(out.contains("42"), "expected 42, got: {}", out);
+}
+
+#[test]
+fn flip_on_unsafe_while_no_flip_injected() {
+    // A while loop that pushes heap values (cons cells) to an outer binding
+    // must NOT get FlipSwap — the outward set makes it unsafe.
+    let (out, _, status) = run(
+        &["--flip=on", "--dump=lir"],
+        "(defn f [] \
+           (def @acc nil) \
+           (def @i 0) \
+           (while (< i 3) \
+             (assign acc (cons i acc)) \
+             (assign i (+ i 1))) \
+           acc)",
+    );
+    assert!(status.success(), "compile failed with --flip=on");
+    // No flip-swap should appear — function-level flip-swap only fires
+    // at tail calls, and while-loop flip-swap was rejected by safety analysis.
+    let flip_swap_count = out.matches("flip-swap").count();
+    assert!(
+        flip_swap_count == 0,
+        "expected 0 flip-swap (unsafe while should be rejected), got {}:\n{}",
+        flip_swap_count,
+        out
+    );
+}
+
+#[test]
 fn flip_invalid_value_is_rejected() {
     let (_, err, status) = run(&["--flip=maybe"], "(+ 1 2)");
     assert!(!status.success());


### PR DESCRIPTION
Replace the CFG heuristic in inject_flip_while_loops with metadata recorded during lowering. lower_while now runs can_flip_while_loop (checks for dangerous outward set and unsafe break values) and records (entry, back_edge, done) triples on LirFunction.while_loops only when the loop body passes safety analysis.

Add flip_depth tracking to Lowerer and BlockLowerContext so that break expressions emit compensating FlipExit instructions when jumping out of flip-eligible while loops.

Pure while loops and yielding while loops on private-arena fibers get FlipSwap (runtime rotate_pools handles shared-alloc as no-op). While loops that mutate outer bindings with heap values or break with heap pointers are rejected at compile time.