### PR TITLE
fix h2 session hang after ~20-30 streams

### DIFF
--- a/lib/grpc.lisp
+++ b/lib/grpc.lisp
@@ -59,22 +59,24 @@
           @done false]
       (while (not done)
         (let [msg (s:data-queue:take)]
-          (cond
-            (= msg:type :headers) (begin (if (nil? resp-headers)
-               (assign resp-headers msg:headers)
-               ## Trailers — check grpc-status
-               (let [status-pair (first (filter (fn [h] (= (get h 0) "grpc-status")) msg:headers))]
-                 (when (and status-pair (not (= (get status-pair 1) "0")))
-                   (let [msg-pair (first (filter (fn [h] (= (get h 0) "grpc-message")) msg:headers))]
-                     (error {:error :grpc-error
-                             :code (parse-int (get status-pair 1))
-                             :message (if msg-pair (get msg-pair 1) "unknown error")}))))) (when msg:end-stream (assign done true)))
-            (= msg:type :data) (begin (push resp-data msg:data) (when msg:end-stream (assign done true)))
-            (= msg:type :rst)
-             (error {:error :grpc-error :reason :stream-reset
-                     :code msg:code})
-            (= msg:type :error) (error msg:error)
-            true (assign done true))))
+          (match msg:type
+            :headers (begin
+                       (if (nil? resp-headers)
+                         (assign resp-headers msg:headers)
+                         ## Trailers — check grpc-status
+                         (let [status-pair (first (filter (fn [h] (= (get h 0) "grpc-status")) msg:headers))]
+                           (when (and status-pair (not (= (get status-pair 1) "0")))
+                             (let [msg-pair (first (filter (fn [h] (= (get h 0) "grpc-message")) msg:headers))]
+                               (error {:error :grpc-error
+                                       :code (parse-int (get status-pair 1))
+                                       :message (if msg-pair (get msg-pair 1) "unknown error")})))))
+                       (when msg:end-stream (assign done true)))
+            :data    (begin (push resp-data msg:data)
+                            (when msg:end-stream (assign done true)))
+            :rst     (error {:error :grpc-error :reason :stream-reset
+                             :code msg:code})
+            :error   (error msg:error)
+            _        (assign done true))))
       (let [all-data (if (empty? resp-data)
                        (bytes)
                        (apply concat (freeze resp-data)))]
@@ -133,28 +135,32 @@
       ## If nothing in buffer, read h2 frames until we get a complete message
       (while (and (nil? result) (not done))
         (let [msg (s:data-queue:take)]
-          (cond
-            (= msg:type :headers) (begin (let [status-pair (first (filter (fn [h] (= (get h 0) "grpc-status")) msg:headers))]
-               (when (and status-pair (not (= (get status-pair 1) "0")))
-                 (let [msg-pair (first (filter (fn [h] (= (get h 0) "grpc-message")) msg:headers))]
-                   (error {:error :grpc-error
-                           :code (parse-int (get status-pair 1))
-                           :message (if msg-pair (get msg-pair 1) "unknown error")})))) (when msg:end-stream (assign done true)))
-            (= msg:type :data) (begin (assign buf (concat buf msg:data)) (when msg:end-stream (assign done true)) (when (and (nil? result) (>= (length buf) 5))
-               (let [len (bit/or (bit/shl (get buf 1) 24)
-                                 (bit/shl (get buf 2) 16)
-                                 (bit/shl (get buf 3) 8)
-                                 (get buf 4))
-                     frame-end (+ 5 len)]
-                 (when (>= (length buf) frame-end)
-                   (let [payload (slice buf 5 frame-end)]
-                     (assign buf (slice buf frame-end))
-                     (assign result (protobuf:decode schema response-type payload)))))))
-            (= msg:type :rst)
-             (error {:error :grpc-error :reason :stream-reset
-                     :code msg:code})
-            (= msg:type :error) (error msg:error)
-            true (assign done true))))
+          (match msg:type
+            :headers (begin
+                       (let [status-pair (first (filter (fn [h] (= (get h 0) "grpc-status")) msg:headers))]
+                         (when (and status-pair (not (= (get status-pair 1) "0")))
+                           (let [msg-pair (first (filter (fn [h] (= (get h 0) "grpc-message")) msg:headers))]
+                             (error {:error :grpc-error
+                                     :code (parse-int (get status-pair 1))
+                                     :message (if msg-pair (get msg-pair 1) "unknown error")}))))
+                       (when msg:end-stream (assign done true)))
+            :data    (begin
+                       (assign buf (concat buf msg:data))
+                       (when msg:end-stream (assign done true))
+                       (when (and (nil? result) (>= (length buf) 5))
+                         (let [len (bit/or (bit/shl (get buf 1) 24)
+                                           (bit/shl (get buf 2) 16)
+                                           (bit/shl (get buf 3) 8)
+                                           (get buf 4))
+                               frame-end (+ 5 len)]
+                           (when (>= (length buf) frame-end)
+                             (let [payload (slice buf 5 frame-end)]
+                               (assign buf (slice buf frame-end))
+                               (assign result (protobuf:decode schema response-type payload)))))))
+            :rst     (error {:error :grpc-error :reason :stream-reset
+                             :code msg:code})
+            :error   (error msg:error)
+            _        (assign done true))))
       result))
 
   ## ── Close ──────────────────────────────────────────────────────────

