### PR TITLE
Rewrite docs/memory.md + fix stale RootSlab/BumpArena references

### DIFF
--- a/docs/impl/values.md
+++ b/docs/impl/values.md
@@ -7,8 +7,8 @@ payload.
 
 ```text
 struct Value {
-    tag: u64,      // type discriminant
-    payload: u64,  // type-specific data
+    tag: u64,      # type discriminant
+    payload: u64,  # type-specific data
 }
 ```
 
@@ -32,52 +32,70 @@ TAG_PTR (7)    raw pointer
 ## Heap types
 
 Heap types store a raw pointer to a `HeapObject` in the payload. The
-`HeapObject` lives in a slab slot owned by the fiber's `FiberHeap` (or
-the parent's `SharedAllocator` for yielding fibers). `Value` is `Copy` —
+`HeapObject` lives in a bump-arena page owned by the fiber's `FiberHeap`
+(or the parent's `SharedAllocator` for yielding fibers). `Value` is `Copy` —
 it is just a tag + pointer, not a reference-counted handle.
 
 ```text
-Tag              Pointed-to type
-──────────────────────────────────
-TAG_STRING (10)  String (immutable)
-TAG_MSTRING (11) MutableString
-TAG_ARRAY (12)   Vec<Value> (frozen)
-TAG_MARRAY (13)  Vec<Value> (mutable)
-TAG_STRUCT (14)  BTreeMap<SymbolId, Value> (frozen)
-TAG_MSTRUCT (15) BTreeMap<SymbolId, Value> (mutable)
-TAG_CONS (16)    (Value, Value) pair
-TAG_CLOSURE (17) Closure
-TAG_NATIVE_FN (18) fn pointer + arity
-TAG_BYTES (19)   Vec<u8> (frozen)
-TAG_MBYTES (20)  Vec<u8> (mutable)
-TAG_SET (21)     BTreeSet<Value> (frozen)
-TAG_MSET (22)    BTreeSet<Value> (mutable)
-TAG_FIBER (23)   Fiber
-TAG_BOX (24)     Box<Cell<Value>>
-TAG_PARAMETER (25) DynamicParameter
-TAG_SYNTAX (26)  Syntax object
+Tag                  HeapObject variant
+──────────────────────────────────────────────────────────
+TAG_STRING (10)      LString { s: InlineSlice<u8>, traits }
+TAG_STRING_MUT (11)  LStringMut { data: Rc<RefCell<Vec<u8>>>, traits }
+TAG_ARRAY (12)       LArray { elements: InlineSlice<Value>, traits }
+TAG_ARRAY_MUT (13)   LArrayMut { data: Rc<RefCell<Vec<Value>>>, traits }
+TAG_STRUCT (14)      LStruct { data: Vec<(TableKey, Value)>, traits }
+TAG_STRUCT_MUT (15)  LStructMut { data: Rc<RefCell<BTreeMap<TableKey, Value>>>, traits }
+TAG_CONS (16)        Pair { first: Value, rest: Value, traits }
+TAG_CLOSURE (17)     Closure { closure: Closure, traits }
+TAG_NATIVE_FN (18)   NativeFn (no traits field)
+TAG_BYTES (19)       LBytes { data: InlineSlice<u8>, traits }
+TAG_BYTES_MUT (20)   LBytesMut { data: Rc<RefCell<Vec<u8>>>, traits }
+TAG_SET (21)         LSet { data: InlineSlice<Value>, traits }
+TAG_SET_MUT (22)     LSetMut { data: Rc<RefCell<BTreeSet<Value>>>, traits }
+TAG_FIBER (23)       Fiber { handle: FiberHandle, traits }
+TAG_LBOX (24)        LBox { cell: Rc<RefCell<Value>>, traits }
+TAG_PARAMETER (25)   Parameter { id: u32, default: Value, traits }
+TAG_SYNTAX (26)      Syntax { syntax: Rc<Syntax>, traits }
 ```
+
+Additional heap types not shown above: `CaptureCell`, `Float` (heap NaN),
+`LibHandle`, `ThreadHandle`, `FFISignature`, `FFIType`, `ManagedPointer`,
+`External`. See `src/value/heap.rs` for the complete list.
 
 ### Heap allocation
 
 `HeapObject` is a Rust enum — a fixed-size tagged union. All variants
 occupy the same number of bytes (the size of the largest variant). Each
-`HeapObject` lives in a slot in the fiber's `RootSlab`, a chunk-based
-typed slab allocator with 256 slots per chunk.
+`HeapObject` lives in a `BumpArena` page owned by the fiber's `SlabPool`.
 
-The slab stores `HeapObject` shells. Many variants contain inner Rust
-heap data — a `Vec<Value>` inside an array, a `BTreeMap` inside a struct,
-an `Rc<Vec<u8>>` inside a closure's bytecode. The `needs_drop()` function
+The arena stores `HeapObject` shells. Many variants contain inner Rust
+heap data — a `Vec<Value>` inside a mutable array, an `Rc<RefCell<...>>`
+inside a closure, a `BTreeMap` inside a struct. The `needs_drop()` function
 tracks which `HeapTag` variants have inner heap allocations that require
 `Drop`. On scope exit or fiber death, destructors run on the `HeapObject`
-(freeing inner data), then the slab slot returns to the free list.
+(freeing inner data), and the arena position rewinds.
 
 This two-level structure means:
-- **Slab allocation is O(1)** — reuse a free-list slot or bump a cursor
-- **Pointer stability** — a `Value`'s payload pointer never moves
-- **Batch deallocation** — fiber death drops all chunks without per-object traversal
-- **Scope reclamation** — `RegionExit` returns slab slots to the free list
-  for non-escaping allocations (gated by escape analysis)
+- **Arena allocation is O(1)** — bump a byte offset within the current page
+- **Pointer stability** — a `Value`'s payload pointer never moves; pages are
+  `Box<[MaybeUninit<u8>]>` at fixed addresses
+- **Batch deallocation** — fiber death runs all destructors then clears the
+  arena (keeps one page for reuse)
+- **Scope reclamation** — `RegionExit` runs destructors and rewinds the arena
+  to the scope-entry position (gated by escape analysis)
+
+### Immutable types use InlineSlice
+
+Immutable collections (arrays, strings, bytes, sets) store their data inline
+in the bump arena via `InlineSlice<T>` — a fat pointer to arena-allocated
+bytes. This avoids inner `Vec` or `Box<str>` allocations for the common case.
+Mutable types use `Rc<RefCell<...>>` for cross-fiber live-update semantics.
+
+### Trait tables
+
+Every user-facing heap variant (19 types) carries a `traits: Value` field
+initialized to `NIL`. Only an immutable struct (`LStruct`) may be stored here.
+The field is invisible to equality, ordering, and hashing.
 
 ## Closures
 
@@ -87,6 +105,8 @@ A `Closure` stores:
 - Arity descriptor
 - Optional docstring
 - Signal profile
+- Location map (bytecode offset → source location)
+- Optional syntax object (for `eval` reconstruction)
 
 ## Arity
 
@@ -110,13 +130,15 @@ across mutability boundaries (`hash [1 2]` = `hash @[1 2]`).
 ## Files
 
 ```text
-src/value/repr/mod.rs    Value struct, tag constants
-src/value/types.rs       Type predicates and conversions
-src/value/heap.rs        HeapObject, HeapTag
-src/value/closure.rs     Closure struct
-src/value/fiberheap/     FiberHeap, RootSlab, routing
-src/value/shared_alloc.rs SharedAllocator for inter-fiber exchange
-src/value/arena.rs       alloc/deref, ArenaMark, ArenaGuard
+src/value/repr/           Value struct, tag constants, constructors, accessors
+src/value/types.rs         Arity, SymbolId, NativeFn, TableKey
+src/value/heap.rs          HeapObject, HeapTag, Pair, ExternalObject
+src/value/closure.rs       Closure struct
+src/value/fiberheap/       FiberHeap, SlabPool, BumpArena, routing
+src/value/shared_alloc.rs  SharedAllocator for inter-fiber exchange
+src/value/arena.rs         alloc/deref, ArenaMark, ArenaGuard
+src/value/inline_slice.rs  InlineSlice<T> for inline arena data
+src/value/allocator.rs     ElleAllocator trait, AllocatorBox
 ```
 
 ---
@@ -125,4 +147,4 @@ src/value/arena.rs       alloc/deref, ArenaMark, ArenaGuard
 
 - [impl/vm.md](vm.md) — VM that operates on Values
 - [types.md](../types.md) — user-facing type system
-- [memory.md](../memory.md) — memory model and ownership topology
+- [memory.md](../memory.md) — memory model, reclamation, and leak-free idioms

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -1,109 +1,261 @@
 # Memory
 
 Elle has no garbage collector. Memory is managed deterministically through
-per-fiber bump arenas, escape-analysis-driven scope reclamation, and
-zero-copy inter-fiber sharing. These three mechanisms are derived from the
-same static analysis that drives the signal system — signal inference tells
-the runtime which fibers yield and which are silent, and that distinction
-determines how memory is allocated, shared, and reclaimed.
+per-fiber tracked pools, compiler-directed scope reclamation, and tail-call
+pool rotation. These mechanisms are derived from the same static analysis that
+drives signal inference — the compiler knows at every allocation site whether
+the value can escape its scope, whether the containing function is a tail call,
+and whether the fiber will yield.
+
+## How to write leak-free code
+
+Most Elle code is naturally leak-free. The three rules:
+
+### 1. Don't assign heap values to outer mutable bindings in a loop
+
+```lisp
+# BAD: struct escapes to outer @var — linear growth
+(def @last nil)
+(def @i 0)
+(while (< i 100)
+  (assign last {:x i})
+  (assign i (+ i 1)))
+# each iteration's struct stays alive — the old value of last is never freed
+
+# GOOD: let-bind the struct — scope reclamation frees it
+(def @i 0)
+(while (< i 100)
+  (let [x {:x i}]
+    x)
+  (assign i (+ i 1)))
+# the struct is reclaimed at each iteration's scope exit
+```
+
+```lisp
+# BAD: strings accumulate via concat to outer @var
+(def @s "")
+(def @i 0)
+(while (< i 100)
+  (assign s (concat s "x"))
+  (assign i (+ i 1)))
+
+# BAD: push stores heap structs into outer mutable array
+(def @acc [])
+(def @i 0)
+(while (< i 100)
+  (push acc {:x i})
+  (assign i (+ i 1)))
+
+# BAD: put stores heap strings into outer mutable struct
+(def @s {:x 0})
+(def @i 0)
+(while (< i 100)
+  (put s :x (string "v" i))
+  (assign i (+ i 1)))
+```
+
+These patterns are inherently leaky — the value genuinely escapes the scope
+and must stay alive because something still references it. Fixing them requires
+drop-on-overwrite semantics (not yet implemented).
+
+### 2. Prefer tail calls for loops with heap allocation
+
+```lisp
+# Tail-recursive loop: trampoline rotation keeps memory bounded
+(defn process-all (n)
+  (if (= n 0)
+    :done
+    (begin
+      {:x n}                       # heap allocation
+      (process-all (- n 1)))))     # tail call — rotation frees {:x n}
+
+(process-all 10000)
+# memory stays bounded despite 10000 struct allocations
+```
+
+The same works for strings, mutual tail recursion, and any allocation that
+doesn't outlive the iteration:
+
+```lisp
+# Mutual tail recursion — also bounded
+(defn ping (n)
+  (if (= n 0) :done
+    (begin (string "ping " n) (pong (- n 1)))))
+
+(defn pong (n)
+  (if (= n 0) :done
+    (begin (string "pong " n) (ping (- n 1)))))
+
+(ping 10000)
+```
+
+### 3. Yielding fibers use flip rotation
+
+Fibers that yield mid-loop cannot use scope reclamation (the fiber suspends
+before `RegionExit` fires). Instead, `FlipSwap` at the loop back-edge rotates
+pools each iteration:
+
+```lisp
+# Yielding fiber — flip rotation keeps memory bounded
+(defn yield-items (n)
+  (fiber/new (fn []
+    (def @i 0)
+    (while (< i n)
+      (yield (string "item-" i))    # heap allocation + yield
+      (assign i (+ i 1))))
+  |:yield|))
+
+(def f (yield-items 10000))
+(while (not= (fiber/status f) :dead)
+  (fiber/resume f))
+# memory stays bounded despite 10000 string allocations across yields
+```
+
+## What is automatically reclaimed
+
+### Scope reclamation
+
+The compiler performs escape analysis on every `let`, `letrec`, and `while`
+body. When it can prove that no allocated value escapes — no captures, no
+suspension, result is immediate, no outward mutation — it emits
+`RegionEnter`/`RegionExit` bytecodes. `RegionExit` runs destructors and
+reclaims pool slots for objects allocated within the scope.
+
+```lisp
+# let-bound struct is reclaimed at scope exit
+(let [x {:a 1 :b 2}]
+  (get x :a))                         # => 1
+# x's struct is freed here
+
+# discarded struct in while body — scope reclaims each iteration
+(def @i 0)
+(while (< i 1000)
+  {:x i :y (+ i 1)}                   # struct allocated and discarded
+  (assign i (+ i 1)))
+# net allocs: ~0 (bounded by scope reclamation)
+```
+
+The escape analysis is conservative but handles common patterns:
+- Discarded expressions (structs, strings, cons cells)
+- `let`-bound values not captured by closures
+- Closures created and called within the same scope
+- `fiber/new` + `fiber/resume` within the same scope
+- `protect` expressions
+- `map`, `filter`, `each` over known-safe collections
+
+### Tail-call rotation
+
+Self-tail-calls in the trampoline get implicit pool rotation. On each tail-call
+iteration, the previous iteration's allocations are moved to a swap pool and
+freed on the next rotation (one-iteration lag ensures argument values remain
+valid). This bounds memory at the working-set size, not the iteration count.
+
+### Flip rotation
+
+`while` loops inside yielding fibers get explicit `FlipEnter`/`FlipSwap`/
+`FlipExit` bytecodes. Each `FlipSwap` at the back-edge rotates generations,
+keeping memory bounded even when scope reclamation is blocked by yield
+suspension.
+
+### Fiber death
+
+When a fiber completes or errors, its `FiberHeap` runs all destructors and
+drops all arena pages. The fiber's entire memory footprint disappears — no
+traversal, no mark phase, no sweep. A server loop spawning one fiber per
+request reclaims all per-request memory at fiber death.
 
 ## How it works
 
 Every `Value` is a 16-byte tagged union. Immediates (integers, keywords,
-booleans, nil) fit inline — no allocation. Heap types (strings, arrays,
-structs, closures, fibers) store a pointer to a `HeapObject` in a bump
-arena owned by the fiber.
+booleans, nil, floats) fit inline — no allocation. Heap types (strings, arrays,
+structs, closures, fibers, cons cells) store a pointer to a `HeapObject` in a
+tracked pool owned by the fiber.
 
 ### Per-fiber heaps
 
