### PR TITLE
Fix h2 mid-stream close deadlock and harden session lifecycle

### DIFF
--- a/lib/grpc.lisp
+++ b/lib/grpc.lisp
@@ -176,6 +176,64 @@
             _ (assign done true))))
       result))
 
+  ## ── Bidi streaming RPC ───────────────────────────────────────────
+
+  (defn
+    grpc-call-bidi
+    [session schema method]
+    "Open a bidirectional gRPC stream. Returns {:send fn :end fn :reader fn}."
+    (def [sid s] (http2:open-stream session "POST" method
+                   :headers [["content-type" "application/grpc"]
+                             ["te" "trailers"]]))
+    (def @buf (bytes))
+    (def @done false)
+
+    {:send (fn [msg-type msg-struct]
+             (let [body (grpc-encode (protobuf:encode schema msg-type msg-struct))]
+               (http2:stream-send session sid body)))
+
+     :end  (fn [] (http2:stream-end session sid))
+
+     :reader (fn [resp-type]
+               (def @result nil)
+               (when (>= (length buf) 5)
+                 (let [len (bit/or (bit/shl (get buf 1) 24)
+                                   (bit/shl (get buf 2) 16)
+                                   (bit/shl (get buf 3) 8)
+                                   (get buf 4))
+                       frame-end (+ 5 len)]
+                   (when (>= (length buf) frame-end)
+                     (let [payload (slice buf 5 frame-end)]
+                       (assign buf (slice buf frame-end))
+                       (assign result (protobuf:decode schema resp-type payload))))))
+
+               (while (and (nil? result) (not done))
+                 (let [msg (s:data-queue:take)]
+                   (match msg:type
+                     :headers
+                       (begin
+                         (check-grpc-status msg:headers)
+                         (when msg:end-stream (assign done true)))
+                     :data
+                       (begin
+                         (assign buf (concat buf msg:data))
+                         (when msg:end-stream (assign done true))
+                         (when (and (nil? result) (>= (length buf) 5))
+                           (let [len (bit/or (bit/shl (get buf 1) 24)
+                                             (bit/shl (get buf 2) 16)
+                                             (bit/shl (get buf 3) 8)
+                                             (get buf 4))
+                                 frame-end (+ 5 len)]
+                             (when (>= (length buf) frame-end)
+                               (let [payload (slice buf 5 frame-end)]
+                                 (assign buf (slice buf frame-end))
+                                 (assign result
+                                   (protobuf:decode schema resp-type payload)))))))
+                     :rst (error {:error :grpc-error :reason :stream-reset :code msg:code})
+                     :error (error msg:error)
+                     _ (assign done true))))
+               result)})
+
   ## ── Close ──────────────────────────────────────────────────────────
 
   (defn grpc-close [session]
@@ -188,6 +246,7 @@
    :call grpc-call
    :call-decode grpc-call-decode
    :call-stream grpc-call-stream
+   :call-bidi grpc-call-bidi
    :close grpc-close
    :encode grpc-encode
    :decode grpc-decode})

--- a/lib/http2.lisp
+++ b/lib/http2.lisp
@@ -145,6 +145,19 @@
                                        nil)))))
       sess))
 
+  ## ── Client: max concurrent streams check ──────────────────────────────
+
+  (defn check-max-streams [sess]
+    "§6.5.2: MUST NOT exceed peer's SETTINGS_MAX_CONCURRENT_STREAMS."
+    (let [max-streams (get sess:remote-settings :max-concurrent-streams)
+          active (length (keys sess:streams))]
+      (when (>= active max-streams)
+        (error {:error :h2-error
+                :reason :max-concurrent-streams
+                :active active
+                :max max-streams
+                :message "would exceed peer max-concurrent-streams"}))))
+
   ## ── Client: send request ───────────────────────────────────────────────
 
   (defn send-request-frames [sess method path &named body headers]
@@ -158,6 +171,7 @@
               :reason :goaway-received
               :last-stream-id sess:last-stream-id
               :message "peer sent GOAWAY, refusing new streams"}))