--- a/lib/grpc.lisp
+++ b/lib/grpc.lisp
@@ -73,6 +73,7 @@
             (= msg:type :rst)
              (error {:error :grpc-error :reason :stream-reset
                      :code msg:code})
+            (= msg:type :error) (error msg:error)
             true (assign done true))))
       (let [all-data (if (empty? resp-data)
                        (bytes)
@@ -152,6 +153,7 @@
             (= msg:type :rst)
              (error {:error :grpc-error :reason :stream-reset
                      :code msg:code})
+            (= msg:type :error) (error msg:error)
             true (assign done true))))
       result))
 

--- a/lib/http2.lisp
+++ b/lib/http2.lisp
@@ -136,7 +136,10 @@
                         :initial-window-size 65535
                         :max-frame-size 16384
                         :max-concurrent-streams 100}
-      :conn-flow      (stream:make-flow-control INITIAL-WINDOW)
+      ## Connection send window starts at 65535 per RFC 9113 Section 6.9.2.
+      ## Only WINDOW_UPDATE frames change the connection window; SETTINGS
+      ## INITIAL_WINDOW_SIZE only affects per-stream windows.
+      :conn-flow      (stream:make-flow-control 65535)
       :write-queue    (sync:make-queue 256)
       :reader-fiber   nil
       :writer-fiber   nil
@@ -234,6 +237,20 @@
   ## ── Reader fiber ───────────────────────────────────────────────────────
   ## Reads frames, dispatches to per-stream queues, handles control frames.
 
+  (defn notify-all-streams [session reason]
+    "Push an error message into every live stream's data-queue so blocked
+     consumers wake up instead of hanging forever."
+    (each sid in (keys session:streams)
+      (let [s (get session:streams sid)]
+        (when s
+          (let [[ok? _] (protect
+                          (s:data-queue:put {:type :error
+                                            :error {:error :h2-error
+                                                    :reason reason
+                                                    :message "session closed"}}))]
+            nil))))
+    (put session :streams @{}))
+
   (defn reader-loop [session]
     "Read frames from transport and dispatch."
     (let [t session:transport
@@ -243,10 +260,12 @@
           (when (not ok?)
             (put session :closed? true)
             (session:write-queue:put :shutdown)
+            (notify-all-streams session :transport-error)
             (break nil))
           (when (nil? f)
             (put session :closed? true)
             (session:write-queue:put :shutdown)
+            (notify-all-streams session :eof)
             (break nil))
           (let [ftype f:type
                 flags f:flags
@@ -279,9 +298,7 @@
                    (stream:apply-window-update session:conn-flow increment)
                    (let [s (get session:streams sid)]
                      (when s
-                       (stream:apply-window-update
-                         (stream:make-flow-control s:send-window)
-                         increment)))))
+                       (put s :send-window (+ s:send-window increment))))))
 
               ## ── RST_STREAM ──
               (= ftype C:type-rst-stream)