-Each fiber owns a `FiberHeap` containing a `SlabPool` — a bump arena
-with destructor tracking. The bump arena allocates sequentially into
-64KB pages. There is no per-slot free list; memory is reclaimed only at
-scope boundaries or fiber death.
+Each fiber owns a `FiberHeap` containing a `SlabPool` — a bump arena with
+destructor tracking and position-based mark/release. The bump arena allocates
+sequentially into 64KB pages. Individual slot deallocation is a no-op; memory
+is reclaimed only at scope boundaries (via mark/release) or fiber death (via
+teardown).
 
-When a fiber completes, its `FiberHeap` runs all destructors and drops
-all arena pages. The fiber's entire memory footprint disappears — no
-traversal, no mark phase, no sweep. A server loop spawning one fiber per
-request reclaims all per-request memory at fiber death.
+When a fiber completes, its `FiberHeap` runs all destructors, tears down all
+owned shared allocators and outboxes, and resets the arena (keeping one page
+for reuse).
 
 ### Bump arena
 
 The `BumpArena` is a byte-level sequential allocator:
 
-- **Pages**: `Vec<Box<[MaybeUninit<u8>; 64KB]>>` — pointer-stable
+- **Pages**: `Vec<Box<[MaybeUninit<u8>]>>` — pointer-stable
 - **Allocation**: bump a byte offset within the current page
 - **Oversized**: allocations >64KB get dedicated pages
