### PR TITLE
fix emitter stack-depth mismatch at control-flow merge points (#802)

### DIFF
--- a/src/lir/emit/mod.rs
+++ b/src/lir/emit/mod.rs
@@ -968,6 +968,14 @@ impl Emitter {
             }
 
             Terminator::Jump(label) => {
+                // Pop trailing orphan values so that all predecessors of a
+                // merge block agree on the operand-stack depth.  Orphans are
+                // created by DupN in ensure_on_top (e.g. inside the splice
+                // path for `apply`).  Without this, branches that create
+                // orphans leave a deeper stack than branches that don't,
+                // causing wrong DupN offsets in the merge block.
+                self.pop_trailing_orphans();
+
                 // Save stack state for the target block, but only if it hasn't
                 // been processed yet. This is used for control flow merges
                 // (e.g., if/and/or) where multiple blocks jump to the same target.

--- a/src/lir/emit/stack.rs
+++ b/src/lir/emit/stack.rs
@@ -59,6 +59,40 @@ impl super::Emitter {
     /// `ensure_on_top` which duplicates via DupN (leaving originals as
     /// orphans), this checks whether the operands are already in position
     /// and only falls back to DupN when they aren't.
+    /// Pop trailing orphan values from the operand stack.
+    ///
+    /// An orphan is a stack entry whose register's canonical position
+    /// (in `reg_to_stack`) differs from its actual stack position.  These
+    /// are left behind when `ensure_on_top` uses DupN to copy a value to
+    /// the top — the original remains on the real VM stack but the
+    /// simulated mapping now points to the copy.
+    ///
+    /// In straight-line code orphans are harmless: they sit below the
+    /// active top and are eventually overwritten.  But when control flow
+    /// branches, one branch may create orphans while another does not,
+    /// leaving different stack depths at the merge point.  This causes
+    /// DupN offsets in the merge block to be wrong, shifting operands and
+    /// producing incorrect results (e.g. a struct value in a hash-key
+    /// slot → "expected hashable value, got struct").
+    ///
+    /// Call this before saving stack state to `yield_stack_state` in
+    /// terminators so that all predecessors of a merge block agree on
+    /// the operand-stack depth.
+    pub(super) fn pop_trailing_orphans(&mut self) {
+        while let Some(&top_reg) = self.stack.last() {
+            if self.reg_to_stack.get(&top_reg) == Some(&(self.stack.len() - 1)) {
+                break; // top element is live — stop
+            }
+            // Top element is an orphan: emit Pop to remove it from the
+            // real VM stack, and drop it from the simulated stack.
+            self.bytecode.emit(Instruction::Pop);
+            self.stack.pop();
+            // Do not call self.pop() — the orphan's register either
+            // isn't in reg_to_stack at all, or points to a different
+            // (canonical) position that must not be disturbed.
+        }
+    }
+
     pub(super) fn ensure_binary_on_top(&mut self, lhs: Reg, rhs: Reg) {
         let stack_len = self.stack.len();
         if stack_len >= 2 {

--- a/tests/elle/struct-apply-orphan.lisp
+++ b/tests/elle/struct-apply-orphan.lisp
@@ -1,0 +1,58 @@
+(elle/epoch 9)
+# Test: struct literal with apply in if-else branch
+#
+# When a struct literal has a nested struct value ({}) AND the if-else
+# branch contains an `apply` (which desugars to CallArrayMut via splice),
+# the emitter's DupN for ensure_on_top can create orphan stack entries
+# in the else block.  If the orphans are not cleaned up before the
+# merge block, the stack depth mismatch causes wrong DupN offsets,
+# shifting key-value pairs so a struct lands in a key position.
+#
+# This is a regression test for the "expected hashable value, got struct"
+# bug in struct literal compilation.
+
+# ── minimal reproduction ──────────────────────────────────
+
+(def @bp @[])
+
+# Struct literal with {} value AND apply in else branch
+(def result {:headers {} :body (if (empty? bp) nil (apply concat (freeze bp)))})
+(assert (= (get result :headers) {}) "headers should be empty struct")
+(assert (= (get result :body) nil) "body should be nil for empty body-parts")
+
+# Same with non-empty body-parts (exercises the else branch)
+(def @parts @["hello" " " "world"])
+(def result2 {:headers {} :body (if (empty? parts) nil (apply concat (freeze parts)))})
+(assert (= (get result2 :headers) {}) "headers preserved with non-empty parts")
+(assert (= (get result2 :body) "hello world") "body should be concatenated")
+
+# ── variations ────────────────────────────────────────────
+
+# Multiple struct values before the if-apply
+(def result3 {:a {} :b {} :c (if (empty? bp) nil (apply + [1 2]))})
+(assert (= (get result3 :a) {}) "first nested struct preserved")
+(assert (= (get result3 :b) {}) "second nested struct preserved")
+(assert (= (get result3 :c) nil) "if result correct")
+
+# Inside a defn called from different contexts
+(defn build-request [body-parts]
+  {:method  :get
+   :path    "/test"
+   :headers {}
+   :body    (if (empty? body-parts)
+              nil
+              (apply concat (freeze body-parts)))})
+
+(def r1 (build-request @[]))
+(assert (= (get r1 :method) :get) "method from defn")
+(assert (= (get r1 :headers) {}) "headers from defn")
+(assert (= (get r1 :body) nil) "body nil from defn")
+
+(def r2 (build-request @["a" "b"]))
+(assert (= (get r2 :body) "ab") "body concat from defn")
+
+# Inside ev/spawn (original failure context)
+(ev/spawn (fn []
+  (def r3 (build-request @[]))
+  (assert (= (get r3 :headers) {}) "headers in fiber")
+  (assert (= (get r3 :body) nil) "body nil in fiber")))


### PR DESCRIPTION
DupN in ensure_on_top leaves orphan entries on the real VM stack. When this happens inside one branch of an if (e.g. the splice path for apply/CallArrayMut) but not the other, the branches end with different operand-stack depths.  The merge block inherits the deeper branch's state; when the shallower branch executes at runtime, all DupN offsets in the merge block are wrong by the orphan count, shifting struct key-value pairs and putting a struct in a key slot.

Fix: pop_trailing_orphans() before saving stack state in Jump terminators, so all predecessors agree on depth.