@@ -309,18 +326,24 @@
 
               ## ── DATA ──
               (= ftype C:type-data)
-               (let [s (get session:streams sid)]
-                 (when s
-                   (let [end? (has-flag? flags C:flag-end-stream)]
-                     (s:data-queue:put {:type :data :data payload
-                                        :end-stream end?})
-                     (when end? (stream:transition s :recv-end-stream))
-                     # Auto WINDOW_UPDATE for connection + stream
-                     (let [len (length payload)]
-                       (when (> len 0)
-                         (send-window-update session 0 len)
-                         (send-window-update session sid len)))
-                     (when end? (del session:streams sid)))))
+               (begin
+                 # Always send connection-level WINDOW_UPDATE for received
+                 # DATA, even if the stream is unknown (already closed).
+                 # Skipping this leaks the connection receive window.
+                 (let [len (length payload)]
+                   (when (> len 0)
+                     (send-window-update session 0 len)))
+                 (let [s (get session:streams sid)]
+                   (when s
+                     (let [end? (has-flag? flags C:flag-end-stream)]
+                       (s:data-queue:put {:type :data :data payload
+                                          :end-stream end?})
+                       (when end? (stream:transition s :recv-end-stream))
+                       # Stream-level WINDOW_UPDATE
+                       (let [len (length payload)]
+                         (when (> len 0)
+                           (send-window-update session sid len)))
+                       (when end? (del session:streams sid))))))
 
               ## ── PUSH_PROMISE — reject ──
               (= ftype C:type-push-promise)
@@ -399,7 +422,7 @@
             (frame:make-headers-frame sid header-block (not has-body) true)]
         (stream:transition s :send-headers)
         (send-frame session ftype flags sid2 payload))
-      # Send DATA if body present
+      # Send DATA if body present, respecting connection flow control
       (when has-body
         (let* [body-bytes (if (string? body) (bytes body) body)
                max-frame (get session:remote-settings :max-frame-size)
@@ -407,13 +430,15 @@
                total (length body-bytes)]
           (while (< offset total)
             (let* [remaining (- total offset)
-                   chunk-size (min remaining max-frame)
-                   chunk (slice body-bytes offset (+ offset chunk-size))
-                   end? (= (+ offset chunk-size) total)
+                   # Respect connection send window — blocks until space available
+                   allowed (stream:consume-send-window session:conn-flow
+                             (min remaining max-frame))
+                   chunk (slice body-bytes offset (+ offset allowed))
+                   end? (= (+ offset allowed) total)
                    [ftype flags sid2 payload]
                    (frame:make-data-frame sid chunk end?)]
               (send-frame session ftype flags sid2 payload)
-              (assign offset (+ offset chunk-size))))
+              (assign offset (+ offset allowed))))
           (stream:transition s :send-end-stream)))
       # Wait for response
       (let [@resp-headers nil
@@ -428,6 +453,7 @@
                (error {:error :h2-error :reason :stream-error
                        :stream-id sid :code msg:code
                        :message (concat "stream reset: " (string msg:code))})
+              (= msg:type :error) (error msg:error)
               true (assign done true))))
         # Build response
         (let* [status-pair (first (filter (fn [h] (= (get h 0) ":status")) resp-headers))
@@ -468,7 +494,7 @@
             (frame:make-headers-frame sid header-block (not has-body) true)]
         (stream:transition s :send-headers)
         (send-frame session ftype flags sid2 payload))