-- **No individual deallocation**: `dealloc_slot()` is a no-op
-- **Reclamation**: `release_to(mark)` truncates pages and resets offset;
-  `clear()` on fiber death resets entirely (keeps first page for reuse)
+- **No individual deallocation**: memory is reclaimed by `release_to(mark)` or
+  `clear()` on fiber death
+- **Pointer stability**: `Value` payloads are raw pointers into arena pages;
+  pages never move once allocated
 
-This gives cache-friendly sequential allocation, zero fragmentation, and
-deterministic bulk reclamation.
+### SlabPool
 
-### Scope reclamation
+`SlabPool` wraps the bump arena with allocation tracking:
 
-The lowerer performs escape analysis on every `let`, `letrec`, and `block`
-scope. When it can prove that no allocated value escapes — no captures, no
-suspension, result is immediate, no outward mutation — it emits
-`RegionEnter` / `RegionExit` bytecodes that reclaim heap objects at scope
-exit rather than waiting for fiber death.
+- `allocs: Vec<*mut HeapObject>` — every allocation in order (for mark/release
+  and rotation)
+- `dtors: Vec<*mut HeapObject>` — objects that need `Drop` (closures, fibers,
+  mutable types with `Rc<RefCell<...>>`)
+- `alloc_count` — running total for `arena/count` introspection
 
