### PR TITLE
Type-aware signal narrowing for escape analysis + refcount rotation

### DIFF
--- a/src/hir/expr.rs
+++ b/src/hir/expr.rs
@@ -573,6 +573,122 @@ impl Hir {
     }
 
     /// Iterate over the immediate child HIR nodes of this node.
+    /// Visit each child mutably, in the same order as `for_each_child`.
+    pub(crate) fn for_each_child_mut(&mut self, mut f: impl FnMut(&mut Hir)) {
+        match &mut self.kind {
+            HirKind::Nil
+            | HirKind::EmptyList
+            | HirKind::Bool(_)
+            | HirKind::Int(_)
+            | HirKind::Float(_)
+            | HirKind::String(_)
+            | HirKind::Keyword(_)
+            | HirKind::Var(_)
+            | HirKind::Quote(_)
+            | HirKind::Error => {}
+
+            HirKind::Let { bindings, body } | HirKind::Letrec { bindings, body } => {
+                for (_, init) in bindings {
+                    f(init);
+                }
+                f(body);
+            }
+            HirKind::Lambda { body, .. } => f(body),
+            HirKind::If {
+                cond,
+                then_branch,
+                else_branch,
+            } => {
+                f(cond);
+                f(then_branch);
+                f(else_branch);
+            }
+            HirKind::Begin(exprs) => {
+                for e in exprs {
+                    f(e);
+                }
+            }
+            HirKind::Block { body, .. } => {
+                for e in body {
+                    f(e);
+                }
+            }
+            HirKind::Break { value, .. } => f(value),
+            HirKind::Call { func, args, .. } => {
+                f(func);
+                for a in args {
+                    f(&mut a.expr);
+                }
+            }
+            HirKind::Assign { value, .. }
+            | HirKind::Define { value, .. }
+            | HirKind::MakeCell { value } => f(value),
+            HirKind::DerefCell { cell } => f(cell),
+            HirKind::SetCell { cell, value } => {
+                f(cell);
+                f(value);
+            }
+            HirKind::While { cond, body } => {
+                f(cond);
+                f(body);
+            }
+            HirKind::Loop { bindings, body } => {
+                for (_, init) in bindings {
+                    f(init);
+                }
+                f(body);
+            }
+            HirKind::Recur { args } => {
+                for a in args {
+                    f(a);
+                }
+            }
+            HirKind::And(exprs) | HirKind::Or(exprs) => {
+                for e in exprs {
+                    f(e);
+                }
+            }
+            HirKind::Cond {
+                clauses,
+                else_branch,
+            } => {
+                for (c, b) in clauses {
+                    f(c);
+                    f(b);
+                }
+                if let Some(eb) = else_branch {
+                    f(eb);
+                }
+            }
+            HirKind::Emit { value, .. } => f(value),
+            HirKind::Match { value, arms } => {
+                f(value);
+                for (_, guard, body) in arms {
+                    if let Some(g) = guard {
+                        f(g);
+                    }
+                    f(body);
+                }
+            }
+            HirKind::Destructure { value, .. } => f(value),
+            HirKind::Eval { expr, env } => {
+                f(expr);
+                f(env);
+            }
+            HirKind::Parameterize { bindings, body } => {
+                for (_, v) in bindings {
+                    f(v);
+                }
+                f(body);
+            }
+            HirKind::Intrinsic { args, .. } => {
+                for a in args {
+                    f(a);
+                }
+            }
+        }
+    }
+
     pub(crate) fn for_each_child(&self, mut f: impl FnMut(&Hir)) {
         match &self.kind {
             HirKind::Nil

--- a/src/hir/mod.rs
+++ b/src/hir/mod.rs
@@ -19,6 +19,7 @@ mod expr;
 pub mod functionalize;
 pub mod lint;
 mod liveness;
+mod narrow;
 mod pattern;
 pub mod region;
 mod regions;

--- a/src/hir/narrow.rs
+++ b/src/hir/narrow.rs
@@ -1,0 +1,221 @@
+//! Type-aware signal narrowing and re-propagation.
+//!
+//! After type inference, strips SIG_ERROR from calls to known primitives
+//! when argument types prove the error path is unreachable. Then
+//! recomputes parent signals bottom-up so narrowed leaves propagate.
+
+use super::arena::BindingArena;
+use super::binding::Binding;
+use super::expr::{CallArg, Hir, HirId, HirKind};
+use super::types::{TyId, TypeInterner};
+use crate::signals::Signal;
+use crate::value::fiber::SignalBits;
+
+use std::collections::HashMap;
+
+/// Strip SIG_ERROR from calls to known primitives when argument types
+/// prove the error path is unreachable.
+pub(super) fn narrow_signals(
+    hir: &mut Hir,
+    interner: &TypeInterner,
+    arena: &BindingArena,
+    symbol_names: &HashMap<u32, String>,
+    hir_types: &HashMap<HirId, TyId>,
+    binding_min_length: &HashMap<Binding, usize>,
+) {
+    // Try to narrow this node
+    if let HirKind::Call { func, args, .. } = &hir.kind {
+        let callee_binding = super::typeinfer::unwrap_callee_binding(func);
+        if let Some(callee_binding) = callee_binding {
+            let callee_sym = arena.get(callee_binding).name;
+            if let Some(name) = symbol_names.get(&callee_sym.0) {
+                let arg_tys: Vec<TyId> = args
+                    .iter()
+                    .map(|a| {
+                        hir_types
+                            .get(&a.expr.id)
+                            .copied()
+                            .unwrap_or(TypeInterner::TOP)
+                    })
+                    .collect();
+                if should_narrow_error(name, &arg_tys, args, interner, arena, binding_min_length) {
+                    let sig_error = SignalBits::from_bit(0); // SIG_ERROR = bit 0
+                    hir.signal.bits = hir.signal.bits.subtract(sig_error);
+                }
+            }
+        }
+    }
+
+    // Recurse into children
+    hir.for_each_child_mut(|child| {
+        narrow_signals(
+            child,
+            interner,
+            arena,
+            symbol_names,
+            hir_types,
+            binding_min_length,
+        );
+    });
+}
+
+/// Determine if a call's SIG_ERROR can be stripped based on argument types.
+fn should_narrow_error(
+    name: &str,
+    arg_tys: &[TyId],
+    args: &[CallArg],
+    interner: &TypeInterner,
+    _arena: &BindingArena,
+    binding_min_length: &HashMap<Binding, usize>,
+) -> bool {
+    match name {
+        // Type predicates: never error
+        "string?" | "int?" | "integer?" | "float?" | "number?" | "nil?" | "boolean?"
+        | "keyword?" | "symbol?" | "pair?" | "list?" | "array?" | "struct?" | "bytes?"
+        | "even?" | "odd?" | "closure?" | "fiber?" | "box?" | "ptr?" | "pointer?" => true,
+
+        // type: never errors
+        "type" => true,
+
+        // empty?: never errors
+        "empty?" => true,
+
+        // string: all args must be stringifiable
+        "string" => arg_tys.iter().all(|t| interner.is_stringifiable(*t)),
+
+        // put on MutableStruct with keyword key
+        "put" => {
+            if arg_tys.len() >= 2 {
+                let target = arg_tys[0];
+                if target == TypeInterner::MUTABLE_STRUCT && arg_tys[1] == TypeInterner::KEYWORD {
+                    return true;
+                }
+                // put on MutableArray with literal int index in bounds
+                if target == TypeInterner::MUTABLE_ARRAY
+                    && arg_tys.len() >= 3
+                    && arg_tys[1] == TypeInterner::INT
+                {
+                    if let Some(idx) = extract_literal_int(&args[1].expr) {
+                        if let Some(min_len) =
+                            extract_target_min_length(&args[0].expr, binding_min_length)
+                        {
+                            if idx >= 0 && (idx as usize) < min_len {
+                                return true;
+                            }
+                        }
+                    }
+                }
+            }
+            false
+        }
+
+        // push on MutableArray
+        "push" => arg_tys
+            .first()
+            .is_some_and(|t| *t == TypeInterner::MUTABLE_ARRAY),
+
+        // abs, floor, ceil, round: arg0 must be Number
+        "abs" | "floor" | "ceil" | "round" => arg_tys
+            .first()
+            .is_some_and(|t| interner.subtype(*t, TypeInterner::NUMBER)),
+
+        // has?: arg0 must be struct-like
+        "has?" => arg_tys.first().is_some_and(|t| interner.is_struct(*t)),
+
+        // length: arg0 is not Top (works on strings, arrays, lists)
+        "length" => arg_tys.first().is_some_and(|t| *t != TypeInterner::TOP),
+
+        // string/contains?: both args must be String
+        "string/contains?" | "string-contains?" => {
+            arg_tys.len() >= 2
+                && arg_tys[0] == TypeInterner::STRING
+                && arg_tys[1] == TypeInterner::STRING
+        }
+
+        // number->string: arg0 must be Number
+        "number->string" => arg_tys
+            .first()
+            .is_some_and(|t| interner.subtype(*t, TypeInterner::NUMBER)),
+
+        _ => false,
+    }
+}
+
+fn extract_literal_int(hir: &Hir) -> Option<i64> {
+    match &hir.kind {
+        HirKind::Int(n) => Some(*n),
+        _ => None,
+    }
+}
+
+fn extract_target_min_length(
+    hir: &Hir,
+    binding_min_length: &HashMap<Binding, usize>,
+) -> Option<usize> {
+    match &hir.kind {
+        HirKind::Var(b) => binding_min_length.get(b).copied(),
+        HirKind::DerefCell { cell } => {
+            if let HirKind::Var(b) = &cell.kind {
+                binding_min_length.get(b).copied()
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
+}
+
+// ── Signal re-propagation ────────────────────────────────────────────
+
+/// Recompute each node's signal bottom-up from its children.
+/// Picks up both intrinsic rewrites (silent) and narrowed calls.
+pub(super) fn repropagate_signals(hir: &mut Hir) {
+    match &mut hir.kind {
+        // Lambda: separate signal scope — recurse inside but don't propagate
+        HirKind::Lambda { body, .. } => {
+            repropagate_signals(body);
+        }
+
+        // Call: preserve narrowed signal, combine with child signals
+        HirKind::Call { func, args, .. } => {
+            repropagate_signals(func);
+            for arg in args.iter_mut() {
+                repropagate_signals(&mut arg.expr);
+            }
+            let mut sig = hir.signal;
+            sig = sig.combine(func.signal);
+            for arg in args.iter() {
+                sig = sig.combine(arg.expr.signal);
+            }
+            hir.signal = sig;
+        }
+
+        // Emit: preserve emitted signal bits, just recurse
+        HirKind::Emit { value, .. } => {
+            repropagate_signals(value);
+        }
+
+        // Eval: always Yields — recurse but don't narrow
+        HirKind::Eval { expr, env } => {
+            repropagate_signals(expr);
+            repropagate_signals(env);
+        }
+
+        // Intrinsic: already silent — just recurse
+        HirKind::Intrinsic { args, .. } => {
+            for arg in args.iter_mut() {
+                repropagate_signals(arg);
+            }
+        }
+
+        // Everything else: recurse, then combine child signals
+        _ => {
+            let mut sig = Signal::silent();
+            hir.for_each_child_mut(|child| {
+                repropagate_signals(child);
+                sig = sig.combine(child.signal);
+            });
+            hir.signal = sig;
+        }
+    }
+}

--- a/src/hir/typeinfer.rs
+++ b/src/hir/typeinfer.rs
@@ -6,6 +6,9 @@
 //! 3. Rewrites stdlib arithmetic/comparison calls to intrinsics when
 //!    argument types prove ⊑ Number
 //! 4. Updates signals for rewritten nodes (intrinsics are silent)
+//! 5. Narrows signals on primitive calls with provably typed args
+//!    (delegates to `narrow.rs`)
+//! 6. Re-propagates signals bottom-up after narrowing
 //!
 //! The pass iterates to a fixed point: type refinements enable rewrites,
 //! which change signals, which enable further refinements.
@@ -91,6 +94,7 @@ pub fn infer_and_rewrite(hir: &mut Hir, arena: &BindingArena, symbols: &SymbolTa
     let symbol_names = symbols.all_names();
     let mut binding_types: HashMap<Binding, TyId> = HashMap::new();
     let mut hir_types: HashMap<HirId, TyId> = HashMap::new();
+    let mut binding_min_length: HashMap<Binding, usize> = HashMap::new();
 
     // Collect parameter info for lambdas: which bindings are params of which lambda
     let mut lambda_params: HashMap<Binding, Vec<Binding>> = HashMap::new();
@@ -109,6 +113,8 @@ pub fn infer_and_rewrite(hir: &mut Hir, arena: &BindingArena, symbols: &SymbolTa
             &mut hir_types,
             &lambda_params,
             &mut lambda_body_type,
+            &symbol_names,
+            &mut binding_min_length,
         );
 
         // Rewrite stdlib calls to intrinsics where types prove it's safe
@@ -126,6 +132,19 @@ pub fn infer_and_rewrite(hir: &mut Hir, arena: &BindingArena, symbols: &SymbolTa
             break;
         }
     }
+
+    // Signal narrowing: strip SIG_ERROR from calls with provably typed args
+    super::narrow::narrow_signals(
+        hir,
+        &interner,
+        arena,
+        &symbol_names,
+        &hir_types,
+        &binding_min_length,
+    );
+
+    // Signal re-propagation: recompute parent signals bottom-up
+    super::narrow::repropagate_signals(hir);
 
     TypeInfo { hir_types }
 }
@@ -153,6 +172,7 @@ fn collect_lambda_info(
 }
 
 /// Forward type inference pass. Returns true if any types changed.
+#[allow(clippy::too_many_arguments)]
 fn infer_types(
     hir: &Hir,
     interner: &TypeInterner,
@@ -161,6 +181,8 @@ fn infer_types(
     hir_types: &mut HashMap<HirId, TyId>,
     lambda_params: &HashMap<Binding, Vec<Binding>>,
     lambda_body_type: &mut HashMap<Binding, TyId>,
+    symbol_names: &HashMap<u32, String>,
+    binding_min_length: &mut HashMap<Binding, usize>,
 ) -> bool {
     let ty = infer_node(
         hir,
@@ -170,12 +192,15 @@ fn infer_types(
         hir_types,
         lambda_params,
         lambda_body_type,
+        symbol_names,
+        binding_min_length,
     );
     let old = hir_types.insert(hir.id, ty);
     old != Some(ty)
 }
 
 /// Infer the type of a single HIR node.
+#[allow(clippy::too_many_arguments)]
 fn infer_node(
     hir: &Hir,
     interner: &TypeInterner,
@@ -184,7 +209,25 @@ fn infer_node(
     hir_types: &mut HashMap<HirId, TyId>,
     lambda_params: &HashMap<Binding, Vec<Binding>>,
     lambda_body_type: &mut HashMap<Binding, TyId>,
+    symbol_names: &HashMap<u32, String>,
+    binding_min_length: &mut HashMap<Binding, usize>,
 ) -> TyId {
+    macro_rules! recurse {
+        ($e:expr) => {
+            infer_node(
+                $e,
+                interner,
+                arena,
+                binding_types,
+                hir_types,
+                lambda_params,
+                lambda_body_type,
+                symbol_names,
+                binding_min_length,
+            )
+        };
+    }
+
     match &hir.kind {
         // Literals
         HirKind::Nil => TypeInterner::NIL,
@@ -203,17 +246,8 @@ fn infer_node(
 
         // Intrinsic operations — known return types
         HirKind::Intrinsic { op, args } => {
-            // Recurse into args first
             for arg in args {
-                let ty = infer_node(
-                    arg,
-                    interner,
-                    arena,
-                    binding_types,
-                    hir_types,
-                    lambda_params,
-                    lambda_body_type,
-                );
+                let ty = recurse!(arg);
                 hir_types.insert(arg.id, ty);
             }
             intrinsic_return_type(*op, args, interner, hir_types)
@@ -222,15 +256,7 @@ fn infer_node(
         // Let/Letrec — seed binding types from init values
         HirKind::Let { bindings, body } | HirKind::Letrec { bindings, body } => {
             for (binding, init) in bindings {
-                let ty = infer_node(
-                    init,
-                    interner,
-                    arena,
-                    binding_types,
-                    hir_types,
-                    lambda_params,
-                    lambda_body_type,
-                );
+                let ty = recurse!(init);
                 hir_types.insert(init.id, ty);
                 // For lambda bindings, track their body's return type
                 if let HirKind::Lambda { body: lam_body, .. } = &init.kind {
@@ -251,33 +277,22 @@ fn infer_node(
                         .unwrap_or(TypeInterner::BOTTOM);
                     let joined = interner.join(old, ty);
                     binding_types.insert(*binding, joined);
+                    // Track min_length for array constructor bindings
+                    if ty == TypeInterner::MUTABLE_ARRAY || ty == TypeInterner::ARRAY {
+                        if let Some(len) = unwrap_to_call(init) {
+                            binding_min_length.insert(*binding, len);
+                        }
+                    }
                 }
             }
-            let body_ty = infer_node(
-                body,
-                interner,
-                arena,
-                binding_types,
-                hir_types,
-                lambda_params,
-                lambda_body_type,
-            );
+            let body_ty = recurse!(body);
             hir_types.insert(body.id, body_ty);
             body_ty
         }
 
         // Lambda — infer body type and track return type
         HirKind::Lambda { body, .. } => {
-            // Recurse into body
-            let body_ty = infer_node(
-                body,
-                interner,
-                arena,
-                binding_types,
-                hir_types,
-                lambda_params,
-                lambda_body_type,
-            );
+            let body_ty = recurse!(body);
             hir_types.insert(body.id, body_ty);
             // We return Top for the lambda value itself — it's a closure
             TypeInterner::TOP
@@ -289,15 +304,7 @@ fn infer_node(
             then_branch,
             else_branch,
         } => {
-            let _cond_ty = infer_node(
-                cond,
-                interner,
-                arena,
-                binding_types,
-                hir_types,
-                lambda_params,
-                lambda_body_type,
-            );
+            let _cond_ty = recurse!(cond);
             hir_types.insert(cond.id, _cond_ty);
 
             // Type guard narrowing: if cond is a type predicate call,
@@ -316,15 +323,7 @@ fn infer_node(
                 saved_types = Vec::new();
             }
 
-            let then_ty = infer_node(
-                then_branch,
-                interner,
-                arena,
-                binding_types,
-                hir_types,
-                lambda_params,
-                lambda_body_type,
-            );
+            let then_ty = recurse!(then_branch);
             hir_types.insert(then_branch.id, then_ty);
 
             // Restore type environment for else branch
@@ -339,15 +338,7 @@ fn infer_node(
                 }
             }
 
-            let else_ty = infer_node(
-                else_branch,
-                interner,
-                arena,
-                binding_types,
-                hir_types,
-                lambda_params,
-                lambda_body_type,
-            );
+            let else_ty = recurse!(else_branch);
             hir_types.insert(else_branch.id, else_ty);
 
             interner.join(then_ty, else_ty)
@@ -355,29 +346,13 @@ fn infer_node(
 
         // Call — forward arg types to callee params; result = callee return type
         HirKind::Call { func, args, .. } => {
-            let _func_ty = infer_node(
-                func,
-                interner,
-                arena,
-                binding_types,
-                hir_types,
-                lambda_params,
-                lambda_body_type,
-            );
+            let _func_ty = recurse!(func);
             hir_types.insert(func.id, _func_ty);
 
             let arg_types: Vec<TyId> = args
                 .iter()
                 .map(|a| {
-                    let ty = infer_node(
-                        &a.expr,
-                        interner,
-                        arena,
-                        binding_types,
-                        hir_types,
-                        lambda_params,
-                        lambda_body_type,
-                    );
+                    let ty = recurse!(&a.expr);
                     hir_types.insert(a.expr.id, ty);
                     ty
                 })
@@ -414,6 +389,15 @@ fn infer_node(
                         .unwrap_or(TypeInterner::BOTTOM);
                     return ret_ty;
                 }
+
+                // Primitive return type inference for unresolved callees
+                let callee_sym = arena.get(callee_binding).name;
+                if let Some(name) = symbol_names.get(&callee_sym.0) {
+                    let prim_ty = primitive_return_type(name, &arg_types, interner);
+                    if prim_ty != TypeInterner::TOP {
+                        return prim_ty;
+                    }
+                }
             }
 
             TypeInterner::TOP
@@ -423,15 +407,7 @@ fn infer_node(
         HirKind::Begin(exprs) => {
             let mut ty = TypeInterner::NIL;
             for expr in exprs {
-                ty = infer_node(
-                    expr,
-                    interner,
-                    arena,
-                    binding_types,
-                    hir_types,
-                    lambda_params,
-                    lambda_body_type,
-                );
+                ty = recurse!(expr);
                 hir_types.insert(expr.id, ty);
             }
             ty
@@ -439,15 +415,7 @@ fn infer_node(
         HirKind::Block { body, .. } => {
             let mut ty = TypeInterner::NIL;
             for expr in body {
-                ty = infer_node(
-                    expr,
-                    interner,
-                    arena,
-                    binding_types,
-                    hir_types,
-                    lambda_params,
-                    lambda_body_type,
-                );
+                ty = recurse!(expr);
                 hir_types.insert(expr.id, ty);
             }
             ty
@@ -456,15 +424,7 @@ fn infer_node(
         // And/Or — conservative: Top
         HirKind::And(_) | HirKind::Or(_) => {
             hir.for_each_child(|child| {
-                let ty = infer_node(
-                    child,
-                    interner,
-                    arena,
-                    binding_types,
-                    hir_types,
-                    lambda_params,
-                    lambda_body_type,
-                );
+                let ty = recurse!(child);
                 hir_types.insert(child.id, ty);
             });
             TypeInterner::TOP
@@ -473,15 +433,7 @@ fn infer_node(
         // Loop — recurse into body
         HirKind::Loop { bindings, body } => {
             for (binding, init) in bindings {
-                let ty = infer_node(
-                    init,
-                    interner,
-                    arena,
-                    binding_types,
-                    hir_types,
-                    lambda_params,
-                    lambda_body_type,
-                );
+                let ty = recurse!(init);
                 hir_types.insert(init.id, ty);
                 let old = binding_types
                     .get(binding)
@@ -489,15 +441,7 @@ fn infer_node(
                     .unwrap_or(TypeInterner::BOTTOM);
                 binding_types.insert(*binding, interner.join(old, ty));
             }
-            let body_ty = infer_node(
-                body,
-                interner,
-                arena,
-                binding_types,
-                hir_types,
-                lambda_params,
-                lambda_body_type,
-            );
+            let body_ty = recurse!(body);
             hir_types.insert(body.id, body_ty);
             body_ty
         }
@@ -508,51 +452,61 @@ fn infer_node(
             binding: target,
             value,
         } => {
-            let ty = infer_node(
-                value,
-                interner,
-                arena,
-                binding_types,
-                hir_types,
-                lambda_params,
-                lambda_body_type,
-            );
+            let ty = recurse!(value);
             hir_types.insert(value.id, ty);
             let old = binding_types
                 .get(target)
                 .copied()
                 .unwrap_or(TypeInterner::BOTTOM);
             binding_types.insert(*target, interner.join(old, ty));
+            // Track min_length for array constructor bindings
+            if ty == TypeInterner::MUTABLE_ARRAY || ty == TypeInterner::ARRAY {
+                if let Some(call) = unwrap_to_call(value) {
+                    binding_min_length.insert(*target, call);
+                }
+            }
             ty
         }
 
-        // MakeCell/DerefCell/SetCell — pass through
+        // MakeCell — propagate inner value type
+        HirKind::MakeCell { value } => {
+            let ty = recurse!(value);
+            hir_types.insert(value.id, ty);
+            ty
+        }
+
+        // DerefCell — return binding type if cell is Var(b)
         HirKind::DerefCell { cell } => {
-            let ty = infer_node(
-                cell,
-                interner,
-                arena,
-                binding_types,
-                hir_types,
-                lambda_params,
-                lambda_body_type,
-            );
+            let ty = recurse!(cell);
             hir_types.insert(cell.id, ty);
-            TypeInterner::TOP
+            if let HirKind::Var(b) = &cell.kind {
+                binding_types.get(b).copied().unwrap_or(TypeInterner::TOP)
+            } else {
+                TypeInterner::TOP
+            }
+        }
+
+        // SetCell — widen binding type
+        HirKind::SetCell { cell, value } => {
+            let cell_ty = recurse!(cell);
+            hir_types.insert(cell.id, cell_ty);
+            let val_ty = recurse!(value);
+            hir_types.insert(value.id, val_ty);
+            // Widen the binding's type with the new value
+            if let HirKind::Var(b) = &cell.kind {
+                let old = binding_types
+                    .get(b)
+                    .copied()
+                    .unwrap_or(TypeInterner::BOTTOM);
+                binding_types.insert(*b, interner.join(old, val_ty));
+            }
+            val_ty
         }
 
         // Everything else — recurse and return Top
         _ => {
             hir.for_each_child(|child| {
-                let ty = infer_node(
-                    child,
-                    interner,
-                    arena,
-                    binding_types,
-                    hir_types,
-                    lambda_params,
-                    lambda_body_type,
-                );
+                let ty = recurse!(child);
                 hir_types.insert(child.id, ty);
             });
             TypeInterner::TOP
@@ -562,7 +516,7 @@ fn infer_node(
 
 /// Extract the binding from a callee expression.
 /// Handles both `Var(b)` and `DerefCell { Var(b) }` (letrec recursive calls).
-fn unwrap_callee_binding(func: &Hir) -> Option<Binding> {
+pub(super) fn unwrap_callee_binding(func: &Hir) -> Option<Binding> {
     match &func.kind {
         HirKind::Var(b) => Some(*b),
         HirKind::DerefCell { cell } => {
@@ -573,6 +527,55 @@ fn unwrap_callee_binding(func: &Hir) -> Option<Binding> {
             }
         }
         _ => None,
+    }
+}
+
+/// Extract arg count from a Call expression, unwrapping MakeCell if needed.
+/// Returns Some(arg_count) for array/struct constructor calls.
+fn unwrap_to_call(hir: &Hir) -> Option<usize> {
+    match &hir.kind {
+        HirKind::Call { args, .. } => Some(args.len()),
+        HirKind::MakeCell { value } => unwrap_to_call(value),
+        _ => None,
+    }
+}
+
+/// Known return types for primitive (stdlib) function calls.
+fn primitive_return_type(name: &str, arg_types: &[TyId], interner: &TypeInterner) -> TyId {
+    match name {
+        "array" => TypeInterner::ARRAY,
+        "@array" => TypeInterner::MUTABLE_ARRAY,
+        "struct" => TypeInterner::STRUCT,
+        "@struct" => TypeInterner::MUTABLE_STRUCT,
+        "string" => TypeInterner::STRING,
+        "push" => {
+            // push returns arg0 type (MutableArray passthrough)
+            arg_types.first().copied().unwrap_or(TypeInterner::TOP)
+        }
+        "put" => {
+            // put returns arg0 type (passthrough)
+            arg_types.first().copied().unwrap_or(TypeInterner::TOP)
+        }
+        "abs" | "floor" | "ceil" | "round" => TypeInterner::NUMBER,
+        "length" => TypeInterner::INT,
+        "type" => TypeInterner::KEYWORD,
+        "has?" | "empty?" | "contains?" => TypeInterner::BOOL,
+        "string?" | "int?" | "integer?" | "float?" | "number?" | "nil?" | "boolean?"
+        | "keyword?" | "symbol?" | "pair?" | "list?" | "array?" | "struct?" | "bytes?"
+        | "even?" | "odd?" | "closure?" | "fiber?" | "box?" | "ptr?" | "pointer?" => {
+            TypeInterner::BOOL
+        }
+        "string/contains?"
+        | "string-contains?"
+        | "string/starts-with?"
+        | "string-starts-with?"
+        | "string/ends-with?"
+        | "string-ends-with?" => TypeInterner::BOOL,
+        "number->string" => TypeInterner::STRING,
+        _ => {
+            let _ = (arg_types, interner);
+            TypeInterner::TOP
+        }
     }
 }
 
@@ -776,136 +779,16 @@ fn rewrite_children(
     hir_types: &HashMap<HirId, TyId>,
 ) -> bool {
     let mut changed = false;
-    macro_rules! rw {
-        ($e:expr) => {
-            changed |= rewrite_calls(
-                $e,
-                interner,
-                arena,
-                rewrite_table,
-                symbol_names,
-                binding_types,
-                hir_types,
-            );
-        };
-    }
-
-    match &mut hir.kind {
-        HirKind::Let { bindings, body } | HirKind::Letrec { bindings, body } => {
-            for (_, init) in bindings.iter_mut() {
-                rw!(init);
-            }
-            rw!(body);
-        }
-        HirKind::Lambda { body, .. } => {
-            rw!(body);
-        }
-        HirKind::If {
-            cond,
-            then_branch,
-            else_branch,
-        } => {
-            rw!(cond);
-            rw!(then_branch);
-            rw!(else_branch);
-        }
-        HirKind::Begin(exprs) | HirKind::And(exprs) | HirKind::Or(exprs) => {
-            for expr in exprs.iter_mut() {
-                rw!(expr);
-            }
-        }
-        HirKind::Block { body, .. } => {
-            for expr in body.iter_mut() {
-                rw!(expr);
-            }
-        }
-        HirKind::Call { func, args, .. } => {
-            rw!(func);
-            for arg in args.iter_mut() {
-                rw!(&mut arg.expr);
-            }
-        }
-        HirKind::Assign { value, .. }
-        | HirKind::Define { value, .. }
-        | HirKind::MakeCell { value }
-        | HirKind::Break { value, .. } => {
-            rw!(value);
-        }
-        HirKind::DerefCell { cell } => {
-            rw!(cell);
-        }
-        HirKind::SetCell { cell, value } => {
-            rw!(cell);
-            rw!(value);
-        }
-        HirKind::While { cond, body } => {
-            rw!(cond);
-            rw!(body);
-        }
-        HirKind::Loop { bindings, body } => {
-            for (_, init) in bindings.iter_mut() {
-                rw!(init);
-            }
-            rw!(body);
-        }
-        HirKind::Recur { args } => {
-            for arg in args.iter_mut() {
-                rw!(arg);
-            }
-        }
-        HirKind::Cond {
-            clauses,
-            else_branch,
-        } => {
-            for (c, b) in clauses.iter_mut() {
-                rw!(c);
-                rw!(b);
-            }
-            if let Some(eb) = else_branch {
-                rw!(eb);
-            }
-        }
-        HirKind::Emit { value, .. } => {
-            rw!(value);
-        }
-        HirKind::Match { value, arms } => {
-            rw!(value);
-            for (_, guard, body) in arms.iter_mut() {
-                if let Some(g) = guard {
-                    rw!(g);
-                }
-                rw!(body);
-            }
-        }
-        HirKind::Destructure { value, .. } => {
-            rw!(value);
-        }
-        HirKind::Eval { expr, env } => {
-            rw!(expr);
-            rw!(env);
-        }
-        HirKind::Parameterize { bindings, body } => {
-            for (_, v) in bindings.iter_mut() {
-                rw!(v);
-            }
-            rw!(body);
-        }
-        HirKind::Intrinsic { args, .. } => {
-            for arg in args.iter_mut() {
-                rw!(arg);
-            }
-        }
-        HirKind::Nil
-        | HirKind::EmptyList
-        | HirKind::Bool(_)
-        | HirKind::Int(_)
-        | HirKind::Float(_)
-        | HirKind::String(_)
-        | HirKind::Keyword(_)
-        | HirKind::Var(_)
-        | HirKind::Quote(_)
-        | HirKind::Error => {}
-    }
-
+    hir.for_each_child_mut(|child| {
+        changed |= rewrite_calls(
+            child,
+            interner,
+            arena,
+            rewrite_table,
+            symbol_names,
+            binding_types,
+            hir_types,
+        );
+    });
     changed
 }

--- a/src/hir/types.rs
+++ b/src/hir/types.rs
@@ -23,6 +23,10 @@ pub(crate) enum TyKind {
     Symbol,
     EmptyList,
     Bytes,
+    Array,
+    MutableArray,
+    Struct,
+    MutableStruct,
     Top,
 }
 
@@ -48,6 +52,10 @@ impl TypeInterner {
     pub const SYMBOL: TyId = TyId(9);
     pub const EMPTY_LIST: TyId = TyId(10);
     pub const BYTES: TyId = TyId(11);
+    pub const ARRAY: TyId = TyId(12);
+    pub const MUTABLE_ARRAY: TyId = TyId(13);
+    pub const STRUCT: TyId = TyId(14);
+    pub const MUTABLE_STRUCT: TyId = TyId(15);
 }
 
 impl Default for TypeInterner {
@@ -71,6 +79,10 @@ impl TypeInterner {
             TyKind::Symbol,
             TyKind::EmptyList,
             TyKind::Bytes,
+            TyKind::Array,
+            TyKind::MutableArray,
+            TyKind::Struct,
+            TyKind::MutableStruct,
         ];
         TypeInterner { types: preinterned }
     }
@@ -161,6 +173,20 @@ impl TypeInterner {
                 || ty == Self::NUMBER
         )
     }
+
+    /// Is this type stringifiable (can be converted to string without error)?
+    pub fn is_stringifiable(&self, id: TyId) -> bool {
+        self.subtype(id, Self::NUMBER)
+            || id == Self::STRING
+            || id == Self::BOOL
+            || id == Self::NIL
+            || id == Self::KEYWORD
+    }
+
+    /// Is this a struct type (Struct or MutableStruct)?
+    pub fn is_struct(&self, id: TyId) -> bool {
+        id == Self::STRUCT || id == Self::MUTABLE_STRUCT
+    }
 }
 
 #[cfg(test)]
@@ -241,5 +267,50 @@ mod tests {
         assert!(i.is_immediate(TypeInterner::BOOL));
         assert!(!i.is_immediate(TypeInterner::STRING));
         assert!(!i.is_immediate(TypeInterner::TOP));
+    }
+
+    #[test]
+    fn join_array_mutable_array_is_top() {
+        let i = TypeInterner::new();
+        assert_eq!(
+            i.join(TypeInterner::ARRAY, TypeInterner::MUTABLE_ARRAY),
+            TypeInterner::TOP
+        );
+    }
+
+    #[test]
+    fn subtype_mutable_array_top() {
+        let i = TypeInterner::new();
+        assert!(i.subtype(TypeInterner::MUTABLE_ARRAY, TypeInterner::TOP));
+    }
+
+    #[test]
+    fn is_immediate_array_false() {
+        let i = TypeInterner::new();
+        assert!(!i.is_immediate(TypeInterner::ARRAY));
+        assert!(!i.is_immediate(TypeInterner::MUTABLE_ARRAY));
+        assert!(!i.is_immediate(TypeInterner::STRUCT));
+        assert!(!i.is_immediate(TypeInterner::MUTABLE_STRUCT));
+    }
+
+    #[test]
+    fn is_stringifiable() {
+        let i = TypeInterner::new();
+        assert!(i.is_stringifiable(TypeInterner::INT));
+        assert!(i.is_stringifiable(TypeInterner::STRING));
+        assert!(i.is_stringifiable(TypeInterner::BOOL));
+        assert!(i.is_stringifiable(TypeInterner::NIL));
+        assert!(i.is_stringifiable(TypeInterner::KEYWORD));
+        assert!(!i.is_stringifiable(TypeInterner::TOP));
+        assert!(!i.is_stringifiable(TypeInterner::ARRAY));
+    }
+
+    #[test]
+    fn is_struct() {
+        let i = TypeInterner::new();
+        assert!(i.is_struct(TypeInterner::STRUCT));
+        assert!(i.is_struct(TypeInterner::MUTABLE_STRUCT));
+        assert!(!i.is_struct(TypeInterner::ARRAY));
+        assert!(!i.is_struct(TypeInterner::TOP));
     }
 }

--- a/tests/elle/leak.lisp
+++ b/tests/elle/leak.lisp
@@ -965,8 +965,8 @@
 
 (let [d100 (leak-push-outer 100)
       d10k (leak-push-outer 10000)]
-  (assert (or checked? (not (bounded? d100 d10k 30)))
-          (string "push-outer: FIXED? d100=" d100 " d10k=" d10k)))
+  (assert (or checked? (bounded? d100 d10k 30))
+          (string "push-outer: d100=" d100 " d10k=" d10k)))
 
 # put stores heap string into outer mutable struct
 # With refcounting: old value decref'd on overwrite → freed at scope exit.
@@ -981,8 +981,8 @@
 
 (let [d100 (leak-put-outer 100)
       d10k (leak-put-outer 10000)]
-  (assert (or checked? (not (bounded? d100 d10k 30)))
-          (string "put-outer: FIXED? d100=" d100 " d10k=" d10k)))
+  (assert (or checked? (bounded? d100 d10k 30))
+          (string "put-outer: d100=" d100 " d10k=" d10k)))
 
 # ── Known leaks: fixable (escape analysis limitations) ──────────
 # These don't genuinely escape heap values but are rejected by
@@ -1105,11 +1105,8 @@
 # and mutable bindings are reclaimed via deferred reference counting.
 # Before refcounting, these leak linearly. After, they are bounded.
 #
-# Known regression (11a-d): loop bodies call stdlib functions with
-# SIG_ERROR (string, struct literals). The corrected may_suspend()
-# treats any signal as a suspension, blocking refcounted rotation.
-# Fix requires type-aware signal narrowing. Inverted assertions
-# expect leaking; they will FAIL when the fix lands.
+# Type-aware signal narrowing strips SIG_ERROR from calls with
+# provably typed arguments, unblocking refcounted rotation.
 
 # 11a: put overwrites heap string in mutable struct — old value freed
 (defn t11-put-overwrite [n]
@@ -1123,8 +1120,8 @@
 
 (let [d100 (t11-put-overwrite 100)
       d10k (t11-put-overwrite 10000)]
-  (assert (or checked? (not (bounded? d100 d10k 30)))
-          (string "t11 put-overwrite: FIXED? d100=" d100 " d10k=" d10k)))
+  (assert (or checked? (bounded? d100 d10k 30))
+          (string "t11 put-overwrite: d100=" d100 " d10k=" d10k)))
 
 # 11b: put overwrites heap struct in mutable struct
 (defn t11-put-struct [n]
@@ -1138,8 +1135,8 @@
 
 (let [d100 (t11-put-struct 100)
       d10k (t11-put-struct 10000)]
-  (assert (or checked? (not (bounded? d100 d10k 30)))
-          (string "t11 put-struct: FIXED? d100=" d100 " d10k=" d10k)))
+  (assert (or checked? (bounded? d100 d10k 30))
+          (string "t11 put-struct: d100=" d100 " d10k=" d10k)))
 
 # 11c: set overwrites heap value in mutable array
 (defn t11-set-array [n]
@@ -1153,8 +1150,8 @@
 
 (let [d100 (t11-set-array 100)
       d10k (t11-set-array 10000)]
-  (assert (or checked? (not (bounded? d100 d10k 30)))
-          (string "t11 set-array: FIXED? d100=" d100 " d10k=" d10k)))
+  (assert (or checked? (bounded? d100 d10k 30))
+          (string "t11 set-array: d100=" d100 " d10k=" d10k)))
 
 # 11d: multiple puts per iteration (roster pattern)
 (defn t11-roster [n]
@@ -1170,8 +1167,8 @@
 
 (let [d100 (t11-roster 100)
       d10k (t11-roster 10000)]
-  (assert (or checked? (not (bounded? d100 d10k 30)))
-          (string "t11 roster: FIXED? d100=" d100 " d10k=" d10k)))
+  (assert (or checked? (bounded? d100 d10k 30))
+          (string "t11 roster: d100=" d100 " d10k=" d10k)))
 
 # 11e: mutable binding reassignment with heap values
 (defn t11-binding-reassign [n]

--- a/tests/integration/escape.rs
+++ b/tests/integration/escape.rs
@@ -118,27 +118,27 @@ fn region_emitted_for_empty_predicate() {
 
 #[test]
 fn region_emitted_for_type_predicate() {
-    // string? returns bool → immediate, but stdlib call has SIG_ERROR
-    // → may_suspend() blocks scope allocation. Needs type-aware narrowing.
-    assert!(!has_region(r#"(let [x "hello"] (string? x))"#));
+    // string? returns bool → immediate. Type-aware signal narrowing
+    // strips SIG_ERROR (type predicates never error).
+    assert!(has_region(r#"(let [x "hello"] (string? x))"#));
 }
 
 #[test]
 fn region_emitted_for_type_of() {
-    // type returns keyword → immediate, but stdlib call has SIG_ERROR
-    assert!(!has_region("(let [x 42] (type x))"));
+    // type returns keyword → immediate. Signal narrowed to silent.
+    assert!(has_region("(let [x 42] (type x))"));
 }
 
 #[test]
 fn region_emitted_for_abs() {
-    // abs returns immediate, but stdlib call has SIG_ERROR
-    assert!(!has_region("(let [x -5] (abs x))"));
+    // abs returns immediate. arg is Int ⊑ Number → signal narrowed.
+    assert!(has_region("(let [x -5] (abs x))"));
 }
 
 #[test]
 fn region_emitted_for_floor() {
-    // floor returns immediate, but stdlib call has SIG_ERROR
-    assert!(!has_region("(let [x 3.7] (floor x))"));
+    // floor returns immediate. arg is Float ⊑ Number → signal narrowed.
+    assert!(has_region("(let [x 3.7] (floor x))"));
 }
 
 #[test]
@@ -149,8 +149,9 @@ fn region_emitted_for_has_key() {
 
 #[test]
 fn region_emitted_for_string_contains() {
-    // string/contains? returns bool → immediate, but stdlib SIG_ERROR
-    assert!(!has_region(
+    // string/contains? returns bool → immediate. Both args are String
+    // → signal narrowed to silent.
+    assert!(has_region(
         r#"(let [s "hello world"] (string/contains? s "world"))"#
     ));
 }


### PR DESCRIPTION
Extend the type inference pass to infer collection types (Array, MutableArray, Struct, MutableStruct) and propagate through MakeCell/DerefCell/SetCell. After inference, strip SIG_ERROR from calls to primitives whose argument types prove the error path is unreachable (type predicates, abs/floor/ceil/round on Number, put on MutableStruct+Keyword, push on MutableArray, etc.). Bottom-up signal re-propagation then updates parent nodes, unblocking both scope allocation and refcounted rotation for loops containing these calls.

Narrowing and re-propagation live in a new narrow.rs; a new Hir::for_each_child_mut visitor deduplicates the tree-walkers.

Fixes 6 leak test regressions (push-outer, put-outer, put-overwrite, put-struct, set-array, roster) and 5 escape test regressions (string?, type, abs, floor, string/contains?).