### PR TITLE
Add close/cancellation to sync:make-queue

### DIFF
--- a/lib/sync.lisp
+++ b/lib/sync.lisp
@@ -183,27 +183,43 @@
 ## ── Blocking queue ───────────────────────────────────────────────────
 
 (defn make-queue [capacity]
-  "Bounded blocking FIFO queue."
+  "Bounded blocking FIFO queue with cancellation via :close."
   (let [lock (make-lock)
         not-full (make-condvar)
         not-empty (make-condvar)
         buf @[]
-        cap capacity]
+        cap capacity
+        @closed false]
     {:put (fn [val]
             (lock:acquire)
-            (while (>= (length buf) cap) (not-full:wait lock))
-            (push buf val)
-            (not-empty:notify)
-            (lock:release)
-            nil)
+            (while (and (not closed) (>= (length buf) cap))
+              (not-full:wait lock))
+            (if closed
+              (begin (lock:release) nil)
+              (begin
+                (push buf val)
+                (not-empty:notify)
+                (lock:release)
+                nil)))
      :take (fn []
              (lock:acquire)
-             (while (= (length buf) 0) (not-empty:wait lock))
-             (let [val (buf 0)]
-               (remove buf 0)
-               (not-full:notify)
-               (lock:release)
-               val))
+             (while (and (not closed) (= (length buf) 0))
+               (not-empty:wait lock))
+             (if (= (length buf) 0)
+               (begin (lock:release) nil)
+               (let [val (buf 0)]
+                 (remove buf 0)
+                 (not-full:notify)
+                 (lock:release)
+                 val)))
+     :close (fn []
+              (lock:acquire)
+              (assign closed true)
+              (not-full:broadcast)
+              (not-empty:broadcast)
+              (lock:release)
+              nil)
+     :closed? (fn [] closed)
      :size (fn [] (length buf))}))
 
 ## ── Monitor ──────────────────────────────────────────────────────────

--- a/tests/elle/sync.lisp
+++ b/tests/elle/sync.lisp
@@ -296,6 +296,46 @@
     (assert (= 6 (length results))
             "9g: all items consumed from multi-producer queue")))
 
+# Queue close: put on closed queue returns nil without blocking
+(let [q (sync:make-queue 3)]
+  (q:put :a)
+  (q:close)
+  (assert (q:closed?) "9h: queue reports closed")
+  (assert (nil? (q:put :b)) "9i: put on closed queue returns nil")
+  # take drains remaining items
+  (assert (= :a (q:take)) "9j: take drains remaining item after close")
+  (assert (nil? (q:take)) "9k: take returns nil when closed and empty"))
+
+# Queue close: unblocks fiber blocked on full-queue put
+(let [q (sync:make-queue 1)
+      result @[nil]]
+  (q:put :fill)  # fill the queue
+  (let [blocked (ev/spawn (fn []
+                             (let [r (q:put :will-not-go)]
+                               (put result 0 :unblocked)
+                               r)))]
+    # Give the fiber time to block
+    (ev/join (ev/spawn (fn [] nil)))
+    (q:close)
+    (ev/join blocked)
+    (assert (= :unblocked (result 0))
+            "9l: close unblocks fiber blocked on full-queue put")))
+
+# Queue close: unblocks fiber blocked on empty-queue take
+(let [q (sync:make-queue 4)
+      result @[nil]]
+  (let [blocked (ev/spawn (fn []
+                             (let [r (q:take)]
+                               (put result 0 :unblocked)
+                               r)))]
+    # Give the fiber time to block
+    (ev/join (ev/spawn (fn [] nil)))
+    (q:close)
+    (let [r (ev/join blocked)]
+      (assert (= :unblocked (result 0))
+              "9m: close unblocks fiber blocked on empty-queue take")
+      (assert (nil? r) "9n: take returns nil when closed and empty"))))
+
 # ============================================================================
 # 10. Monitor
 # ============================================================================


### PR DESCRIPTION
Bounded blocking queues had no way to interrupt fibers blocked on put (full queue) or take (empty queue). Add :close and :closed? methods that wake all waiters via broadcast, making put return nil on a closed queue and take drain remaining items then return nil.