-`RegionEnter` pushes an `ArenaMark` recording the arena's page/offset and
-destructor count. `RegionExit` pops the mark, runs destructors for objects
-allocated since the mark, and rewinds the arena to the mark position. This
-is transparent to user code.
+`release(mark)` runs destructors, truncates tracking vecs, and resets the arena
+to the mark position. `teardown()` does a full reset.
 
-### Zero-copy inter-fiber sharing
+### Scope marks
 
-When a fiber yields a value to its parent, that value must survive the
-child's death. Copying is expensive and breaks identity. Instead, the
-runtime uses signal inference to solve this at the allocation level.
+`RegionEnter` pushes an `ArenaMark` recording the pool's position and destructor
+count. `RegionExit` pops the mark, runs destructors for objects allocated since
+the mark, and rewinds the pool. This is transparent to user code — it's
+entirely compiler-directed.
 
-The compiler knows at fiber-creation time whether a fiber can yield
-(its signal includes `SIG_YIELD`). For yielding fibers, the runtime
-installs a `SharedAllocator` owned by the parent's `FiberHeap`. While the
-child executes, **all** of its allocations route to this shared arena — not
-selectively, not per-scope. The parent reads yielded values directly from
-shared memory: zero copy, zero serialization.
+### Inter-fiber value exchange
 
-For silent fibers (no yields), the shared allocator is never installed.
-The fiber allocates exclusively into its own private arena with no
-indirection overhead.
+When a fiber yields a value to its parent, that value must survive the child's
+death. Two mechanisms handle this, chosen at fiber creation time based on signal
+inference:
 
-### Outbox
+**Shared allocator routing** (yielding fibers): The child fiber routes all
+allocations to a `SharedAllocator` owned by the parent's `FiberHeap`. The
+parent reads yielded values directly — zero copy, zero serialization.
 
-For yield-safe allocation, the runtime uses an outbox mechanism:
+**Outbox mechanism** (newer path): The parent installs an outbox `SlabPool`
+before child execution. Between `OutboxEnter`/`OutboxExit` bytecodes,
+allocations go to the outbox. At yield time, values in the private pool are
+deep-copied to the outbox; values already in the outbox are returned directly.
+Previous outboxes are preserved so the parent can read values from earlier
+yields. All outboxes are freed in bulk on fiber death.
 