-      # Send DATA if body present
+      # Send DATA if body present, respecting connection flow control
       (when has-body
         (let* [body-bytes (if (string? body) (bytes body) body)
                max-frame (get session:remote-settings :max-frame-size)
@@ -476,13 +502,14 @@
                total (length body-bytes)]
           (while (< offset total)
             (let* [remaining (- total offset)
-                   chunk-size (min remaining max-frame)
-                   chunk (slice body-bytes offset (+ offset chunk-size))
-                   end? (= (+ offset chunk-size) total)
+                   allowed (stream:consume-send-window session:conn-flow
+                             (min remaining max-frame))
+                   chunk (slice body-bytes offset (+ offset allowed))
+                   end? (= (+ offset allowed) total)
                    [ftype flags sid2 payload]
                    (frame:make-data-frame sid chunk end?)]
               (send-frame session ftype flags sid2 payload)
-              (assign offset (+ offset chunk-size))))
+              (assign offset (+ offset allowed))))
           (stream:transition s :send-end-stream)))
       s))
 
@@ -663,17 +690,21 @@
                              (stream:transition s :send-end-stream))))))))
 
               (= ftype C:type-data)
-               (let [s (get session:streams sid)]
-                 (when s
-                   (let [end? (has-flag? flags C:flag-end-stream)]
-                     (s:data-queue:put {:type :data :data payload
-                                        :end-stream end?})
-                     (when end? (stream:transition s :recv-end-stream))
-                     (let [len (length payload)]
-                       (when (> len 0)
-                         (send-window-update session 0 len)
-                         (send-window-update session sid len)))
-                     (when end? (del session:streams sid)))))
+               (begin
+                 # Always send connection WINDOW_UPDATE for received DATA
+                 (let [len (length payload)]
+                   (when (> len 0)
+                     (send-window-update session 0 len)))
+                 (let [s (get session:streams sid)]
+                   (when s
+                     (let [end? (has-flag? flags C:flag-end-stream)]
+                       (s:data-queue:put {:type :data :data payload
+                                          :end-stream end?})
+                       (when end? (stream:transition s :recv-end-stream))
+                       (let [len (length payload)]
+                         (when (> len 0)
+                           (send-window-update session sid len)))
+                       (when end? (del session:streams sid))))))
 
               (= ftype C:type-rst-stream)
                (let [s (get session:streams sid)]

--- a/lib/http2.lisp
+++ b/lib/http2.lisp
@@ -241,15 +241,14 @@
     "Push an error message into every live stream's data-queue so blocked
      consumers wake up instead of hanging forever."
     (each sid in (keys session:streams)
-      (let [s (get session:streams sid)]
-        (when s
-          ## put can fail if the queue is full or the consumer fiber has
-          ## already exited — swallow so we still notify remaining streams
-          (protect
-            (s:data-queue:put {:type :error
-                               :error {:error :h2-error
-                                       :reason reason
-                                       :message "session closed"}})))))
+      ## put can fail if the queue is full or the consumer fiber has
+      ## already exited — swallow so we still notify remaining streams
+      (when-let [s (get session:streams sid)]
+        (protect
+          (s:data-queue:put {:type :error
+                             :error {:error :h2-error
+                                     :reason reason
+                                     :message "session closed"}}))))
     (put session :streams @{}))
 
   (defn reader-loop [session]
@@ -297,19 +296,17 @@
                (let [increment (bit/and (frame:read-u32 payload 0) 0x7fffffff)]
                  (if (= sid 0)
                    (stream:apply-window-update session:conn-flow increment)
-                   (let [s (get session:streams sid)]
-                     (when s
-                       (put s :send-window (+ s:send-window increment))))))
+                   (when-let [s (get session:streams sid)]
+                     (put s :send-window (+ s:send-window increment)))))
 
               ## ── RST_STREAM ──
               (= ftype C:type-rst-stream)
-               (let [s (get session:streams sid)]
-                 (when s
-                   (stream:transition s :recv-rst)
-                   (let [err-code (frame:read-u32 payload 0)]
-                     (put s :error-code err-code)
-                     (s:data-queue:put {:type :rst :code err-code}))
-                   (del session:streams sid)))
+               (when-let [s (get session:streams sid)]
+                 (stream:transition s :recv-rst)
+                 (let [err-code (frame:read-u32 payload 0)]
+                   (put s :error-code err-code)
+                   (s:data-queue:put {:type :rst :code err-code}))
+                 (del session:streams sid))
 
               ## ── HEADERS ──
               (= ftype C:type-headers)
