### PR TITLE
Add socket options to connect and accept primitives

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /target
 /.cargo/
 site/
+demos/embedding/chost
 
 # Profiling data
 perf.data

--- a/lib/grpc.lisp
+++ b/lib/grpc.lisp
@@ -24,28 +24,28 @@
     "Wrap protobuf bytes in gRPC length-prefixed frame."
     (let [len (length message-bytes)]
       (concat (bytes 0  # not compressed
-                      (bit/shr len 24) (bit/and (bit/shr len 16) 0xff)
-                     (bit/and (bit/shr len 8) 0xff) (bit/and len 0xff))
+                     (bit/shr len 24)
+                     (bit/and (bit/shr len 16) 255)
+                     (bit/and (bit/shr len 8) 255)
+                     (bit/and len 255))
               message-bytes)))
-
   (defn grpc-decode [frame-bytes]
     "Extract protobuf bytes from gRPC length-prefixed frame.
      Returns the payload bytes, or nil if frame is empty."
     (when (and frame-bytes (>= (length frame-bytes) 5))
       (let [len (bit/or (bit/shl (get frame-bytes 1) 24)
                         (bit/shl (get frame-bytes 2) 16)
-                        (bit/shl (get frame-bytes 3) 8) (get frame-bytes 4))]
+                        (bit/shl (get frame-bytes 3) 8)
+                        (get frame-bytes 4))]
         (when (>= (length frame-bytes) (+ 5 len))
           (slice frame-bytes 5 (+ 5 len))))))
 
   ## ── Connect ────────────────────────────────────────────────────────
 
   (def h2-transport ((import "std/http2/transport")))