-- Parent installs an outbox (`Box<SlabPool>`) before child execution
-- Child allocates between `OutboxEnter`/`OutboxExit` bytecodes into the
-  outbox arena
-- At yield time, parent reads the outbox and stores it
-- On fiber death, all outboxes are freed in bulk
-
-This ensures yielded values don't reference the child's private heap.
+**Silent fibers** (no yields): neither mechanism is needed. The fiber allocates
+exclusively into its own private pool with no indirection overhead.
 
 ### Ownership topology
 
 ```text
 root fiber
-├── private arena        ← root's own allocations (BumpArena pages)
-├── shared allocator     ← child A's allocations (yielded values live here)
+├── private pool            ← root's own allocations (SlabPool → BumpArena pages)
+├── shared allocator        ← child A's allocations (yielded values live here)
 │   └── child A
-│       ├── private arena  ← idle (child yields, so everything routes to parent)
-│       ├── outbox         ← yield-bound allocations
-│       └── shared alloc   ← grandchild's allocations
+│       ├── private pool    ← idle (child yields; allocations route to parent)
+│       └── shared alloc    ← grandchild's allocations
 │           └── grandchild
 │               └── ...
 └── (child B: silent)
-    └── private arena    ← child B's own allocations (no sharing needed)
+    └── private pool        ← child B's own allocations (no sharing needed)
 ```
 
-- **Silent fibers** use their private arena exclusively. Scope marks
-  reclaim short-lived objects. `clear()` on death reclaims everything.
-- **Yielding fibers** route all allocations to the parent's shared arena.
-  Their private arena is idle.
-- **Parent fibers** own shared allocators in `owned_shared`. The shared
-  allocator has its own bump arena and destructor tracking.
+- **Silent fibers** use their private pool exclusively. Scope marks reclaim
+  short-lived objects. Teardown on death reclaims everything.
+- **Yielding fibers** route allocations to the parent's shared allocator (or
+  outbox). Their private pool is essentially idle.
+- **Parent fibers** own shared allocators in `owned_shared` and outboxes in
+  `old_outboxes`. Both are torn down on `clear()`.
 
 ## Why this works without a GC
 
@@ -120,21 +272,99 @@ The memory model exploits two properties that the compiler guarantees:
    These scopes get `RegionEnter`/`RegionExit` instrumentation for free.
 
 Together, these give deterministic memory management with no GC pauses, no
-write barriers, no card tables, and no stop-the-world collection. Memory
-is reclaimed at three granularities: scope exit, fiber death, and shared
-allocator teardown — all in bounded time.
+write barriers, no card tables, and no stop-the-world collection. Memory is
+reclaimed at four granularities: scope exit, tail-call rotation, flip
+rotation, and fiber death — all in bounded time.
 
 ## Introspection
 
 ```lisp
-# current object count
-(arena/count)              # => integer
+# current object count (local + shared)
+(arena/count)               # => integer
 
-# detailed stats
-(def stats (arena/stats))
-stats:object-count         # total live objects
-stats:allocated-bytes      # bytes committed by arena pages
+# bytes committed by arena pages
+(arena/bytes)               # => integer
+
+# peak object count since last reset
+(arena/peak)                # => integer
+
+# net allocations from a thunk
+(def result (arena/allocs (fn [] (pair 1 2))))
+(first result)              # => (1 2)
+(rest result)               # => 1
+
+# detailed stats (returns a struct via vm/query)
+(arena/stats)
+# => {:object-count N :peak-count N :allocated-bytes N
+#     :object-limit nil :scope-depth N :dtor-count N
+#     :root-live-count N :root-alloc-count N :shared-count N
+#     :active-allocator nil :scope-enter-count N :scope-dtor-count N}
+
+# allocation limits (dangerous — for debugging only)
+(arena/set-object-limit 10000)  # => previous limit or nil
+(arena/object-limit)            # => 10000
+(arena/set-object-limit nil)    # => 10000 (restore unlimited)
+
+# manual checkpoint/reset (dangerous — invalidates live Values)
+(def m (arena/checkpoint))
+(pair 1 2)
+(arena/reset m)
+# the cons cell is now invalid — do not reference it
 ```
 
-`arena/count` operates directly on thread-local state with zero
-allocation overhead.
+`arena/count` and `arena/bytes` operate directly on thread-local state with
+zero allocation overhead. `arena/stats` uses a query signal so the VM can
+snapshot heap state consistently.
+
+## Measuring your code
+
+The `arena/allocs` primitive measures net heap allocations from any expression:
+
+```lisp
+(def result (arena/allocs (fn [] (string "hello" " " "world"))))
+(first result)              # => "hello world"
+(rest result)               # => 1 (one string allocation)
+```
+
+For loop patterns, measure at two scales to detect linear leaks:
+
+```lisp
+(defn measure-loop [n]
+  (def before (arena/count))
+  (def @i 0)
+  (while (< i n)
+    {:x i}
+    (assign i (+ i 1)))
+  (- (arena/count) before))
+
+(def d100 (measure-loop 100))
+(def d10k (measure-loop 10000))
+
+# bounded: d100 and d10k are both small, d10k is not 100x d100
+(println "d100=" d100 " d10k=" d10k)
+```
+
+## Known leak patterns
+
+These patterns leak linearly and cannot be fixed without drop-on-overwrite
+semantics or reference counting:
+
+| Pattern | Why it leaks |
+|---------|-------------|
+| `(assign var (struct ...))` in a loop | Old value referenced by `var` |
+| `(assign s (concat s "x"))` in a loop | Old string referenced by `s` |
+| `(push arr (struct ...))` in a loop | Struct stored in growing array |
+| `(put s :key (string ...))` in a loop | Old string stored in struct |
+
+These are inherent — the value genuinely escapes its scope. If you must
+accumulate, be aware that the accumulated data lives until the containing
+fiber dies.
+
+---
+
+## See also
+
+- [impl/values.md](impl/values.md) — value representation and heap types
+- [signals/](signals/) — signal inference (drives scope reclamation and
+  shared-allocator routing)
+- [types.md](types.md) — user-facing type system