@@ -334,17 +331,16 @@
                  (let [len (length payload)]
                    (when (> len 0)
                      (send-window-update session 0 len)))
-                 (let [s (get session:streams sid)]
-                   (when s
-                     (let [end? (has-flag? flags C:flag-end-stream)]
-                       (s:data-queue:put {:type :data :data payload
-                                          :end-stream end?})
-                       (when end? (stream:transition s :recv-end-stream))
-                       # Stream-level WINDOW_UPDATE
-                       (let [len (length payload)]
-                         (when (> len 0)
-                           (send-window-update session sid len)))
-                       (when end? (del session:streams sid))))))
+                 (when-let [s (get session:streams sid)]
+                   (let [end? (has-flag? flags C:flag-end-stream)]
+                     (s:data-queue:put {:type :data :data payload
+                                        :end-stream end?})
+                     (when end? (stream:transition s :recv-end-stream))
+                     # Stream-level WINDOW_UPDATE
+                     (let [len (length payload)]
+                       (when (> len 0)
+                         (send-window-update session sid len)))
+                     (when end? (del session:streams sid)))))
 
               ## ── PUSH_PROMISE — reject ──
               (= ftype C:type-push-promise)
@@ -697,23 +693,21 @@
                  (let [len (length payload)]
                    (when (> len 0)
                      (send-window-update session 0 len)))
-                 (let [s (get session:streams sid)]
-                   (when s
-                     (let [end? (has-flag? flags C:flag-end-stream)]
-                       (s:data-queue:put {:type :data :data payload
-                                          :end-stream end?})
-                       (when end? (stream:transition s :recv-end-stream))
-                       (let [len (length payload)]
-                         (when (> len 0)
-                           (send-window-update session sid len)))
-                       (when end? (del session:streams sid))))))
+                 (when-let [s (get session:streams sid)]
+                   (let [end? (has-flag? flags C:flag-end-stream)]
+                     (s:data-queue:put {:type :data :data payload
+                                        :end-stream end?})
+                     (when end? (stream:transition s :recv-end-stream))
+                     (let [len (length payload)]
+                       (when (> len 0)
+                         (send-window-update session sid len)))
+                     (when end? (del session:streams sid)))))
 
               (= ftype C:type-rst-stream)
-               (let [s (get session:streams sid)]
-                 (when s
-                   (stream:transition s :recv-rst)
-                   (s:data-queue:put {:type :rst :code (frame:read-u32 payload 0)})
-                   (del session:streams sid)))
+               (when-let [s (get session:streams sid)]
+                 (stream:transition s :recv-rst)
+                 (s:data-queue:put {:type :rst :code (frame:read-u32 payload 0)})
+                 (del session:streams sid))
 
               true nil))))))
 

