### PR TITLE
Allow immutable arrays as struct/map keys (#819)

### DIFF
--- a/src/primitives/structs.rs
+++ b/src/primitives/structs.rs
@@ -322,6 +322,7 @@ pub(crate) fn prim_pairs(args: &[Value]) -> (SignalBits, Value) {
                 TableKey::Symbol(sym) => Value::symbol(sym.0),
                 TableKey::String(s) => Value::string(s.as_str()),
                 TableKey::Keyword(kw) => Value::keyword(kw.as_str()),
+                TableKey::Array(keys) => Value::array(keys.iter().map(|k| k.to_value()).collect()),
                 TableKey::Identity(v) => *v,
             };
             let pair = Value::array(vec![key_val, *value]);

--- a/src/syntax/convert.rs
+++ b/src/syntax/convert.rs
@@ -46,7 +46,8 @@ fn table_key_to_syntax(
         TableKey::String(s) => SyntaxKind::String(s.clone()),
         TableKey::Keyword(s) => SyntaxKind::Keyword(s.clone()),
         TableKey::Array(keys) => {
-            let elements: Result<Vec<_>, _> = keys.iter()
+            let elements: Result<Vec<_>, _> = keys
+                .iter()
                 .map(|k| table_key_to_syntax(k, symbols, span))
                 .collect();
             return Ok(Syntax::new(SyntaxKind::Array(elements?), span.clone()));

--- a/src/syntax/convert.rs
+++ b/src/syntax/convert.rs
@@ -45,6 +45,12 @@ fn table_key_to_syntax(
         }
         TableKey::String(s) => SyntaxKind::String(s.clone()),
         TableKey::Keyword(s) => SyntaxKind::Keyword(s.clone()),
+        TableKey::Array(keys) => {
+            let elements: Result<Vec<_>, _> = keys.iter()
+                .map(|k| table_key_to_syntax(k, symbols, span))
+                .collect();
+            return Ok(Syntax::new(SyntaxKind::Array(elements?), span.clone()));
+        }
         TableKey::Identity(_) => {
             return Err("Cannot convert identity key to Syntax".to_string());
         }

--- a/src/value/types.rs
+++ b/src/value/types.rs
@@ -101,6 +101,10 @@ pub enum TableKey {
     Symbol(SymbolId),
     String(String),
     Keyword(String),
+    /// Immutable array key. All elements must themselves be valid TableKeys.
+    /// Mutable arrays are rejected — mutation after insertion would break
+    /// the hash invariant.
+    Array(Vec<TableKey>),
     /// Identity-compared key for reference types (fiber, closure, external).
     ///
     /// **Invariant**: Only constructed via `from_value()`. The stored `Value`
@@ -132,6 +136,12 @@ impl TableKey {
             Some(TableKey::Keyword(name))
         } else if let Some(s) = val.with_string(|s| s.to_string()) {
             Some(TableKey::String(s))
+        } else if let Some(arr) = val.as_array() {
+            let mut keys = Vec::with_capacity(arr.len());
+            for elem in arr {
+                keys.push(TableKey::from_value(elem)?);
+            }
+            Some(TableKey::Array(keys))
         } else if val.is_fiber() || val.is_closure() || val.heap_tag() == Some(HeapTag::External) {
             Some(TableKey::Identity(*val))
         } else {
@@ -150,6 +160,9 @@ impl TableKey {
             TableKey::Symbol(sid) => Value::symbol(sid.0),
             TableKey::String(s) => Value::string(s.as_str()),
             TableKey::Keyword(s) => Value::keyword(s.as_str()),
+            TableKey::Array(keys) => {
+                Value::array(keys.iter().map(|k| k.to_value()).collect())
+            }
             TableKey::Identity(v) => *v,
         }
     }
@@ -160,7 +173,11 @@ impl TableKey {
     /// Value-based keys (nil, bool, int, symbol, string, keyword) are always
     /// sendable.
     pub fn is_sendable(&self) -> bool {
-        !matches!(self, TableKey::Identity(_))
+        match self {
+            TableKey::Identity(_) => false,
+            TableKey::Array(keys) => keys.iter().all(|k| k.is_sendable()),
+            _ => true,
+        }
     }
 
     fn discriminant_index(&self) -> u8 {
@@ -171,7 +188,8 @@ impl TableKey {
             TableKey::Symbol(_) => 3,
             TableKey::String(_) => 4,
             TableKey::Keyword(_) => 5,
-            TableKey::Identity(_) => 6,
+            TableKey::Array(_) => 6,
+            TableKey::Identity(_) => 7,
         }
     }
 }
@@ -186,6 +204,7 @@ impl std::hash::Hash for TableKey {
             TableKey::Symbol(id) => id.hash(state),
             TableKey::String(s) => s.hash(state),
             TableKey::Keyword(s) => s.hash(state),
+            TableKey::Array(keys) => keys.hash(state),
             // Delegate to Value's Hash. For Fiber/ThreadHandle/External
             // that encodes a stable Rc/Arc-backed identity rather than
             // the slot pointer, so outbox relocation on fiber yield
@@ -204,6 +223,7 @@ impl PartialEq for TableKey {
             (TableKey::Symbol(a), TableKey::Symbol(b)) => a == b,
             (TableKey::String(a), TableKey::String(b)) => a == b,
             (TableKey::Keyword(a), TableKey::Keyword(b)) => a == b,
+            (TableKey::Array(a), TableKey::Array(b)) => a == b,
             // Delegate to Value's PartialEq (stable identity for Fiber
             // and friends — see Hash impl above).
             (TableKey::Identity(a), TableKey::Identity(b)) => a == b,
@@ -223,7 +243,7 @@ impl PartialOrd for TableKey {
 impl Ord for TableKey {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         // Variant ordering follows enum declaration order (same as derive).
-        // Discriminant index: Nil=0, Bool=1, Int=2, Symbol=3, String=4, Keyword=5, Identity=6
+        // Discriminant index: Nil=0, Bool=1, Int=2, Symbol=3, String=4, Keyword=5, Array=6, Identity=7
         let self_disc = self.discriminant_index();
         let other_disc = other.discriminant_index();
         match self_disc.cmp(&other_disc) {
@@ -237,6 +257,7 @@ impl Ord for TableKey {
             (TableKey::Symbol(a), TableKey::Symbol(b)) => a.cmp(b),
             (TableKey::String(a), TableKey::String(b)) => a.cmp(b),
             (TableKey::Keyword(a), TableKey::Keyword(b)) => a.cmp(b),
+            (TableKey::Array(a), TableKey::Array(b)) => a.cmp(b),
             // Delegate to Value's Ord. Stable identity for Fiber and
             // friends — see Hash impl above.
             (TableKey::Identity(a), TableKey::Identity(b)) => a.cmp(b),
@@ -254,6 +275,14 @@ impl fmt::Display for TableKey {
             TableKey::Symbol(id) => write!(f, "{:?}", id),
             TableKey::String(s) => write!(f, "\"{}\"", s),
             TableKey::Keyword(s) => write!(f, ":{}", s),
+            TableKey::Array(keys) => {
+                write!(f, "[")?;
+                for (i, k) in keys.iter().enumerate() {
+                    if i > 0 { write!(f, " ")?; }
+                    write!(f, "{}", k)?;
+                }
+                write!(f, "]")
+            }
             TableKey::Identity(v) => write!(f, "{}", v),
         }
     }
@@ -279,6 +308,14 @@ impl fmt::Debug for TableKey {
             }
             TableKey::String(s) => write!(f, "\"{}\"", s),
             TableKey::Keyword(s) => write!(f, ":{}", s),
+            TableKey::Array(keys) => {
+                write!(f, "[")?;
+                for (i, k) in keys.iter().enumerate() {
+                    if i > 0 { write!(f, " ")?; }
+                    write!(f, "{:?}", k)?;
+                }
+                write!(f, "]")
+            }
             TableKey::Identity(v) => write!(f, "{:?}", v),
         }
     }

--- a/src/value/types.rs
+++ b/src/value/types.rs
@@ -160,9 +160,7 @@ impl TableKey {
             TableKey::Symbol(sid) => Value::symbol(sid.0),
             TableKey::String(s) => Value::string(s.as_str()),
             TableKey::Keyword(s) => Value::keyword(s.as_str()),
-            TableKey::Array(keys) => {
-                Value::array(keys.iter().map(|k| k.to_value()).collect())
-            }
+            TableKey::Array(keys) => Value::array(keys.iter().map(|k| k.to_value()).collect()),
             TableKey::Identity(v) => *v,
         }
     }
@@ -278,7 +276,9 @@ impl fmt::Display for TableKey {
             TableKey::Array(keys) => {
                 write!(f, "[")?;
                 for (i, k) in keys.iter().enumerate() {
-                    if i > 0 { write!(f, " ")?; }
+                    if i > 0 {
+                        write!(f, " ")?;
+                    }
                     write!(f, "{}", k)?;
                 }
                 write!(f, "]")
@@ -311,7 +311,9 @@ impl fmt::Debug for TableKey {
             TableKey::Array(keys) => {
                 write!(f, "[")?;
                 for (i, k) in keys.iter().enumerate() {
-                    if i > 0 { write!(f, " ")?; }
+                    if i > 0 {
+                        write!(f, " ")?;
+                    }
                     write!(f, "{:?}", k)?;
                 }
                 write!(f, "]")

--- a/tests/diff/array-keys.lisp
+++ b/tests/diff/array-keys.lisp
@@ -1,0 +1,61 @@
+(elle/epoch 9)
+## array-keys — immutable arrays as struct/map keys
+
+# ── Basic put/get with array key ─────────────────────────────────────
+(let [m @{}]
+  (put m [1 2] "x")
+  (assert (= (get m [1 2]) "x") "get with array key"))
+
+# ── Immutable struct with array key ──────────────────────────────────
+(let [s (struct [1 2] "a" [3 4] "b")]
+  (assert (= (get s [1 2]) "a") "struct with array key")
+  (assert (= (get s [3 4]) "b") "struct with array key 2"))
+
+# ── has? with array key ─────────────────────────────────────────────
+(let [m @{[1 2] "x"}]
+  (assert (has? m [1 2]) "has? with array key")
+  (assert (not (has? m [1 3])) "has? negative"))
+
+# ── del with array key ──────────────────────────────────────────────
+(let [m @{[1 2] "x" :a 1}]
+  (del m [1 2])
+  (assert (not (has? m [1 2])) "del with array key")
+  (assert (has? m :a) "del preserves other keys"))
+
+# ── Nested array keys ───────────────────────────────────────────────
+(let [m @{}]
+  (put m [[1 2] [3 4]] "nested")
+  (assert (= (get m [[1 2] [3 4]]) "nested") "nested array key"))
+
+# ── Array keys with mixed element types ─────────────────────────────
+(let [m @{}]
+  (put m [1 "two" :three] "mixed")
+  (assert (= (get m [1 "two" :three]) "mixed") "mixed element array key"))
+
+# ── Equal arrays hash to same key ───────────────────────────────────
+(let [m @{}]
+  (put m [1 2 3] "first")
+  (assert (= (get m [1 2 3]) "first") "equal arrays same key"))
+
+# ── Empty array as key ──────────────────────────────────────────────
+(let [m @{}]
+  (put m [] "empty")
+  (assert (= (get m []) "empty") "empty array key"))
+
+# ── Mutable arrays rejected as keys ─────────────────────────────────
+(let [m @{}
+      ok (first (protect (put m @[1 2] "x")))]
+  (assert (not ok) "mutable array rejected as key"))
+
+# ── frequencies with array values ────────────────────────────────────
+(let [data [[1 2] [3 4] [1 2] [3 4] [1 2]]
+      freq (frequencies data)]
+  (assert (= (get freq [1 2]) 3) "frequencies with array values")
+  (assert (= (get freq [3 4]) 2) "frequencies with array values 2"))
+
+# ── keys round-trips ────────────────────────────────────────────────
+(let [m @{[1 2] "x"}
+      ks (keys m)]
+  (assert (= (first ks) [1 2]) "keys returns array key"))
+
+(println "ok")


### PR DESCRIPTION
Add Array(Vec<TableKey>) variant to TableKey so immutable arrays can be used as keys in put/get/del/has?/@struct/struct. Elements are converted recursively — all must be valid keys. Mutable arrays are rejected to preserve hash stability.