--- a/src/value/AGENTS.md
+++ b/src/value/AGENTS.md
@@ -22,7 +22,7 @@ Runtime value representation using a tagged union.
 | `fiber.rs` | `Fiber`, `FiberHandle`, `WeakFiberHandle`, `SuspendedFrame`, `Frame`, `FiberStatus`, `SignalBits` |
 | `error.rs` | `error_val()`, `error_val_extra()`, and `format_error()` helpers for error structs |
 | `ffi.rs` | `LibHandle` for C interop |
-| `fiberheap/` | `FiberHeap` struct (RootSlab + destructor tracking + scope marks + scope stats + active_allocator + shared alloc ownership), thread-local routing, `region_enter`/`region_exit`. Used by all fibers including root. |
+| `fiberheap/` | `FiberHeap` struct (SlabPool/BumpArena + destructor tracking + scope marks + scope stats + active_allocator + shared alloc ownership + outbox), thread-local routing, `region_enter`/`region_exit`. Used by all fibers including root. |
 | `shared_alloc.rs` | `SharedAllocator` for zero-copy inter-fiber value exchange |
 | `arena.rs` | Heap arena: `alloc`, `deref`, `ArenaMark`, `ArenaGuard`, mark/release lifecycle. All allocations go through `FiberHeap`. |
 | `heap.rs` | `HeapObject` enum, `Cons`, `ThreadHandle`, `BindingInner`, `BindingScope`, `LSet`, `LSetMut` (re-exports arena functions) |
@@ -40,7 +40,7 @@ Runtime value representation using a tagged union.
 | `Fiber` | `fiber.rs` | Independent execution context with stack, frames, signal mask |
 | `FiberHandle` | `fiber.rs` | `Rc<RefCell<Option<Fiber>>>` — take/put semantics for VM fiber swap |
 | `WeakFiberHandle` | `fiber.rs` | Weak reference for parent back-pointers (avoids Rc cycles) |
-| `FiberHeap` | `fiberheap/` | Per-fiber slab allocator (RootSlab) with destructor tracking and shared alloc ownership |
+| `FiberHeap` | `fiberheap/` | Per-fiber allocator (SlabPool/BumpArena) with destructor tracking and shared alloc ownership |
 | `SharedAllocator` | `shared_alloc.rs` | Bump allocator for zero-copy inter-fiber value exchange |
 | `Parameter` | `heap.rs` | Dynamic binding with id and default value, looked up at runtime |
 | `LSet` | `heap.rs` | Immutable set (`BTreeSet<Value>`), no `RefCell` |
@@ -226,7 +226,7 @@ Each `SendValue` variant for the 19 traitable types carries a
 | `types.rs` | ~150 | Arity, SymbolId, NativeFn, etc. |
 | `closure.rs` | ~70 | Closure struct |
 | `fiber.rs` | ~540 | Fiber, FiberHandle, WeakFiberHandle, SuspendedFrame, Frame, SignalBits |
-| `fiberheap/` | ~890 | FiberHeap (RootSlab + destructor tracking + scope marks + scope stats + ActiveAlloc + shared alloc ownership/routing), thread-local routing, `needs_drop`, `region_enter`/`region_exit` |
+| `fiberheap/` | ~890 | FiberHeap (SlabPool/BumpArena + destructor tracking + scope marks + scope stats + ActiveAlloc + shared alloc ownership/routing + outbox), thread-local routing, `needs_drop`, `region_enter`/`region_exit` |
 | `shared_alloc.rs` | ~180 | SharedAllocator (bump + destructor tracking), teardown, Drop impl |
 | `error.rs` | ~150 | error_val(), error_val_extra(), and format_error() helpers |
 | `ffi.rs` | ~22 | LibHandle |

--- a/src/value/fiberheap/AGENTS.md
+++ b/src/value/fiberheap/AGENTS.md
@@ -7,7 +7,7 @@ Per-fiber heap allocator with thread-local routing.
 - Allocate and track `HeapObject` values for a single fiber's lifetime
 - Run destructors (`Drop`) for heap-allocated objects on `release()` and `clear()`
 - Manage scope marks (`push_scope_mark` / `pop_scope_mark_and_release`)
-- Route inter-fiber value exchange through `SharedAllocator`
+- Route inter-fiber value exchange through `SharedAllocator` and outbox
 - Provide thread-local install/save/restore for the active `FiberHeap`
 
 ## Files
@@ -16,43 +16,63 @@ Per-fiber heap allocator with thread-local routing.
 |------|---------|
 | `mod.rs` | `FiberHeap` struct, `CustomAllocState`, `needs_drop()` |
 | `routing.rs` | Thread-local `CURRENT_FIBER_HEAP`, install/save/restore helpers |
