### PR TITLE
fix grpc transport for h2 rewrite + add h2 trailer support (#804)

### DIFF
--- a/lib/grpc.lisp
+++ b/lib/grpc.lisp
@@ -43,17 +43,28 @@
 
   ## ── Connect ────────────────────────────────────────────────────────
 
+  (def h2-transport ((import "std/http2/transport")))
+
   (defn grpc-connect [socket-path]
     "Connect to a gRPC server over a Unix socket. Returns an h2 session."
-    (let* [port (unix/connect socket-path)
-           transport (http2:unix-transport port)]
+    (let [transport (h2-transport:tcp (unix/connect socket-path))]
       (http2:connect nil :transport transport)))
 
   ## ── Collect gRPC response from stream ──────────────────────────────
 
+  (defn check-grpc-status [headers]
+    "Check grpc-status in headers/trailers. Raises on non-zero status."
+    (let [status-pair (first (filter (fn [h] (= (get h 0) "grpc-status")) headers))]
+      (when (and status-pair (not (= (get status-pair 1) "0")))
+        (let [msg-pair (first (filter (fn [h] (= (get h 0) "grpc-message")) headers))]
+          (error {:error :grpc-error
+                  :code (parse-int (get status-pair 1))
+                  :message (if msg-pair (get msg-pair 1) "unknown error")})))))
+
   (defn collect-grpc-response [s]
     "Read data + trailers from an h2 stream. Returns raw gRPC frame bytes.
-     Raises on grpc-status != 0."
+     Raises on grpc-status != 0. Handles both trailers-only and
+     headers+data+trailers gRPC responses."
     (let [@resp-headers nil
           @resp-data @[]
           @done false]
@@ -62,14 +73,13 @@
           (match msg:type
             :headers (begin
                        (if (nil? resp-headers)
-                         (assign resp-headers msg:headers)
-                         ## Trailers — check grpc-status
-                         (let [status-pair (first (filter (fn [h] (= (get h 0) "grpc-status")) msg:headers))]
-                           (when (and status-pair (not (= (get status-pair 1) "0")))
-                             (let [msg-pair (first (filter (fn [h] (= (get h 0) "grpc-message")) msg:headers))]
-                               (error {:error :grpc-error
-                                       :code (parse-int (get status-pair 1))
-                                       :message (if msg-pair (get msg-pair 1) "unknown error")})))))
+                         (begin
+                           (assign resp-headers msg:headers)
+                           ## Trailers-only: check grpc-status on initial headers
+                           (when msg:end-stream
+                             (check-grpc-status msg:headers)))
+                         ## Trailers after data
+                         (check-grpc-status msg:headers))
                        (when msg:end-stream (assign done true)))
             :data    (begin (push resp-data msg:data)
                             (when msg:end-stream (assign done true)))
@@ -137,12 +147,7 @@
         (let [msg (s:data-queue:take)]
           (match msg:type
             :headers (begin
-                       (let [status-pair (first (filter (fn [h] (= (get h 0) "grpc-status")) msg:headers))]
-                         (when (and status-pair (not (= (get status-pair 1) "0")))
-                           (let [msg-pair (first (filter (fn [h] (= (get h 0) "grpc-message")) msg:headers))]
-                             (error {:error :grpc-error
-                                     :code (parse-int (get status-pair 1))
-                                     :message (if msg-pair (get msg-pair 1) "unknown error")}))))
+                       (check-grpc-status msg:headers)
                        (when msg:end-stream (assign done true)))
             :data    (begin
                        (assign buf (concat buf msg:data))

--- a/lib/http2.lisp
+++ b/lib/http2.lisp
@@ -165,13 +165,17 @@
     "Send an HTTP/2 request. Returns response struct."
     (let* [[sid s] (send-request-frames sess method path :body body :headers headers)
            @resp-headers nil
+           @resp-trailers nil
            @resp-body @[]
            @done false]
       (while (not done)
         (let [msg (s:data-queue:take)]
           (match msg:type
-            :headers (begin (assign resp-headers msg:headers)
-                            (when msg:end-stream (assign done true)))
+            :headers (begin
+                       (if (nil? resp-headers)
+                         (assign resp-headers msg:headers)
+                         (assign resp-trailers msg:headers))
+                       (when msg:end-stream (assign done true)))
             :data    (begin (push resp-body msg:data)
                             (when msg:end-stream (assign done true)))
             :rst     (error {:error :h2-error :reason :stream-error
@@ -181,17 +185,22 @@
             _        (assign done true))))
       (let* [status-pair (first (filter (fn [h] (= (get h 0) ":status")) resp-headers))
              status (if status-pair (parse-int (get status-pair 1)) 0)
-             hdrs @{}]
+             hdrs @{}
+             trailers @{}]
         (each h in resp-headers
           (let [name (get h 0)
                 value (get h 1)]
             (unless (string/starts-with? name ":")
               (put hdrs (keyword name) value))))
-        {:status  status
-         :headers (freeze hdrs)
-         :body    (if (empty? resp-body)
-                    (bytes)
-                    (apply concat (freeze resp-body)))})))
+        (when resp-trailers
+          (each h in resp-trailers
+            (put trailers (keyword (get h 0)) (get h 1))))
+        {:status   status
+         :headers  (freeze hdrs)
+         :trailers (freeze trailers)
+         :body     (if (empty? resp-body)
+                     (bytes)
+                     (apply concat (freeze resp-body)))})))
 
   (defn h2-send-raw [sess method path &named body headers]
     "Send request, return stream for caller to collect response."

--- a/lib/http2/server.lisp
+++ b/lib/http2/server.lisp
@@ -44,6 +44,7 @@
       (if ok?
         (let* [status (string (or response:status 200))
                resp-headers (or response:headers {})
+               trailers response:trailers
                resp-body (if (nil? response:body)
                            (bytes)
                            (if (string? response:body)
@@ -52,10 +53,15 @@
                @h-pairs @[[":status" status]]
                _ (each k in (keys resp-headers)
                    (push h-pairs [(string k) (string (get resp-headers k))]))
-               has-body (> (length resp-body) 0)]
-          (session:encode-and-send-headers sess sid (freeze h-pairs) (not has-body))
+               has-body (> (length resp-body) 0)
+               has-trailers (and trailers (not (empty? trailers)))
+               end-on-headers (and (not has-body) (not has-trailers))]
+          (session:encode-and-send-headers sess sid (freeze h-pairs) end-on-headers)
           (when has-body
-            (session:send-data-with-flow-control sess sid s:flow resp-body))
+            (session:send-data-with-flow-control sess sid s:flow resp-body
+              :end-stream (not has-trailers)))
+          (when has-trailers
+            (session:encode-and-send-headers sess sid trailers true))
           (stream:transition s :send-end-stream))
         (begin
           (let [h-pairs [[":status" "500"]]

--- a/lib/http2/session.lisp
+++ b/lib/http2/session.lisp
@@ -159,10 +159,14 @@
 
   ## ── DATA with connection + stream flow control ─────────────────────────
 
-  (defn send-data-with-flow-control [session sid s-flow body-bytes]
+  (defn send-data-with-flow-control [session sid s-flow body-bytes
+                                    &named @end-stream]
     "Send DATA frames respecting both connection and per-stream windows.
      Computes allowed = min(remaining, max-frame, conn-window, stream-window)
-     atomically to avoid window leaks."
+     atomically to avoid window leaks.
+     When end-stream is false, omits END_STREAM on the final chunk
+     (used when trailers follow the body)."
+    (default end-stream true)
     (let* [max-frame (get session:remote-settings :max-frame-size)
            @offset 0
            total (length body-bytes)]
@@ -176,7 +180,8 @@
           (when (< allowed conn-allowed)
             (stream:apply-window-update session:conn-flow (- conn-allowed allowed)))
           (let* [chunk (slice body-bytes offset (+ offset allowed))
-                 end? (= (+ offset allowed) total)
+                 last? (= (+ offset allowed) total)
+                 end? (and last? end-stream)
                  [ft fl si pl] (frame:make-data-frame sid chunk end?)]
             (send-frame session ft fl si pl)
             (assign offset (+ offset allowed)))))))

--- a/tests/elle/grpc.lisp
+++ b/tests/elle/grpc.lisp
@@ -1,55 +1,244 @@
 (elle/epoch 9)
-## tests/elle/grpc.lisp — gRPC framing tests
+## tests/elle/grpc.lisp — gRPC client tests
 ##
-## Tests the pure framing functions (encode/decode) without needing a
-## running gRPC server or the protobuf plugin.
+## Part 1: framing (encode/decode) — no network needed.
+## Part 2: integration — full gRPC-over-h2 against http2:serve with trailers.
 
 
-## ── Init with fake protobuf ──────────────────────────────────────
+## ── Dependencies ──────────────────────────────────────────────────
 
-(def fake-pb {:encode (fn [s t d] (bytes 1 2 3))
-              :decode (fn [s t b] {})})
 (def http2 ((import "std/http2")))
-(def grpc  ((import "std/grpc") :http2 http2 :protobuf fake-pb))
 
-## ── Encode: empty payload ────────────────────────────────────────
+## Fake protobuf: encode returns raw bytes, decode returns a struct
+(def fake-pb {:encode (fn [s t d] (bytes 1 2 3))
+              :decode (fn [s t b] {:decoded true :len (length b)})})
+(def grpc ((import "std/grpc") :http2 http2 :protobuf fake-pb))
 
-(let [frame (grpc:encode (bytes))]
-  (assert (= frame (bytes 0 0 0 0 0)) "encode empty: 5-byte header, zero length"))
 
-## ── Encode/decode roundtrip: small payload ───────────────────────
+## ── Helpers ───────────────────────────────────────────────────────
 
-(let* [payload (bytes 10 20 30)
-       frame (grpc:encode payload)
-       decoded (grpc:decode frame)]
-  (assert (= decoded payload) "roundtrip small payload"))
+(defn listen-ephemeral []
+  (let* [listener (tcp/listen "127.0.0.1" 0)
+         lpath (port/path listener)
+         lport (parse-int (slice lpath (+ 1 (string/find lpath ":"))))]
+    [listener lport]))
 
-## ── Encode/decode roundtrip: multi-byte length ───────────────────
+(defn with-server [handler test-fn]
+  "Start an h2-serve listener, run test-fn with session, clean up."
+  (let* [[listener lport] (listen-ephemeral)
+         sf (ev/spawn
+           (fn []
+             (let [[ok? _] (protect (http2:serve listener handler))]
+               nil)))
+         url (concat "http://127.0.0.1:" (string lport))
+         session (http2:connect url)]
+    (defer (begin (protect (http2:close session))
+                  (protect (port/close listener))
+                  (protect (ev/abort sf)))
+      (test-fn session))))
 
-(let* [payload (apply bytes (map (fn [i] (% i 256)) (range 300)))
-       frame (grpc:encode payload)
-       decoded (grpc:decode frame)]
-  (assert (= (length frame) (+ 5 300)) "multi-byte: frame length")
-  (assert (= decoded payload) "multi-byte: roundtrip"))
 
-## ── Decode nil → nil ─────────────────────────────────────────────
+## ── Part 1: Framing tests ────────────────────────────────────────
 
-(assert (nil? (grpc:decode nil)) "decode nil")
+(defn test-encode-empty []
+  (let [frame (grpc:encode (bytes))]
+    (assert (= frame (bytes 0 0 0 0 0)) "encode empty: 5-byte header, zero length")))
 
-## ── Decode truncated frame → nil ─────────────────────────────────
+(defn test-roundtrip-small []
+  (let* [payload (bytes 10 20 30)
+         frame (grpc:encode payload)
+         decoded (grpc:decode frame)]
+    (assert (= decoded payload) "roundtrip small payload")))
 
-(assert (nil? (grpc:decode (bytes 0 0 0))) "decode truncated: 3 bytes")
-(assert (nil? (grpc:decode (bytes 0 0 0 0))) "decode truncated: 4 bytes")
+(defn test-roundtrip-multibyte-length []
+  (let* [payload (apply bytes (map (fn [i] (% i 256)) (range 300)))
+         frame (grpc:encode payload)
+         decoded (grpc:decode frame)]
+    (assert (= (length frame) (+ 5 300)) "multi-byte: frame length")
+    (assert (= decoded payload) "multi-byte: roundtrip")))
 
-## ── Decode length exceeding available bytes → nil ────────────────
+(defn test-decode-nil []
+  (assert (nil? (grpc:decode nil)) "decode nil"))
 
-(let [frame (bytes 0 0 0 0 10 1 2 3)]  # claims 10 bytes, only 3 available
-  (assert (nil? (grpc:decode frame)) "decode: length exceeds data"))
+(defn test-decode-truncated []
+  (assert (nil? (grpc:decode (bytes 0 0 0))) "decode truncated: 3 bytes")
+  (assert (nil? (grpc:decode (bytes 0 0 0 0))) "decode truncated: 4 bytes"))
 
-## ── Verify all export keys exist ─────────────────────────────────
+(defn test-decode-length-exceeds []
+  (let [frame (bytes 0 0 0 0 10 1 2 3)]
+    (assert (nil? (grpc:decode frame)) "decode: length exceeds data")))
 
-(each key in [:connect :call :call-decode :close :encode :decode]
-  (assert (not (nil? (get grpc key)))
-          (string "export key exists: " key)))
+(defn test-exports []
+  (each key in [:connect :call :call-decode :call-stream :close :encode :decode]
+    (assert (not (nil? (get grpc key)))
+            (string "export key exists: " key))))
+
+
+## ── Part 2: Integration tests (gRPC over h2 loopback) ───────────
+
+(defn grpc-handler [req]
+  "Route gRPC requests by path. Returns response with trailers."
+  (let [path req:path
+        body (or req:body (bytes))]
+    (cond
+      ## Echo the body back as gRPC response
+      (= path "/test.Svc/Echo")
+       (let [payload (grpc:decode body)]
+         {:status 200
+          :headers {:content-type "application/grpc"}
+          :body (grpc:encode (or payload (bytes 7 8 9)))
+          :trailers [["grpc-status" "0"]]})
+
+      ## Return a fixed response
+      (= path "/test.Svc/Fixed")
+       {:status 200
+        :headers {:content-type "application/grpc"}
+        :body (grpc:encode (bytes 4 5 6))
+        :trailers [["grpc-status" "0"]]}
+
+      ## Return gRPC error in trailers
+      (= path "/test.Svc/Error")
+       {:status 200
+        :headers {:content-type "application/grpc"}
+        :body (bytes)
+        :trailers [["grpc-status" "13"]
+                   ["grpc-message" "internal error"]]}
+
+      ## Trailers-only error (no body, status in trailers)
+      (= path "/test.Svc/NotFound")
+       {:status 200
+        :headers {:content-type "application/grpc"}
+        :trailers [["grpc-status" "5"]
+                   ["grpc-message" "not found"]]}
+
+      ## Empty success (no data)
+      (= path "/test.Svc/Empty")
+       {:status 200
+        :headers {:content-type "application/grpc"}
+        :trailers [["grpc-status" "0"]]}
+
+      ## Large payload
+      (= path "/test.Svc/Large")
+       (let [big (apply bytes (map (fn [i] (% i 256)) (range 2000)))]
+         {:status 200
+          :headers {:content-type "application/grpc"}
+          :body (grpc:encode big)
+          :trailers [["grpc-status" "0"]]})
+
+      ## Sequential — echo stream ID in response
+      (string/starts-with? path "/test.Svc/Seq")
+       {:status 200
+        :headers {:content-type "application/grpc"}
+        :body (grpc:encode (bytes 42))
+        :trailers [["grpc-status" "0"]]}
+
+      ## Default: not found
+      true
+       {:status 200
+        :headers {:content-type "application/grpc"}
+        :trailers [["grpc-status" "12"]
+                   ["grpc-message" "unimplemented"]]})))
+
+(defn test-unary-rpc []
+  "Full unary gRPC call: connect → send → receive → decode."
+  (with-server grpc-handler
+    (fn [sess]
+      (let [raw (grpc:call sess nil "/test.Svc/Fixed" "test.Req" {})]
+        (assert (not (nil? raw)) "unary: got response bytes")
+        (assert (= raw (bytes 4 5 6)) "unary: response payload matches")))))
+
+(defn test-unary-decode []
+  "Full unary gRPC call with decode: exercises grpc:call-decode."
+  (with-server grpc-handler
+    (fn [sess]
+      (let [result (grpc:call-decode sess nil "/test.Svc/Fixed"
+                     "test.Req" {} "test.Resp")]
+        (assert (= result:decoded true) "decode: fake-pb decoded")
+        (assert (= result:len 3) "decode: correct payload length")))))
+
+(defn test-grpc-error-in-trailers []
+  "Server returns grpc-status != 0 in trailers: client should raise."
+  (with-server grpc-handler
+    (fn [sess]
+      (let [[ok? err] (protect
+            (grpc:call sess nil "/test.Svc/Error" "test.Req" {}))]
+        (assert (not ok?) "error: should raise")
+        (assert (= err:error :grpc-error) "error: type is :grpc-error")
+        (assert (= err:code 13) "error: code 13")
+        (assert (= err:message "internal error") "error: message propagated")))))
+
+(defn test-trailers-only-error []
+  "Server sends trailers-only (no DATA), non-zero status."
+  (with-server grpc-handler
+    (fn [sess]
+      (let [[ok? err] (protect
+            (grpc:call sess nil "/test.Svc/NotFound" "test.Req" {}))]
+        (assert (not ok?) "trailers-only: should raise")
+        (assert (= err:code 5) "trailers-only: code 5")))))
+
+(defn test-empty-response []
+  "Server sends grpc-status 0 with no data — decoded result should be nil."
+  (with-server grpc-handler
+    (fn [sess]
+      (let [raw (grpc:call sess nil "/test.Svc/Empty" "test.Req" {})]
+        (assert (nil? raw) "empty response: nil")))))
+
+(defn test-large-payload []
+  "Unary RPC with payload > 1KB."
+  (let [expected (apply bytes (map (fn [i] (% i 256)) (range 2000)))]
+    (with-server grpc-handler
+      (fn [sess]
+        (let [raw (grpc:call sess nil "/test.Svc/Large" "test.Req" {})]
+          (assert (= (length raw) 2000) "large: correct length")
+          (assert (= raw expected) "large: payload matches"))))))
+
+(defn test-sequential-rpcs []
+  "Multiple sequential unary RPCs on the same session."
+  (with-server grpc-handler
+    (fn [sess]
+      (each i in (range 5)
+        (let [raw (grpc:call sess nil (concat "/test.Svc/Seq" (string i))
+                    "test.Req" {})]
+          (assert (not (nil? raw))
+                  (concat "seq " (string i) ": got response")))))))
+
+
+## ── Run ──────────────────────────────────────────────────────────
+
+(println "tests/elle/grpc.lisp:")
+
+## Framing
+(println "  framing:")
+(test-encode-empty)
+(println "    PASS: encode empty")
+(test-roundtrip-small)
+(println "    PASS: roundtrip small")
+(test-roundtrip-multibyte-length)
+(println "    PASS: roundtrip multi-byte length")
+(test-decode-nil)
+(println "    PASS: decode nil")
+(test-decode-truncated)
+(println "    PASS: decode truncated")
+(test-decode-length-exceeds)
+(println "    PASS: decode length exceeds")
+(test-exports)
+(println "    PASS: all exports present")
+
+## Integration
+(println "  integration:")
+(test-unary-rpc)
+(println "    PASS: unary RPC")
+(test-unary-decode)
+(println "    PASS: unary decode")
+(test-grpc-error-in-trailers)
+(println "    PASS: grpc error in trailers")
+(test-trailers-only-error)
+(println "    PASS: trailers-only error")
+(test-empty-response)
+(println "    PASS: empty response")
+(test-large-payload)
+(println "    PASS: large payload")
+(test-sequential-rpcs)
+(println "    PASS: sequential RPCs")
 
 (println "tests/elle/grpc.lisp: all tests passed")

--- a/tests/h2-same-scheduler.lisp
+++ b/tests/h2-same-scheduler.lisp
@@ -78,10 +78,55 @@
                 (concat "post: body " (string resp:body))))))
   (println "  PASS: request with body"))
 
+## ── Test 4: response with trailers ───────────────────────────────────
+
+(defn test-trailers-with-body []
+  (with-server
+    (fn [req]
+      {:status 200
+       :headers {:content-type "application/grpc"}
+       :body "payload"
+       :trailers [["grpc-status" "0"] ["custom-trailer" "value"]]})
+    (fn [session]
+      (let [resp (http2:send session "GET" "/trailers")]
+        (assert (= resp:status 200) "trailers+body: status 200")
+        (assert (= (string resp:body) "payload") "trailers+body: body")
+        (assert (= resp:trailers:grpc-status "0") "trailers+body: grpc-status")
+        (assert (= resp:trailers:custom-trailer "value") "trailers+body: custom-trailer"))))
+  (println "  PASS: trailers with body"))
+
+## ── Test 5: trailers-only (no body) ─────────────────────────────────
+
+(defn test-trailers-only []
+  (with-server
+    (fn [req]
+      {:status 200
+       :headers {:content-type "application/grpc"}
+       :trailers [["grpc-status" "0"]]})
+    (fn [session]
+      (let [resp (http2:send session "GET" "/trailers-only")]
+        (assert (= resp:status 200) "trailers-only: status 200")
+        (assert (= resp:trailers:grpc-status "0") "trailers-only: grpc-status"))))
+  (println "  PASS: trailers-only (no body)"))
+
+## ── Test 6: no trailers (backward compat) ───────────────────────────
+
+(defn test-no-trailers []
+  (with-server
+    (fn [req] {:status 200 :body "still works"})
+    (fn [session]
+      (let [resp (http2:send session "GET" "/no-trailers")]
+        (assert (= resp:status 200) "no-trailers: status 200")
+        (assert (= (string resp:body) "still works") "no-trailers: body"))))
+  (println "  PASS: no trailers (backward compat)"))
+
 ## ── Run ────────────────────────────────────────────────────────────────
 
 (println "h2 same-scheduler tests:")
 (test-single-request)
 (test-sequential-requests)
 (test-request-with-body)
+(test-trailers-with-body)
+(test-trailers-only)
+(test-no-trailers)
 (println "all h2 same-scheduler tests passed")


### PR DESCRIPTION
- grpc: use h2-transport:tcp instead of removed http2:unix-transport
- grpc: fix collect-grpc-response to handle trailers-only responses (grpc-status in initial headers with end-stream)
- grpc: extract check-grpc-status helper, used by both unary and streaming
- h2/session: add &named end-stream to send-data-with-flow-control (allows omitting END_STREAM when trailers follow)
- h2/server: support :trailers in handler response structs (sends trailing HEADERS frame with END_STREAM after body)
- h2 client: h2-send now separates headers from trailers in response (response struct gains :trailers field)
- tests: comprehensive grpc test suite (framing + 7 integration tests against http2:serve with trailer support)
- tests: h2-same-scheduler gains 3 trailer tests (with body, without body, backward compat)