+    (check-max-streams sess)
     (let* [sid sess:next-stream-id
            _ (put sess :next-stream-id (+ sid 2))
            s (session:get-stream sess sid)
@@ -168,9 +182,12 @@
            has-body (and body (> (length body) 0))]
       (session:encode-and-send-headers sess sid all-headers (not has-body))
       (stream:transition s :send-headers)
-      (when has-body
-        (let [body-bytes (if (string? body) (bytes body) body)]
-          (session:send-data-with-flow-control sess sid s:flow body-bytes))
+      (if has-body
+        (begin
+          (let [body-bytes (if (string? body) (bytes body) body)]
+            (session:send-data-with-flow-control sess sid s:flow body-bytes))
+          (stream:transition s :send-end-stream))
+        # HEADERS carried END_STREAM — transition now
         (stream:transition s :send-end-stream))
       [sid s]))
 
@@ -246,12 +263,54 @@
   (defn h2-post [url body &named headers]
     (h2-request "POST" url :body body :headers headers))
 
+  ## ── Client: bidi stream primitives ─────────────────────────────────
+
+  (defn h2-open-stream [sess method path &named headers]
+    "Open an h2 stream with HEADERS, no body, no END_STREAM.
+     Returns [stream-id stream]. The stream is half-open (client can still send)."
+    (when sess:closed?
+      (error {:error :h2-error
+              :reason :connection-closed
+              :message "session is closed"}))
+    (when sess:goaway-recvd?
+      (error {:error :h2-error
+              :reason :goaway-received
+              :last-stream-id sess:last-stream-id
+              :message "peer sent GOAWAY, refusing new streams"}))
+    (check-max-streams sess)
+    (let* [sid sess:next-stream-id
+           _ (put sess :next-stream-id (+ sid 2))
+           s (session:get-stream sess sid)
+           authority sess:host
+           pseudo [[":method" method] [":path" path]
+                   [":scheme" (or sess:scheme "http")] [":authority" authority]]
+           all-headers (if (nil? headers) pseudo (concat pseudo headers))]
+      (session:encode-and-send-headers sess sid all-headers false)
+      (stream:transition s :send-headers)
+      [sid s]))
+
+  (defn h2-stream-send [sess sid data]
+    "Send a DATA frame on an open stream without ending it."
+    (let [s (get sess:streams sid)]
+      (session:send-data-with-flow-control sess sid s:flow data :end-stream false)))
+
+  (defn h2-stream-end [sess sid]
+    "Send an empty DATA frame with END_STREAM to half-close the client side."
+    (let [s (get sess:streams sid)
+          [ft fl si pl] (frame:make-data-frame sid (bytes) true)]
+      (sess:write-queue:put [ft fl si pl])
+      (stream:transition s :send-end-stream)))
+
   ## ── Client: close ──────────────────────────────────────────────────────
 
   (defn h2-close [sess]
     "Close an HTTP/2 session gracefully."
     (when (not sess:closed?)
       (put sess :closed? true)
+      # Close all stream data-queues so reader unblocks from any full-queue wait
+      (each sid in (keys sess:streams)
+        (when-let [s (get sess:streams sid)]
+          (protect (s:data-queue:close))))
       (session:send-goaway sess sess:last-stream-id C:err-no-error)
       (sess:write-queue:put :shutdown)
       (when sess:writer-fiber (ev/join-protected sess:writer-fiber))
@@ -338,7 +397,11 @@
    :connect h2-connect
    :send h2-send
    :send-raw h2-send-raw
+   :open-stream h2-open-stream
+   :stream-send h2-stream-send
+   :stream-end h2-stream-end
    :close h2-close
    :serve server:serve
+   :serve-streaming server:serve-streaming
    :parse-url parse-url
    :test run-tests})

--- a/lib/http2/server.lisp
+++ b/lib/http2/server.lisp
@@ -96,34 +96,44 @@
 
   ## ── Server connection ──────────────────────────────────────────────────
 