-
   (defn grpc-connect [socket-path]
     "Connect to a gRPC server over a Unix socket. Returns an h2 session."
-    (let [transport (h2-transport:tcp
-                      (unix/connect socket-path :sndbuf 2097152))]
+    (let [transport (h2-transport:tcp (unix/connect socket-path :sndbuf 2097152))]
       (http2:connect nil :transport transport)))
 
   ## ── Collect gRPC response from stream ──────────────────────────────
@@ -53,7 +53,6 @@
   (defn find-header [headers name]
     (let [matches (filter (fn [h] (= (h 0) name)) headers)]
       (when (not (empty? matches)) (first matches))))
-
   (defn check-grpc-status [headers]
     "Check grpc-status in headers/trailers. Raises on non-zero status."
     (if-let [pair (find-header headers "grpc-status")]
@@ -61,8 +60,8 @@
               (let [msg (find-header headers "grpc-message")]
                 (error {:error :grpc-error
                         :code (parse-int (pair 1))
-                        :message (if msg (msg 1) "unknown error")}))) nil))
-
+                        :message (if msg (msg 1) "unknown error")})))
+            nil))
   (defn collect-grpc-response [s]
     "Read data + trailers from an h2 stream. Returns raw gRPC frame bytes.
      Raises on grpc-status != 0. Handles both trailers-only and
@@ -98,11 +97,13 @@
   (defn grpc-call [session schema method request-type request-struct]
     "Make a unary gRPC call. Returns raw protobuf bytes of response."
     (let* [body (grpc-encode (protobuf:encode schema request-type request-struct))
-           stream (http2:send-raw session "POST" method :body body
+           stream (http2:send-raw session
+                                  "POST"
+                                  method
+                                  :body body
                                   :headers [["content-type" "application/grpc"]
                                   ["te" "trailers"]])]
       (collect-grpc-response stream)))
-
   (defn
     grpc-call-decode
     [session schema method request-type request-struct response-type]
@@ -123,7 +124,10 @@
      splits on the 5-byte length-prefixed frame headers."
     (def body (grpc-encode (protobuf:encode schema request-type request-struct)))
     (def s
-      (http2:send-raw session "POST" method :body body
+      (http2:send-raw session
+                      "POST"
+                      method
+                      :body body
                       :headers [["content-type" "application/grpc"]
                                 ["te" "trailers"]]))
     (def @buf (bytes))
@@ -133,8 +137,10 @@
     (fn []  ## Try to extract a complete gRPC frame from buf
       (def @result nil)
       (when (>= (length buf) 5)
-        (let [len (bit/or (bit/shl (get buf 1) 24) (bit/shl (get buf 2) 16)
-                          (bit/shl (get buf 3) 8) (get buf 4))
+        (let [len (bit/or (bit/shl (get buf 1) 24)
+                          (bit/shl (get buf 2) 16)
+                          (bit/shl (get buf 3) 8)
+                          (get buf 4))
               frame-end (+ 5 len)]
           (when (>= (length buf) frame-end)
             (let [payload (slice buf 5 frame-end)]
@@ -156,7 +162,8 @@
                 (when (and (nil? result) (>= (length buf) 5))
                   (let [len (bit/or (bit/shl (get buf 1) 24)
                                     (bit/shl (get buf 2) 16)
-                                    (bit/shl (get buf 3) 8) (get buf 4))
+                                    (bit/shl (get buf 3) 8)
+                                    (get buf 4))
                         frame-end (+ 5 len)]
                     (when (>= (length buf) frame-end)
                       (let [payload (slice buf 5 frame-end)]

--- a/lib/grpc.lisp
+++ b/lib/grpc.lisp
@@ -44,7 +44,8 @@
 
   (defn grpc-connect [socket-path]
     "Connect to a gRPC server over a Unix socket. Returns an h2 session."
-    (let [transport (h2-transport:tcp (unix/connect socket-path))]
+    (let [transport (h2-transport:tcp
+                      (unix/connect socket-path :sndbuf 2097152))]
       (http2:connect nil :transport transport)))
 
   ## ── Collect gRPC response from stream ──────────────────────────────

--- a/src/io/aio.rs
+++ b/src/io/aio.rs
@@ -366,7 +366,7 @@ impl AsyncBackend {
 
         // Dispatch by operation type
         match &request.op {
-            IoOp::Accept => {
+            IoOp::Accept { ref options } => {
                 let listener_kind = Some(port.kind());
 
                 let AsyncBackendInner {
@@ -390,7 +390,9 @@ impl AsyncBackend {
                 pending.insert(
                     id,
                     PendingOp::Port {
-                        op: IoOp::Accept,
+                        op: IoOp::Accept {
+                            options: options.clone(),
+                        },
                         port_key,
                         port: request.port,
                         buffer_handle: buf_handle,
@@ -639,12 +641,18 @@ impl AsyncBackend {
                         // If parsing failed (hostname), fall back to thread pool
                         // which uses TcpStream::connect (calls getaddrinfo internally).
                         let pool_op = match addr {
-                            ConnectAddr::Tcp { addr: host, port } => PoolOp::ConnectTcp {
+                            ConnectAddr::Tcp {
+                                addr: host,
+                                port,
+                                ref options,
+                            } => PoolOp::ConnectTcp {
                                 addr: crate::io::sockaddr::format_host_port(host, *port),
+                                options: options.clone(),
                             },
-                            ConnectAddr::Unix { path } => {
-                                PoolOp::ConnectUnix { path: path.clone() }
-                            }
+                            ConnectAddr::Unix { path, ref options } => PoolOp::ConnectUnix {
+                                path: path.clone(),
+                                options: options.clone(),
+                            },
                         };
                         network_pool.submit(id, pool_op)?;
                         None
@@ -654,10 +662,18 @@ impl AsyncBackend {
             PlatformBackend::ThreadPool(_) => {
                 let _ = buffer_pool;
                 let pool_op = match addr {
-                    ConnectAddr::Tcp { addr: host, port } => PoolOp::ConnectTcp {
+                    ConnectAddr::Tcp {
+                        addr: host,
+                        port,
+                        ref options,
+                    } => PoolOp::ConnectTcp {
                         addr: crate::io::sockaddr::format_host_port(host, *port),
+                        options: options.clone(),
                     },
-                    ConnectAddr::Unix { path } => PoolOp::ConnectUnix { path: path.clone() },
+                    ConnectAddr::Unix { path, ref options } => PoolOp::ConnectUnix {
+                        path: path.clone(),
+                        options: options.clone(),
+                    },
                 };
                 network_pool.submit(id, pool_op)?;
                 None
@@ -668,11 +684,19 @@ impl AsyncBackend {
             id,
             PendingOp::Connect {
                 addr: match addr {
-                    ConnectAddr::Tcp { addr: host, port } => ConnectAddr::Tcp {
+                    ConnectAddr::Tcp {
+                        addr: host,
+                        port,
+                        ref options,
+                    } => ConnectAddr::Tcp {
                         addr: host.clone(),
                         port: *port,
+                        options: options.clone(),
                     },
-                    ConnectAddr::Unix { path } => ConnectAddr::Unix { path: path.clone() },
+                    ConnectAddr::Unix { path, ref options } => ConnectAddr::Unix {
+                        path: path.clone(),
+                        options: options.clone(),
+                    },
                 },
                 buffer_handle: buf_handle,
                 connect_fd: uring_fd,
@@ -1447,7 +1471,7 @@ impl AsyncBackendInner {
             IoOp::ReadAll => StdinOpKind::ReadAll,
             IoOp::Write { .. }
             | IoOp::Flush
-            | IoOp::Accept
+            | IoOp::Accept { .. }
             | IoOp::Connect { .. }
             | IoOp::SendTo { .. }
             | IoOp::RecvFrom { .. }
@@ -1840,7 +1864,9 @@ mod tests {
         let backend = AsyncBackend::new().unwrap();
         let accept_id = backend
             .submit(&IoRequest {
-                op: IoOp::Accept,
+                op: IoOp::Accept {
+                    options: Default::default(),
+                },
                 port: listener_port,
                 timeout: None,
             })
@@ -1931,7 +1957,9 @@ mod tests {
 
         // Submit Accept
         let accept_req = IoRequest {
-            op: IoOp::Accept,
+            op: IoOp::Accept {
+                options: Default::default(),
+            },
             port: listener_port,
             timeout: None,
         };
@@ -1992,6 +2020,7 @@ mod tests {
                 addr: crate::io::request::ConnectAddr::Tcp {
                     addr: "127.0.0.1".to_string(),
                     port: bound_addr.port(),
+                    options: Default::default(),
                 },
             },
             port: Value::NIL,
@@ -2070,7 +2099,9 @@ mod tests {
 
         let accept_id = backend
             .submit(&IoRequest {
-                op: IoOp::Accept,
+                op: IoOp::Accept {
+                    options: Default::default(),
+                },
                 port: listener_port,
                 timeout: None,
             })
@@ -2082,6 +2113,7 @@ mod tests {
                     addr: crate::io::request::ConnectAddr::Tcp {
                         addr: "127.0.0.1".to_string(),
                         port: bound_port,
+                        options: Default::default(),
                     },
                 },
                 port: Value::NIL,

--- a/src/io/aio.rs
+++ b/src/io/aio.rs
@@ -566,14 +566,11 @@ impl AsyncBackend {
                         let _ = buffer_pool;
                         let pool_op = match &request.op {
                             IoOp::ReadLine => PoolOp::ReadLine { fd },
-                            IoOp::Read { .. } | IoOp::ReadAll => {
-                                let size = match &request.op {
-                                    IoOp::Read { count } => *count - read_buffered,
-                                    IoOp::ReadAll => 4096,
-                                    _ => unreachable!(),
-                                };
-                                PoolOp::Read { fd, size }
-                            }
+                            IoOp::ReadAll => PoolOp::ReadAll { fd },
+                            IoOp::Read { count } => PoolOp::Read {
+                                fd,
+                                size: *count - read_buffered,
+                            },
                             IoOp::Write { data } => {
                                 let bytes = Self::extract_write_bytes(data);
                                 PoolOp::Write { fd, data: bytes }

--- a/src/io/completion.rs
+++ b/src/io/completion.rs
@@ -436,7 +436,7 @@ pub(super) fn process_raw_completion(
                     let peer_addr = crate::io::sockaddr::peer_address(fd);
                     let fd = unsafe { OwnedFd::from_raw_fd(fd) };
                     // Apply user-specified socket options to the accepted fd.
-                    crate::io::uring::apply_socket_options(fd.as_raw_fd(), options);
+                    crate::io::request::apply_socket_options(fd.as_raw_fd(), options);
                     let new_port = match listener_kind {
                         Some(PortKind::TcpListener) => {
                             set_tcp_nodelay(&fd);

--- a/src/io/completion.rs
+++ b/src/io/completion.rs
@@ -171,10 +171,10 @@ pub(super) fn process_raw_completion(
             let fd = connect_fd.unwrap_or(result_code as RawFd);
             let fd = unsafe { OwnedFd::from_raw_fd(fd) };
             let peer_addr = match addr {
-                ConnectAddr::Tcp { addr: host, port } => {
-                    crate::io::sockaddr::format_host_port(host, *port)
-                }
-                ConnectAddr::Unix { path } => path.clone(),
+                ConnectAddr::Tcp {
+                    addr: host, port, ..
+                } => crate::io::sockaddr::format_host_port(host, *port),
+                ConnectAddr::Unix { path, .. } => path.clone(),
             };
             let new_port = match addr {
                 ConnectAddr::Tcp { .. } => {
@@ -429,12 +429,14 @@ pub(super) fn process_raw_completion(
                 }
                 IoOp::Write { .. } | IoOp::SendTo { .. } => Value::int(result_code as i64),
                 IoOp::Flush | IoOp::Shutdown { .. } | IoOp::Sleep { .. } => Value::NIL,
-                IoOp::Accept => {
+                IoOp::Accept { ref options } => {
                     // Accept: result_code is the new fd (from both io_uring and thread pool).
                     // Peer address is obtained via getpeername() — works uniformly.
                     let fd = result_code;
                     let peer_addr = crate::io::sockaddr::peer_address(fd);
                     let fd = unsafe { OwnedFd::from_raw_fd(fd) };
+                    // Apply user-specified socket options to the accepted fd.
+                    crate::io::uring::apply_socket_options(fd.as_raw_fd(), options);
                     let new_port = match listener_kind {
                         Some(PortKind::TcpListener) => {
                             set_tcp_nodelay(&fd);

--- a/src/io/mock.rs
+++ b/src/io/mock.rs
@@ -110,7 +110,7 @@ impl crate::io::IoBackend for MockBackend {
             IoOp::ReadAll => "read-all",
             IoOp::Write { .. } => "write",
             IoOp::Flush => "flush",
-            IoOp::Accept => "accept",
+            IoOp::Accept { .. } => "accept",
             IoOp::Connect { .. } => "connect",
             IoOp::SendTo { .. } => "send-to",
             IoOp::RecvFrom { .. } => "recv-from",
@@ -172,7 +172,7 @@ impl crate::io::IoBackend for MockBackend {
                     });
                     return Ok(id);
                 }
-                IoOp::Accept => Err(error_val("io-error", "mock: accept not supported")),
+                IoOp::Accept { .. } => Err(error_val("io-error", "mock: accept not supported")),
                 IoOp::Connect { .. } => Err(error_val("io-error", "mock: connect not supported")),
                 IoOp::SendTo { data, .. } => {
                     let len = data

--- a/src/io/request.rs
+++ b/src/io/request.rs
@@ -245,6 +245,50 @@ pub struct SocketOptions {
     pub keepalive: Option<bool>,
 }
 
+/// Apply socket options (SO_SNDBUF, SO_RCVBUF, TCP_NODELAY, SO_KEEPALIVE) to a socket fd.
+pub(crate) fn apply_socket_options(fd: std::os::unix::io::RawFd, opts: &SocketOptions) {
+    unsafe {
+        if let Some(val) = opts.sndbuf {
+            libc::setsockopt(
+                fd,
+                libc::SOL_SOCKET,
+                libc::SO_SNDBUF,
+                &val as *const i32 as *const libc::c_void,
+                std::mem::size_of::<i32>() as libc::socklen_t,
+            );
+        }
+        if let Some(val) = opts.rcvbuf {
+            libc::setsockopt(
+                fd,
+                libc::SOL_SOCKET,
+                libc::SO_RCVBUF,
+                &val as *const i32 as *const libc::c_void,
+                std::mem::size_of::<i32>() as libc::socklen_t,
+            );
+        }
+        if let Some(val) = opts.nodelay {
+            let opt: i32 = val as i32;
+            libc::setsockopt(
+                fd,
+                libc::IPPROTO_TCP,
+                libc::TCP_NODELAY,
+                &opt as *const i32 as *const libc::c_void,
+                std::mem::size_of::<i32>() as libc::socklen_t,
+            );
+        }
+        if let Some(val) = opts.keepalive {
+            let opt: i32 = val as i32;
+            libc::setsockopt(
+                fd,
+                libc::SOL_SOCKET,
+                libc::SO_KEEPALIVE,
+                &opt as *const i32 as *const libc::c_void,
+                std::mem::size_of::<i32>() as libc::socklen_t,
+            );
+        }
+    }
+}
+
 /// Address for connect operations.
 #[derive(Debug)]
 pub enum ConnectAddr {

--- a/src/io/request.rs
+++ b/src/io/request.rs
@@ -178,7 +178,8 @@ pub enum IoOp {
     /// Returns the logical byte offset as int.
     Tell,
     /// Accept a connection on a listener. Returns new stream port.
-    Accept,
+    /// Socket options are applied to the accepted fd after accept(2).
+    Accept { options: SocketOptions },
     /// Connect to a remote address. Returns connected stream port.
     Connect { addr: ConnectAddr },
     /// Send data to a remote address via UDP. Returns bytes sent.
@@ -235,11 +236,36 @@ pub enum IoOp {
     },
 }
 
+/// Socket options for connect operations.
+#[derive(Debug, Default, Clone)]
+pub struct SocketOptions {
+    pub sndbuf: Option<i32>,
+    pub rcvbuf: Option<i32>,
+    pub nodelay: Option<bool>,
+    pub keepalive: Option<bool>,
+}
+
 /// Address for connect operations.
 #[derive(Debug)]
 pub enum ConnectAddr {
-    Tcp { addr: String, port: u16 },
-    Unix { path: String },
+    Tcp {
+        addr: String,
+        port: u16,
+        options: SocketOptions,
+    },
+    Unix {
+        path: String,
+        options: SocketOptions,
+    },
+}
+
+impl ConnectAddr {
+    pub fn options(&self) -> &SocketOptions {
+        match self {
+            ConnectAddr::Tcp { options, .. } => options,
+            ConnectAddr::Unix { options, .. } => options,
+        }
+    }
 }
 
 /// A typed I/O request. Wrapped as ExternalObject with type_name "io-request".

--- a/src/io/threadpool.rs
+++ b/src/io/threadpool.rs
@@ -155,16 +155,28 @@ impl ThreadPoolBackend {
                     }
                 }
                 PoolOp::Write { fd, data } => {
-                    let ret = unsafe {
-                        libc::write(fd, data.as_ptr() as *const libc::c_void, data.len())
-                    };
-                    if ret < 0 {
-                        (
-                            -(std::io::Error::last_os_error().raw_os_error().unwrap_or(1)),
-                            Vec::new(),
-                        )
-                    } else {
-                        (ret as i32, Vec::new())
+                    let mut total = 0usize;
+                    loop {
+                        let ret = unsafe {
+                            libc::write(
+                                fd,
+                                data[total..].as_ptr() as *const libc::c_void,
+                                data.len() - total,
+                            )
+                        };
+                        if ret < 0 {
+                            if total == 0 {
+                                break (
+                                    -(std::io::Error::last_os_error().raw_os_error().unwrap_or(1)),
+                                    Vec::new(),
+                                );
+                            }
+                            break (total as i32, Vec::new());
+                        }
+                        total += ret as usize;
+                        if total >= data.len() {
+                            break (total as i32, Vec::new());
+                        }
                     }
                 }
                 PoolOp::Flush { fd } => {

--- a/src/io/threadpool.rs
+++ b/src/io/threadpool.rs
@@ -115,38 +115,16 @@ impl ThreadPoolBackend {
             let (result_code, data) = match op {
                 PoolOp::Read { fd, size } => {
                     let mut buf = vec![0u8; size];
-                    let mut total = 0usize;
-                    loop {
-                        let ret = unsafe {
-                            libc::read(
-                                fd,
-                                buf[total..].as_mut_ptr() as *mut libc::c_void,
-                                size - total,
-                            )
-                        };
-                        if ret < 0 {
-                            if total == 0 {
-                                break (
-                                    -(std::io::Error::last_os_error().raw_os_error().unwrap_or(1)),
-                                    Vec::new(),
-                                );
-                            }
-                            // Return whatever we accumulated before the error
-                            break (total as i32, {
-                                buf.truncate(total);
-                                buf
-                            });
-                        }
-                        if ret == 0 {
-                            break (total as i32, {
-                                buf.truncate(total);
-                                buf
-                            });
-                        }
-                        total += ret as usize;
-                        if total >= size {
-                            break (total as i32, buf);
-                        }
+                    let ret =
+                        unsafe { libc::read(fd, buf.as_mut_ptr() as *mut libc::c_void, size) };
+                    if ret < 0 {
+                        (
+                            -(std::io::Error::last_os_error().raw_os_error().unwrap_or(1)),
+                            Vec::new(),
+                        )
+                    } else {
+                        buf.truncate(ret as usize);
+                        (ret as i32, buf)
                     }
                 }
                 PoolOp::ReadLine { fd } => {

--- a/src/io/threadpool.rs
+++ b/src/io/threadpool.rs
@@ -237,7 +237,7 @@ impl ThreadPoolBackend {
                     Ok(stream) => {
                         let peer = stream.peer_addr().map(|a| a.to_string()).unwrap_or(addr);
                         let new_fd = stream.into_raw_fd();
-                        crate::io::uring::apply_socket_options(new_fd, &options);
+                        crate::io::request::apply_socket_options(new_fd, &options);
                         (new_fd, peer.into_bytes())
                     }
                     Err(e) => (
@@ -253,7 +253,7 @@ impl ThreadPoolBackend {
                             Vec::new(),
                         )
                     } else {
-                        crate::io::uring::apply_socket_options(sock_fd, &options);
+                        crate::io::request::apply_socket_options(sock_fd, &options);
                         match crate::io::sockaddr::build_unix(&path) {
                             Err(msg) => {
                                 unsafe { libc::close(sock_fd) };

--- a/src/io/threadpool.rs
+++ b/src/io/threadpool.rs
@@ -66,6 +66,10 @@ pub(super) enum PoolOp {
     ReadLine {
         fd: RawFd,
     },
+    /// Read until EOF. Loops internally, accumulating all data.
+    ReadAll {
+        fd: RawFd,
+    },
     /// Blocking read on an inotify/kqueue fd for filesystem watch events.
     WatchRead {
         fd: RawFd,
@@ -127,7 +131,8 @@ impl ThreadPoolBackend {
                         (ret as i32, buf)
                     }
                 }
-                PoolOp::ReadLine { fd } => {
+                PoolOp::ReadLine { fd } | PoolOp::ReadAll { fd } => {
+                    let until_newline = matches!(op, PoolOp::ReadLine { .. });
                     let mut accumulated = Vec::new();
                     let mut chunk = vec![0u8; 4096];
                     loop {
@@ -149,7 +154,7 @@ impl ThreadPoolBackend {
                             break (accumulated.len() as i32, accumulated);
                         }
                         accumulated.extend_from_slice(&chunk[..ret as usize]);
-                        if accumulated.contains(&b'\n') {
+                        if until_newline && accumulated.contains(&b'\n') {
                             break (accumulated.len() as i32, accumulated);
                         }
                     }

--- a/src/io/threadpool.rs
+++ b/src/io/threadpool.rs
@@ -1,5 +1,6 @@
 //! Thread-pool backend and stdin thread for async I/O.
 
+use crate::io::request::SocketOptions;
 use std::os::unix::io::{IntoRawFd, RawFd};
 
 /// Typed thread-pool operation (replaces `op_kind: u8` + overloaded `data`/`size`/`fd`).
@@ -20,9 +21,11 @@ pub(super) enum PoolOp {
     },
     ConnectTcp {
         addr: String,
+        options: SocketOptions,
     },
     ConnectUnix {
         path: String,
+        options: SocketOptions,
     },
     SendTo {
         fd: RawFd,
@@ -230,10 +233,11 @@ impl ThreadPoolBackend {
                         (new_fd, result_data)
                     }
                 }
-                PoolOp::ConnectTcp { addr } => match std::net::TcpStream::connect(&addr) {
+                PoolOp::ConnectTcp { addr, options } => match std::net::TcpStream::connect(&addr) {
                     Ok(stream) => {
                         let peer = stream.peer_addr().map(|a| a.to_string()).unwrap_or(addr);
                         let new_fd = stream.into_raw_fd();
+                        crate::io::uring::apply_socket_options(new_fd, &options);
                         (new_fd, peer.into_bytes())
                     }
                     Err(e) => (
@@ -241,7 +245,7 @@ impl ThreadPoolBackend {
                         format!("{}", e).into_bytes(),
                     ),
                 },
-                PoolOp::ConnectUnix { path } => {
+                PoolOp::ConnectUnix { path, options } => {
                     let sock_fd = unsafe { libc::socket(libc::AF_UNIX, libc::SOCK_STREAM, 0) };
                     if sock_fd < 0 {
                         (
@@ -249,6 +253,7 @@ impl ThreadPoolBackend {
                             Vec::new(),
                         )
                     } else {
+                        crate::io::uring::apply_socket_options(sock_fd, &options);
                         match crate::io::sockaddr::build_unix(&path) {
                             Err(msg) => {
                                 unsafe { libc::close(sock_fd) };

--- a/src/io/uring.rs
+++ b/src/io/uring.rs
@@ -4,13 +4,57 @@ use crate::io::aio::TIMEOUT_USER_DATA_TAG;
 use crate::io::completion::process_raw_completion;
 use crate::io::pending::PendingOp;
 use crate::io::pool::{BufferHandle, BufferPool};
-use crate::io::request::{ConnectAddr, IoOp};
+use crate::io::request::{ConnectAddr, IoOp, SocketOptions};
 use crate::io::types::{FdState, PortKey};
 use crate::io::Completion;
 use crate::port::{Port, PortKind};
 use std::collections::{HashMap, VecDeque};
 use std::os::unix::io::RawFd;
 use std::time::Duration;
+
+/// Apply socket options (SO_SNDBUF, SO_RCVBUF, TCP_NODELAY, SO_KEEPALIVE) to a socket fd.
+pub(super) fn apply_socket_options(fd: RawFd, opts: &SocketOptions) {
+    unsafe {
+        if let Some(val) = opts.sndbuf {
+            libc::setsockopt(
+                fd,
+                libc::SOL_SOCKET,
+                libc::SO_SNDBUF,
+                &val as *const i32 as *const libc::c_void,
+                std::mem::size_of::<i32>() as libc::socklen_t,
+            );
+        }
+        if let Some(val) = opts.rcvbuf {
+            libc::setsockopt(
+                fd,
+                libc::SOL_SOCKET,
+                libc::SO_RCVBUF,
+                &val as *const i32 as *const libc::c_void,
+                std::mem::size_of::<i32>() as libc::socklen_t,
+            );
+        }
+        if let Some(val) = opts.nodelay {
+            let opt: i32 = val as i32;
+            libc::setsockopt(
+                fd,
+                libc::IPPROTO_TCP,
+                libc::TCP_NODELAY,
+                &opt as *const i32 as *const libc::c_void,
+                std::mem::size_of::<i32>() as libc::socklen_t,
+            );
+        }
+        if let Some(val) = opts.keepalive {
+            let opt: i32 = val as i32;
+            libc::setsockopt(
+                fd,
+                libc::SOL_SOCKET,
+                libc::SO_KEEPALIVE,
+                &opt as *const i32 as *const libc::c_void,
+                std::mem::size_of::<i32>() as libc::socklen_t,
+            );
+        }
+    }
+}
 
 /// Submit a stream I/O operation (Read, ReadLine, ReadAll, Write, Flush).
 ///
@@ -158,6 +202,7 @@ pub(super) fn submit_uring_connect(
         ConnectAddr::Tcp {
             addr: host,
             port: port_num,
+            ..
         } => {
             let resolved = format!("{}:{}", host, port_num)
                 .parse::<std::net::SocketAddr>()
@@ -179,7 +224,7 @@ pub(super) fn submit_uring_connect(
             let (sa_bytes, sa_len) = crate::io::sockaddr::build_inet(&resolved);
             (fd, sa_bytes, sa_len)
         }
-        ConnectAddr::Unix { path } => {
+        ConnectAddr::Unix { path, .. } => {
             let fd =
                 unsafe { libc::socket(libc::AF_UNIX, libc::SOCK_STREAM | libc::SOCK_NONBLOCK, 0) };
             if fd < 0 {
@@ -205,6 +250,9 @@ pub(super) fn submit_uring_connect(
             (fd, bytes, addr_len)
         }
     };
+
+    // Apply socket options before connect
+    apply_socket_options(sock_fd, addr.options());
 
     // Stash the sockaddr in the caller's buffer so it lives until the CQE
     // completes. The caller passes its buf_handle — no second allocation.
@@ -962,4 +1010,214 @@ pub(super) fn submit_uring_watch_next(
     ring.submit()
         .map_err(|e| format!("io/submit: io_uring submit failed: {}", e))?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Verify apply_socket_options actually sets SO_SNDBUF on a socket fd.
+    #[test]
+    fn test_apply_sndbuf() {
+        let fd = unsafe { libc::socket(libc::AF_UNIX, libc::SOCK_STREAM, 0) };
+        assert!(fd >= 0, "socket() failed");
+
+        let opts = SocketOptions {
+            sndbuf: Some(1048576),
+            ..Default::default()
+        };
+        apply_socket_options(fd, &opts);
+
+        let mut val: i32 = 0;
+        let mut len: libc::socklen_t = std::mem::size_of::<i32>() as libc::socklen_t;
+        let ret = unsafe {
+            libc::getsockopt(
+                fd,
+                libc::SOL_SOCKET,
+                libc::SO_SNDBUF,
+                &mut val as *mut i32 as *mut libc::c_void,
+                &mut len,
+            )
+        };
+        unsafe { libc::close(fd) };
+        assert_eq!(ret, 0, "getsockopt failed");
+        // Linux doubles the value (adds overhead accounting)
+        assert!(
+            val >= 1048576,
+            "SO_SNDBUF should be >= requested: got {}",
+            val
+        );
+    }
+
+    /// Verify apply_socket_options actually sets SO_RCVBUF.
+    #[test]
+    fn test_apply_rcvbuf() {
+        let fd = unsafe { libc::socket(libc::AF_UNIX, libc::SOCK_STREAM, 0) };
+        assert!(fd >= 0, "socket() failed");
+
+        let opts = SocketOptions {
+            rcvbuf: Some(524288),
+            ..Default::default()
+        };
+        apply_socket_options(fd, &opts);
+
+        let mut val: i32 = 0;
+        let mut len: libc::socklen_t = std::mem::size_of::<i32>() as libc::socklen_t;
+        let ret = unsafe {
+            libc::getsockopt(
+                fd,
+                libc::SOL_SOCKET,
+                libc::SO_RCVBUF,
+                &mut val as *mut i32 as *mut libc::c_void,
+                &mut len,
+            )
+        };
+        unsafe { libc::close(fd) };
+        assert_eq!(ret, 0, "getsockopt failed");
+        assert!(
+            val >= 524288,
+            "SO_RCVBUF should be >= requested: got {}",
+            val
+        );
+    }
+
+    /// Verify SO_KEEPALIVE is actually enabled.
+    #[test]
+    fn test_apply_keepalive() {
+        let fd = unsafe { libc::socket(libc::AF_INET, libc::SOCK_STREAM, 0) };
+        assert!(fd >= 0, "socket() failed");
+
+        let opts = SocketOptions {
+            keepalive: Some(true),
+            ..Default::default()
+        };
+        apply_socket_options(fd, &opts);
+
+        let mut val: i32 = 0;
+        let mut len: libc::socklen_t = std::mem::size_of::<i32>() as libc::socklen_t;
+        let ret = unsafe {
+            libc::getsockopt(
+                fd,
+                libc::SOL_SOCKET,
+                libc::SO_KEEPALIVE,
+                &mut val as *mut i32 as *mut libc::c_void,
+                &mut len,
+            )
+        };
+        unsafe { libc::close(fd) };
+        assert_eq!(ret, 0, "getsockopt failed");
+        assert_eq!(val, 1, "SO_KEEPALIVE should be enabled");
+    }
+
+    /// Verify TCP_NODELAY is actually enabled.
+    #[test]
+    fn test_apply_nodelay() {
+        let fd = unsafe { libc::socket(libc::AF_INET, libc::SOCK_STREAM, 0) };
+        assert!(fd >= 0, "socket() failed");
+
+        let opts = SocketOptions {
+            nodelay: Some(true),
+            ..Default::default()
+        };
+        apply_socket_options(fd, &opts);
+
+        let mut val: i32 = 0;
+        let mut len: libc::socklen_t = std::mem::size_of::<i32>() as libc::socklen_t;
+        let ret = unsafe {
+            libc::getsockopt(
+                fd,
+                libc::IPPROTO_TCP,
+                libc::TCP_NODELAY,
+                &mut val as *mut i32 as *mut libc::c_void,
+                &mut len,
+            )
+        };
+        unsafe { libc::close(fd) };
+        assert_eq!(ret, 0, "getsockopt failed");
+        assert_eq!(val, 1, "TCP_NODELAY should be enabled");
+    }
+
+    /// TCP_NODELAY on a Unix socket doesn't panic (silently ignored).
+    #[test]
+    fn test_nodelay_on_unix_is_harmless() {
+        let fd = unsafe { libc::socket(libc::AF_UNIX, libc::SOCK_STREAM, 0) };
+        assert!(fd >= 0, "socket() failed");
+
+        let opts = SocketOptions {
+            nodelay: Some(true),
+            ..Default::default()
+        };
+        apply_socket_options(fd, &opts);
+        unsafe { libc::close(fd) };
+    }
+
+    /// Default SocketOptions is a no-op.
+    #[test]
+    fn test_default_is_noop() {
+        let fd = unsafe { libc::socket(libc::AF_INET, libc::SOCK_STREAM, 0) };
+        assert!(fd >= 0, "socket() failed");
+
+        let mut before: i32 = 0;
+        let mut len: libc::socklen_t = std::mem::size_of::<i32>() as libc::socklen_t;
+        unsafe {
+            libc::getsockopt(
+                fd,
+                libc::SOL_SOCKET,
+                libc::SO_SNDBUF,
+                &mut before as *mut i32 as *mut libc::c_void,
+                &mut len,
+            );
+        }
+
+        apply_socket_options(fd, &SocketOptions::default());
+
+        let mut after: i32 = 0;
+        unsafe {
+            libc::getsockopt(
+                fd,
+                libc::SOL_SOCKET,
+                libc::SO_SNDBUF,
+                &mut after as *mut i32 as *mut libc::c_void,
+                &mut len,
+            );
+        }
+        unsafe { libc::close(fd) };
+        assert_eq!(before, after, "default options should not change SO_SNDBUF");
+    }
+
+    /// All four options can be set together without conflict.
+    #[test]
+    fn test_all_combined() {
+        let fd = unsafe { libc::socket(libc::AF_INET, libc::SOCK_STREAM, 0) };
+        assert!(fd >= 0, "socket() failed");
+
+        let opts = SocketOptions {
+            sndbuf: Some(2097152),
+            rcvbuf: Some(1048576),
+            nodelay: Some(true),
+            keepalive: Some(true),
+        };
+        apply_socket_options(fd, &opts);
+
+        let read_opt = |level: i32, optname: i32| -> i32 {
+            let mut val: i32 = 0;
+            let mut len: libc::socklen_t = std::mem::size_of::<i32>() as libc::socklen_t;
+            unsafe {
+                libc::getsockopt(
+                    fd,
+                    level,
+                    optname,
+                    &mut val as *mut i32 as *mut libc::c_void,
+                    &mut len,
+                );
+            }
+            val
+        };
+
+        assert!(read_opt(libc::SOL_SOCKET, libc::SO_SNDBUF) >= 2097152);
+        assert!(read_opt(libc::SOL_SOCKET, libc::SO_RCVBUF) >= 1048576);
+        assert_eq!(read_opt(libc::IPPROTO_TCP, libc::TCP_NODELAY), 1);
+        assert_eq!(read_opt(libc::SOL_SOCKET, libc::SO_KEEPALIVE), 1);
+        unsafe { libc::close(fd) };
+    }
 }

--- a/src/io/uring.rs
+++ b/src/io/uring.rs
@@ -4,57 +4,13 @@ use crate::io::aio::TIMEOUT_USER_DATA_TAG;
 use crate::io::completion::process_raw_completion;
 use crate::io::pending::PendingOp;
 use crate::io::pool::{BufferHandle, BufferPool};
-use crate::io::request::{ConnectAddr, IoOp, SocketOptions};
+use crate::io::request::{apply_socket_options, ConnectAddr, IoOp};
 use crate::io::types::{FdState, PortKey};
 use crate::io::Completion;
 use crate::port::{Port, PortKind};
 use std::collections::{HashMap, VecDeque};
 use std::os::unix::io::RawFd;
 use std::time::Duration;
-
-/// Apply socket options (SO_SNDBUF, SO_RCVBUF, TCP_NODELAY, SO_KEEPALIVE) to a socket fd.
-pub(super) fn apply_socket_options(fd: RawFd, opts: &SocketOptions) {
-    unsafe {
-        if let Some(val) = opts.sndbuf {
-            libc::setsockopt(
-                fd,
-                libc::SOL_SOCKET,
-                libc::SO_SNDBUF,
-                &val as *const i32 as *const libc::c_void,
-                std::mem::size_of::<i32>() as libc::socklen_t,
-            );
-        }
-        if let Some(val) = opts.rcvbuf {
-            libc::setsockopt(
-                fd,
-                libc::SOL_SOCKET,
-                libc::SO_RCVBUF,
-                &val as *const i32 as *const libc::c_void,
-                std::mem::size_of::<i32>() as libc::socklen_t,
-            );
-        }
-        if let Some(val) = opts.nodelay {
-            let opt: i32 = val as i32;
-            libc::setsockopt(
-                fd,
-                libc::IPPROTO_TCP,
-                libc::TCP_NODELAY,
-                &opt as *const i32 as *const libc::c_void,
-                std::mem::size_of::<i32>() as libc::socklen_t,
-            );
-        }
-        if let Some(val) = opts.keepalive {
-            let opt: i32 = val as i32;
-            libc::setsockopt(
-                fd,
-                libc::SOL_SOCKET,
-                libc::SO_KEEPALIVE,
-                &opt as *const i32 as *const libc::c_void,
-                std::mem::size_of::<i32>() as libc::socklen_t,
-            );
-        }
-    }
-}
 
 /// Submit a stream I/O operation (Read, ReadLine, ReadAll, Write, Flush).
 ///
@@ -1015,6 +971,7 @@ pub(super) fn submit_uring_watch_next(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::io::request::SocketOptions;
 
     /// Verify apply_socket_options actually sets SO_SNDBUF on a socket fd.
     #[test]

--- a/src/primitives/kwarg.rs
+++ b/src/primitives/kwarg.rs
@@ -3,9 +3,16 @@
 //! Provides `extract_keyword_timeout` for parsing optional `:timeout ms`
 //! keyword arguments from primitive arg slices.
 
+use crate::io::request::SocketOptions;
 use crate::value::fiber::{SignalBits, SIG_ERROR};
 use crate::value::{error_val, Value};
 use std::time::Duration;
+
+/// Parsed keyword arguments for connect primitives.
+pub(crate) struct ConnectKwargs {
+    pub timeout: Option<Duration>,
+    pub options: SocketOptions,
+}
 
 /// Scan args starting at `start` for keyword-value pairs.
 ///
@@ -94,6 +101,157 @@ pub(crate) fn extract_keyword_timeout(
     Ok(timeout)
 }
 
+/// Extract connect keyword arguments: `:timeout`, `:sndbuf`, `:rcvbuf`, `:nodelay`, `:keepalive`.
+///
+/// Returns `ConnectKwargs` with parsed socket options.
+pub(crate) fn extract_connect_kwargs(
+    args: &[Value],
+    start: usize,
+    prim_name: &str,
+) -> Result<ConnectKwargs, (SignalBits, Value)> {
+    let mut result = ConnectKwargs {
+        timeout: None,
+        options: SocketOptions::default(),
+    };
+
+    if args.len() <= start {
+        return Ok(result);
+    }
+
+    let remaining = &args[start..];
+    if !remaining.len().is_multiple_of(2) {
+        return Err((
+            SIG_ERROR,
+            error_val(
+                "arity-error",
+                format!(
+                    "{}: keyword arguments must be key-value pairs, got odd count",
+                    prim_name
+                ),
+            ),
+        ));
+    }
+
+    let mut i = 0;
+    while i < remaining.len() {
+        let key = &remaining[i];
+        let val = &remaining[i + 1];
+
+        match key.as_keyword_name().as_deref() {
+            Some("timeout") => match val.as_int() {
+                Some(ms) if ms >= 0 => {
+                    result.timeout = Some(Duration::from_millis(ms as u64));
+                }
+                Some(ms) => {
+                    return Err((
+                        SIG_ERROR,
+                        error_val(
+                            "value-error",
+                            format!("{}: :timeout must be non-negative, got {}", prim_name, ms),
+                        ),
+                    ));
+                }
+                None => {
+                    return Err((
+                        SIG_ERROR,
+                        error_val(
+                            "type-error",
+                            format!(
+                                "{}: :timeout value must be integer, got {}",
+                                prim_name,
+                                val.type_name()
+                            ),
+                        ),
+                    ));
+                }
+            },
+            Some("sndbuf") => {
+                result.options.sndbuf = Some(extract_positive_int(val, "sndbuf", prim_name)?);
+            }
+            Some("rcvbuf") => {
+                result.options.rcvbuf = Some(extract_positive_int(val, "rcvbuf", prim_name)?);
+            }
+            Some("nodelay") => {
+                result.options.nodelay = Some(extract_bool(val, "nodelay", prim_name)?);
+            }
+            Some("keepalive") => {
+                result.options.keepalive = Some(extract_bool(val, "keepalive", prim_name)?);
+            }
+            Some(other) => {
+                return Err((
+                    SIG_ERROR,
+                    error_val(
+                        "value-error",
+                        format!("{}: unknown keyword :{}", prim_name, other),
+                    ),
+                ));
+            }
+            None => {
+                return Err((
+                    SIG_ERROR,
+                    error_val(
+                        "type-error",
+                        format!("{}: expected keyword, got {}", prim_name, key.type_name()),
+                    ),
+                ));
+            }
+        }
+        i += 2;
+    }
+
+    Ok(result)
+}
+
+fn extract_positive_int(
+    val: &Value,
+    name: &str,
+    prim_name: &str,
+) -> Result<i32, (SignalBits, Value)> {
+    match val.as_int() {
+        Some(n) if n > 0 && n <= i32::MAX as i64 => Ok(n as i32),
+        Some(n) => Err((
+            SIG_ERROR,
+            error_val(
+                "value-error",
+                format!(
+                    "{}: :{} must be a positive integer, got {}",
+                    prim_name, name, n
+                ),
+            ),
+        )),
+        None => Err((
+            SIG_ERROR,
+            error_val(
+                "type-error",
+                format!(
+                    "{}: :{} value must be integer, got {}",
+                    prim_name,
+                    name,
+                    val.type_name()
+                ),
+            ),
+        )),
+    }
+}
+
+fn extract_bool(val: &Value, name: &str, prim_name: &str) -> Result<bool, (SignalBits, Value)> {
+    match val.as_bool() {
+        Some(b) => Ok(b),
+        None => Err((
+            SIG_ERROR,
+            error_val(
+                "type-error",
+                format!(
+                    "{}: :{} value must be boolean, got {}",
+                    prim_name,
+                    name,
+                    val.type_name()
+                ),
+            ),
+        )),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -164,5 +322,53 @@ mod tests {
         let args = [Value::string("positional")];
         let result = extract_keyword_timeout(&args, 1, "test").unwrap();
         assert_eq!(result, None);
+    }
+
+    // --- ConnectKwargs tests ---
+
+    #[test]
+    fn test_connect_kwargs_sndbuf() {
+        let args = [Value::keyword("sndbuf"), Value::int(1048576)];
+        let result = extract_connect_kwargs(&args, 0, "test").unwrap();
+        assert_eq!(result.options.sndbuf, Some(1048576));
+        assert!(result.timeout.is_none());
+    }
+
+    #[test]
+    fn test_connect_kwargs_combined() {
+        let args = [
+            Value::keyword("sndbuf"),
+            Value::int(2097152),
+            Value::keyword("timeout"),
+            Value::int(5000),
+        ];
+        let result = extract_connect_kwargs(&args, 0, "test").unwrap();
+        assert_eq!(result.options.sndbuf, Some(2097152));
+        assert_eq!(result.timeout, Some(Duration::from_millis(5000)));
+    }
+
+    #[test]
+    fn test_connect_kwargs_nodelay() {
+        let args = [Value::keyword("nodelay"), Value::TRUE];
+        let result = extract_connect_kwargs(&args, 0, "test").unwrap();
+        assert_eq!(result.options.nodelay, Some(true));
+    }
+
+    #[test]
+    fn test_connect_kwargs_negative_sndbuf_errors() {
+        let args = [Value::keyword("sndbuf"), Value::int(-1)];
+        assert!(extract_connect_kwargs(&args, 0, "test").is_err());
+    }
+
+    #[test]
+    fn test_connect_kwargs_string_sndbuf_errors() {
+        let args = [Value::keyword("sndbuf"), Value::string("foo")];
+        assert!(extract_connect_kwargs(&args, 0, "test").is_err());
+    }
+
+    #[test]
+    fn test_connect_kwargs_unknown_keyword_errors() {
+        let args = [Value::keyword("bogus"), Value::int(1)];
+        assert!(extract_connect_kwargs(&args, 0, "test").is_err());
     }
 }

--- a/src/primitives/net.rs
+++ b/src/primitives/net.rs
@@ -9,7 +9,7 @@
 use crate::io::request::{ConnectAddr, IoOp, IoRequest};
 use crate::port::{Port, PortKind};
 use crate::primitives::def::PrimitiveDef;
-use crate::primitives::kwarg::extract_keyword_timeout;
+use crate::primitives::kwarg::{extract_connect_kwargs, extract_keyword_timeout};
 use crate::signals::Signal;
 use crate::value::fiber::{SignalBits, SIG_ERROR, SIG_IO, SIG_OK, SIG_YIELD};
 use crate::value::types::Arity;
@@ -244,23 +244,29 @@ fn prim_tcp_listen(args: &[Value]) -> (SignalBits, Value) {
     }
 }
 
-/// (tcp/accept listener [:timeout ms]) → stream-port
+/// (tcp/accept listener [:sndbuf n] [:rcvbuf n] [:nodelay bool] [:keepalive bool] [:timeout ms]) → stream-port
 fn prim_tcp_accept(args: &[Value]) -> (SignalBits, Value) {
     let port_val = match extract_port_of_kind(&args[0], PortKind::TcpListener, "tcp/accept") {
         Ok(v) => v,
         Err(e) => return e,
     };
-    let timeout = match extract_keyword_timeout(args, 1, "tcp/accept") {
-        Ok(t) => t,
+    let kwargs = match extract_connect_kwargs(args, 1, "tcp/accept") {
+        Ok(k) => k,
         Err(e) => return e,
     };
     (
         SIG_YIELD | SIG_IO,
-        IoRequest::with_timeout(IoOp::Accept, port_val, timeout),
+        IoRequest::with_timeout(
+            IoOp::Accept {
+                options: kwargs.options,
+            },
+            port_val,
+            kwargs.timeout,
+        ),
     )
 }
 
-/// (tcp/connect addr port [:timeout ms]) → stream-port
+/// (tcp/connect addr port [:sndbuf n] [:rcvbuf n] [:nodelay bool] [:keepalive bool] [:timeout ms]) → stream-port
 fn prim_tcp_connect(args: &[Value]) -> (SignalBits, Value) {
     let addr = match extract_string(&args[0], "addr", "tcp/connect") {
         Ok(s) => s,
@@ -270,18 +276,22 @@ fn prim_tcp_connect(args: &[Value]) -> (SignalBits, Value) {
         Ok(p) => p,
         Err(e) => return e,
     };
-    let timeout = match extract_keyword_timeout(args, 2, "tcp/connect") {
-        Ok(t) => t,
+    let kwargs = match extract_connect_kwargs(args, 2, "tcp/connect") {
+        Ok(k) => k,
         Err(e) => return e,
     };
     (
         SIG_YIELD | SIG_IO,
         IoRequest::with_timeout(
             IoOp::Connect {
-                addr: ConnectAddr::Tcp { addr, port },
+                addr: ConnectAddr::Tcp {
+                    addr,
+                    port,
+                    options: kwargs.options,
+                },
             },
             Value::NIL,
-            timeout,
+            kwargs.timeout,
         ),
     )
 }

--- a/src/primitives/unix.rs
+++ b/src/primitives/unix.rs
@@ -3,7 +3,7 @@
 use crate::io::request::{ConnectAddr, IoOp, IoRequest};
 use crate::port::{Port, PortKind};
 use crate::primitives::def::PrimitiveDef;
-use crate::primitives::kwarg::extract_keyword_timeout;
+use crate::primitives::kwarg::extract_connect_kwargs;
 use crate::signals::Signal;
 use crate::value::fiber::{SignalBits, SIG_ERROR, SIG_IO, SIG_OK, SIG_YIELD};
 use crate::value::types::Arity;
@@ -89,40 +89,49 @@ pub(crate) fn prim_unix_listen(args: &[Value]) -> (SignalBits, Value) {
     (SIG_OK, Value::external("port", p))
 }
 
-/// (unix/accept listener [:timeout ms]) → stream-port
+/// (unix/accept listener [:sndbuf n] [:rcvbuf n] [:keepalive bool] [:timeout ms]) → stream-port
 pub(crate) fn prim_unix_accept(args: &[Value]) -> (SignalBits, Value) {
     let port_val = match extract_port_of_kind(&args[0], PortKind::UnixListener, "unix/accept") {
         Ok(v) => v,
         Err(e) => return e,
     };
-    let timeout = match extract_keyword_timeout(args, 1, "unix/accept") {
-        Ok(t) => t,
+    let kwargs = match extract_connect_kwargs(args, 1, "unix/accept") {
+        Ok(k) => k,
         Err(e) => return e,
     };
     (
         SIG_YIELD | SIG_IO,
-        IoRequest::with_timeout(IoOp::Accept, port_val, timeout),
+        IoRequest::with_timeout(
+            IoOp::Accept {
+                options: kwargs.options,
+            },
+            port_val,
+            kwargs.timeout,
+        ),
     )
 }
 
-/// (unix/connect path [:timeout ms]) → stream-port
+/// (unix/connect path [:sndbuf n] [:rcvbuf n] [:keepalive bool] [:timeout ms]) → stream-port
 pub(crate) fn prim_unix_connect(args: &[Value]) -> (SignalBits, Value) {
     let path = match extract_string(&args[0], "path", "unix/connect") {
         Ok(s) => s,
         Err(e) => return e,
     };
-    let timeout = match extract_keyword_timeout(args, 1, "unix/connect") {
-        Ok(t) => t,
+    let kwargs = match extract_connect_kwargs(args, 1, "unix/connect") {
+        Ok(k) => k,
         Err(e) => return e,
     };
     (
         SIG_YIELD | SIG_IO,
         IoRequest::with_timeout(
             IoOp::Connect {
-                addr: ConnectAddr::Unix { path },
+                addr: ConnectAddr::Unix {
+                    path,
+                    options: kwargs.options,
+                },
             },
             Value::NIL,
-            timeout,
+            kwargs.timeout,
         ),
     )
 }

--- a/tests/elle/socket-options.lisp
+++ b/tests/elle/socket-options.lisp
@@ -8,18 +8,18 @@
 # ── Helpers ──────────────────────────────────────────────────────────
 
 (defn echo-server [listener]
-  "Accept one connection, read a chunk, write it back, close."
+  "Accept one connection, read until EOF, write it back, close."
   (ev/spawn (fn []
     (let [conn (unix/accept listener :timeout 5000)
-          data (port/read conn 65536)]
+          data (port/read-all conn)]
       (port/write conn data)
       (port/close conn)))))
 
 (defn tcp-echo-server [listener]
-  "Accept one connection, read a chunk, write it back, close."
+  "Accept one connection, read until EOF, write it back, close."
   (ev/spawn (fn []
     (let [conn (tcp/accept listener :timeout 5000)
-          data (port/read conn 65536)]
+          data (port/read-all conn)]
       (port/write conn data)
       (port/close conn)))))
 
@@ -35,7 +35,8 @@
   (echo-server listener)
   (let [conn (unix/connect path :sndbuf 1048576 :timeout 5000)]
     (port/write conn "hello-sndbuf")
-    (let [resp (string (port/read conn 1024))]
+    (unix/shutdown conn :write)
+    (let [resp (string (port/read-all conn))]
       (assert (= resp "hello-sndbuf") "unix :sndbuf roundtrip"))
     (port/close conn))
   (port/close listener))
@@ -47,7 +48,8 @@
   (echo-server listener)
   (let [conn (unix/connect path :rcvbuf 1048576 :timeout 5000)]
     (port/write conn "hello-rcvbuf")
-    (let [resp (string (port/read conn 1024))]
+    (unix/shutdown conn :write)
+    (let [resp (string (port/read-all conn))]
       (assert (= resp "hello-rcvbuf") "unix :rcvbuf roundtrip"))
     (port/close conn))
   (port/close listener))
@@ -59,7 +61,8 @@
   (tcp-echo-server listener)
   (let [conn (tcp/connect "127.0.0.1" port :sndbuf 1048576 :timeout 5000)]
     (port/write conn "hello-tcp-sndbuf")
-    (let [resp (string (port/read conn 1024))]
+    (tcp/shutdown conn :write)
+    (let [resp (string (port/read-all conn))]
       (assert (= resp "hello-tcp-sndbuf") "tcp :sndbuf roundtrip"))
     (port/close conn))
   (port/close listener))
@@ -71,7 +74,8 @@
   (tcp-echo-server listener)
   (let [conn (tcp/connect "127.0.0.1" port :nodelay true :timeout 5000)]
     (port/write conn "hello-nodelay")
-    (let [resp (string (port/read conn 1024))]
+    (tcp/shutdown conn :write)
+    (let [resp (string (port/read-all conn))]
       (assert (= resp "hello-nodelay") "tcp :nodelay roundtrip"))
     (port/close conn))
   (port/close listener))
@@ -83,7 +87,8 @@
   (tcp-echo-server listener)
   (let [conn (tcp/connect "127.0.0.1" port :keepalive true :timeout 5000)]
     (port/write conn "hello-keepalive")
-    (let [resp (string (port/read conn 1024))]
+    (tcp/shutdown conn :write)
+    (let [resp (string (port/read-all conn))]
       (assert (= resp "hello-keepalive") "tcp :keepalive roundtrip"))
     (port/close conn))
   (port/close listener))
@@ -95,7 +100,8 @@
   (tcp-echo-server listener)
   (let [conn (tcp/connect "127.0.0.1" port :rcvbuf 1048576 :timeout 5000)]
     (port/write conn "hello-tcp-rcvbuf")
-    (let [resp (string (port/read conn 1024))]
+    (tcp/shutdown conn :write)
+    (let [resp (string (port/read-all conn))]
       (assert (= resp "hello-tcp-rcvbuf") "tcp :rcvbuf roundtrip"))
     (port/close conn))
   (port/close listener))
@@ -107,7 +113,8 @@
   (echo-server listener)
   (let [conn (unix/connect path :keepalive true :timeout 5000)]
     (port/write conn "hello-unix-keepalive")
-    (let [resp (string (port/read conn 1024))]
+    (unix/shutdown conn :write)
+    (let [resp (string (port/read-all conn))]
       (assert (= resp "hello-unix-keepalive") "unix :keepalive roundtrip"))
     (port/close conn))
   (port/close listener))
@@ -119,7 +126,8 @@
   (echo-server listener)
   (let [conn (unix/connect path :sndbuf 1048576 :timeout 5000)]
     (port/write conn "combined-test")
-    (let [resp (string (port/read conn 1024))]
+    (unix/shutdown conn :write)
+    (let [resp (string (port/read-all conn))]
       (assert (= resp "combined-test") "unix combined :sndbuf :timeout"))
     (port/close conn))
   (port/close listener))
@@ -133,7 +141,8 @@
                :sndbuf 1048576 :rcvbuf 524288 :nodelay true :keepalive true
                :timeout 5000)]
     (port/write conn "all-four-options")
-    (let [resp (string (port/read conn 1024))]
+    (tcp/shutdown conn :write)
+    (let [resp (string (port/read-all conn))]
       (assert (= resp "all-four-options") "tcp all four options combined"))
     (port/close conn))
   (port/close listener))
@@ -245,12 +254,13 @@
       port (tcp-port listener)]
   (ev/spawn (fn []
     (let [conn (tcp/accept listener :sndbuf 1048576 :timeout 5000)
-          data (port/read conn 65536)]
+          data (port/read-all conn)]
       (port/write conn data)
       (port/close conn))))
   (let [conn (tcp/connect "127.0.0.1" port :timeout 5000)]
     (port/write conn "accept-tcp-sndbuf")
-    (let [resp (string (port/read conn 1024))]
+    (tcp/shutdown conn :write)
+    (let [resp (string (port/read-all conn))]
       (assert (= resp "accept-tcp-sndbuf") "tcp/accept :sndbuf roundtrip"))
     (port/close conn))
   (port/close listener))

--- a/tests/elle/socket-options.lisp
+++ b/tests/elle/socket-options.lisp
@@ -8,18 +8,18 @@
 # ── Helpers ──────────────────────────────────────────────────────────
 
 (defn echo-server [listener]
-  "Accept one connection, read until EOF, write it back, close."
+  "Accept one connection, read a chunk, write it back, close."
   (ev/spawn (fn []
     (let [conn (unix/accept listener :timeout 5000)
-          data (port/read-all conn)]
+          data (port/read conn 65536)]
       (port/write conn data)
       (port/close conn)))))
 
 (defn tcp-echo-server [listener]
-  "Accept one connection, read until EOF, write it back, close."
+  "Accept one connection, read a chunk, write it back, close."
   (ev/spawn (fn []
     (let [conn (tcp/accept listener :timeout 5000)
-          data (port/read-all conn)]
+          data (port/read conn 65536)]
       (port/write conn data)
       (port/close conn)))))
 
@@ -35,8 +35,7 @@
   (echo-server listener)
   (let [conn (unix/connect path :sndbuf 1048576 :timeout 5000)]
     (port/write conn "hello-sndbuf")
-    (unix/shutdown conn :write)
-    (let [resp (string (port/read-all conn))]
+    (let [resp (string (port/read conn 1024))]
       (assert (= resp "hello-sndbuf") "unix :sndbuf roundtrip"))
     (port/close conn))
   (port/close listener))
@@ -48,8 +47,7 @@
   (echo-server listener)
   (let [conn (unix/connect path :rcvbuf 1048576 :timeout 5000)]
     (port/write conn "hello-rcvbuf")
-    (unix/shutdown conn :write)
-    (let [resp (string (port/read-all conn))]
+    (let [resp (string (port/read conn 1024))]
       (assert (= resp "hello-rcvbuf") "unix :rcvbuf roundtrip"))
     (port/close conn))
   (port/close listener))
@@ -61,8 +59,7 @@
   (tcp-echo-server listener)
   (let [conn (tcp/connect "127.0.0.1" port :sndbuf 1048576 :timeout 5000)]
     (port/write conn "hello-tcp-sndbuf")
-    (tcp/shutdown conn :write)
-    (let [resp (string (port/read-all conn))]
+    (let [resp (string (port/read conn 1024))]
       (assert (= resp "hello-tcp-sndbuf") "tcp :sndbuf roundtrip"))
     (port/close conn))
   (port/close listener))
@@ -74,8 +71,7 @@
   (tcp-echo-server listener)
   (let [conn (tcp/connect "127.0.0.1" port :nodelay true :timeout 5000)]
     (port/write conn "hello-nodelay")
-    (tcp/shutdown conn :write)
-    (let [resp (string (port/read-all conn))]
+    (let [resp (string (port/read conn 1024))]
       (assert (= resp "hello-nodelay") "tcp :nodelay roundtrip"))
     (port/close conn))
   (port/close listener))
@@ -87,8 +83,7 @@
   (tcp-echo-server listener)
   (let [conn (tcp/connect "127.0.0.1" port :keepalive true :timeout 5000)]
     (port/write conn "hello-keepalive")
-    (tcp/shutdown conn :write)
-    (let [resp (string (port/read-all conn))]
+    (let [resp (string (port/read conn 1024))]
       (assert (= resp "hello-keepalive") "tcp :keepalive roundtrip"))
     (port/close conn))
   (port/close listener))
@@ -100,8 +95,7 @@
   (tcp-echo-server listener)
   (let [conn (tcp/connect "127.0.0.1" port :rcvbuf 1048576 :timeout 5000)]
     (port/write conn "hello-tcp-rcvbuf")
-    (tcp/shutdown conn :write)
-    (let [resp (string (port/read-all conn))]
+    (let [resp (string (port/read conn 1024))]
       (assert (= resp "hello-tcp-rcvbuf") "tcp :rcvbuf roundtrip"))
     (port/close conn))
   (port/close listener))
@@ -113,8 +107,7 @@
   (echo-server listener)
   (let [conn (unix/connect path :keepalive true :timeout 5000)]
     (port/write conn "hello-unix-keepalive")
-    (unix/shutdown conn :write)
-    (let [resp (string (port/read-all conn))]
+    (let [resp (string (port/read conn 1024))]
       (assert (= resp "hello-unix-keepalive") "unix :keepalive roundtrip"))
     (port/close conn))
   (port/close listener))
@@ -126,8 +119,7 @@
   (echo-server listener)
   (let [conn (unix/connect path :sndbuf 1048576 :timeout 5000)]
     (port/write conn "combined-test")
-    (unix/shutdown conn :write)
-    (let [resp (string (port/read-all conn))]
+    (let [resp (string (port/read conn 1024))]
       (assert (= resp "combined-test") "unix combined :sndbuf :timeout"))
     (port/close conn))
   (port/close listener))
@@ -141,8 +133,7 @@
                :sndbuf 1048576 :rcvbuf 524288 :nodelay true :keepalive true
                :timeout 5000)]
     (port/write conn "all-four-options")
-    (tcp/shutdown conn :write)
-    (let [resp (string (port/read-all conn))]
+    (let [resp (string (port/read conn 1024))]
       (assert (= resp "all-four-options") "tcp all four options combined"))
     (port/close conn))
   (port/close listener))
@@ -254,13 +245,12 @@
       port (tcp-port listener)]
   (ev/spawn (fn []
     (let [conn (tcp/accept listener :sndbuf 1048576 :timeout 5000)
-          data (port/read-all conn)]
+          data (port/read conn 65536)]
       (port/write conn data)
       (port/close conn))))
   (let [conn (tcp/connect "127.0.0.1" port :timeout 5000)]
     (port/write conn "accept-tcp-sndbuf")
-    (tcp/shutdown conn :write)
-    (let [resp (string (port/read-all conn))]
+    (let [resp (string (port/read conn 1024))]
       (assert (= resp "accept-tcp-sndbuf") "tcp/accept :sndbuf roundtrip"))
     (port/close conn))
   (port/close listener))

--- a/tests/elle/socket-options.lisp
+++ b/tests/elle/socket-options.lisp
@@ -10,18 +10,18 @@
 (defn echo-server [listener]
   "Accept one connection, read a chunk, write it back, close."
   (ev/spawn (fn []
-    (let [conn (unix/accept listener :timeout 5000)
-          data (port/read conn 65536)]
-      (port/write conn data)
-      (port/close conn)))))
+              (let [conn (unix/accept listener :timeout 5000)
+                    data (port/read conn 65536)]
+                (port/write conn data)
+                (port/close conn)))))
 
 (defn tcp-echo-server [listener]
   "Accept one connection, read a chunk, write it back, close."
   (ev/spawn (fn []
-    (let [conn (tcp/accept listener :timeout 5000)
-          data (port/read conn 65536)]
-      (port/write conn data)
-      (port/close conn)))))
+              (let [conn (tcp/accept listener :timeout 5000)
+                    data (port/read conn 65536)]
+                (port/write conn data)
+                (port/close conn)))))
 
 (defn tcp-port [listener]
   "Extract the numeric port from a listener's path (e.g. '127.0.0.1:8080')."
@@ -129,9 +129,13 @@
 (let [listener (tcp/listen "127.0.0.1" 0)
       port (tcp-port listener)]
   (tcp-echo-server listener)
-  (let [conn (tcp/connect "127.0.0.1" port
-               :sndbuf 1048576 :rcvbuf 524288 :nodelay true :keepalive true
-               :timeout 5000)]
+  (let [conn (tcp/connect "127.0.0.1"
+                          port
+                          :sndbuf 1048576
+                          :rcvbuf 524288
+                          :nodelay true
+                          :keepalive true
+                          :timeout 5000)]
     (port/write conn "all-four-options")
     (let [resp (string (port/read conn 1024))]
       (assert (= resp "all-four-options") "tcp all four options combined"))
@@ -193,11 +197,11 @@
 (defn large-read-server [listener]
   "Accept one connection, read all data, write back the byte count, close."
   (ev/spawn (fn []
-    (let [conn (unix/accept listener :timeout 10000)
-          data (port/read-all conn)
-          count (string (length data))]
-      (port/write conn count)
-      (port/close conn)))))
+              (let [conn (unix/accept listener :timeout 10000)
+                    data (port/read-all conn)
+                    count (string (length data))]
+                (port/write conn count)
+                (port/close conn)))))
 
 (let [path "/tmp/elle-test-sockopt-large.sock"
       listener (unix/listen path)
@@ -208,7 +212,8 @@
     (port/write conn payload)
     (unix/shutdown conn :write)
     (let [resp (string (port/read-all conn))]
-      (assert (= resp (string size)) "large unix write: server received all bytes"))
+      (assert (= resp (string size))
+              "large unix write: server received all bytes"))
     (port/close conn))
   (port/close listener))
 
@@ -221,10 +226,10 @@
 (defn large-write-server [listener size]
   "Accept with :sndbuf, read all, write back the full payload."
   (ev/spawn (fn []
-    (let [conn (unix/accept listener :sndbuf 2097152 :timeout 10000)
-          data (port/read-all conn)]
-      (port/write conn data)
-      (port/close conn)))))
+              (let [conn (unix/accept listener :sndbuf 2097152 :timeout 10000)
+                    data (port/read-all conn)]
+                (port/write conn data)
+                (port/close conn)))))
 
 (let [path "/tmp/elle-test-sockopt-accept-sndbuf.sock"
       listener (unix/listen path)
@@ -244,10 +249,10 @@
 (let [listener (tcp/listen "127.0.0.1" 0)
       port (tcp-port listener)]
   (ev/spawn (fn []
-    (let [conn (tcp/accept listener :sndbuf 1048576 :timeout 5000)
-          data (port/read conn 65536)]
-      (port/write conn data)
-      (port/close conn))))
+              (let [conn (tcp/accept listener :sndbuf 1048576 :timeout 5000)
+                    data (port/read conn 65536)]
+                (port/write conn data)
+                (port/close conn))))
   (let [conn (tcp/connect "127.0.0.1" port :timeout 5000)]
     (port/write conn "accept-tcp-sndbuf")
     (let [resp (string (port/read conn 1024))]

--- a/tests/elle/socket-options.lisp
+++ b/tests/elle/socket-options.lisp
@@ -1,0 +1,272 @@
+(elle/epoch 9)
+# Socket options tests — :sndbuf, :rcvbuf, :nodelay, :keepalive on connect primitives
+#
+# Tests verify that socket option keywords are accepted, correctly validated,
+# and produce working connections. Rust-level tests (uring::tests) verify
+# the actual setsockopt/getsockopt round-trip on the fd.
+
+# ── Helpers ──────────────────────────────────────────────────────────
+
+(defn echo-server [listener]
+  "Accept one connection, read a chunk, write it back, close."
+  (ev/spawn (fn []
+    (let [conn (unix/accept listener :timeout 5000)
+          data (port/read conn 65536)]
+      (port/write conn data)
+      (port/close conn)))))
+
+(defn tcp-echo-server [listener]
+  "Accept one connection, read a chunk, write it back, close."
+  (ev/spawn (fn []
+    (let [conn (tcp/accept listener :timeout 5000)
+          data (port/read conn 65536)]
+      (port/write conn data)
+      (port/close conn)))))
+
+(defn tcp-port [listener]
+  "Extract the numeric port from a listener's path (e.g. '127.0.0.1:8080')."
+  (let [parts (string/split (port/path listener) ":")]
+    (parse-int (get parts (- (length parts) 1)))))
+
+# ── 1. unix/connect :sndbuf — basic roundtrip ────────────────────────
+
+(let [path "/tmp/elle-test-sockopt-sndbuf.sock"
+      listener (unix/listen path)]
+  (echo-server listener)
+  (let [conn (unix/connect path :sndbuf 1048576 :timeout 5000)]
+    (port/write conn "hello-sndbuf")
+    (let [resp (string (port/read conn 1024))]
+      (assert (= resp "hello-sndbuf") "unix :sndbuf roundtrip"))
+    (port/close conn))
+  (port/close listener))
+
+# ── 2. unix/connect :rcvbuf — basic roundtrip ────────────────────────
+
+(let [path "/tmp/elle-test-sockopt-rcvbuf.sock"
+      listener (unix/listen path)]
+  (echo-server listener)
+  (let [conn (unix/connect path :rcvbuf 1048576 :timeout 5000)]
+    (port/write conn "hello-rcvbuf")
+    (let [resp (string (port/read conn 1024))]
+      (assert (= resp "hello-rcvbuf") "unix :rcvbuf roundtrip"))
+    (port/close conn))
+  (port/close listener))
+
+# ── 3. tcp/connect :sndbuf — basic roundtrip ─────────────────────────
+
+(let [listener (tcp/listen "127.0.0.1" 0)
+      port (tcp-port listener)]
+  (tcp-echo-server listener)
+  (let [conn (tcp/connect "127.0.0.1" port :sndbuf 1048576 :timeout 5000)]
+    (port/write conn "hello-tcp-sndbuf")
+    (let [resp (string (port/read conn 1024))]
+      (assert (= resp "hello-tcp-sndbuf") "tcp :sndbuf roundtrip"))
+    (port/close conn))
+  (port/close listener))
+
+# ── 4. tcp/connect :nodelay — basic roundtrip ────────────────────────
+
+(let [listener (tcp/listen "127.0.0.1" 0)
+      port (tcp-port listener)]
+  (tcp-echo-server listener)
+  (let [conn (tcp/connect "127.0.0.1" port :nodelay true :timeout 5000)]
+    (port/write conn "hello-nodelay")
+    (let [resp (string (port/read conn 1024))]
+      (assert (= resp "hello-nodelay") "tcp :nodelay roundtrip"))
+    (port/close conn))
+  (port/close listener))
+
+# ── 5. tcp/connect :keepalive — basic roundtrip ──────────────────────
+
+(let [listener (tcp/listen "127.0.0.1" 0)
+      port (tcp-port listener)]
+  (tcp-echo-server listener)
+  (let [conn (tcp/connect "127.0.0.1" port :keepalive true :timeout 5000)]
+    (port/write conn "hello-keepalive")
+    (let [resp (string (port/read conn 1024))]
+      (assert (= resp "hello-keepalive") "tcp :keepalive roundtrip"))
+    (port/close conn))
+  (port/close listener))
+
+# ── 6. tcp/connect :rcvbuf — option works on TCP too ─────────────────
+
+(let [listener (tcp/listen "127.0.0.1" 0)
+      port (tcp-port listener)]
+  (tcp-echo-server listener)
+  (let [conn (tcp/connect "127.0.0.1" port :rcvbuf 1048576 :timeout 5000)]
+    (port/write conn "hello-tcp-rcvbuf")
+    (let [resp (string (port/read conn 1024))]
+      (assert (= resp "hello-tcp-rcvbuf") "tcp :rcvbuf roundtrip"))
+    (port/close conn))
+  (port/close listener))
+
+# ── 7. unix/connect :keepalive — option works on Unix too ────────────
+
+(let [path "/tmp/elle-test-sockopt-keepalive-unix.sock"
+      listener (unix/listen path)]
+  (echo-server listener)
+  (let [conn (unix/connect path :keepalive true :timeout 5000)]
+    (port/write conn "hello-unix-keepalive")
+    (let [resp (string (port/read conn 1024))]
+      (assert (= resp "hello-unix-keepalive") "unix :keepalive roundtrip"))
+    (port/close conn))
+  (port/close listener))
+
+# ── 8. Combined — :sndbuf + :timeout on unix ─────────────────────────
+
+(let [path "/tmp/elle-test-sockopt-combined.sock"
+      listener (unix/listen path)]
+  (echo-server listener)
+  (let [conn (unix/connect path :sndbuf 1048576 :timeout 5000)]
+    (port/write conn "combined-test")
+    (let [resp (string (port/read conn 1024))]
+      (assert (= resp "combined-test") "unix combined :sndbuf :timeout"))
+    (port/close conn))
+  (port/close listener))
+
+# ── 9. All four options on tcp/connect ────────────────────────────────
+
+(let [listener (tcp/listen "127.0.0.1" 0)
+      port (tcp-port listener)]
+  (tcp-echo-server listener)
+  (let [conn (tcp/connect "127.0.0.1" port
+               :sndbuf 1048576 :rcvbuf 524288 :nodelay true :keepalive true
+               :timeout 5000)]
+    (port/write conn "all-four-options")
+    (let [resp (string (port/read conn 1024))]
+      (assert (= resp "all-four-options") "tcp all four options combined"))
+    (port/close conn))
+  (port/close listener))
+
+# ── 10. Error: :sndbuf with string value ──────────────────────────────
+
+(let [[ok? err] (protect ((fn [] (unix/connect "/tmp/x.sock" :sndbuf "foo"))))]
+  (assert (not ok?) ":sndbuf string value signals type error"))
+
+# ── 11. Error: :sndbuf with negative value ────────────────────────────
+
+(let [[ok? err] (protect ((fn [] (unix/connect "/tmp/x.sock" :sndbuf -1))))]
+  (assert (not ok?) ":sndbuf negative value signals error"))
+
+# ── 12. Error: :sndbuf with zero ──────────────────────────────────────
+
+(let [[ok? err] (protect ((fn [] (unix/connect "/tmp/x.sock" :sndbuf 0))))]
+  (assert (not ok?) ":sndbuf zero signals error"))
+
+# ── 13. Error: unknown keyword ────────────────────────────────────────
+
+(let [[ok? err] (protect ((fn [] (unix/connect "/tmp/x.sock" :bogus 1))))]
+  (assert (not ok?) "unknown keyword :bogus signals error"))
+
+# ── 14. Error: :nodelay with non-boolean ──────────────────────────────
+
+(let [[ok? err] (protect ((fn [] (tcp/connect "127.0.0.1" 1234 :nodelay 42))))]
+  (assert (not ok?) ":nodelay with int signals type error"))
+
+# ── 15. Error: :keepalive with string ─────────────────────────────────
+
+(let [[ok? err] (protect ((fn [] (tcp/connect "127.0.0.1" 1234 :keepalive "yes"))))]
+  (assert (not ok?) ":keepalive with string signals type error"))
+
+# ── 16. Error: :rcvbuf with float ─────────────────────────────────────
+
+(let [[ok? err] (protect ((fn [] (unix/connect "/tmp/x.sock" :rcvbuf 3.14))))]
+  (assert (not ok?) ":rcvbuf with float signals type error"))
+
+# ── 17. Error: odd keyword count ──────────────────────────────────────
+
+(let [[ok? err] (protect ((fn [] (unix/connect "/tmp/x.sock" :sndbuf))))]
+  (assert (not ok?) "odd keyword count signals arity error"))
+
+# ── 18. Error: non-keyword key ───────────────────────────────────────
+
+(let [[ok? err] (protect ((fn [] (unix/connect "/tmp/x.sock" 42 1048576))))]
+  (assert (not ok?) "non-keyword key signals type error"))
+
+# ── 19. Large unix write — :sndbuf enables 300KB single write ────────
+#
+# Without an enlarged send buffer, a single port/write of 300KB to a Unix
+# socket may block (default kernel buffer ~208KB). With :sndbuf 2MB the
+# write completes. The server reads all data and reports the byte count
+# back, proving the full payload traversed the socket.
+
+(defn large-read-server [listener]
+  "Accept one connection, read all data, write back the byte count, close."
+  (ev/spawn (fn []
+    (let [conn (unix/accept listener :timeout 10000)
+          data (port/read-all conn)
+          count (string (length data))]
+      (port/write conn count)
+      (port/close conn)))))
+
+(let [path "/tmp/elle-test-sockopt-large.sock"
+      listener (unix/listen path)
+      size 307200
+      payload (string/repeat "A" size)]
+  (large-read-server listener)
+  (let [conn (unix/connect path :sndbuf 2097152 :timeout 10000)]
+    (port/write conn payload)
+    (unix/shutdown conn :write)
+    (let [resp (string (port/read-all conn))]
+      (assert (= resp (string size)) "large unix write: server received all bytes"))
+    (port/close conn))
+  (port/close listener))
+
+# ── 20. unix/accept :sndbuf — server-side buffer ─────────────────────
+#
+# The server accepts with :sndbuf 2MB, then writes back 300KB.
+# Without enlarged send buffer on the accepted socket, the server's
+# write can deadlock against the default ~208KB kernel buffer.
+
+(defn large-write-server [listener size]
+  "Accept with :sndbuf, read all, write back the full payload."
+  (ev/spawn (fn []
+    (let [conn (unix/accept listener :sndbuf 2097152 :timeout 10000)
+          data (port/read-all conn)]
+      (port/write conn data)
+      (port/close conn)))))
+
+(let [path "/tmp/elle-test-sockopt-accept-sndbuf.sock"
+      listener (unix/listen path)
+      size 307200
+      payload (string/repeat "B" size)]
+  (large-write-server listener size)
+  (let [conn (unix/connect path :sndbuf 2097152 :rcvbuf 2097152 :timeout 10000)]
+    (port/write conn payload)
+    (unix/shutdown conn :write)
+    (let [resp (port/read-all conn)]
+      (assert (= (length resp) size) "accept :sndbuf: full 300KB echo"))
+    (port/close conn))
+  (port/close listener))
+
+# ── 21. tcp/accept :sndbuf — server-side buffer on TCP ───────────────
+
+(let [listener (tcp/listen "127.0.0.1" 0)
+      port (tcp-port listener)]
+  (ev/spawn (fn []
+    (let [conn (tcp/accept listener :sndbuf 1048576 :timeout 5000)
+          data (port/read conn 65536)]
+      (port/write conn data)
+      (port/close conn))))
+  (let [conn (tcp/connect "127.0.0.1" port :timeout 5000)]
+    (port/write conn "accept-tcp-sndbuf")
+    (let [resp (string (port/read conn 1024))]
+      (assert (= resp "accept-tcp-sndbuf") "tcp/accept :sndbuf roundtrip"))
+    (port/close conn))
+  (port/close listener))
+
+# ── 22. accept error: unknown keyword ─────────────────────────────────
+
+(let [listener (unix/listen "/tmp/elle-test-sockopt-accept-err.sock")]
+  (let [[ok? err] (protect ((fn [] (unix/accept listener :bogus 1))))]
+    (assert (not ok?) "unix/accept unknown keyword signals error"))
+  (port/close listener))
+
+# ── 23. accept error: bad :sndbuf type ────────────────────────────────
+
+(let [listener (unix/listen "/tmp/elle-test-sockopt-accept-err2.sock")]
+  (let [[ok? err] (protect ((fn [] (unix/accept listener :sndbuf "big"))))]
+    (assert (not ok?) "unix/accept :sndbuf string signals type error"))
+  (port/close listener))
+
+(println "socket-options: all 23 tests passed")


### PR DESCRIPTION
Expose :sndbuf, :rcvbuf, :nodelay, :keepalive as keyword arguments on unix/connect, tcp/connect, unix/accept, and tcp/accept. Options are applied via setsockopt after socket creation (connect) or after accept(2) returns the new fd (accept).

This fixes the client→server direction of the h2 deadlock over Unix sockets: large gRPC request bodies no longer block against the default 208KB kernel buffer.

- SocketOptions struct + ConnectAddr fields in request.rs
- extract_connect_kwargs parser in kwarg.rs (reused by all 4 primitives)
- apply_socket_options helper in uring.rs (shared by uring + threadpool)
- 23 Elle tests (roundtrip, error cases, large write, accept options)
- 7 Rust getsockopt verification tests, 6 kwarg parser tests
- grpc.lisp: unix/connect with :sndbuf 2097152