-| `slab.rs` | `RootSlab` — chunk-based typed slab with intrusive free list |
+| `pool.rs` | `SlabPool` — bump arena + destructor tracking + position marks |
+| `bump.rs` | `BumpArena` — byte-level sequential allocator (64KB pages) |
+| `slab.rs` | `RootSlab` — legacy chunk-based typed slab (superseded by bump arena) |
 | `tests.rs` | Unit tests for `FiberHeap` and routing |
 
 ## Allocator dispatch
 
-`FiberHeap::alloc()` dispatches allocations through three layers in priority order:
+`FiberHeap::alloc()` dispatches allocations through four layers in priority order:
 
-1. **Shared allocator** (`shared_alloc` non-null): routes all allocations to a
+1. **Outbox** (`outbox_active` true): routes to the outbox `SlabPool` for
+   yield-bound values between `OutboxEnter`/`OutboxExit` bytecodes.
+2. **Shared allocator** (`shared_alloc` non-null): routes all allocations to a
    `SharedAllocator` owned by the parent fiber. Used by yielding child fibers
    for the entire duration of their execution — not per-scope, per-fiber.
-2. **Custom allocator** (`custom_alloc_stack` non-empty): routes to the top
-   Rust trait-object allocator; falls through to slab on null return.
-3. **Root slab** (`root_slab: RootSlab`): chunk-based typed slab with
-   intrusive free list. Default allocation path.
+   (Legacy path, will be replaced by outbox once fully wired.)
+3. **Custom allocator** (`custom_alloc_stack` non-empty): routes to the top
+   Rust trait-object allocator; falls through to pool on null return.
+4. **Private pool** (`pool: SlabPool`): bump arena with tracking. Default
+   allocation path.
 
-## Root slab (`RootSlab`)
+## SlabPool
 
-`root_slab` is a chunk-based typed slab allocator (`slab.rs`). Each chunk is a
-`Box<[MaybeUninit<HeapObject>]>` with 256 slots — pointer-stable, heap-allocated.
+`SlabPool` is the shared core of `FiberHeap` and `SharedAllocator`. It wraps
+a `BumpArena` with allocation and destructor tracking:
 
-Key properties:
-- `alloc()` reuses a free-list slot or bumps a cursor within the last chunk
-- `dealloc(ptr)` returns a slot to the intrusive free list (reused on next alloc)
-- `allocated_bytes()` reflects committed chunk memory (not live objects)
-- `clear()` keeps the first chunk, drops the rest, resets free list and cursor
+- `allocs: Vec<*mut HeapObject>` — every allocation in order (for release/rotation)
+- `dtors: Vec<*mut HeapObject>` — objects needing `Drop`
+- `alloc_count` — running total
 
-`root_allocs: Vec<*mut HeapObject>` tracks all root-slab allocations in order.
-`release(mark)` uses `mark.root_allocs_len()` to dealloc only the post-mark slots.
-This makes `release()` return slab memory to the free list, bounding memory at the
-working-set size rather than growing monotonically.
+`mark()` captures a `SlabMark` (allocs length, dtors length, arena position).
+`release(mark)` runs destructors, truncates tracking vecs, resets arena.
+`teardown()` does a full reset.
+
+`dealloc_slot()` is a no-op compatibility shim — individual slots cannot be
+freed in the bump-arena model. Memory is reclaimed by scope release or teardown.
+
+## BumpArena
+
+`BumpArena` is a byte-level sequential allocator in `bump.rs`:
+
+- **Pages**: `Vec<Box<[MaybeUninit<u8>]>>` — pointer-stable, heap-allocated
+- **Page size**: 64KB; oversized allocations get dedicated pages
+- **Allocation**: bump a byte offset within the current page
+- **No individual deallocation**: reclaimed by `release_to(mark)` or `clear()`
+- **Pointer stability**: pages never move once allocated
+
+## RootSlab (legacy)
+
+`RootSlab` in `slab.rs` is a chunk-based typed slab with intrusive free list
+(256 `HeapObject` slots per chunk). It is `#[allow(dead_code)]` — superseded
+by the bump arena in `SlabPool`. Retained for potential future use.
 
 ## Scope marks
 
-`RegionEnter` pushes a mark recording the current slab position (alloc count,
-dtor count, root allocs count). `RegionExit` pops the mark and calls `release()`
-to run destructors and return slab slots to the free list for objects allocated
-within the scope.
+`RegionEnter` pushes a mark recording the current pool position (alloc count,
+dtor count, root allocs count, bump arena position). `RegionExit` pops the
+mark and calls `release()` to run destructors and rewind the pool.
 
 The lowerer gates `RegionEnter`/`RegionExit` emission on escape analysis
 (`src/lir/lower/escape.rs`): only scopes where no allocated values can escape
@@ -61,24 +81,36 @@ result is immediate, no outward mutation.
 
 When a shared allocator is active (yielding child fiber), scope marks are
 forwarded to the shared allocator as well, so scope-based reclamation works