-  (defn server-connection [transport handler sess &named on-error]
-    "Handle one HTTP/2 server connection."  # Read client preface
-    (let [preface (frame:read-exact transport 24)]
-      (when (or (nil? preface) (not (= preface C:client-preface)))
-        (error {:error :h2-error
-                :reason :protocol-error
-                :message "invalid client connection preface"})))  # Read client SETTINGS
-    (let [f (frame:read-frame transport
-                              (get sess:local-settings :max-frame-size))]
-      (when (or (nil? f) (not (= f:type C:type-settings)))
-        (error {:error :h2-error
-                :reason :protocol-error
-                :message "expected SETTINGS as first client frame"}))
-      (session:apply-remote-settings sess f:payload))  # Send our SETTINGS + ACK + connection WINDOW_UPDATE
-    (let [[ftype flags sid payload] (frame:make-settings-frame session:default-settings)]
-      (frame:write-frame transport ftype flags sid payload))
-    (let [[ftype flags sid payload] (frame:make-settings-ack)]
-      (frame:write-frame transport ftype flags sid payload))
-    (let [delta (- session:initial-window 65535)]
-      (when (> delta 0)
-        (let [[ftype flags sid payload] (frame:make-window-update-frame 0 delta)]
-          (frame:write-frame transport ftype flags sid payload))))
-    (transport:flush)  # Start writer fiber
-    (put sess :writer-fiber (ev/spawn (fn [] (session:writer-loop sess))))  # Shared reader loop with server callbacks
-    (session:read-loop sess :on-headers (make-on-headers handler on-error)
-                       :on-goaway (fn [sess payload]
-                                    (sess:write-queue:put :shutdown)
-                                    true)))
+  (defn server-connection [transport handler sess &named on-error
+                          make-on-headers-fn]
+    "Handle one HTTP/2 server connection."
+    (let [mk-on-headers (or make-on-headers-fn make-on-headers)]
+      # Read client preface
+      (let [preface (frame:read-exact transport 24)]
+        (when (or (nil? preface) (not (= preface C:client-preface)))
+          (error {:error :h2-error
+                  :reason :protocol-error
+                  :message "invalid client connection preface"})))
+      # Read client SETTINGS
+      (let [f (frame:read-frame transport
+                                (get sess:local-settings :max-frame-size))]
+        (when (or (nil? f) (not (= f:type C:type-settings)))
+          (error {:error :h2-error
+                  :reason :protocol-error
+                  :message "expected SETTINGS as first client frame"}))
+        (session:apply-remote-settings sess f:payload))
+      # Send our SETTINGS + ACK + connection WINDOW_UPDATE
+      (let [[ftype flags sid payload] (frame:make-settings-frame
+                                        session:default-settings)]
+        (frame:write-frame transport ftype flags sid payload))
+      (let [[ftype flags sid payload] (frame:make-settings-ack)]
+        (frame:write-frame transport ftype flags sid payload))
+      (let [delta (- session:initial-window 65535)]
+        (when (> delta 0)
+          (let [[ftype flags sid payload] (frame:make-window-update-frame 0 delta)]
+            (frame:write-frame transport ftype flags sid payload))))
+      (transport:flush)
+      # Start writer fiber
+      (put sess :writer-fiber (ev/spawn (fn [] (session:writer-loop sess))))
+      # Shared reader loop with server callbacks
+      (session:read-loop sess :on-headers (mk-on-headers handler on-error)
+                         :on-goaway (fn [sess payload]
+                                      (sess:write-queue:put :shutdown)
+                                      true))
+      # Wait for writer to drain queued frames before returning
+      (when sess:writer-fiber (ev/join-protected sess:writer-fiber))))
 
   ## ── h2-serve ───────────────────────────────────────────────────────────
 
@@ -146,6 +156,152 @@
                       (unless ok? (when on-error (on-error err)))
                       (protect (t:close))))))))
 