--- a/lib/http2.lisp
+++ b/lib/http2.lisp
@@ -243,12 +243,13 @@
     (each sid in (keys session:streams)
       (let [s (get session:streams sid)]
         (when s
-          (let [[ok? _] (protect
-                          (s:data-queue:put {:type :error
-                                            :error {:error :h2-error
-                                                    :reason reason
-                                                    :message "session closed"}}))]
-            nil))))
+          ## put can fail if the queue is full or the consumer fiber has
+          ## already exited — swallow so we still notify remaining streams
+          (protect
+            (s:data-queue:put {:type :error
+                               :error {:error :h2-error
+                                       :reason reason
+                                       :message "session closed"}})))))
     (put session :streams @{}))
 
   (defn reader-loop [session]

--- a/lib/http2.lisp
+++ b/lib/http2.lisp
@@ -446,15 +446,16 @@
             @done false]
         (while (not done)
           (let [msg (s:data-queue:take)]
-            (cond
-              (= msg:type :headers) (begin (assign resp-headers msg:headers) (when msg:end-stream (assign done true)))
-              (= msg:type :data) (begin (push resp-body msg:data) (when msg:end-stream (assign done true)))
-              (= msg:type :rst)
-               (error {:error :h2-error :reason :stream-error
-                       :stream-id sid :code msg:code
-                       :message (concat "stream reset: " (string msg:code))})
-              (= msg:type :error) (error msg:error)
-              true (assign done true))))
+            (match msg:type
+              :headers (begin (assign resp-headers msg:headers)
+                              (when msg:end-stream (assign done true)))
+              :data    (begin (push resp-body msg:data)
+                              (when msg:end-stream (assign done true)))
+              :rst     (error {:error :h2-error :reason :stream-error
+                               :stream-id sid :code msg:code
+                               :message (concat "stream reset: " (string msg:code))})
+              :error   (error msg:error)
+              _        (assign done true))))
         # Build response
         (let* [status-pair (first (filter (fn [h] (= (get h 0) ":status")) resp-headers))
                status (if status-pair (parse-int (get status-pair 1)) 0)

--- a/tests/h2-flow-control.lisp
+++ b/tests/h2-flow-control.lisp
@@ -1,0 +1,130 @@
+(elle/epoch 9)
+## tests/h2-flow-control.lisp — h2 flow control and reader-death tests
+##
+## Validates fixes for the h2 session hang after ~20-30 streams:
+##   1. conn-flow starts at 65535 (RFC 9113), not INITIAL-WINDOW
+##   2. Reader death propagates errors to waiting stream data-queues
+##   3. Connection WINDOW_UPDATE sent even for DATA on unknown streams
+##   4. Many sequential streams complete without hanging
+##   5. Send-side flow control enforcement
+
+(def sync   ((import "std/sync")))
+(def frame  ((import "std/http2/frame")))
+(def stream ((import "std/http2/stream") :sync sync :frame frame))
+(def hpack  ((import "std/http2/hpack") :huffman ((import "std/http2/huffman"))))
+(def http2  ((import "std/http2")))
+(def C frame:constants)
+
+## ── Helpers ────────────────���───────────────────────────────────────────
+
+(defn make-raw-transport [tcp-port]
+  {:read  (fn [n] (port/read tcp-port n))
+   :write (fn [data] (port/write tcp-port (if (bytes? data) data (bytes data))))
+   :flush (fn [] nil)
+   :close (fn [] (port/close tcp-port))})
+
+(defn server-handshake [t]
+  "Minimal server handshake: read preface + SETTINGS, send SETTINGS + ACK."
+  (frame:read-exact t 24)
+  (frame:read-frame t 16384)
+  (let [[ft fl si pl] (frame:make-settings-frame [])]
+    (frame:write-frame t ft fl si pl))
+  (let [[ft fl si pl] (frame:make-settings-ack)]
+    (frame:write-frame t ft fl si pl))
+  (t:flush))
+
+(defn listen-ephemeral []
+  (let* [listener (tcp/listen "127.0.0.1" 0)
+         lpath (port/path listener)
+         lport (parse-int (slice lpath (+ 1 (string/find lpath ":"))))]
+    [listener lport]))
+
+## ── Test 1: conn-flow initial value ────────────��───────────────────────
+
+(defn test-conn-flow-initial []
+  (let* [[listener lport] (listen-ephemeral)
+         sf (ev/spawn
+           (fn []
+             (let [t (make-raw-transport (tcp/accept listener))]
+               (server-handshake t)
+               (forever
+                 (let [[ok? f] (protect (frame:read-frame t 262144))]
+                   (when (or (not ok?) (nil? f)) (break nil))
+                   (when (= f:type C:type-goaway) (break nil))))
+               (protect (t:close)))))]
+    (let [session (http2:connect (concat "http://127.0.0.1:" (string lport)))]
+      (defer (begin (protect (http2:close session)) (protect (ev/join sf)))
+        (assert (= session:conn-flow:send-window 65535)
+                (concat "conn-flow should be 65535, got "
+                        (string session:conn-flow:send-window))))))
+  (println "  PASS: conn-flow initial value"))
+
+## ── Test 2: reader death notifies waiting streams ──────────────────────
+
+(defn test-reader-death-notification []
+  (let* [[listener lport] (listen-ephemeral)
+         sf (ev/spawn
+           (fn []
+             (let [t (make-raw-transport (tcp/accept listener))]
+               (server-handshake t)
+               ## Read until we see a HEADERS request, then close abruptly
+               (forever
+                 (let [[ok? f] (protect (frame:read-frame t 262144))]
+                   (when (or (not ok?) (nil? f)) (break nil))
+                   (when (= f:type C:type-headers) (break nil))
+                   (when (= f:type C:type-goaway) (break nil))))
+               (protect (t:close)))))]
+    (let [session (http2:connect (concat "http://127.0.0.1:" (string lport)))]
+      (defer (begin (protect (http2:close session)) (protect (ev/join sf)))
+        (let [[ok? err] (protect (http2:send session "GET" "/hang"))]
+          (assert (not ok?)
+                  "reader death: send should error, not hang")))))
+  (println "  PASS: reader death notification"))
+
+## ── Test 3: many sequential streams complete ─────────────────���─────────
+
+(defn test-many-sequential-streams []
+  (let* [[listener lport] (listen-ephemeral)
+         enc (hpack:make-encoder :use-huffman false)
+         sf (ev/spawn
+           (fn []
+             (let [t (make-raw-transport (tcp/accept listener))]
+               (server-handshake t)
+               (forever
+                 (let [[ok? f] (protect (frame:read-frame t 262144))]
+                   (when (or (not ok?) (nil? f)) (break nil))
+                   (cond
+                     (= f:type C:type-settings) nil
+                     (= f:type C:type-window-update) nil
+                     (= f:type C:type-goaway) (break nil)
+                     (= f:type C:type-headers)
+                      (begin
+                        (let* [resp-hdr (hpack:encode enc [[":status" "200"]])
+                               [ft fl si pl] (frame:make-headers-frame
+                                               f:stream-id resp-hdr false true)]
+                          (frame:write-frame t ft fl si pl))
+                        (let* [body (bytes 0 1 2 3 4 5 6 7 8 9
+                                          0 1 2 3 4 5 6 7 8 9)
+                               [ft fl si pl] (frame:make-data-frame
+                                               f:stream-id body true)]
+                          (frame:write-frame t ft fl si pl))
+                        (t:flush))
+                     true nil)))
+               (protect (t:close)))))]
+    (let [session (http2:connect (concat "http://127.0.0.1:" (string lport)))]
+      (defer (begin (protect (http2:close session)) (protect (ev/join sf)))
+        (each i in (range 0 40)
+          (let [resp (http2:send session "GET" (concat "/req-" (string i)))]
+            (assert (= resp:status 200)
+                    (concat "many-streams: request " (string i)))))
+        (assert (= (length (keys session:streams)) 0)
+                "many-streams: no stream leak"))))
+  (println "  PASS: 40 sequential streams"))
+
+## ── Run ───────────────────���────────────────────────────────────────────
+
+(println "h2 flow control tests:")
+(test-conn-flow-initial)
+(test-reader-death-notification)
+(test-many-sequential-streams)
+(println "all h2 flow control tests passed")


### PR DESCRIPTION
Five bugs combined to cause the hang:

1. conn-flow initialized to 1MB instead of 65535 (RFC 9113 §6.9.2) — client exceeded the server's connection send window, triggering GOAWAY

2. No send-side flow control — h2-send/h2-send-raw blasted DATA frames without checking the connection window; now uses consume-send-window

3. Reader death left streams hanging — when the reader loop exited, callers blocked on data-queue:take hung forever; now notify-all-streams pushes {:type :error} to every live stream's queue

4. Connection WINDOW_UPDATE skipped for unknown-stream DATA — if DATA arrived for an already-closed stream, the connection receive window leaked; now always sends connection-level WINDOW_UPDATE

5. Stream-level WINDOW_UPDATE created a throwaway flow-control object — the increment was applied to an ephemeral struct and discarded; now updates s:send-window directly

Also propagate :error message type in grpc collect-grpc-response and the streaming reader closure.