### PR TITLE
Fix check-grpc-status crash on empty header list

### DIFF
--- a/lib/grpc.lisp
+++ b/lib/grpc.lisp
@@ -52,14 +52,19 @@
 
   ## ── Collect gRPC response from stream ──────────────────────────────
 
+  (defn find-header [headers name]
+    (let [matches (filter (fn [h] (= (h 0) name)) headers)]
+      (when (not (empty? matches)) (first matches))))
+
   (defn check-grpc-status [headers]
     "Check grpc-status in headers/trailers. Raises on non-zero status."
-    (let [status-pair (first (filter (fn [h] (= (get h 0) "grpc-status")) headers))]
-      (when (and status-pair (not (= (get status-pair 1) "0")))
-        (let [msg-pair (first (filter (fn [h] (= (get h 0) "grpc-message")) headers))]
+    (if-let [pair (find-header headers "grpc-status")]
+      (when (not= (pair 1) "0")
+        (let [msg (find-header headers "grpc-message")]
           (error {:error :grpc-error
-                  :code (parse-int (get status-pair 1))
-                  :message (if msg-pair (get msg-pair 1) "unknown error")})))))
+                  :code (parse-int (pair 1))
+                  :message (if msg (msg 1) "unknown error")})))
+      nil))
 
   (defn collect-grpc-response [s]
     "Read data + trailers from an h2 stream. Returns raw gRPC frame bytes.

--- a/tests/elle/grpc.lisp
+++ b/tests/elle/grpc.lisp
@@ -132,6 +132,15 @@
         :body (grpc:encode (bytes 42))
         :trailers [["grpc-status" "0"]]}
 
+      ## Server-streaming: multiple gRPC frames + trailers
+      (= path "/test.Svc/Stream")
+       {:status 200
+        :headers {:content-type "application/grpc"}
+        :body (concat (grpc:encode (bytes 10 11))
+                      (grpc:encode (bytes 20 21))
+                      (grpc:encode (bytes 30 31)))
+        :trailers [["grpc-status" "0"]]}
+
       ## Default: not found
       true
        {:status 200
@@ -203,6 +212,22 @@
                   (concat "seq " (string i) ": got response")))))))
 
 
+(defn test-server-streaming []
+  "Server-streaming RPC: initial headers have no grpc-status, data arrives
+   as multiple gRPC frames, grpc-status comes in trailers."
+  (with-server grpc-handler
+    (fn [sess]
+      (let [reader (grpc:call-stream sess nil "/test.Svc/Stream"
+                     "test.Req" {} "test.Resp")]
+        (def msg1 (reader))
+        (assert (not (nil? msg1)) "stream: got message 1")
+        (def msg2 (reader))
+        (assert (not (nil? msg2)) "stream: got message 2")
+        (def msg3 (reader))
+        (assert (not (nil? msg3)) "stream: got message 3")
+        (def msg4 (reader))
+        (assert (nil? msg4) "stream: nil at end")))))
+
 ## ── Run ──────────────────────────────────────────────────────────
 
 (println "tests/elle/grpc.lisp:")
@@ -240,5 +265,7 @@
 (println "    PASS: large payload")
 (test-sequential-rpcs)
 (println "    PASS: sequential RPCs")
+(test-server-streaming)
+(println "    PASS: server-streaming (call-stream)")
 
 (println "tests/elle/grpc.lisp: all tests passed")


### PR DESCRIPTION
filter returns () (empty list) when no grpc-status header is present. first(()) throws in Elle (nil ≠ ()). Use find-header helper with empty? guard and if-let to handle the missing-header case cleanly.

This broke server-streaming RPCs (call-stream) where the initial response headers don't contain grpc-status — only trailers do.