-correctly regardless of which slab the objects actually live in.
+correctly regardless of which pool the objects actually live in.
+
+## Outbox
+
+For yield-safe allocation, `FiberHeap` has an outbox mechanism:
+
+- Parent installs an outbox (`Box<SlabPool>`) before child execution
+- Child allocates between `OutboxEnter`/`OutboxExit` bytecodes into the outbox
+- At yield time, values in the private pool are deep-copied to the outbox;
+  values already in the outbox are returned directly
+- Previous outboxes are preserved so the parent can read earlier yields
+- On fiber death, all outboxes are freed in bulk
+
+This ensures yielded values don't reference the child's private pool.
 
 ## Ownership topology
 
 The memory model has a specific ownership structure driven by signal inference:
 
-- **Silent fibers** allocate exclusively into their own `root_slab`. Scope marks
+- **Silent fibers** allocate exclusively into their own private pool. Scope marks
   reclaim short-lived objects. `clear()` on fiber death reclaims everything.
 
-- **Yielding child fibers** route all allocations to their parent's
-  `SharedAllocator` (set by `with_child_fiber`, cleared on swap-back). The
-  child's private slab is essentially idle. This ensures yielded values survive
-  the child's death — the parent reads them directly, zero-copy.
+- **Yielding child fibers** route allocations to the parent's shared allocator
+  or outbox (set by `with_child_fiber`, cleared on swap-back). The child's
+  private pool is essentially idle. This ensures yielded values survive the
+  child's death — the parent reads them directly, zero-copy.
 
-- **Parent fibers** own `SharedAllocator`s in `owned_shared`. The shared
-  allocator is also a `RootSlab` with its own destructor and scope-mark
-  tracking. `get_or_create_shared_allocator()` reuses the last allocator to
-  avoid per-resume accumulation.
+- **Parent fibers** own `SharedAllocator`s in `owned_shared` and outboxes in
+  `old_outboxes`. `get_or_create_shared_allocator()` reuses the last allocator
+  to avoid per-resume accumulation.
 
 The chain is recursive: if a child spawns a yielding grandchild, the child
 becomes a parent with its own shared allocator, and the grandchild routes
@@ -86,13 +118,13 @@ allocations there.
 
 ## Invariants
 
-1. **Destructor ordering.** `run_dtors()` is always called before slab memory
-   is reclaimed. `drop_in_place` runs on objects still in `dtors`, then the slab
-   slot is freed.
+1. **Destructor ordering.** `run_dtors()` is always called before arena memory
+   is reclaimed. `drop_in_place` runs on objects still in `dtors`, then the
+   arena position rewinds.
 
-2. **`root_allocs` mirrors `root_slab.live_count`.** Every root-slab `alloc()`
-   appends to `root_allocs`; every `release()` or `clear()` pops the tail and
-   calls `root_slab.dealloc()`. The two must stay in sync.
+2. **`allocs` and `dtors` are truncated on release.** `release(mark)` truncates
+   `allocs` to `mark.allocs_len` and `dtors` to `mark.dtor_len`. The two must
+   stay in sync with `alloc_count`.
 
 3. **`needs_drop` is exhaustive.** Adding a `HeapTag` variant causes a compile
    error in `needs_drop()`. Every new variant must have an explicit `true`/`false`

--- a/src/vm/AGENTS.md
+++ b/src/vm/AGENTS.md
@@ -271,12 +271,12 @@ heap as the thread-local allocation target. All `Value::cons()`, `Value::closure
 etc. calls during child execution route to the child's `FiberHeap`. On swap-back,
 the parent's heap (always non-null after issue-525) is restored.
 
-`FiberHeap` uses a chunk-based slab allocator (`RootSlab`) for root-context
+`FiberHeap` uses a bump arena (`BumpArena`) wrapped in `SlabPool` for all
 allocations. Destructor tracking ensures `HeapObject` variants with inner heap
-allocations (`Vec`, `Rc`, `BTreeMap`, `Box<str>`) have their `Drop` impls
-called on `release()` and `clear()`. `release()` returns freed slots to the
-slab free list for reuse. Scope allocations still use `bumpalo::Bump` (freed
-atomically on `RegionExit`).
+allocations (`Vec`, `Rc`, `BTreeMap`) have their `Drop` impls called on
+`release()` and `clear()`. `release()` runs destructors and rewinds the arena
+to the scope-entry position. Individual slot deallocation is a no-op; memory
+is reclaimed only by scope release or fiber death.
 
 The root fiber uses the persistent `ROOT_HEAP` thread-local (a leaked `Box<FiberHeap>`
 created by `ensure_root_heap()`). The heap outlives any individual VM, so Values


### PR DESCRIPTION
docs/memory.md: complete rewrite to match current SlabPool/BumpArena reality. Adds programmer guide for leak-free idioms with literate examples, known leak patterns, and introspection API. All lisp fences pass doctest.

docs/impl/values.md: fix heap types table (TAG_BOX→TAG_LBOX, old type names→actual HeapObject variant fields), RootSlab→SlabPool/BumpArena, add InlineSlice/trait tables sections.

src/value/AGENTS.md, src/value/fiberheap/AGENTS.md, src/vm/AGENTS.md: update stale RootSlab/free-list/bumpalo references to SlabPool/BumpArena.