### PR TITLE
Double-buffered scope marks: enable slab slot recycling in loops

### DIFF
--- a/src/compiler/bytecode.rs
+++ b/src/compiler/bytecode.rs
@@ -207,6 +207,16 @@ pub enum Instruction {
     /// frees only the range between them (arg temporaries).
     RegionExitCall,
 
+    /// Rotate loop scope marks (soft — no slot deallocation).
+    /// Resets alloc_count, runs dtors, truncates tracking vecs.
+    /// Used when loop params may chain across iterations.
+    RegionRotate,
+
+    /// Rotate loop scope marks (hard — with slot deallocation).
+    /// Same as RegionRotate but returns slab slots to the free list.
+    /// Used when no loop param references previous iteration's allocs.
+    RegionRotateDealloc,
+
     /// Push a parameter frame onto the fiber's param_frames stack.
     /// Operand: u8 count (number of (param, value) pairs on the stack).
     /// Stack: [param1, val1, param2, val2, ...] → [] (all consumed).
@@ -551,6 +561,8 @@ pub fn disassemble_lines(instructions: &[u8]) -> Vec<String> {
             Instruction::RegionEnter
             | Instruction::RegionExit
             | Instruction::RegionExitCall
+            | Instruction::RegionRotate
+            | Instruction::RegionRotateDealloc
             | Instruction::OutboxEnter
             | Instruction::OutboxExit
             | Instruction::FlipEnter

--- a/src/hir/regions.rs
+++ b/src/hir/regions.rs
@@ -315,10 +315,16 @@ impl RegionInference {
                 }
             }
 
-            // Loop: introduce loop region
+            // Loop: introduce loop region (gated on suspension)
             HirKind::Loop { bindings, body } => {
-                let loop_region = self.fresh_region(self.current_region, RegionKind::Loop);
-                self.scope_region.insert(hir.id, loop_region);
+                let may_suspend = hir.signal.may_suspend();
+                let loop_region = if may_suspend {
+                    self.current_region
+                } else {
+                    let r = self.fresh_region(self.current_region, RegionKind::Loop);
+                    self.scope_region.insert(hir.id, r);
+                    r
+                };
 
                 // Inits are evaluated in the ENCLOSING region
                 for (b, init) in bindings {
@@ -575,10 +581,22 @@ impl RegionInference {
                 self.walk(body)
             }
 
-            // While: should be eliminated by functionalize, but handle
+            // While: normally eliminated by functionalize, but handle
+            // with a scope region for correctness (same gate as Let).
             HirKind::While { cond, body } => {
-                self.walk(cond);
-                self.walk(body);
+                let may_suspend = hir.signal.may_suspend();
+                if !may_suspend {
+                    let r = self.fresh_region(self.current_region, RegionKind::Scope);
+                    self.scope_region.insert(hir.id, r);
+                    let saved = self.current_region;
+                    self.current_region = r;
+                    self.walk(cond);
+                    self.walk(body);
+                    self.current_region = saved;
+                } else {
+                    self.walk(cond);
+                    self.walk(body);
+                }
                 None
             }
 
@@ -714,15 +732,33 @@ impl RegionInference {
                     }
                 }
                 RegionKind::Loop => {
-                    let has_loop_allocs = alloc_region
-                        .values()
-                        .any(|r| *r == *region || self.tree.is_ancestor(*region, *r));
-                    if has_loop_allocs {
-                        stats.scopes_loop += 1;
-                        RegionKind::Loop
+                    // Same escape check as Scope: if any alloc physically
+                    // inside this loop was widened past it, it's not safe
+                    // to reclaim per-iteration.
+                    let any_escaped = self.alloc_var.values().any(|&var_id| {
+                        let initial = self.var_initial_region[var_id as usize];
+                        let solved = self.var_regions[var_id as usize];
+                        let inside = initial == *region || self.tree.is_ancestor(*region, initial);
+                        if !inside {
+                            return false;
+                        }
+                        let stayed = solved == *region || self.tree.is_ancestor(*region, solved);
+                        !stayed
+                    });
+                    if any_escaped {
+                        stats.scopes_global += 1;
+                        RegionKind::Global
                     } else {
-                        stats.scopes_scope += 1;
-                        RegionKind::Scope
+                        let has_loop_allocs = alloc_region
+                            .values()
+                            .any(|r| *r == *region || self.tree.is_ancestor(*region, *r));
+                        if has_loop_allocs {
+                            stats.scopes_loop += 1;
+                            RegionKind::Loop
+                        } else {
+                            stats.scopes_scope += 1;
+                            RegionKind::Scope
+                        }
                     }
                 }
                 RegionKind::Function => {
@@ -1481,6 +1517,48 @@ mod tests {
         assert!(
             find_scope_kind(&info, RegionKind::Global) >= 1,
             "let with non-immediate user call should be Global"
+        );
+    }
+
+    // ── While scope region tests ─────────────────────────────────
+
+    #[test]
+    fn while_immediate_body_gets_scope() {
+        // A while loop whose body is silent (no suspension, no escaping allocs)
+        // should get a Scope region for per-iteration deallocation.
+        let (_, _, info) = analyze("(def @n 0) (while (%lt n 10) (assign n (%add n 1)))");
+        assert!(
+            find_scope_kind(&info, RegionKind::Scope) >= 1,
+            "while with immediate body should produce Scope region, got scope_kinds: {:?}",
+            info.scope_kind
+        );
+    }
+
+    #[test]
+    fn while_with_alloc_body_gets_scope_or_global() {
+        // A while loop whose body allocates (unknown call) → the scope
+        // should be Global because the call may escape values.
+        let (_, _, info) =
+            analyze("(def @n 0) (while (%lt n 10) (begin (f n) (assign n (%add n 1))))");
+        // f is an unknown call → allocation escapes → Global
+        assert!(
+            info.stats.regions_created >= 2,
+            "while with unknown call should create regions"
+        );
+    }
+
+    #[test]
+    fn loop_suspending_body_no_loop_region() {
+        // A loop whose body suspends AND allocates should NOT get a Loop
+        // region — suspension means we can't safely reclaim per-iteration.
+        // (f i) is an unknown call that allocates; (emit :yield) suspends.
+        let (_, _, info) = analyze("(loop [i 0] (begin (emit :yield (f i)) (recur (%add i 1))))");
+        // The Loop HIR node must not produce a Loop region when it suspends.
+        assert_eq!(
+            find_scope_kind(&info, RegionKind::Loop),
+            0,
+            "suspending loop must not get Loop region, got scope_kinds: {:?}",
+            info.scope_kind
         );
     }
 }

--- a/src/jit/dispatch.rs
+++ b/src/jit/dispatch.rs
@@ -376,6 +376,20 @@ pub extern "C" fn elle_jit_region_exit_call() -> JitValue {
     JitValue::nil()
 }
 
+/// Rotate loop scope marks: pop current, release previous, push current
+/// as new previous, push fresh mark as new current.
+#[no_mangle]
+pub extern "C" fn elle_jit_region_rotate() -> JitValue {
+    crate::value::fiberheap::region_rotate();
+    JitValue::nil()
+}
+
+#[no_mangle]
+pub extern "C" fn elle_jit_region_rotate_dealloc() -> JitValue {
+    crate::value::fiberheap::region_rotate_dealloc();
+    JitValue::nil()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/jit/translate.rs
+++ b/src/jit/translate.rs
@@ -1092,6 +1092,20 @@ impl<'a> FunctionTranslator<'a> {
                 let call = builder.ins().call(func_ref, &[]);
                 let _ = builder.inst_results(call);
             }
+            LirInstr::RegionRotate => {
+                let func_ref = self
+                    .module
+                    .declare_func_in_func(self.helpers.region_rotate, builder.func);
+                let call = builder.ins().call(func_ref, &[]);
+                let _ = builder.inst_results(call);
+            }
+            LirInstr::RegionRotateDealloc => {
+                let func_ref = self
+                    .module
+                    .declare_func_in_func(self.helpers.region_rotate_dealloc, builder.func);
+                let call = builder.ins().call(func_ref, &[]);
+                let _ = builder.inst_results(call);
+            }
 
             LirInstr::PushParamFrame { pairs } => {
                 let vm = self.vm_ptr.ok_or_else(|| {

--- a/src/jit/vtable.rs
+++ b/src/jit/vtable.rs
@@ -105,6 +105,8 @@ pub(crate) struct RuntimeHelpers {
     pub(crate) region_enter: FuncId,
     pub(crate) region_exit: FuncId,
     pub(crate) region_exit_call: FuncId,
+    pub(crate) region_rotate: FuncId,
+    pub(crate) region_rotate_dealloc: FuncId,
     pub(crate) rotate_pools: FuncId,
     // New intrinsic helpers
     pub(crate) is_empty: FuncId,
@@ -336,6 +338,14 @@ pub(crate) fn register_symbols(builder: &mut JITBuilder) {
         dispatch::elle_jit_region_exit_call as *const u8,
     );
     builder.symbol(
+        "elle_jit_region_rotate",
+        dispatch::elle_jit_region_rotate as *const u8,
+    );
+    builder.symbol(
+        "elle_jit_region_rotate_dealloc",
+        dispatch::elle_jit_region_rotate_dealloc as *const u8,
+    );
+    builder.symbol(
         "elle_jit_rotate_pools",
         dispatch::elle_jit_rotate_pools as *const u8,
     );
@@ -544,6 +554,8 @@ pub(crate) fn declare_helpers(module: &mut JITModule) -> Result<RuntimeHelpers, 
         region_enter: declare(module, "elle_jit_region_enter", &void_to_value)?,
         region_exit: declare(module, "elle_jit_region_exit", &void_to_value)?,
         region_exit_call: declare(module, "elle_jit_region_exit_call", &void_to_value)?,
+        region_rotate: declare(module, "elle_jit_region_rotate", &void_to_value)?,
+        region_rotate_dealloc: declare(module, "elle_jit_region_rotate_dealloc", &void_to_value)?,
         rotate_pools: declare(module, "elle_jit_rotate_pools", &vm_to_void)?,
         // New intrinsic helpers
         is_empty: declare(module, "elle_jit_is_empty", &value_unary)?,

--- a/src/lir/display.rs
+++ b/src/lir/display.rs
@@ -230,6 +230,8 @@ impl fmt::Display for LirInstr {
             LirInstr::RegionEnter => f.write_str("region-enter"),
             LirInstr::RegionExit => f.write_str("region-exit"),
             LirInstr::RegionExitCall => f.write_str("region-exit-call"),
+            LirInstr::RegionRotate => f.write_str("region-rotate"),
+            LirInstr::RegionRotateDealloc => f.write_str("region-rotate-dealloc"),
             LirInstr::OutboxEnter => f.write_str("outbox-enter"),
             LirInstr::OutboxExit => f.write_str("outbox-exit"),
             LirInstr::FlipEnter => f.write_str("flip-enter"),

--- a/src/lir/emit/mod.rs
+++ b/src/lir/emit/mod.rs
@@ -907,6 +907,13 @@ impl Emitter {
                 // No stack effect
             }
 
+            LirInstr::RegionRotate => {
+                self.bytecode.emit(Instruction::RegionRotate);
+            }
+            LirInstr::RegionRotateDealloc => {
+                self.bytecode.emit(Instruction::RegionRotateDealloc);
+            }
+
             LirInstr::OutboxEnter => {
                 self.bytecode.emit(Instruction::OutboxEnter);
                 // No stack effect

--- a/src/lir/lower/binding.rs
+++ b/src/lir/lower/binding.rs
@@ -10,7 +10,13 @@ impl<'a> Lowerer<'a> {
         body: &Hir,
         hir_id: HirId,
     ) -> Result<Reg, String> {
-        let scoped = self.region_scope_check(hir_id);
+        // Region inference says scope is reclaimable, but tail calls to
+        // scope-bound callees are unsafe: RegionExit frees the callee's
+        // slot before the tail call executes.
+        let scope_refs: Vec<(Binding, &Hir)> =
+            bindings.iter().map(|(b, init)| (*b, init)).collect();
+        let scoped = self.region_scope_check(hir_id)
+            && !Self::tail_call_callee_is_scope_bound(body, &scope_refs);
         if scoped {
             self.emit_region_enter();
         }
@@ -103,7 +109,10 @@ impl<'a> Lowerer<'a> {
         body: &Hir,
         hir_id: HirId,
     ) -> Result<Reg, String> {
-        let scoped = self.region_scope_check(hir_id);
+        let scope_refs: Vec<(Binding, &Hir)> =
+            bindings.iter().map(|(b, init)| (*b, init)).collect();
+        let scoped = self.region_scope_check(hir_id)
+            && !Self::tail_call_callee_is_scope_bound(body, &scope_refs);
         if scoped {
             self.emit_region_enter();
         }

--- a/src/lir/lower/escape.rs
+++ b/src/lir/lower/escape.rs
@@ -1703,4 +1703,153 @@ impl<'a> Lowerer<'a> {
         }
         true
     }
+
+    /// Check if dealloc_slot is safe within RegionRotate for a loop body.
+    ///
+    /// Double-buffered scope marks delay freeing by one iteration, so
+    /// recur arg values survive the rotation. But if a loop param is
+    /// assigned a heap value that REFERENCES the previous param value
+    /// (e.g., `(pair val acc)` where cdr → old acc), freeing iteration
+    /// N-1 corrupts iteration N's cons chain.
+    ///
+    /// Returns false when a loop param is assigned a non-safe value whose
+    /// arguments include another loop param — indicating a reference chain
+    /// across iterations.
+    pub(super) fn can_dealloc_in_loop(
+        &self,
+        body: &Hir,
+        loop_bindings: &[(Binding, &Hir)],
+    ) -> bool {
+        !self.loop_param_chains(body, loop_bindings)
+    }
+
+    /// Check if a loop param is assigned a value that chains across iterations.
+    ///
+    /// True when: `(assign loop_param (call ... other_loop_param ...))` — the
+    /// call's result may contain a reference to the old param value.
+    fn loop_param_chains(&self, hir: &Hir, scope_bindings: &[(Binding, &Hir)]) -> bool {
+        match &hir.kind {
+            HirKind::Assign { target, value } => {
+                let is_loop_param = scope_bindings.iter().any(|(b, _)| b == target);
+                if is_loop_param
+                    && !self.result_is_safe(value, scope_bindings)
+                    && Self::expr_references_loop_param(value, scope_bindings)
+                {
+                    return true;
+                }
+                self.loop_param_chains(value, scope_bindings)
+            }
+            HirKind::Lambda { .. } | HirKind::Loop { .. } => false,
+            HirKind::If {
+                cond,
+                then_branch,
+                else_branch,
+            } => {
+                self.loop_param_chains(cond, scope_bindings)
+                    || self.loop_param_chains(then_branch, scope_bindings)
+                    || self.loop_param_chains(else_branch, scope_bindings)
+            }
+            HirKind::Begin(exprs) | HirKind::And(exprs) | HirKind::Or(exprs) => exprs
+                .iter()
+                .any(|e| self.loop_param_chains(e, scope_bindings)),
+            HirKind::Let { bindings, body } | HirKind::Letrec { bindings, body } => {
+                bindings
+                    .iter()
+                    .any(|(_, init)| self.loop_param_chains(init, scope_bindings))
+                    || self.loop_param_chains(body, scope_bindings)
+            }
+            HirKind::Call { func, args, .. } => {
+                self.loop_param_chains(func, scope_bindings)
+                    || args
+                        .iter()
+                        .any(|a| self.loop_param_chains(&a.expr, scope_bindings))
+            }
+            HirKind::Cond {
+                clauses,
+                else_branch,
+            } => {
+                clauses.iter().any(|(c, b)| {
+                    self.loop_param_chains(c, scope_bindings)
+                        || self.loop_param_chains(b, scope_bindings)
+                }) || else_branch
+                    .as_ref()
+                    .is_some_and(|b| self.loop_param_chains(b, scope_bindings))
+            }
+            HirKind::Match { value, arms } => {
+                self.loop_param_chains(value, scope_bindings)
+                    || arms.iter().any(|(_, guard, body)| {
+                        guard
+                            .as_ref()
+                            .is_some_and(|g| self.loop_param_chains(g, scope_bindings))
+                            || self.loop_param_chains(body, scope_bindings)
+                    })
+            }
+            HirKind::Block { body, .. } => body
+                .iter()
+                .any(|e| self.loop_param_chains(e, scope_bindings)),
+            HirKind::While { cond, body } => {
+                self.loop_param_chains(cond, scope_bindings)
+                    || self.loop_param_chains(body, scope_bindings)
+            }
+            HirKind::SetCell { cell, value } => {
+                self.loop_param_chains(cell, scope_bindings)
+                    || self.loop_param_chains(value, scope_bindings)
+            }
+            HirKind::MakeCell { value }
+            | HirKind::DerefCell { cell: value }
+            | HirKind::Define { value, .. }
+            | HirKind::Break { value, .. }
+            | HirKind::Emit { value, .. } => self.loop_param_chains(value, scope_bindings),
+            HirKind::Recur { args } => args
+                .iter()
+                .any(|a| self.loop_param_chains(a, scope_bindings)),
+            HirKind::Intrinsic { args, .. } => args
+                .iter()
+                .any(|a| self.loop_param_chains(a, scope_bindings)),
+            HirKind::Eval { expr, env } => {
+                self.loop_param_chains(expr, scope_bindings)
+                    || self.loop_param_chains(env, scope_bindings)
+            }
+            HirKind::Parameterize { bindings, body } => {
+                bindings.iter().any(|(k, v)| {
+                    self.loop_param_chains(k, scope_bindings)
+                        || self.loop_param_chains(v, scope_bindings)
+                }) || self.loop_param_chains(body, scope_bindings)
+            }
+            HirKind::Destructure { value, .. } => self.loop_param_chains(value, scope_bindings),
+            _ => false,
+        }
+    }
+
+    /// Check if an expression directly references a loop parameter Var.
+    fn expr_references_loop_param(hir: &Hir, scope_bindings: &[(Binding, &Hir)]) -> bool {
+        match &hir.kind {
+            HirKind::Var(b) => scope_bindings.iter().any(|(sb, _)| sb == b),
+            HirKind::Call { func, args, .. } => {
+                Self::expr_references_loop_param(func, scope_bindings)
+                    || args
+                        .iter()
+                        .any(|a| Self::expr_references_loop_param(&a.expr, scope_bindings))
+            }
+            HirKind::Intrinsic { args, .. } => args
+                .iter()
+                .any(|a| Self::expr_references_loop_param(a, scope_bindings)),
+            HirKind::If {
+                cond,
+                then_branch,
+                else_branch,
+            } => {
+                Self::expr_references_loop_param(cond, scope_bindings)
+                    || Self::expr_references_loop_param(then_branch, scope_bindings)
+                    || Self::expr_references_loop_param(else_branch, scope_bindings)
+            }
+            HirKind::Begin(exprs) => exprs
+                .iter()
+                .any(|e| Self::expr_references_loop_param(e, scope_bindings)),
+            HirKind::DerefCell { cell } => Self::expr_references_loop_param(cell, scope_bindings),
+            // Don't recurse into lambdas
+            HirKind::Lambda { .. } => false,
+            _ => false,
+        }
+    }
 }

--- a/src/lir/lower/expr.rs
+++ b/src/lir/lower/expr.rs
@@ -72,7 +72,7 @@ impl<'a> Lowerer<'a> {
                 strict,
             } => self.lower_destructure_expr(pattern, value, *strict, &hir.span),
 
-            HirKind::While { cond, body } => self.lower_while(cond, body),
+            HirKind::While { cond, body } => self.lower_while(cond, body, hir.id),
             HirKind::Loop { bindings, body } => self.lower_loop(bindings, body, hir.id),
             HirKind::Recur { args } => self.lower_recur(args),
 
@@ -426,9 +426,12 @@ impl<'a> Lowerer<'a> {
         Ok(self.fresh_reg())
     }
 
-    fn lower_while(&mut self, cond: &Hir, body: &Hir) -> Result<Reg, String> {
+    fn lower_while(&mut self, cond: &Hir, body: &Hir, _hir_id: HirId) -> Result<Reg, String> {
         let result_reg = self.fresh_reg();
         let flip_eligible = self.can_flip_while_loop(body, &[]);
+        // All flip-eligible loops get double-buffered scope marks.
+        let scope_eligible = flip_eligible;
+        let dealloc_eligible = scope_eligible && self.can_dealloc_in_loop(body, &[]);
 
         let cond_label = self.fresh_label();
         let body_label = self.fresh_label();
@@ -436,6 +439,12 @@ impl<'a> Lowerer<'a> {
 
         // The entry block is the current block before we jump to cond.
         let entry_label = self.current_block.label;
+
+        // Double-buffered scope marks: push prev (guard) + curr before loop.
+        if scope_eligible {
+            self.emit_region_enter(); // prev (guard mark)
+            self.emit_region_enter(); // curr (first iteration)
+        }
 
         // Jump to condition check
         self.terminate(Terminator::Jump(cond_label));
@@ -455,17 +464,17 @@ impl<'a> Lowerer<'a> {
         if flip_eligible {
             self.flip_depth += 1;
         }
-        let scope_eligible = flip_eligible; // same escape-analysis gate
         self.current_block = BasicBlock::new(body_label);
-
-        if scope_eligible {
-            self.emit_region_enter(); // per-iteration scope mark
-        }
 
         let _body_reg = self.lower_expr(body)?;
 
+        // Back-edge: rotate scope marks (free prev iteration, start new curr)
         if scope_eligible {
-            self.emit_region_exit(); // release iteration allocs
+            if dealloc_eligible {
+                self.emit_region_rotate_dealloc();
+            } else {
+                self.emit_region_rotate();
+            }
         }
 
         // The back-edge block is whatever block we're in after lowering
@@ -484,8 +493,12 @@ impl<'a> Lowerer<'a> {
                 .push((entry_label, back_edge_label, done_label));
         }
 
-        // Done block — emit nil result here so it's tracked in this block
+        // Done block — release both scope marks (curr + prev)
         self.current_block = BasicBlock::new(done_label);
+        if scope_eligible {
+            self.emit_region_exit(); // curr
+            self.emit_region_exit(); // prev
+        }
         self.emit(LirInstr::Const {
             dst: result_reg,
             value: LirConst::Nil,
@@ -500,13 +513,11 @@ impl<'a> Lowerer<'a> {
         _hir_id: HirId,
     ) -> Result<Reg, String> {
         let result_reg = self.fresh_reg();
-        // Flip (rotation) requires stricter analysis than scope allocation.
-        // Keep escape analysis for flip until region inference handles
-        // rotation safety (heap values crossing iteration boundaries).
-        // Pass loop bindings as scope_bindings so assigns to loop parameters
-        // aren't treated as dangerous outward sets.
         let loop_scope: Vec<(Binding, &Hir)> = bindings.iter().map(|(b, h)| (*b, h)).collect();
         let flip_eligible = self.can_flip_while_loop(body, &loop_scope);
+        // All flip-eligible loops get double-buffered scope marks.
+        let scope_eligible = flip_eligible;
+        let dealloc_eligible = scope_eligible && self.can_dealloc_in_loop(body, &loop_scope);
 
         let loop_label = self.fresh_label();
         let done_label = self.fresh_label();
@@ -525,6 +536,12 @@ impl<'a> Lowerer<'a> {
             binding_slots.push(slot);
         }
 
+        // Double-buffered scope marks: push prev (guard) + curr before loop.
+        if scope_eligible {
+            self.emit_region_enter(); // prev (guard mark)
+            self.emit_region_enter(); // curr (first iteration)
+        }
+
         // Jump to loop header
         self.terminate(Terminator::Jump(loop_label));
         self.finish_block();
@@ -533,16 +550,10 @@ impl<'a> Lowerer<'a> {
         if flip_eligible {
             self.flip_depth += 1;
         }
-        let scope_eligible = flip_eligible;
         self.current_block = BasicBlock::new(loop_label);
 
-        if scope_eligible {
-            self.emit_region_enter();
-        }
-
-        // Save depth counters — Recur emits RegionExit which decrements
-        // region_depth in the back-edge path, but that path jumps to the
-        // loop header. The normal exit path needs the original depths.
+        // Save depth counters — Recur emits RegionRotate which doesn't
+        // change region_depth, but the normal exit path needs original depths.
         let saved_region_depth = self.region_depth;
         let saved_flip_depth = self.flip_depth;
 
@@ -551,6 +562,7 @@ impl<'a> Lowerer<'a> {
             loop_label,
             binding_slots: binding_slots.clone(),
             scope_eligible,
+            dealloc_eligible,
         });
 
         let body_reg = self.lower_expr(body)?;
@@ -562,8 +574,6 @@ impl<'a> Lowerer<'a> {
         self.flip_depth = saved_flip_depth;
 
         // If we reach here (no Recur), body_reg is the loop result.
-        // Store to a slot so it's accessible from the done block
-        // (same pattern as lower_if).
         let result_slot = self.current_func.num_locals;
         self.current_func.num_locals += 1;
         self.emit(LirInstr::StoreLocal {
@@ -571,8 +581,10 @@ impl<'a> Lowerer<'a> {
             src: body_reg,
         });
 
+        // Release both scope marks (curr + prev)
         if scope_eligible {
-            self.emit_region_exit();
+            self.emit_region_exit(); // curr
+            self.emit_region_exit(); // prev
         }
 
         let back_edge_label = self.current_block.label;
@@ -604,6 +616,7 @@ impl<'a> Lowerer<'a> {
         let loop_label = ctx.loop_label;
         let binding_slots = ctx.binding_slots.clone();
         let scope_eligible = ctx.scope_eligible;
+        let dealloc_eligible = ctx.dealloc_eligible;
 
         if args.len() != binding_slots.len() {
             return Err(format!(
@@ -619,14 +632,21 @@ impl<'a> Lowerer<'a> {
             arg_regs.push(self.lower_expr(arg)?);
         }
 
-        // Release iteration allocs before the back-edge jump
-        if scope_eligible {
-            self.emit_region_exit();
-        }
-
-        // Store new values to loop binding slots
+        // Store new values to loop binding slots BEFORE rotating scope marks.
+        // With double-buffered marks, RegionRotate frees the PREVIOUS
+        // iteration's allocs, not the current one — so recur arg values
+        // survive the rotation even if they reference current-iteration allocs.
         for (reg, &slot) in arg_regs.iter().zip(&binding_slots) {
             self.emit(LirInstr::StoreLocal { slot, src: *reg });
+        }
+
+        // Rotate scope marks: free prev iteration, start new curr
+        if scope_eligible {
+            if dealloc_eligible {
+                self.emit_region_rotate_dealloc();
+            } else {
+                self.emit_region_rotate();
+            }
         }
 
         // Jump back to loop header

--- a/src/lir/lower/mod.rs
+++ b/src/lir/lower/mod.rs
@@ -226,6 +226,8 @@ struct LoopLowerContext {
     loop_label: Label,
     binding_slots: Vec<u16>,
     scope_eligible: bool,
+    /// Whether RegionRotate should also dealloc slab slots.
+    dealloc_eligible: bool,
 }
 
 /// Tracks an active block during lowering so `break` can find its
@@ -650,6 +652,17 @@ impl<'a> Lowerer<'a> {
         self.region_depth -= 1;
     }
 
+    /// Emit `RegionRotate` for double-buffered loop scope rotation.
+    /// Does not change region_depth — the mark count stays the same
+    /// (pop prev + push new = net zero change from the 2-mark state).
+    fn emit_region_rotate(&mut self) {
+        self.emit(LirInstr::RegionRotate);
+    }
+
+    fn emit_region_rotate_dealloc(&mut self) {
+        self.emit(LirInstr::RegionRotateDealloc);
+    }
+
     /// Discard an unused value by storing it to a scratch slot.
     /// The emitter's auto-pop after StoreLocal cleans up the value
     /// from the operand stack. The scratch slot is lazily allocated
@@ -732,6 +745,15 @@ impl<'a> Lowerer<'a> {
 
         // Condition 3: result is immediate
         if !self.result_is_safe(body, &scope_binding_refs) {
+            self.scope_stats.rejected_unsafe_result += 1;
+            return false;
+        }
+
+        // Condition 3b: tail call callee must not be scope-bound.
+        // RegionExit fires before tail calls, so if the callee is a
+        // closure allocated inside the scope, its slot is freed before
+        // the tail call reads it.
+        if Self::tail_call_callee_is_scope_bound(body, &scope_binding_refs) {
             self.scope_stats.rejected_unsafe_result += 1;
             return false;
         }
@@ -1728,6 +1750,59 @@ impl<'a> Lowerer<'a> {
             HirKind::Match { arms, .. } => arms
                 .iter()
                 .all(|(_, _, body)| Self::body_is_tail_call(body)),
+            _ => false,
+        }
+    }
+
+    /// Check if the body's tail call callee is a scope-bound binding.
+    /// If so, RegionExit before the tail call would free the callee's slot.
+    fn tail_call_callee_is_scope_bound(hir: &Hir, scope_bindings: &[(Binding, &Hir)]) -> bool {
+        match &hir.kind {
+            HirKind::Call {
+                is_tail: true,
+                func,
+                ..
+            } => {
+                if let HirKind::Var(b) = &func.kind {
+                    scope_bindings.iter().any(|(sb, _)| sb == b)
+                } else if let HirKind::DerefCell { cell } = &func.kind {
+                    if let HirKind::Var(b) = &cell.kind {
+                        scope_bindings.iter().any(|(sb, _)| sb == b)
+                    } else {
+                        false
+                    }
+                } else {
+                    false
+                }
+            }
+            HirKind::If {
+                then_branch,
+                else_branch,
+                ..
+            } => {
+                Self::tail_call_callee_is_scope_bound(then_branch, scope_bindings)
+                    || Self::tail_call_callee_is_scope_bound(else_branch, scope_bindings)
+            }
+            HirKind::Begin(exprs) => exprs
+                .last()
+                .is_some_and(|e| Self::tail_call_callee_is_scope_bound(e, scope_bindings)),
+            HirKind::Let { body, .. } | HirKind::Letrec { body, .. } => {
+                Self::tail_call_callee_is_scope_bound(body, scope_bindings)
+            }
+            HirKind::Cond {
+                clauses,
+                else_branch,
+            } => {
+                clauses
+                    .iter()
+                    .any(|(_, body)| Self::tail_call_callee_is_scope_bound(body, scope_bindings))
+                    || else_branch
+                        .as_ref()
+                        .is_some_and(|b| Self::tail_call_callee_is_scope_bound(b, scope_bindings))
+            }
+            HirKind::Match { arms, .. } => arms
+                .iter()
+                .any(|(_, _, body)| Self::tail_call_callee_is_scope_bound(body, scope_bindings)),
             _ => false,
         }
     }

--- a/src/lir/types.rs
+++ b/src/lir/types.rs
@@ -599,6 +599,10 @@ pub enum LirInstr {
     /// objects between the two marks (arg temporaries), leaving the
     /// callee's allocations intact.
     RegionExitCall,
+    /// Rotate loop scope marks (soft — no slot deallocation).
+    RegionRotate,
+    /// Rotate loop scope marks (hard — with slot deallocation).
+    RegionRotateDealloc,
 
     // === Dynamic Parameters ===
     /// Push a parameter frame. `pairs` contains (param_reg, value_reg) pairs.

--- a/src/value/fiberheap/mod.rs
+++ b/src/value/fiberheap/mod.rs
@@ -357,16 +357,15 @@ impl FiberHeap {
         self.pool.run_dtors(mark.dtor_len());
         self.pool.dtors.truncate(mark.dtor_len());
 
-        // Dealloc slab slots allocated after the mark. Slot recycling
-        // is deferred until scope eligibility for while/loop forms is
-        // routed through region inference (follow-up to this PR).
+        // Dealloc slab slots allocated after the mark, returning them
+        // to the free list for reuse. Scope eligibility is gated by
+        // Tofte-Talpin region inference (suspension + escape analysis).
         for i in (mark.root_allocs_len()..self.pool.allocs.len()).rev() {
-            // SAFETY: pool.run_dtors already ran destructors.
-            // TODO: enable dealloc_slot once region inference covers while/loop.
-            // unsafe {
-            //     self.pool.dealloc_slot(self.pool.allocs[i]);
-            // }
-            let _ = i;
+            // SAFETY: pool.run_dtors already ran destructors; scope
+            // eligibility proves no live values reference these slots.
+            unsafe {
+                self.pool.dealloc_slot(self.pool.allocs[i]);
+            }
         }
         self.pool.allocs.truncate(mark.root_allocs_len());
 
@@ -450,6 +449,64 @@ impl FiberHeap {
         self.scope_dtors_run += dtors_before - self.pool.dtors.len();
     }
 
+    /// Rotate loop scope marks for double-buffered deallocation.
+    ///
+    /// The scope mark stack has two marks: [prev, curr]. This operation:
+    /// 1. Pops curr (saves it)
+    /// 2. Pops prev and releases (frees the iteration-before-last's allocs)
+    /// 3. Pushes saved curr as new prev
+    /// 4. Pushes a fresh mark as new curr
+    ///
+    /// This ensures that values from the PREVIOUS iteration survive into
+    /// the CURRENT iteration (recur args, loop params), and only the
+    /// iteration-before-last's allocs are freed.
+    pub fn rotate_scope_marks(&mut self) {
+        if self.scope_marks.len() < 2 {
+            return; // guard: no-op if marks are missing
+        }
+        if !self.shared_alloc.is_null() {
+            unsafe { &mut *self.shared_alloc }.rotate_marks();
+        }
+        let curr = self.scope_marks.pop().unwrap();
+        let dtors_before = self.pool.dtors.len();
+        let prev = self
+            .scope_marks
+            .pop()
+            .expect("RegionRotate: missing previous scope mark");
+        // Use release_no_dealloc: run dtors and reset alloc_count, but
+        // don't free slab slots. Loop iteration values may chain across
+        // generations (cons lists, etc.), making slot freeing unsafe.
+        // Let-scope RegionExit still uses release() with dealloc.
+        self.release_no_dealloc(prev);
+        self.scope_dtors_run += dtors_before - self.pool.dtors.len();
+        self.scope_marks.push(curr);
+        self.scope_marks.push(self.mark());
+        self.scope_enters += 1;
+    }
+
+    /// Like `rotate_scope_marks` but also deallocates slab slots.
+    /// Only safe when no loop param's value references a previous
+    /// iteration's alloc (no cons-chain pattern).
+    pub fn rotate_scope_marks_dealloc(&mut self) {
+        if self.scope_marks.len() < 2 {
+            return;
+        }
+        if !self.shared_alloc.is_null() {
+            unsafe { &mut *self.shared_alloc }.rotate_marks();
+        }
+        let curr = self.scope_marks.pop().unwrap();
+        let dtors_before = self.pool.dtors.len();
+        let prev = self
+            .scope_marks
+            .pop()
+            .expect("RegionRotateDealloc: missing previous scope mark");
+        self.release(prev);
+        self.scope_dtors_run += dtors_before - self.pool.dtors.len();
+        self.scope_marks.push(curr);
+        self.scope_marks.push(self.mark());
+        self.scope_enters += 1;
+    }
+
     /// Pop two scope marks and release only the range between them.
     ///
     /// Used by `RegionExitCall`: mark2 (top) is the barrier pushed
@@ -479,9 +536,11 @@ impl FiberHeap {
         self.scope_dtors_run += dtors_freed;
 
         // Dealloc slab slots for the range, then drain the entries.
-        // TODO: enable dealloc_slot once region inference covers while/loop.
         for i in (mark1.root_allocs_len()..mark2.root_allocs_len()).rev() {
-            let _ = i;
+            // SAFETY: dtors already ran for this range above.
+            unsafe {
+                self.pool.dealloc_slot(self.pool.allocs[i]);
+            }
         }
         self.pool
             .allocs

--- a/src/value/fiberheap/pool.rs
+++ b/src/value/fiberheap/pool.rs
@@ -168,7 +168,6 @@ impl SlabPool {
     /// pool and must not have been deallocated since. No live `Value` may
     /// reference this slot after this call.
     #[inline]
-    #[allow(dead_code)] // Used by release() once scope eligibility is fully wired
     pub unsafe fn dealloc_slot(&mut self, ptr: *mut HeapObject) {
         self.slab.dealloc(ptr);
     }

--- a/src/value/fiberheap/routing.rs
+++ b/src/value/fiberheap/routing.rs
@@ -173,6 +173,22 @@ pub fn region_exit_call() {
     }
 }
 
+/// Rotate loop scope marks on the current FiberHeap (`RegionRotate`).
+pub fn region_rotate() {
+    let ptr = current_heap_ptr();
+    if !ptr.is_null() {
+        unsafe { (*ptr).rotate_scope_marks() };
+    }
+}
+
+/// Rotate loop scope marks with dealloc (`RegionRotateDealloc`).
+pub fn region_rotate_dealloc() {
+    let ptr = current_heap_ptr();
+    if !ptr.is_null() {
+        unsafe { (*ptr).rotate_scope_marks_dealloc() };
+    }
+}
+
 /// Push a flip frame on the current FiberHeap (`FlipEnter`).
 pub fn flip_enter() {
     let ptr = current_heap_ptr();

--- a/src/value/fiberheap/tests.rs
+++ b/src/value/fiberheap/tests.rs
@@ -471,7 +471,6 @@ fn flip_noop_without_frame() {
 // through region inference (follow-up branch).
 
 #[test]
-#[ignore = "dealloc_slot disabled until scope eligibility uses region inference"]
 fn region_exit_returns_slots_to_free_list() {
     // RegionExit must return slab slots to the free list so subsequent
     // allocations reuse them. This is the Phase 1 enabling condition:
@@ -530,7 +529,6 @@ fn region_exit_returns_slots_to_free_list() {
 }
 
 #[test]
-#[ignore = "dealloc_slot disabled until scope eligibility uses region inference"]
 fn region_exit_reclaims_dtor_objects() {
     // RegionExit must run destructors AND return slots for objects that
     // need Drop (LString, Closure, etc.). Verifies that dtor ordering
@@ -573,7 +571,6 @@ fn region_exit_reclaims_dtor_objects() {
 }
 
 #[test]
-#[ignore = "dealloc_slot disabled until scope eligibility uses region inference"]
 fn region_exit_call_returns_middle_range() {
     // RegionExitCall pops two marks and frees only the range between
     // them (arg temporaries). Objects before mark1 and after mark2
@@ -621,7 +618,6 @@ fn region_exit_call_returns_middle_range() {
 }
 
 #[test]
-#[ignore = "dealloc_slot disabled until scope eligibility uses region inference"]
 fn region_exit_nested_scopes_dealloc_innermost_first() {
     // Nested RegionEnter/RegionExit must dealloc innermost scope's slots
     // first, then outer scope's. The free list is LIFO, so inner slots

--- a/src/value/shared_alloc.rs
+++ b/src/value/shared_alloc.rs
@@ -79,6 +79,21 @@ impl SharedAllocator {
         self.pool.release(&mark.slab);
     }
 
+    /// Double-buffered scope mark rotation for loop scope marks.
+    /// Same logic as FiberHeap::rotate_scope_marks but on the shared pool.
+    pub fn rotate_marks(&mut self) {
+        if self.marks.len() < 2 {
+            return;
+        }
+        let curr = self.marks.pop().unwrap();
+        let prev = self.marks.pop().unwrap();
+        self.pool.release(&prev.slab);
+        self.marks.push(curr);
+        self.marks.push(SharedMark {
+            slab: self.pool.mark(),
+        });
+    }
+
     /// Capture the current pool position for rotation.
     #[allow(dead_code)]
     pub(crate) fn rotation_mark(&self) -> SlabMark {

--- a/src/vm/dispatch.rs
+++ b/src/vm/dispatch.rs
@@ -435,6 +435,12 @@ impl VM {
                 Instruction::RegionExitCall => {
                     crate::value::fiberheap::region_exit_call();
                 }
+                Instruction::RegionRotate => {
+                    crate::value::fiberheap::region_rotate();
+                }
+                Instruction::RegionRotateDealloc => {
+                    crate::value::fiberheap::region_rotate_dealloc();
+                }
 
                 // Outbox routing: toggle allocation target for yield-bound values.
                 Instruction::OutboxEnter => {

--- a/src/wasm/instruction.rs
+++ b/src/wasm/instruction.rs
@@ -187,7 +187,11 @@ impl WasmEmitter {
                     self.emit_tail_call_dispatch(f);
                 }
             }
-            LirInstr::RegionEnter | LirInstr::RegionExit | LirInstr::RegionExitCall => {}
+            LirInstr::RegionEnter
+            | LirInstr::RegionExit
+            | LirInstr::RegionExitCall
+            | LirInstr::RegionRotate
+            | LirInstr::RegionRotateDealloc => {}
             // Outbox routing is VM-only.
             LirInstr::OutboxEnter | LirInstr::OutboxExit => {}
             // Flip rotation is VM-only (the WASM backend uses its own

--- a/src/wasm/regalloc.rs
+++ b/src/wasm/regalloc.rs
@@ -282,6 +282,8 @@ pub fn for_each_def(instr: &LirInstr, mut f: impl FnMut(Reg)) {
         | LirInstr::RegionEnter
         | LirInstr::RegionExit
         | LirInstr::RegionExitCall
+        | LirInstr::RegionRotate
+        | LirInstr::RegionRotateDealloc
         | LirInstr::PushParamFrame { .. }
         | LirInstr::PopParamFrame
         | LirInstr::CheckSignalBound { .. }
@@ -435,6 +437,8 @@ pub fn for_each_use(instr: &LirInstr, mut f: impl FnMut(Reg)) {
         LirInstr::RegionEnter
         | LirInstr::RegionExit
         | LirInstr::RegionExitCall
+        | LirInstr::RegionRotate
+        | LirInstr::RegionRotateDealloc
         | LirInstr::PopParamFrame
         | LirInstr::OutboxEnter
         | LirInstr::OutboxExit


### PR DESCRIPTION
RegionRotate (soft) and RegionRotateDealloc (hard) instructions
implement double-buffered scope mark rotation for while/loop bodies.
At the recur/back-edge, they free the iteration-before-last's allocs
(not the current iteration's), so recur arg values survive the
rotation boundary.

Soft rotation (RegionRotate) resets alloc_count and runs dtors but
does not free slab slots — used when loop params may chain across
iterations (cons lists via pair). Hard rotation (RegionRotateDealloc)
also returns slab slots to the free list — used when can_dealloc_in_loop
proves no loop param references a previous iteration's allocs.

All flip-eligible loops get scope marks (scope_eligible = flip_eligible),
ensuring the JIT backend gets alloc_count reset even though it skips
FlipSwap. dealloc_slot is enabled in release() and
pop_call_scope_marks_and_release() for let-scope RegionExit paths.

Region inference: Loop handler gated on !may_suspend(), loop solver
checks for escaping allocs. Four counter-factual tests un-ignored.