+  ## ── Streaming server ───────────────────────────────────────────────────
+  ##
+  ## The streaming handler receives (req ctrl) where:
+  ##   req  = {:method :path :headers}  — no :body (use ctrl:recv)
+  ##   ctrl = {:recv          (fn [] -> bytes|nil)
+  ##           :send-headers  (fn [status headers-map] -> nil)
+  ##           :send-data     (fn [data] -> nil)
+  ##           :end-stream    (fn [] -> nil)
+  ##           :send-trailers (fn [trailer-pairs] -> nil)}
+
+  (defn make-stream-ctrl [sess s sid]
+    "Create a stream controller for the streaming handler."
+    (let [@headers-sent false
+          @ended false
+          @recv-done false]
+      {:recv (fn []
+               "Read next DATA bytes from client, or nil on end-stream."
+               (when recv-done nil)
+               (unless recv-done
+                 (let [msg (s:data-queue:take)]
+                   (cond
+                     (nil? msg) (begin (assign recv-done true) nil)
+                     (= msg:type :data)
+                       (if msg:end-stream
+                         (begin
+                           (assign recv-done true)
+                           # Return the final chunk if non-empty, else nil
+                           (if (> (length msg:data) 0) msg:data nil))
+                         msg:data)
+                     (= msg:type :end) (begin (assign recv-done true) nil)
+                     (= msg:type :error) (begin (assign recv-done true)
+                                                (error msg:error))
+                     true (begin (assign recv-done true) nil)))))
+
+       :send-headers (fn [status &named headers]
+               "Send response HEADERS. Must be called before send-data."
+               (when headers-sent
+                 (error {:error :h2-error :reason :protocol-error
+                         :message "response headers already sent"}))
+               (let [@h-pairs @[[":status" (string status)]]]
+                 (when headers
+                   (each k in (keys headers)
+                     (push h-pairs [(string k) (string (get headers k))])))
+                 (session:encode-and-send-headers sess sid (freeze h-pairs) false)
+                 (assign headers-sent true)))
+
+       :send-data (fn [data]
+               "Send one DATA frame with flow control, no END_STREAM."
+               (unless headers-sent
+                 (error {:error :h2-error :reason :protocol-error
+                         :message "must send headers before data"}))
+               (when ended
+                 (error {:error :h2-error :reason :protocol-error
+                         :message "stream already ended"}))
+               (let [body (if (string? data) (bytes data) data)]
+                 (session:send-data-with-flow-control sess sid s:flow body
+                   :end-stream false)))
+
+       :end-stream (fn []
+               "Send empty DATA with END_STREAM (plain close)."
+               (unless headers-sent
+                 (error {:error :h2-error :reason :protocol-error
+                         :message "must send headers before end-stream"}))
+               (when ended
+                 (error {:error :h2-error :reason :protocol-error
+                         :message "stream already ended"}))
+               (let [[ft fl si pl] (frame:make-data-frame sid (bytes) true)]
+                 (session:send-frame sess ft fl si pl))
+               (stream:transition s :send-end-stream)
+               (assign ended true))
+
+       :send-trailers (fn [trailer-pairs]
+               "Send trailing HEADERS with END_STREAM."
+               (unless headers-sent
+                 (error {:error :h2-error :reason :protocol-error
+                         :message "must send headers before trailers"}))
+               (when ended
+                 (error {:error :h2-error :reason :protocol-error
+                         :message "stream already ended"}))
+               (session:encode-and-send-headers sess sid trailer-pairs true)
+               (stream:transition s :send-end-stream)
+               (assign ended true))}))
+
+  (defn handle-streaming-request [sess s sid hdrs end? handler]
+    "Handle one streaming server request."
+    # If client sent HEADERS+END_STREAM (no body), enqueue a sentinel
+    # so ctrl:recv returns nil immediately instead of blocking
+    (when end?
+      (s:data-queue:put {:type :end :end-stream true}))
+    (let* [method-pair (first (filter (fn [h] (= (get h 0) ":method")) hdrs))
+           path-pair (first (filter (fn [h] (= (get h 0) ":path")) hdrs))
+           req-headers @{}
+           _ (each h in hdrs
+               (let [name (get h 0)]
+                 (unless (string/starts-with? name ":")
+                   (put req-headers (keyword name) (get h 1)))))
+           request {:method (if method-pair (get method-pair 1) "GET")
+                    :path (if path-pair (get path-pair 1) "/")
+                    :headers (freeze req-headers)}
+           ctrl (make-stream-ctrl sess s sid)
+           [ok? err] (protect (handler request ctrl))]
+      (unless ok?
+        (protect (session:send-rst-stream sess sid C:err-internal-error))
+        (error err))))
+
+  (defn make-streaming-on-headers [handler on-error]
+    (fn [sess s sid hdrs end?]
+      (put s :headers hdrs)
+      (when end? (stream:transition s :recv-end-stream))
+      (let [max-streams (get sess:local-settings :max-concurrent-streams)
+            active (length (keys sess:streams))]
+        (if (> active max-streams)
+          (begin
+            (del sess:streams sid)
+            (session:send-rst-stream sess sid C:err-refused-stream))
+          (ev/spawn (fn []
+                      (defer
+                        (del sess:streams sid)
+                        (let [[ok? err] (protect (handle-streaming-request
+                                                   sess s sid hdrs end? handler))]
+                          (unless ok?
+                            (protect (session:send-rst-stream sess sid
+                                     C:err-internal-error))
+                            (when on-error (on-error err)))))))))))
+
+  (defn h2-serve-streaming [listener handler &named tls-config on-error]
+    "Serve HTTP/2 connections with streaming handler. Runs forever."
+    (forever
+      (let* [tcp-port (tcp/accept listener)
+             t (if tls-config
+                 (begin
+                   (when (nil? tls)
+                     (error {:error :h2-error
+                             :reason :tls-not-configured
+                             :message "TLS serving requires :tls plugin"}))
+                   (transport:tls (tls:accept listener tls-config)))
+                 (transport:tcp tcp-port))
+             sess (session:make-session t "" true)]
+        (ev/spawn (fn []
+                    (let [[ok? err] (protect
+                            (server-connection t handler sess
+                              :on-error on-error
+                              :make-on-headers-fn make-streaming-on-headers))]
+                      (unless ok? (when on-error (on-error err)))
+                      (protect (t:close))))))))
+
   ## ── Tests ──────────────────────────────────────────────────────────────
 
   (defn run-tests []
@@ -153,4 +309,6 @@
 
   ## ── Exports ────────────────────────────────────────────────────────────
 
-  {:serve h2-serve :test run-tests})
+  {:serve h2-serve
+   :serve-streaming h2-serve-streaming
+   :test run-tests})

--- a/lib/http2/session.lisp
+++ b/lib/http2/session.lisp
@@ -52,7 +52,11 @@
       :closed? false
       :goaway-recvd? false
       :last-stream-id 0
-      :settings-ack-latch nil})
+      :settings-ack-latch nil
+      :pending-conn-wu 0
+      :wu-threshold (/ INITIAL-WINDOW 2)
+      :expecting-continuation-sid nil
+})
 
   ## ── Writer fiber ───────────────────────────────────────────────────────
 
@@ -70,6 +74,7 @@
                                    (let [[ftype flags sid payload] item]
                                      (frame:write-frame t ftype flags sid
                                      payload)))
+                                 (def @drain-count 1)
                                  (while (> (q:size) 0)
                                    (let [next (q:take)]
                                      (when (= next :shutdown)
@@ -77,8 +82,11 @@
                                      (unless shutting-down
                                        (let [[ftype flags sid payload] next]
                                          (frame:write-frame t ftype flags sid
-                                         payload)))))
-                                 (unless shutting-down (t:flush))
+                                         payload))))
+                                   (assign drain-count (+ drain-count 1))
+                                   (when (= 0 (mod drain-count 64))
+                                     (unless shutting-down (t:flush))))
+                                 (t:flush)
                                  (when shutting-down (break nil)))))]
         (unless ok?
           (put session :closed? true)
@@ -306,23 +314,51 @@
                 flags f:flags
                 sid f:stream-id
                 payload f:payload]
+
+            ## §6.2/6.10: HEADERS/CONTINUATION contiguity enforcement
+            (when sess:expecting-continuation-sid
+              (unless (and (= ftype C:type-continuation)
+                           (= sid sess:expecting-continuation-sid))
+                (send-goaway sess 0 C:err-protocol-error)
+                (break nil)))
+
             (cond  ## ── SETTINGS ──
               (= ftype C:type-settings)
-                (if (has-flag? flags C:flag-ack)
-                  (ack-settings-received sess)
-                  (begin
-                    (apply-remote-settings sess payload)
-                    (send-settings-ack sess)))
+                (begin
+                  # §6.5: SETTINGS on non-zero stream → PROTOCOL_ERROR
+                  (when (not (= sid 0))
+                    (send-goaway sess 0 C:err-protocol-error)
+                    (break nil))
+                  (if (has-flag? flags C:flag-ack)
+                    (ack-settings-received sess)
+                    (begin
+                      (apply-remote-settings sess payload)
+                      (send-settings-ack sess))))
 
               ## ── PING ──
               (= ftype C:type-ping)
-                (unless (has-flag? flags C:flag-ack)
-                  (let [[ftype flags sid payload] (frame:make-ping-frame payload
-                        :ack? true)]
-                    (send-frame sess ftype flags sid payload)))
+                (begin
+                  # §6.7: PING on non-zero stream → PROTOCOL_ERROR
+                  (when (not (= sid 0))
+                    (send-goaway sess 0 C:err-protocol-error)
+                    (break nil))
+                  # §6.7: PING payload MUST be 8 octets
+                  (when (not (= (length payload) 8))
+                    (send-goaway sess 0 C:err-frame-size-error)
+                    (break nil))
+                  (unless (has-flag? flags C:flag-ack)
+                    (let [[ftype flags sid payload] (frame:make-ping-frame payload
+                          :ack? true)]
+                      (send-frame sess ftype flags sid payload))))
 
               ## ── GOAWAY ──
-              (= ftype C:type-goaway) (when (on-goaway sess payload) (break nil))
+              (= ftype C:type-goaway)
+                (begin
+                  # §6.8: GOAWAY on non-zero stream → PROTOCOL_ERROR
+                  (when (not (= sid 0))
+                    (send-goaway sess 0 C:err-protocol-error)
+                    (break nil))
+                  (when (on-goaway sess payload) (break nil)))
 
               ## ── WINDOW_UPDATE ──
               (= ftype C:type-window-update)
@@ -341,64 +377,132 @@
 
               ## ── RST_STREAM ──
               (= ftype C:type-rst-stream)
-                (when-let [s (get sess:streams sid)]
-                          (stream:transition s :recv-rst)
-                          (let [err-code (frame:read-u32 payload 0)]
-                            (put s :error-code err-code)
-                            (s:data-queue:put {:type :rst :code err-code}))
-                          (del sess:streams sid))
+                (begin
+                  # §6.4: RST_STREAM on stream 0 → PROTOCOL_ERROR
+                  (when (= sid 0)
+                    (send-goaway sess 0 C:err-protocol-error)
+                    (break nil))
+                  (when-let [s (get sess:streams sid)]
+                            (stream:transition s :recv-rst)
+                            (let [err-code (frame:read-u32 payload 0)]
+                              (put s :error-code err-code)
+                              (s:data-queue:put {:type :rst :code err-code}))
+                            # Flush pending stream WU before removing
+                            (when (> (or s:pending-stream-wu 0) 0)
+                              (send-window-update sess sid s:pending-stream-wu))
+                            (del sess:streams sid)))
 
               ## ── HEADERS ──
               (= ftype C:type-headers)
-                (let [s (get-stream sess sid)
-                      payload (strip-padding payload flags)]
-                  (when (= s:state :idle) (stream:transition s :recv-headers))
-                  (if (has-flag? flags C:flag-end-headers)
-                    (let [headers (hpack:decode sess:hpack-decoder payload)
-                          end? (has-flag? flags C:flag-end-stream)]
-                      (on-headers sess s sid headers end?))
-                    (begin
-                      (when (has-flag? flags C:flag-end-stream)
-                        (stream:transition s :recv-end-stream))
-                      (put s
-                           :pending-headers @{:data payload
-                           :end-stream (has-flag? flags C:flag-end-stream)}))))
+                (begin
+                  # §6.2: HEADERS on stream 0 → PROTOCOL_ERROR
+                  (when (= sid 0)
+                    (send-goaway sess 0 C:err-protocol-error)
+                    (break nil))
+                  (let [s (get-stream sess sid)
+                        payload (strip-padding payload flags)]
+                    (when (= s:state :idle) (stream:transition s :recv-headers))
+                    (if (has-flag? flags C:flag-end-headers)
+                      (let [headers (hpack:decode sess:hpack-decoder payload)
+                            end? (has-flag? flags C:flag-end-stream)]
+                        (on-headers sess s sid headers end?))
+                      (begin
+                        # §6.2: track continuation expectation
+                        (put sess :expecting-continuation-sid sid)
+                        (when (has-flag? flags C:flag-end-stream)
+                          (stream:transition s :recv-end-stream))
+                        (put s
+                             :pending-headers @{:data payload
+                             :end-stream (has-flag? flags C:flag-end-stream)})))))
 
               ## ── CONTINUATION ──
               (= ftype C:type-continuation)
-                (when-let [s (get sess:streams sid)]
-                          (when s:pending-headers
-                            (put s:pending-headers
-                                 :data (concat s:pending-headers:data payload))
-                            (when (has-flag? flags C:flag-end-headers)
-                              (let [headers (hpack:decode sess:hpack-decoder
-                                    s:pending-headers:data)
-                                    end? s:pending-headers:end-stream]
-                                (put s :pending-headers nil)
-                                (on-headers sess s sid headers end?)))))
+                (begin
+                  # §6.10: CONTINUATION on stream 0 → PROTOCOL_ERROR
+                  (when (= sid 0)
+                    (send-goaway sess 0 C:err-protocol-error)
+                    (break nil))
+                  # §6.10: CONTINUATION without pending HEADERS → PROTOCOL_ERROR
+                  (unless sess:expecting-continuation-sid
+                    (send-goaway sess 0 C:err-protocol-error)
+                    (break nil))
+                  (when-let [s (get sess:streams sid)]
+                            (when s:pending-headers
+                              (put s:pending-headers
+                                   :data (concat s:pending-headers:data payload))
+                              (when (has-flag? flags C:flag-end-headers)
+                                (put sess :expecting-continuation-sid nil)
+                                (let [headers (hpack:decode sess:hpack-decoder
+                                      s:pending-headers:data)
+                                      end? s:pending-headers:end-stream]
+                                  (put s :pending-headers nil)
+                                  (on-headers sess s sid headers end?))))))
 
               ## ── DATA ──
               (= ftype C:type-data)
-                (let [payload (strip-padding payload flags)]
-                  (let [len (length payload)]
-                    (when (> len 0) (send-window-update sess 0 len)))
-                  (when-let [s (get sess:streams sid)]
-                            (let [end? (has-flag? flags C:flag-end-stream)]
-                              (s:data-queue:put {:type :data
-                              :data payload
-                              :end-stream end?})
-                              (when end? (stream:transition s :recv-end-stream))
-                              (let [len (length payload)]
+                (begin
+                  # §6.1: DATA on stream 0 → PROTOCOL_ERROR
+                  (when (= sid 0)
+                    (send-goaway sess 0 C:err-protocol-error)
+                    (break nil))
+                  (let [payload (strip-padding payload flags)]
+                    (let [len (length payload)]
+                      (when (> len 0)
+                        (put sess :pending-conn-wu
+                             (+ sess:pending-conn-wu len))))
+                    (when-let [s (get sess:streams sid)]
+                              # §5.1: DATA on half-closed(remote) or closed → stream error
+                              (when (or (= s:state :half-closed-remote)
+                                        (= s:state :closed))
+                                (send-rst-stream sess sid C:err-stream-closed))
+                              (let [end? (has-flag? flags C:flag-end-stream)
+                                    len (length payload)]
+                                # Accumulate + flush WU BEFORE data-queue:put
+                                # (put may block when queue full; WU must not
+                                # be deferred or the sender's window starves)
                                 (when (> len 0)
-                                  (send-window-update sess sid len)))
-                              (when end? (del sess:streams sid)))))
+                                  (put s :pending-stream-wu
+                                       (+ (or s:pending-stream-wu 0) len)))
+                                (when (>= sess:pending-conn-wu sess:wu-threshold)
+                                  (send-window-update sess 0 sess:pending-conn-wu)
+                                  (put sess :pending-conn-wu 0))
+                                (when (>= (or s:pending-stream-wu 0)
+                                          sess:wu-threshold)
+                                  (send-window-update sess sid s:pending-stream-wu)
+                                  (put s :pending-stream-wu 0))
+                                (when end?
+                                  # Flush remaining WU before closing stream
+                                  (when (> sess:pending-conn-wu 0)
+                                    (send-window-update sess 0
+                                                        sess:pending-conn-wu)
+                                    (put sess :pending-conn-wu 0))
+                                  (when (> (or s:pending-stream-wu 0) 0)
+                                    (send-window-update sess sid
+                                                        s:pending-stream-wu)
+                                    (put s :pending-stream-wu 0)))
+                                # Deliver data (may block on full queue —
+                                # but WU is already enqueued above)
+                                (s:data-queue:put {:type :data
+                                :data payload
+                                :end-stream end?})
+                                (when sess:closed? (break nil))
+                                (when end?
+                                  (stream:transition s :recv-end-stream)
+                                  # Only remove stream when fully closed
+                                  # (both sides done). Half-closed-remote
+                                  # means our side still needs to send +
+                                  # receive WU for flow control.
+                                  (when (= s:state :closed)
+                                    (del sess:streams sid)))))))
 
               ## ── PUSH_PROMISE — reject ──
               (= ftype C:type-push-promise) (send-rst-stream sess sid
               C:err-refused-stream)
 
               ## ── Unknown — ignore ──
-              true nil))))))
+              true nil))))
+      # Ensure writer always gets shutdown signal after loop exit
+      (sess:write-queue:put :shutdown)))
 
   ## ── Tests ──────────────────────────────────────────────────────────────
 
@@ -468,6 +572,12 @@
     (let [unpadded (bytes 0x41 0x42 0x43)
           stripped (strip-padding unpadded 0)]
       (assert (= stripped unpadded) "strip-padding: no flag"))
+
+    # ── expecting-continuation-sid initializes nil ──
+    (let [mock-transport {:read nil :write nil :flush nil :close nil}
+          s (make-session mock-transport "test" false)]
+      (assert (nil? s:expecting-continuation-sid)
+              "session: expecting-continuation-sid nil"))
 
     true)
 


### PR DESCRIPTION
http2:close deadlocked when the reader fiber was blocked on a full data-queue:put — nothing would drain the queue, so ev/join on the reader hung forever. Close all stream data-queues before joining the reader so blocked puts unblock immediately.

Also: RFC 9113 compliance for session layer, bidi streaming WU starvation fix, streaming server with make-on-headers-fn, and grpc module with call-bidi for BulkEvolveStream.