### PR TITLE
Dispatch-level arity checking: remove ~2800 lines of manual checks

### DIFF
--- a/src/arithmetic.rs
+++ b/src/arithmetic.rs
@@ -97,67 +97,6 @@ pub(crate) fn div_values(a: &Value, b: &Value) -> Result<Value, Value> {
     }
 }
 
-/// Negate a numeric value
-#[allow(dead_code)]
-pub(crate) fn negate_value(a: &Value) -> Result<Value, Value> {
-    if let Some(n) = a.as_int() {
-        return match n.checked_neg() {
-            Some(r) => Ok(Value::int(r)),
-            None => Err(error_val("overflow", "negate: integer overflow")),
-        };
-    }
-    match a.as_float() {
-        Some(f) => Ok(Value::float(-f)),
-        None => Err(error_val(
-            "type-error",
-            format!("negate: expected number, got {}", a.type_name()),
-        )),
-    }
-}
-
-/// Reciprocal of a numeric value (1/x). Integer zero errors;
-/// float zero returns Inf per IEEE 754.
-#[allow(dead_code)]
-pub(crate) fn reciprocal_value(a: &Value) -> Result<Value, Value> {
-    if let Some(n) = a.as_int() {
-        if n == 0 {
-            return Err(error_val(
-                "division-by-zero",
-                "reciprocal: division by zero",
-            ));
-        }
-        return Ok(Value::float(1.0 / n as f64));
-    }
-    match a.as_float() {
-        Some(f) => Ok(Value::float(1.0 / f)),
-        None => Err(error_val(
-            "type-error",
-            format!("reciprocal: expected number, got {}", a.type_name()),
-        )),
-    }
-}
-
-/// Modulo operation (Euclidean modulo - result has same sign as divisor)
-#[allow(dead_code)]
-pub(crate) fn mod_values(a: &Value, b: &Value) -> Result<Value, Value> {
-    match (a.as_int(), b.as_int()) {
-        (Some(x), Some(y)) => {
-            if y == 0 {
-                return Err(error_val("division-by-zero", "mod: division by zero"));
-            }
-            Ok(Value::int(x.rem_euclid(y)))
-        }
-        _ => Err(error_val(
-            "type-error",
-            format!(
-                "mod: expected integer, got {} and {}",
-                a.type_name(),
-                b.type_name()
-            ),
-        )),
-    }
-}
-
 /// Remainder operation (truncated division - result has same sign as dividend)
 pub(crate) fn remainder_values(a: &Value, b: &Value) -> Result<Value, Value> {
     match (a.as_int(), a.as_float(), b.as_int(), b.as_float()) {
@@ -257,22 +196,9 @@ mod tests {
     }
 
     #[test]
-    fn test_mod_values() {
-        let a = Value::int(17);
-        let b = Value::int(5);
-        assert_eq!(mod_values(&a, &b).unwrap(), Value::int(2));
-    }
-
-    #[test]
     fn test_abs_value() {
         let a = Value::int(-5);
         assert_eq!(abs_value(&a).unwrap(), Value::int(5));
-    }
-
-    #[test]
-    fn test_negate_value() {
-        let a = Value::int(5);
-        assert_eq!(negate_value(&a).unwrap(), Value::int(-5));
     }
 
     #[test]

--- a/src/compiler/bytecode.rs
+++ b/src/compiler/bytecode.rs
@@ -322,6 +322,11 @@ pub enum Instruction {
     IntrThaw,
     /// Bitwise tag+payload equality (pops b, pops a, pushes bool)
     Identical,
+
+    /// Arity-checked function call (arg_count). Compiler verified arity.
+    CallChecked,
+    /// Arity-checked tail call (arg_count). Compiler verified arity.
+    TailCallChecked,
 }
 
 /// Compiled bytecode with constants
@@ -504,7 +509,12 @@ pub fn disassemble_lines(instructions: &[u8]) -> Vec<String> {
                 line.push_str(&format!(" (depth={}, index={})", depth, index));
                 i += 3;
             }
-            Instruction::Call | Instruction::TailCall if i + 1 < instructions.len() => {
+            Instruction::Call
+            | Instruction::TailCall
+            | Instruction::CallChecked
+            | Instruction::TailCallChecked
+                if i + 1 < instructions.len() =>
+            {
                 let arg_count = ((instructions[i] as u16) << 8) | (instructions[i + 1] as u16);
                 line.push_str(&format!(" (args={})", arg_count));
                 i += 2;

--- a/src/jit/compiler.rs
+++ b/src/jit/compiler.rs
@@ -1069,6 +1069,7 @@ mod tests {
                 dst: Reg(6),
                 func: Reg(5),
                 args: vec![Reg(4)],
+                arity_checked: false,
             },
             Span::synthetic(),
         ));
@@ -1103,6 +1104,7 @@ mod tests {
             LirInstr::TailCall {
                 func: Reg(1),
                 args: vec![Reg(0)],
+                arity_checked: false,
             },
             Span::synthetic(),
         ));

--- a/src/jit/group.rs
+++ b/src/jit/group.rs
@@ -191,6 +191,7 @@ mod tests {
                 dst: Reg(2),
                 func: Reg(1),
                 args: vec![Reg(0)],
+                arity_checked: false,
             },
             Span::synthetic(),
         ));
@@ -506,6 +507,7 @@ mod tests {
             LirInstr::TailCall {
                 func: Reg(1),
                 args: vec![Reg(0)],
+                arity_checked: false,
             },
             Span::synthetic(),
         ));

--- a/src/jit/mod.rs
+++ b/src/jit/mod.rs
@@ -36,6 +36,7 @@ mod compiler;
 mod data;
 pub(crate) mod dispatch;
 mod fastpath;
+#[allow(dead_code)]
 mod group;
 mod helpers;
 mod runtime;
@@ -48,7 +49,6 @@ pub(crate) mod worker;
 pub use code::JitCode;
 pub use compiler::{BatchMember, JitCompiler};
 pub use dispatch::{TAIL_CALL_SENTINEL, YIELD_SENTINEL};
-pub(crate) use group::discover_compilation_group;
 pub use value::JitValue;
 
 use std::fmt;

--- a/src/jit/translate.rs
+++ b/src/jit/translate.rs
@@ -458,7 +458,9 @@ impl<'a> FunctionTranslator<'a> {
                 }
             }
 
-            LirInstr::Call { dst, func, args } => {
+            LirInstr::Call {
+                dst, func, args, ..
+            } => {
                 let (ft, fp) = self.use_var_pair(builder, func.0);
                 let vm = self
                     .vm_ptr
@@ -545,7 +547,7 @@ impl<'a> FunctionTranslator<'a> {
                 }
             }
 
-            LirInstr::TailCall { func, args } => {
+            LirInstr::TailCall { func, args, .. } => {
                 let (ft, fp) = self.use_var_pair(builder, func.0);
                 let vm = self.vm_ptr.ok_or_else(|| {
                     JitError::InvalidLir("TailCall without vm pointer".to_string())
@@ -947,7 +949,9 @@ impl<'a> FunctionTranslator<'a> {
                 return Err(JitError::UnsupportedInstruction("Eval".to_string()));
             }
 
-            LirInstr::SuspendingCall { dst, func, args } => {
+            LirInstr::SuspendingCall {
+                dst, func, args, ..
+            } => {
                 // SuspendingCall: the callee may yield. Handled identically
                 // to Call, with an unconditional yield check after the call.
                 // LBox cells are first-class values in registers (no auto-

--- a/src/lir/display.rs
+++ b/src/lir/display.rs
@@ -120,15 +120,38 @@ impl fmt::Display for LirInstr {
             }
 
             // === Function Calls ===
-            LirInstr::Call { dst, func, args } | LirInstr::SuspendingCall { dst, func, args } => {
+            LirInstr::Call {
+                dst,
+                func,
+                args,
+                arity_checked,
+            }
+            | LirInstr::SuspendingCall {
+                dst,
+                func,
+                args,
+                arity_checked,
+            } => {
                 write!(f, "{} ← {}(", dst, func)?;
                 fmt_regs(args, f)?;
-                f.write_str(")")
+                if *arity_checked {
+                    f.write_str(") ✓")
+                } else {
+                    f.write_str(")")
+                }
             }
-            LirInstr::TailCall { func, args } => {
+            LirInstr::TailCall {
+                func,
+                args,
+                arity_checked,
+            } => {
                 write!(f, "tailcall {}(", func)?;
                 fmt_regs(args, f)?;
-                f.write_str(")")
+                if *arity_checked {
+                    f.write_str(") ✓")
+                } else {
+                    f.write_str(")")
+                }
             }
 
             // === Data Construction ===
@@ -395,6 +418,7 @@ mod tests {
             dst: Reg(5),
             func: Reg(3),
             args: vec![Reg(4)],
+            arity_checked: false,
         };
         assert_eq!(format!("{}", instr), "r5 ← r3(r4)");
     }
@@ -405,6 +429,7 @@ mod tests {
             dst: Reg(5),
             func: Reg(3),
             args: vec![Reg(1), Reg(2)],
+            arity_checked: false,
         };
         assert_eq!(format!("{}", instr), "r5 ← r3(r1, r2)");
     }
@@ -414,6 +439,7 @@ mod tests {
         let instr = LirInstr::TailCall {
             func: Reg(0),
             args: vec![Reg(1), Reg(2)],
+            arity_checked: false,
         };
         assert_eq!(format!("{}", instr), "tailcall r0(r1, r2)");
     }

--- a/src/lir/emit/mod.rs
+++ b/src/lir/emit/mod.rs
@@ -433,7 +433,18 @@ impl Emitter {
                 self.push_reg(*dst);
             }
 
-            LirInstr::Call { dst, func, args } | LirInstr::SuspendingCall { dst, func, args } => {
+            LirInstr::Call {
+                dst,
+                func,
+                args,
+                arity_checked,
+            }
+            | LirInstr::SuspendingCall {
+                dst,
+                func,
+                args,
+                arity_checked,
+            } => {
                 // Call expects: [arg1, arg2, ..., argN, func] on stack
                 // Check if values are already in the correct positions at the top of the stack
                 let total_values = args.len() + 1; // args + func
@@ -462,7 +473,11 @@ impl Emitter {
                     self.ensure_on_top(*func);
                 }
 
-                self.bytecode.emit(Instruction::Call);
+                if *arity_checked {
+                    self.bytecode.emit(Instruction::CallChecked);
+                } else {
+                    self.bytecode.emit(Instruction::Call);
+                }
                 self.bytecode.emit_u16(args.len() as u16);
                 let call_resume_ip = self.bytecode.current_pos();
 
@@ -488,7 +503,11 @@ impl Emitter {
                 self.push_reg(*dst);
             }
 
-            LirInstr::TailCall { func, args } => {
+            LirInstr::TailCall {
+                func,
+                args,
+                arity_checked,
+            } => {
                 // Check if values are already in the correct positions at the top of the stack
                 let total_values = args.len() + 1; // args + func
                 let stack_len = self.stack.len();
@@ -513,7 +532,11 @@ impl Emitter {
                     }
                     self.ensure_on_top(*func);
                 }
-                self.bytecode.emit(Instruction::TailCall);
+                if *arity_checked {
+                    self.bytecode.emit(Instruction::TailCallChecked);
+                } else {
+                    self.bytecode.emit(Instruction::TailCall);
+                }
                 self.bytecode.emit_u16(args.len() as u16);
             }
 

--- a/src/lir/lower/control.rs
+++ b/src/lir/lower/control.rs
@@ -41,6 +41,23 @@ impl<'a> Lowerer<'a> {
                 self.emit_region_enter(); // mark2: barrier before Call
             }
 
+            // Determine if the compiler verified arity for this call.
+            // True when the callee is a primitive binding that hasn't been
+            // shadowed or mutated (the analyzer would have errored on arity
+            // mismatch, so if compilation succeeded the arity is correct).
+            let arity_checked = if let HirKind::Var(binding) = &func.kind {
+                let bi = self.arena.get(*binding);
+                bi.is_primitive
+                    && bi.is_immutable
+                    && !bi.is_mutated
+                    && self
+                        .immutable_values
+                        .get(binding)
+                        .is_some_and(|v| v.is_native_fn())
+            } else {
+                false
+            };
+
             if is_tail {
                 // Emit pending RegionExits before TailCall — the scope's
                 // allocations must be freed before the frame is replaced.
@@ -55,6 +72,7 @@ impl<'a> Lowerer<'a> {
                 self.emit(LirInstr::TailCall {
                     func: func_reg,
                     args: arg_regs,
+                    arity_checked,
                 });
                 Ok(self.fresh_reg())
             } else {
@@ -66,12 +84,14 @@ impl<'a> Lowerer<'a> {
                         dst,
                         func: func_reg,
                         args: arg_regs,
+                        arity_checked,
                     });
                 } else {
                     self.emit(LirInstr::Call {
                         dst,
                         func: func_reg,
                         args: arg_regs,
+                        arity_checked,
                     });
                 }
                 if call_scoped {

--- a/src/lir/lower/decision/mod.rs
+++ b/src/lir/lower/decision/mod.rs
@@ -781,17 +781,16 @@ fn compile_matrix(matrix: PatternMatrix, col_access: Vec<AccessPath>) -> Decisio
     }
 }
 
-// ── Reachability analysis ──────────────────────────────────────────
+// ── Test-only helpers ─────────────────────────────────────────────
 
-/// Find which arm indices are reachable in the decision tree.
-#[allow(dead_code)]
-pub fn find_reachable_arms(tree: &DecisionTree) -> HashSet<usize> {
+#[cfg(test)]
+fn find_reachable_arms(tree: &DecisionTree) -> HashSet<usize> {
     let mut reachable = HashSet::new();
     collect_reachable(tree, &mut reachable);
     reachable
 }
 
-#[allow(dead_code)]
+#[cfg(test)]
 fn collect_reachable(tree: &DecisionTree, out: &mut HashSet<usize>) {
     match tree {
         DecisionTree::Leaf { arm_index, .. } => {

--- a/src/lir/types.rs
+++ b/src/lir/types.rs
@@ -459,14 +459,31 @@ pub enum LirInstr {
 
     // === Function Calls ===
     /// Call a function (callee is known to not suspend).
-    Call { dst: Reg, func: Reg, args: Vec<Reg> },
+    /// When `arity_checked` is true, the compiler verified arity at compile time.
+    Call {
+        dst: Reg,
+        func: Reg,
+        args: Vec<Reg>,
+        arity_checked: bool,
+    },
     /// Call a function that may suspend (yield, I/O, etc.).
     /// The WASM emitter creates a call-site continuation with spill/restore
     /// so the caller can resume if the callee yields.
     /// Only emitted inside functions whose signal includes may_suspend().
-    SuspendingCall { dst: Reg, func: Reg, args: Vec<Reg> },
+    /// When `arity_checked` is true, the compiler verified arity at compile time.
+    SuspendingCall {
+        dst: Reg,
+        func: Reg,
+        args: Vec<Reg>,
+        arity_checked: bool,
+    },
     /// Tail call (no return)
-    TailCall { func: Reg, args: Vec<Reg> },
+    /// When `arity_checked` is true, the compiler verified arity at compile time.
+    TailCall {
+        func: Reg,
+        args: Vec<Reg>,
+        arity_checked: bool,
+    },
 
     // === Data Construction ===
     /// Construct a cons cell

--- a/src/primitives/access.rs
+++ b/src/primitives/access.rs
@@ -45,16 +45,6 @@ pub(crate) fn resolve_slice_index(index: i64, len: usize) -> usize {
 /// Polymorphic get - works on arrays, @arrays, strings, @strings, and structs
 /// `(get collection key [default])`
 pub(crate) fn prim_get(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() < 2 || args.len() > 3 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("get: expected 2-3 arguments, got {}", args.len()),
-            ),
-        );
-    }
-
     let default = if args.len() == 3 { args[2] } else { Value::NIL };
 
     // Array (mutable indexed collection)
@@ -400,16 +390,6 @@ pub(crate) fn prim_put(args: &[Value]) -> (SignalBits, Value) {
             ),
         );
     }
-    if args.len() != 3 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("put: expected 2-3 arguments, got {}", args.len()),
-            ),
-        );
-    }
-
     // @string (mutable string — indexed by grapheme cluster position)
     if let Some(buf_ref) = args[0].as_string_mut() {
         let index = match args[1].as_int() {

--- a/src/primitives/allocator.rs
+++ b/src/primitives/allocator.rs
@@ -37,16 +37,6 @@ use crate::value::{error_val, Value};
 ///
 /// Must only be called via the `with-allocator` macro. See module doc.
 fn prim_install_allocator(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("allocator/install: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
-
     // Extract Rc<AllocatorBox> from the ExternalObject.
     // The ExternalObject.data is Rc<dyn Any>. We need to get Rc<AllocatorBox>.
     // value.as_external::<AllocatorBox>() gives &AllocatorBox (a ref into the Rc).
@@ -94,20 +84,7 @@ fn prim_install_allocator(args: &[Value]) -> (SignalBits, Value) {
 /// # Safety
 ///
 /// Must only be called via the `with-allocator` macro. See module doc.
-fn prim_uninstall_allocator(args: &[Value]) -> (SignalBits, Value) {
-    if !args.is_empty() {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!(
-                    "allocator/uninstall: expected 0 arguments, got {}",
-                    args.len()
-                ),
-            ),
-        );
-    }
-
+fn prim_uninstall_allocator(_args: &[Value]) -> (SignalBits, Value) {
     match with_current_heap_mut(|heap| heap.pop_custom_allocator()) {
         Some(true) => (SIG_OK, Value::NIL),
         Some(false) => (

--- a/src/primitives/arena.rs
+++ b/src/primitives/arena.rs
@@ -11,16 +11,7 @@ use crate::value::{error_val, Value};
 /// Return current heap object count.
 ///
 /// Operates directly on thread-local state (no SIG_QUERY).
-pub(crate) fn prim_arena_count(args: &[Value]) -> (SignalBits, Value) {
-    if !args.is_empty() {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("arena/count: expected 0 arguments, got {}", args.len()),
-            ),
-        );
-    }
+pub(crate) fn prim_arena_count(_args: &[Value]) -> (SignalBits, Value) {
     let heap_ptr = crate::value::fiberheap::current_heap_ptr();
     debug_assert!(!heap_ptr.is_null(), "root heap must always be installed");
     let count = unsafe { (*heap_ptr).visible_len() };
@@ -35,22 +26,16 @@ pub(crate) fn prim_arena_count(args: &[Value]) -> (SignalBits, Value) {
 /// :dtor-count, :root-live-count, :root-alloc-count, :shared-count, :active-allocator,
 /// :scope-enter-count, :scope-dtor-count.
 pub(crate) fn prim_arena_stats(args: &[Value]) -> (SignalBits, Value) {
-    match args.len() {
-        0 => (
+    if args.is_empty() {
+        (
             SIG_QUERY,
             Value::pair(Value::keyword("arena/stats"), Value::NIL),
-        ),
-        1 => (
+        )
+    } else {
+        (
             SIG_QUERY,
             Value::pair(Value::keyword("arena/stats"), args[0]),
-        ),
-        n => (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("arena/stats: expected 0 or 1 arguments, got {n}"),
-            ),
-        ),
+        )
     }
 }
 
@@ -63,18 +48,6 @@ pub(crate) fn prim_arena_stats(args: &[Value]) -> (SignalBits, Value) {
 /// cons cells for the query message — those allocations would themselves be
 /// subject to the limit, creating a chicken-and-egg problem.
 pub(crate) fn prim_arena_set_object_limit(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!(
-                    "arena/set-object-limit: expected 1 argument, got {}",
-                    args.len()
-                ),
-            ),
-        );
-    }
     let limit = if args[0].is_nil() {
         None
     } else if let Some(n) = args[0].as_int() {
@@ -115,19 +88,7 @@ pub(crate) fn prim_arena_set_object_limit(args: &[Value]) -> (SignalBits, Value)
 /// Get current object limit on the current FiberHeap. Returns int or nil (unlimited).
 ///
 /// Operates directly on thread-local state (no SIG_QUERY).
-pub(crate) fn prim_arena_object_limit(args: &[Value]) -> (SignalBits, Value) {
-    if !args.is_empty() {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!(
-                    "arena/object-limit: expected 0 arguments, got {}",
-                    args.len()
-                ),
-            ),
-        );
-    }
+pub(crate) fn prim_arena_object_limit(_args: &[Value]) -> (SignalBits, Value) {
     let heap_ptr = crate::value::fiberheap::current_heap_ptr();
     debug_assert!(!heap_ptr.is_null(), "root heap must always be installed");
     let limit = unsafe { (*heap_ptr).object_limit() };
@@ -143,16 +104,7 @@ pub(crate) fn prim_arena_object_limit(args: &[Value]) -> (SignalBits, Value) {
 /// Return bytes consumed by the current FiberHeap.
 ///
 /// Operates directly on thread-local state (no SIG_QUERY).
-pub(crate) fn prim_arena_bytes(args: &[Value]) -> (SignalBits, Value) {
-    if !args.is_empty() {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("arena/bytes: expected 0 arguments, got {}", args.len()),
-            ),
-        );
-    }
+pub(crate) fn prim_arena_bytes(_args: &[Value]) -> (SignalBits, Value) {
     let heap_ptr = crate::value::fiberheap::current_heap_ptr();
     debug_assert!(!heap_ptr.is_null(), "root heap must always be installed");
     let bytes = unsafe { (*heap_ptr).allocated_bytes() };
@@ -166,16 +118,7 @@ pub(crate) fn prim_arena_bytes(args: &[Value]) -> (SignalBits, Value) {
 ///
 /// Dangerous: any Value allocated after this mark becomes invalid after
 /// arena/reset with this mark.
-pub(crate) fn prim_arena_checkpoint(args: &[Value]) -> (SignalBits, Value) {
-    if !args.is_empty() {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("arena/checkpoint: expected 0 arguments, got {}", args.len()),
-            ),
-        );
-    }
+pub(crate) fn prim_arena_checkpoint(_args: &[Value]) -> (SignalBits, Value) {
     let mark = crate::value::heap::heap_arena_mark();
     // Wrap in External so the mark survives across VM state without
     // being mistaken for an integer.
@@ -191,15 +134,6 @@ pub(crate) fn prim_arena_checkpoint(args: &[Value]) -> (SignalBits, Value) {
 ///
 /// Dangerous: any Value pointing into the freed region is now invalid.
 pub(crate) fn prim_arena_reset(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("arena/reset: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
     // Extract the ArenaMark from the External wrapper.
     let mark: &crate::value::ArenaMark = match args[0].as_external::<crate::value::ArenaMark>() {
         Some(m) => m,
@@ -254,15 +188,6 @@ pub(crate) fn prim_arena_reset(args: &[Value]) -> (SignalBits, Value) {
 /// specially: it snapshots the heap count, calls the thunk, snapshots
 /// again, and returns a cons of (result . net-allocs).
 pub(crate) fn prim_arena_allocs(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("arena/allocs: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
     (
         SIG_QUERY,
         Value::pair(Value::keyword("arena/allocs"), args[0]),
@@ -270,16 +195,7 @@ pub(crate) fn prim_arena_allocs(args: &[Value]) -> (SignalBits, Value) {
 }
 
 /// (arena/peak) — return peak object count (high-water mark)
-pub(crate) fn prim_arena_peak(args: &[Value]) -> (SignalBits, Value) {
-    if !args.is_empty() {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("arena/peak: expected 0 arguments, got {}", args.len()),
-            ),
-        );
-    }
+pub(crate) fn prim_arena_peak(_args: &[Value]) -> (SignalBits, Value) {
     let heap_ptr = crate::value::fiberheap::current_heap_ptr();
     debug_assert!(!heap_ptr.is_null(), "root heap must always be installed");
     let peak = unsafe { (*heap_ptr).peak_alloc_count() };
@@ -287,16 +203,7 @@ pub(crate) fn prim_arena_peak(args: &[Value]) -> (SignalBits, Value) {
 }
 
 /// (arena/reset-peak) — reset peak to current count, return previous peak
-pub(crate) fn prim_arena_reset_peak(args: &[Value]) -> (SignalBits, Value) {
-    if !args.is_empty() {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("arena/reset-peak: expected 0 arguments, got {}", args.len()),
-            ),
-        );
-    }
+pub(crate) fn prim_arena_reset_peak(_args: &[Value]) -> (SignalBits, Value) {
     let heap_ptr = crate::value::fiberheap::current_heap_ptr();
     debug_assert!(!heap_ptr.is_null(), "root heap must always be installed");
     let prev = unsafe { (*heap_ptr).reset_peak() };

--- a/src/primitives/arithmetic.rs
+++ b/src/primitives/arithmetic.rs
@@ -6,15 +6,6 @@ use crate::value::types::Arity;
 use crate::value::{error_val, Value};
 
 pub(crate) fn prim_abs(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("abs: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
     match arithmetic::abs_value(&args[0]) {
         Ok(val) => (SIG_OK, val),
         Err(err_val) => (SIG_ERROR, err_val),
@@ -22,13 +13,6 @@ pub(crate) fn prim_abs(args: &[Value]) -> (SignalBits, Value) {
 }
 
 pub(crate) fn prim_min(args: &[Value]) -> (SignalBits, Value) {
-    if args.is_empty() {
-        return (
-            SIG_ERROR,
-            error_val("arity-error", "min: expected at least 1 argument, got 0"),
-        );
-    }
-
     let mut min = args[0];
     for arg in &args[1..] {
         if !arg.is_number() {
@@ -46,13 +30,6 @@ pub(crate) fn prim_min(args: &[Value]) -> (SignalBits, Value) {
 }
 
 pub(crate) fn prim_max(args: &[Value]) -> (SignalBits, Value) {
-    if args.is_empty() {
-        return (
-            SIG_ERROR,
-            error_val("arity-error", "max: expected at least 1 argument, got 0"),
-        );
-    }
-
     let mut max = args[0];
     for arg in &args[1..] {
         if !arg.is_number() {
@@ -70,16 +47,6 @@ pub(crate) fn prim_max(args: &[Value]) -> (SignalBits, Value) {
 }
 
 pub(crate) fn prim_even(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("even?: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
-
     match args[0].as_int() {
         Some(n) => (SIG_OK, Value::bool(n % 2 == 0)),
         _ => (
@@ -93,16 +60,6 @@ pub(crate) fn prim_even(args: &[Value]) -> (SignalBits, Value) {
 }
 
 pub(crate) fn prim_odd(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("odd?: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
-
     match args[0].as_int() {
         Some(n) => (SIG_OK, Value::bool(n % 2 != 0)),
         _ => (

--- a/src/primitives/array.rs
+++ b/src/primitives/array.rs
@@ -25,16 +25,6 @@ pub(crate) fn prim_tuple(args: &[Value]) -> (SignalBits, Value) {
 /// pre-allocation of a fixed-size array with a uniform initial value.
 /// Returns @array (mutable), not array (immutable).
 pub(crate) fn prim_array_new(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 2 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("array/new: expected 2 arguments, got {}", args.len()),
-            ),
-        );
-    }
-
     let n = match args[0].as_int() {
         Some(i) => {
             if i < 0 {
@@ -70,16 +60,6 @@ pub(crate) fn prim_array_new(args: &[Value]) -> (SignalBits, Value) {
 
 /// Push a value onto the end of an array or @string (mutates in place, returns the collection)
 pub(crate) fn prim_push(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 2 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("push: expected 2 arguments, got {}", args.len()),
-            ),
-        );
-    }
-
     if let Some(vec_ref) = args[0].as_array_mut() {
         fiberheap::incref(args[1]);
         let mut vec = vec_ref.borrow_mut();
@@ -220,16 +200,6 @@ pub(crate) fn prim_push(args: &[Value]) -> (SignalBits, Value) {
 
 /// Pop a value from the end of an @array or @string (mutates in place, returns the removed element)
 pub(crate) fn prim_pop(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("pop: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
-
     if let Some(vec_ref) = args[0].as_array_mut() {
         let mut vec = vec_ref.borrow_mut();
         match vec.pop() {
@@ -310,16 +280,6 @@ pub(crate) fn prim_pop(args: &[Value]) -> (SignalBits, Value) {
 
 /// Pop n values from the end of an @array or @string and return them as a new collection
 pub(crate) fn prim_popn(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 2 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("popn: expected 2 arguments, got {}", args.len()),
-            ),
-        );
-    }
-
     let n = match args[1].as_int() {
         Some(i) => {
             if i < 0 {
@@ -384,16 +344,6 @@ pub(crate) fn prim_popn(args: &[Value]) -> (SignalBits, Value) {
 
 /// Insert a value at an index in an @array or @string (mutates in place, returns the collection)
 pub(crate) fn prim_insert(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 3 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("insert: expected 3 arguments, got {}", args.len()),
-            ),
-        );
-    }
-
     use crate::primitives::access::resolve_index;
 
     let raw_index = match args[1].as_int() {
@@ -510,16 +460,6 @@ pub(crate) fn prim_insert(args: &[Value]) -> (SignalBits, Value) {
 
 /// Remove element(s) at an index from an @array or @string (mutates in place, returns the collection)
 pub(crate) fn prim_remove(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() < 2 || args.len() > 3 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("remove: expected 2-3 arguments, got {}", args.len()),
-            ),
-        );
-    }
-
     use crate::primitives::access::resolve_index;
 
     let raw_index = match args[1].as_int() {

--- a/src/primitives/bitwise.rs
+++ b/src/primitives/bitwise.rs
@@ -35,16 +35,6 @@ fn coerce_to_int(val: &Value, name: &str) -> Result<i64, (SignalBits, Value)> {
 
 /// Bitwise AND: fold all arguments with &
 pub(crate) fn prim_bit_and(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() < 2 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("bit/and: expected at least 2 arguments, got {}", args.len()),
-            ),
-        );
-    }
-
     let mut result = match coerce_to_int(&args[0], "bit/and") {
         Ok(n) => n,
         Err(e) => return e,
@@ -62,16 +52,6 @@ pub(crate) fn prim_bit_and(args: &[Value]) -> (SignalBits, Value) {
 
 /// Bitwise OR: fold all arguments with |
 pub(crate) fn prim_bit_or(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() < 2 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("bit/or: expected at least 2 arguments, got {}", args.len()),
-            ),
-        );
-    }
-
     let mut result = match coerce_to_int(&args[0], "bit/or") {
         Ok(n) => n,
         Err(e) => return e,
@@ -89,16 +69,6 @@ pub(crate) fn prim_bit_or(args: &[Value]) -> (SignalBits, Value) {
 
 /// Bitwise XOR: fold all arguments with ^
 pub(crate) fn prim_bit_xor(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() < 2 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("bit/xor: expected at least 2 arguments, got {}", args.len()),
-            ),
-        );
-    }
-
     let mut result = match coerce_to_int(&args[0], "bit/xor") {
         Ok(n) => n,
         Err(e) => return e,
@@ -116,16 +86,6 @@ pub(crate) fn prim_bit_xor(args: &[Value]) -> (SignalBits, Value) {
 
 /// Bitwise NOT: apply ! to single integer argument
 pub(crate) fn prim_bit_not(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("bit/not: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
-
     match coerce_to_int(&args[0], "bit/not") {
         Ok(n) => (SIG_OK, Value::int(!n)),
         Err(e) => e,
@@ -134,16 +94,6 @@ pub(crate) fn prim_bit_not(args: &[Value]) -> (SignalBits, Value) {
 
 /// Left shift: shift first argument left by second argument (clamped to 0-63)
 pub(crate) fn prim_bit_shift_left(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 2 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("bit/shift-left: expected 2 arguments, got {}", args.len()),
-            ),
-        );
-    }
-
     let value = match coerce_to_int(&args[0], "bit/shift-left") {
         Ok(v) => v,
         Err(e) => return e,
@@ -182,16 +132,6 @@ pub(crate) fn prim_bit_shift_left(args: &[Value]) -> (SignalBits, Value) {
 
 /// Arithmetic right shift: shift first argument right by second argument (clamped to 0-63)
 pub(crate) fn prim_bit_shift_right(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 2 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("bit/shift-right: expected 2 arguments, got {}", args.len()),
-            ),
-        );
-    }
-
     let value = match coerce_to_int(&args[0], "bit/shift-right") {
         Ok(v) => v,
         Err(e) => return e,

--- a/src/primitives/box.rs
+++ b/src/primitives/box.rs
@@ -11,16 +11,6 @@ use crate::value::{error_val, Value};
 ///
 /// Creates a mutable box that can be modified with rebox
 pub(crate) fn prim_box(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("box: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
-
     (SIG_OK, Value::lbox(args[0]))
 }
 
@@ -30,16 +20,6 @@ pub(crate) fn prim_box(args: &[Value]) -> (SignalBits, Value) {
 ///
 /// Returns the current value stored in the box
 pub(crate) fn prim_unbox(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("unbox: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
-
     if let Some(cell) = args[0].as_lbox() {
         let borrowed = cell.borrow();
         (SIG_OK, *borrowed)
@@ -60,16 +40,6 @@ pub(crate) fn prim_unbox(args: &[Value]) -> (SignalBits, Value) {
 ///
 /// Sets the box to contain the new value and returns the new value
 pub(crate) fn prim_rebox(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 2 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("rebox: expected 2 arguments, got {}", args.len()),
-            ),
-        );
-    }
-
     if let Some(cell) = args[0].as_lbox() {
         let mut borrowed = cell.borrow_mut();
         *borrowed = args[1];
@@ -91,16 +61,6 @@ pub(crate) fn prim_rebox(args: &[Value]) -> (SignalBits, Value) {
 ///
 /// Returns true if the value is a box, false otherwise
 pub(crate) fn prim_box_p(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("box?: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
-
     (SIG_OK, Value::bool(args[0].is_lbox()))
 }
 

--- a/src/primitives/bytes.rs
+++ b/src/primitives/bytes.rs
@@ -177,16 +177,6 @@ where
 /// Integer input: big-endian, minimal bytes, no leading zero bytes except
 /// that 0 itself produces "00".  Negative integers → value-error.
 pub(crate) fn prim_seq_to_hex(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("seq->hex: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
-
     // Immutable bytes → immutable string
     if let Some(b) = args[0].as_bytes() {
         return (SIG_OK, Value::string(bytes_to_hex_string(b)));
@@ -274,15 +264,6 @@ pub(crate) fn prim_seq_to_hex(args: &[Value]) -> (SignalBits, Value) {
 /// Supports: bytes, @bytes, array, @array, list, string, @string.
 /// Indices are 0-based, clamped to length. start >= end returns empty.
 pub(crate) fn prim_slice(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() < 2 || args.len() > 3 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("slice: expected 2-3 arguments, got {}", args.len()),
-            ),
-        );
-    }
     use crate::primitives::access::resolve_slice_index;
 
     let raw_start = match args[1].as_int() {

--- a/src/primitives/calling.rs
+++ b/src/primitives/calling.rs
@@ -7,12 +7,6 @@ use crate::value::types::Arity;
 use crate::value::{error_val, Value};
 
 pub(crate) fn prim_ffi_call(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() < 2 {
-        return (
-            SIG_ERROR,
-            error_val("arity-error", "ffi/call: expected at least 2 arguments"),
-        );
-    }
     if args[0].is_nil() {
         return (
             SIG_ERROR,

--- a/src/primitives/chan.rs
+++ b/src/primitives/chan.rs
@@ -99,44 +99,34 @@ fn extract_receiver<'a>(
 ///
 /// Returns `[sender receiver]` as an array.
 fn prim_chan_new(args: &[Value]) -> (SignalBits, Value) {
-    let (tx, rx) = match args.len() {
-        0 => crossbeam_channel::unbounded(),
-        1 => {
-            let cap = match args[0].as_int() {
-                Some(n) if n >= 0 => n as usize,
-                Some(n) => {
-                    return (
-                        SIG_ERROR,
-                        error_val(
-                            "value-error",
-                            format!("chan: capacity must be non-negative, got {}", n),
+    let (tx, rx) = if args.is_empty() {
+        crossbeam_channel::unbounded()
+    } else {
+        let cap = match args[0].as_int() {
+            Some(n) if n >= 0 => n as usize,
+            Some(n) => {
+                return (
+                    SIG_ERROR,
+                    error_val(
+                        "value-error",
+                        format!("chan: capacity must be non-negative, got {}", n),
+                    ),
+                );
+            }
+            None => {
+                return (
+                    SIG_ERROR,
+                    error_val(
+                        "type-error",
+                        format!(
+                            "chan: expected integer for capacity, got {}",
+                            args[0].type_name()
                         ),
-                    );
-                }
-                None => {
-                    return (
-                        SIG_ERROR,
-                        error_val(
-                            "type-error",
-                            format!(
-                                "chan: expected integer for capacity, got {}",
-                                args[0].type_name()
-                            ),
-                        ),
-                    );
-                }
-            };
-            crossbeam_channel::bounded(cap)
-        }
-        n => {
-            return (
-                SIG_ERROR,
-                error_val(
-                    "arity-error",
-                    format!("chan: expected 0 or 1 arguments, got {}", n),
-                ),
-            );
-        }
+                    ),
+                );
+            }
+        };
+        crossbeam_channel::bounded(cap)
     };
 
     let sender = Value::external("chan/sender", ChanSender(RefCell::new(Some(tx))));
@@ -148,16 +138,6 @@ fn prim_chan_new(args: &[Value]) -> (SignalBits, Value) {
 ///
 /// Returns `[:ok]`, `[:full]`, or `[:disconnected]`.
 fn prim_chan_send(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 2 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("chan/send: expected 2 arguments, got {}", args.len()),
-            ),
-        );
-    }
-
     let sender = match extract_sender(&args[0], "chan/send") {
         Ok(s) => s,
         Err(e) => return e,
@@ -182,16 +162,6 @@ fn prim_chan_send(args: &[Value]) -> (SignalBits, Value) {
 ///
 /// Returns `[:ok msg]`, `[:empty]`, or `[:disconnected]`.
 fn prim_chan_recv(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("chan/recv: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
-
     let receiver = match extract_receiver(&args[0], "chan/recv") {
         Ok(r) => r,
         Err(e) => return e,
@@ -214,16 +184,6 @@ fn prim_chan_recv(args: &[Value]) -> (SignalBits, Value) {
 
 /// `(chan/clone sender)` — clone the sender half.
 fn prim_chan_clone(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("chan/clone: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
-
     let sender = match extract_sender(&args[0], "chan/clone") {
         Ok(s) => s,
         Err(e) => return e,
@@ -249,16 +209,6 @@ fn prim_chan_clone(args: &[Value]) -> (SignalBits, Value) {
 ///
 /// Drops the inner `Sender`, disconnecting the channel from this end.
 fn prim_chan_close(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("chan/close: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
-
     let sender = match extract_sender(&args[0], "chan/close") {
         Ok(s) => s,
         Err(e) => return e,
@@ -272,16 +222,6 @@ fn prim_chan_close(args: &[Value]) -> (SignalBits, Value) {
 ///
 /// Drops the inner `Receiver`, disconnecting the channel from this end.
 fn prim_chan_close_recv(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("chan/close-recv: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
-
     let receiver = match extract_receiver(&args[0], "chan/close-recv") {
         Ok(r) => r,
         Err(e) => return e,
@@ -296,16 +236,6 @@ fn prim_chan_close_recv(args: &[Value]) -> (SignalBits, Value) {
 /// Blocks until one receiver has a message. Returns `[index msg]`.
 /// With timeout, returns `[:timeout]` if no message arrives in time.
 fn prim_chan_select(args: &[Value]) -> (SignalBits, Value) {
-    if args.is_empty() || args.len() > 2 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("chan/select: expected 1 or 2 arguments, got {}", args.len()),
-            ),
-        );
-    }
-
     // Extract the array of receivers.
     let receivers_cell = match args[0].as_array_mut() {
         Some(arr) => arr,

--- a/src/primitives/comparison.rs
+++ b/src/primitives/comparison.rs
@@ -1,9 +1,9 @@
 //! Comparison primitives
 use crate::primitives::def::PrimitiveDef;
 use crate::signals::Signal;
-use crate::value::fiber::{SignalBits, SIG_ERROR, SIG_OK};
+use crate::value::fiber::{SignalBits, SIG_OK};
 use crate::value::types::Arity;
-use crate::value::{error_val, Value};
+use crate::value::Value;
 use std::cmp::Ordering;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
@@ -13,15 +13,6 @@ use std::hash::{Hash, Hasher};
 /// Otherwise, uses structural equality (PartialEq).
 /// Chained: (= a b c) means all pairs are equal.
 pub(crate) fn prim_eq(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() < 2 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("=: expected at least 2 arguments, got {}", args.len()),
-            ),
-        );
-    }
     for i in 0..args.len() - 1 {
         // Fast path: bitwise identical (covers same-type immediates)
         if args[i] == args[i + 1] {
@@ -52,15 +43,6 @@ pub(crate) fn prim_eq(args: &[Value]) -> (SignalBits, Value) {
 /// Inequality comparison — negation of `=`.
 /// Numeric-aware: (not= 1 1.0) is false. Accepts exactly 2 arguments.
 pub(crate) fn prim_not_eq(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 2 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("not=: expected 2 arguments, got {}", args.len()),
-            ),
-        );
-    }
     // Fast path: bitwise identical
     if args[0] == args[1] {
         return (SIG_OK, Value::FALSE);
@@ -79,15 +61,6 @@ pub(crate) fn prim_not_eq(args: &[Value]) -> (SignalBits, Value) {
 /// Strict identity comparison — bitwise/structural equality with no coercion.
 /// This is what `=` used to be: (identical? 1 1.0) is false.
 pub(crate) fn prim_identical(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 2 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("identical?: expected 2 arguments, got {}", args.len()),
-            ),
-        );
-    }
     (
         SIG_OK,
         if args[0] == args[1] {
@@ -107,15 +80,6 @@ pub(crate) fn prim_identical(args: &[Value]) -> (SignalBits, Value) {
 /// values, callers that assumed compare is pure would silently misbehave.
 /// Declaring errors() keeps the contract honest.
 pub(crate) fn prim_compare(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 2 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("compare: expected 2 arguments, got {}", args.len()),
-            ),
-        );
-    }
     let result: i64 = match args[0].cmp(&args[1]) {
         Ordering::Less => -1,
         Ordering::Equal => 0,

--- a/src/primitives/compile/mod.rs
+++ b/src/primitives/compile/mod.rs
@@ -937,15 +937,6 @@ pub(super) fn get_handle<'a>(
     args: &'a [Value],
     name: &str,
 ) -> Result<&'a AnalysisHandle, (SignalBits, Value)> {
-    if args.is_empty() {
-        return Err((
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("{}: expected at least 1 argument, got 0", name),
-            ),
-        ));
-    }
     match args[0].as_external::<AnalysisHandle>() {
         Some(h) => Ok(h),
         None => Err((
@@ -968,20 +959,6 @@ pub(super) fn resolve_name(
     idx: usize,
     prim_name: &str,
 ) -> Result<String, (SignalBits, Value)> {
-    if args.len() <= idx {
-        return Err((
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!(
-                    "{}: expected {} arguments, got {}",
-                    prim_name,
-                    idx + 1,
-                    args.len()
-                ),
-            ),
-        ));
-    }
     // Accept keyword or string.
     if let Some(name) = args[idx].as_keyword_name() {
         return Ok(name.to_string());

--- a/src/primitives/compile/query.rs
+++ b/src/primitives/compile/query.rs
@@ -19,19 +19,6 @@ use super::{
 
 /// `(compile/analyze source [opts])` → analysis handle
 pub(super) fn prim_compile_analyze(args: &[Value]) -> (SignalBits, Value) {
-    if args.is_empty() || args.len() > 2 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!(
-                    "compile/analyze: expected 1-2 arguments, got {}",
-                    args.len()
-                ),
-            ),
-        );
-    }
-
     let source = match args[0].with_string(|s| s.to_string()) {
         Some(s) => s,
         None => {

--- a/src/primitives/compile/transform.rs
+++ b/src/primitives/compile/transform.rs
@@ -109,12 +109,6 @@ pub(super) fn prim_compile_extract(args: &[Value]) -> (SignalBits, Value) {
         Ok(h) => h,
         Err(e) => return e,
     };
-    if args.len() < 2 {
-        return (
-            SIG_ERROR,
-            error_val("arity-error", "compile/extract: expected 2 arguments"),
-        );
-    }
     let opts = match args[1].as_struct() {
         Some(f) => f,
         None => {
@@ -289,12 +283,6 @@ pub(super) fn prim_compile_parallelize(args: &[Value]) -> (SignalBits, Value) {
         Ok(h) => h,
         Err(e) => return e,
     };
-    if args.len() < 2 {
-        return (
-            SIG_ERROR,
-            error_val("arity-error", "compile/parallelize: expected 2 arguments"),
-        );
-    }
     let fn_names: Vec<String> = match args[1].as_array() {
         Some(arr) => {
             let mut names = Vec::new();
@@ -536,18 +524,6 @@ pub(super) fn prim_compile_add_handler(args: &[Value]) -> (SignalBits, Value) {
 /// the VM's `dispatch_compile_run_on` handler does the actual work because it
 /// needs `&mut VM` access for the JIT cache, MLIR cache, and call machinery.
 pub(super) fn prim_compile_run_on(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() < 2 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!(
-                    "compile/run-on: expected at least 2 arguments (tier closure & args), got {}",
-                    args.len()
-                ),
-            ),
-        );
-    }
     // Cheap front-end validation — full type checks happen in the dispatch handler.
     if args[0].as_keyword_name().is_none() {
         return (

--- a/src/primitives/concurrency.rs
+++ b/src/primitives/concurrency.rs
@@ -36,8 +36,7 @@ fn spawn_closure_impl(closure: &crate::value::Closure) -> LResult<Value> {
             .expect("bug: SendBundle root was not a closure")
             .clone();
 
-        // Set location map for error reporting in the spawned thread.
-        vm.set_location_map((*closure.template.location_map).clone());
+        // Location map is carried on the closure template, not the VM.
 
         // Build execution environment: captured values + NIL slots for locals.
         // Use num_params directly (not derived from arity.min()) — they differ for
@@ -95,16 +94,6 @@ fn spawn_closure_impl(closure: &crate::value::Closure) -> LResult<Value> {
 ///
 /// For JIT-compiled closures, falls back to the source closure for thread-safe execution.
 pub(crate) fn prim_spawn(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("spawn: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
-
     if let Some(closure) = args[0].as_closure() {
         match spawn_closure_impl(closure) {
             Ok(val) => (SIG_OK, val),
@@ -135,16 +124,6 @@ pub(crate) fn prim_spawn(args: &[Value]) -> (SignalBits, Value) {
 /// Blocks until the spawned thread completes and returns the actual Value result.
 /// If the thread produced an error, that error is propagated.
 pub(crate) fn prim_join(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("join: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
-
     if let Some(handle) = args[0].as_thread_handle() {
         // Wait for the result to be available
         // We need to poll since we can't block indefinitely in a primitive

--- a/src/primitives/config.rs
+++ b/src/primitives/config.rs
@@ -12,32 +12,22 @@ use crate::primitives::def::PrimitiveDef;
 use crate::signals::Signal;
 use crate::value::fiber::{SignalBits, SIG_ERROR, SIG_QUERY};
 use crate::value::types::Arity;
-use crate::value::{error_val, Value};
+use crate::value::Value;
 
 /// `(vm/config)` or `(vm/config key)` — read runtime configuration.
 ///
 /// With no args: returns the full config as a struct.
 /// With a keyword arg: returns the value of that config field.
 pub(crate) fn prim_vm_config(args: &[Value]) -> (SignalBits, Value) {
-    match args.len() {
-        0 => {
-            // Return full config — SIG_QUERY "vm/config" nil
-            (
-                SIG_QUERY,
-                Value::pair(Value::keyword("vm/config"), Value::NIL),
-            )
-        }
-        1 => {
-            // Return specific field — SIG_QUERY "vm/config" key
-            (SIG_QUERY, Value::pair(Value::keyword("vm/config"), args[0]))
-        }
-        _ => (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("vm/config: expected 0-1 arguments, got {}", args.len()),
-            ),
-        ),
+    if args.is_empty() {
+        // Return full config — SIG_QUERY "vm/config" nil
+        (
+            SIG_QUERY,
+            Value::pair(Value::keyword("vm/config"), Value::NIL),
+        )
+    } else {
+        // Return specific field — SIG_QUERY "vm/config" key
+        (SIG_QUERY, Value::pair(Value::keyword("vm/config"), args[0]))
     }
 }
 
@@ -47,15 +37,6 @@ pub(crate) fn prim_vm_config(args: &[Value]) -> (SignalBits, Value) {
 /// The analyzer rewrites `(put (vm/config) :trace ...)` to this.
 /// For now, we use SIG_QUERY for both read and write.
 pub(crate) fn prim_vm_config_set(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 2 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("vm/config-set: expected 2 arguments, got {}", args.len()),
-            ),
-        );
-    }
     // SIG_QUERY "vm/config-set" (key . value)
     (
         SIG_QUERY,

--- a/src/primitives/convert.rs
+++ b/src/primitives/convert.rs
@@ -8,15 +8,6 @@ use crate::value::{error_val, error_val_extra, Value};
 /// Numeric-only integer conversion. Accepts int (identity) or float (truncation).
 /// String/keyword parsing is handled by `parse-int`.
 pub(crate) fn prim_to_int(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("integer: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
     if let Some(n) = args[0].as_int() {
         return (SIG_OK, Value::int(n));
     }
@@ -34,16 +25,6 @@ pub(crate) fn prim_to_int(args: &[Value]) -> (SignalBits, Value) {
 
 /// Parse a string or keyword to integer, with optional radix (2–36).
 pub(crate) fn prim_parse_int(args: &[Value]) -> (SignalBits, Value) {
-    if args.is_empty() || args.len() > 2 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("parse-int: expected 1-2 arguments, got {}", args.len()),
-            ),
-        );
-    }
-
     let radix: Option<u32> = if args.len() == 2 {
         match args[1].as_int() {
             Some(r) if (2..=36).contains(&r) => Some(r as u32),
@@ -109,15 +90,6 @@ fn parse_int(s: &str, radix: Option<u32>) -> (SignalBits, Value) {
 /// Numeric-only float conversion. Accepts int (→ f64) or float (identity).
 /// String/keyword parsing is handled by `parse-float`.
 pub(crate) fn prim_to_float(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("float: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
     if let Some(n) = args[0].as_int() {
         return (SIG_OK, Value::float(n as f64));
     }
@@ -135,15 +107,6 @@ pub(crate) fn prim_to_float(args: &[Value]) -> (SignalBits, Value) {
 
 /// Parse a string or keyword to float.
 pub(crate) fn prim_parse_float(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("parse-float: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
     if let Some(result) = args[0].with_string(parse_float) {
         return result;
     }
@@ -182,16 +145,6 @@ fn parse_float(s: &str) -> (SignalBits, Value) {
 /// 2 args: `(number->string n radix)` — convert integer `n` to string in the
 ///   given base. Float with radix → type-error.
 pub(crate) fn prim_number_to_string(args: &[Value]) -> (SignalBits, Value) {
-    if args.is_empty() || args.len() > 2 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("number->string: expected 1-2 arguments, got {}", args.len()),
-            ),
-        );
-    }
-
     if args.len() == 1 {
         // 1-arg: integer or float, decimal
         if let Some(n) = args[0].as_int() {

--- a/src/primitives/coroutines.rs
+++ b/src/primitives/coroutines.rs
@@ -25,16 +25,6 @@ use crate::value::{error_val, Value};
 ///
 /// Creates a fiber with SIG_YIELD mask from a closure.
 pub(crate) fn prim_make_coroutine(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("coro/new: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
-
     if let Some(c) = args[0].as_closure() {
         let fiber = Fiber::new(std::rc::Rc::new(c.clone()), SIG_YIELD);
         (SIG_OK, Value::fiber(fiber))
@@ -55,16 +45,6 @@ pub(crate) fn prim_make_coroutine(args: &[Value]) -> (SignalBits, Value) {
 /// :new → :created, :alive → :running, :dead → :done,
 /// :suspended and :error unchanged.
 pub(crate) fn prim_coroutine_status(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("coro/status: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
-
     let handle = match args[0].as_fiber() {
         Some(h) => h,
         None => {
@@ -95,16 +75,6 @@ pub(crate) fn prim_coroutine_status(args: &[Value]) -> (SignalBits, Value) {
 
 /// (coro/done? co) → bool
 pub(crate) fn prim_coroutine_done(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("coro/done?: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
-
     let handle = match args[0].as_fiber() {
         Some(h) => h,
         None => {
@@ -132,16 +102,6 @@ pub(crate) fn prim_coroutine_done(args: &[Value]) -> (SignalBits, Value) {
 ///
 /// Returns the signal payload from the fiber's last signal.
 pub(crate) fn prim_coroutine_value(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("coro/value: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
-
     let handle = match args[0].as_fiber() {
         Some(h) => h,
         None => {
@@ -166,16 +126,6 @@ pub(crate) fn prim_coroutine_value(args: &[Value]) -> (SignalBits, Value) {
 ///
 /// Returns true if the value is a fiber (coroutines are fibers).
 pub(crate) fn prim_is_coroutine(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("coroutine?: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
-
     (SIG_OK, Value::bool(args[0].is_fiber()))
 }
 
@@ -184,16 +134,6 @@ pub(crate) fn prim_is_coroutine(args: &[Value]) -> (SignalBits, Value) {
 ///
 /// Resume a fiber. Returns SIG_RESUME for the VM to handle.
 pub(crate) fn prim_coroutine_resume(args: &[Value]) -> (SignalBits, Value) {
-    if args.is_empty() || args.len() > 2 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("coro/resume: expected 1-2 arguments, got {}", args.len()),
-            ),
-        );
-    }
-
     let handle = match args[0].as_fiber() {
         Some(h) => h,
         None => {
@@ -241,16 +181,6 @@ pub(crate) fn prim_coroutine_resume(args: &[Value]) -> (SignalBits, Value) {
 ///
 /// Identity — fibers are iterable.
 pub(crate) fn prim_coroutine_to_iterator(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("coro/>iterator: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
-
     if args[0].is_fiber() {
         (SIG_OK, args[0])
     } else {

--- a/src/primitives/debug.rs
+++ b/src/primitives/debug.rs
@@ -9,16 +9,6 @@ use crate::value::{error_val, list, Value};
 /// Prints a value with debug information
 /// (debug-print value)
 pub(crate) fn prim_debug_print(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("debug-print: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
-
     eprintln!("[DEBUG] {:?}", args[0]);
     (SIG_OK, args[0])
 }
@@ -30,16 +20,6 @@ pub(crate) fn prim_debug_print(args: &[Value]) -> (SignalBits, Value) {
 /// name via the thread-local symbol table (same access pattern as
 /// string).
 pub(crate) fn prim_trace(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 2 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("trace: expected 2 arguments, got {}", args.len()),
-            ),
-        );
-    }
-
     if args[0]
         .with_string(|s| {
             eprintln!("[TRACE] {}: {:?}", s, args[1]);

--- a/src/primitives/disassembly.rs
+++ b/src/primitives/disassembly.rs
@@ -14,18 +14,6 @@ use std::collections::BTreeMap;
 /// Returns a sorted list of strings. With no arguments, returns all names.
 /// With a category keyword or string, filters by category (e.g., :math, :"special form").
 pub(crate) fn prim_list_primitives(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() > 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!(
-                    "vm/list-primitives: expected 0-1 arguments, got {}",
-                    args.len()
-                ),
-            ),
-        );
-    }
     let filter = if args.is_empty() { Value::NIL } else { args[0] };
     (
         SIG_QUERY,
@@ -38,15 +26,6 @@ pub(crate) fn prim_list_primitives(args: &[Value]) -> (SignalBits, Value) {
 /// Returns a struct with keys: "name", "doc", "params", "category", "example", "arity", "signal".
 /// Returns nil if the primitive is not found.
 pub(crate) fn prim_primitive_meta(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("vm/primitive-meta: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
     (
         SIG_QUERY,
         Value::pair(Value::keyword("primitive-meta"), args[0]),
@@ -55,15 +34,6 @@ pub(crate) fn prim_primitive_meta(args: &[Value]) -> (SignalBits, Value) {
 
 /// (fn/disasm closure) — disassemble bytecode as array of strings
 pub(crate) fn prim_disbit(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("disbit: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
     if let Some(closure) = args[0].as_closure() {
         let mut lines = crate::compiler::disassemble_lines(&closure.template.bytecode);
         for (i, c) in closure.template.constants.iter().enumerate() {
@@ -86,15 +56,6 @@ pub(crate) fn prim_disbit(args: &[Value]) -> (SignalBits, Value) {
 
 /// (fn/disasm-jit closure) — return Cranelift IR as array of strings, or nil
 pub(crate) fn prim_disjit(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("disjit: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
     #[cfg(feature = "jit")]
     if let Some(closure) = args[0].as_closure() {
         let lir = match &closure.template.lir_function {
@@ -328,15 +289,6 @@ fn flow_from_closure(closure: &crate::value::heap::Closure) -> (SignalBits, Valu
 /// Returns nil if the closure has no LIR (e.g., native function or LIR discarded).
 /// Errors if argument is not a closure or fiber, or if the fiber is currently executing.
 pub(crate) fn prim_fn_flow(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("fn/flow: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
     if let Some(closure) = args[0].as_closure() {
         flow_from_closure(closure)
     } else if let Some(handle) = args[0].as_fiber() {

--- a/src/primitives/ffi.rs
+++ b/src/primitives/ffi.rs
@@ -90,8 +90,6 @@ mod tests {
     use crate::value::fiber::{SIG_ERROR, SIG_OK};
     use crate::value::Value;
 
-    #[cfg(feature = "ffi")]
-    use super::super::calling::prim_ffi_call;
     use super::super::loading::{prim_ffi_native, prim_ffi_signature};
     use super::super::memory::{
         prim_ffi_align, prim_ffi_array, prim_ffi_free, prim_ffi_malloc, prim_ffi_read,
@@ -200,13 +198,6 @@ mod tests {
     #[test]
     fn test_ffi_read_null_error() {
         let result = prim_ffi_read(&[Value::NIL, Value::keyword("i32")]);
-        assert_eq!(result.0, SIG_ERROR);
-    }
-
-    #[cfg(feature = "ffi")]
-    #[test]
-    fn test_ffi_call_arity_error() {
-        let result = prim_ffi_call(&[]);
         assert_eq!(result.0, SIG_ERROR);
     }
 

--- a/src/primitives/fiber_introspect.rs
+++ b/src/primitives/fiber_introspect.rs
@@ -23,16 +23,6 @@ use crate::value::{error_val, Value};
 /// Returns the signal bits from the fiber's last signal.
 /// Returns 0 if the fiber has no signal.
 pub(crate) fn prim_fiber_bits(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("fiber/bits: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
-
     let handle = match args[0].as_fiber() {
         Some(h) => h,
         None => {
@@ -54,16 +44,6 @@ pub(crate) fn prim_fiber_bits(args: &[Value]) -> (SignalBits, Value) {
 ///
 /// Returns the fiber's signal mask.
 pub(crate) fn prim_fiber_mask(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("fiber/mask: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
-
     let handle = match args[0].as_fiber() {
         Some(h) => h,
         None => {
@@ -85,16 +65,6 @@ pub(crate) fn prim_fiber_mask(args: &[Value]) -> (SignalBits, Value) {
 ///
 /// Type predicate: returns true if the value is a fiber.
 pub(crate) fn prim_is_fiber(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("fiber?: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
-
     (SIG_OK, Value::bool(args[0].is_fiber()))
 }
 
@@ -103,16 +73,6 @@ pub(crate) fn prim_is_fiber(args: &[Value]) -> (SignalBits, Value) {
 /// Returns the parent fiber, or nil if the fiber has no parent
 /// (or the parent has been dropped).
 pub(crate) fn prim_fiber_parent(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("fiber/parent: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
-
     let handle = match args[0].as_fiber() {
         Some(h) => h,
         None => {
@@ -134,16 +94,6 @@ pub(crate) fn prim_fiber_parent(args: &[Value]) -> (SignalBits, Value) {
 ///
 /// Returns the most recently resumed child fiber, or nil if none.
 pub(crate) fn prim_fiber_child(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("fiber/child: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
-
     let handle = match args[0].as_fiber() {
         Some(h) => h,
         None => {
@@ -169,16 +119,6 @@ pub(crate) fn prim_fiber_child(args: &[Value]) -> (SignalBits, Value) {
 /// Returns SIG_PROPAGATE — the VM sets parent.child = fiber and propagates
 /// the fiber's signal upward.
 pub(crate) fn prim_fiber_propagate(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("fiber/propagate: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
-
     let handle = match args[0].as_fiber() {
         Some(h) => h,
         None => {
@@ -222,16 +162,6 @@ pub(crate) fn prim_fiber_propagate(args: &[Value]) -> (SignalBits, Value) {
 /// fiber), returns SIG_ERROR | SIG_TERMINAL which terminates the dispatch
 /// loop without unwinding.
 pub(crate) fn prim_fiber_cancel(args: &[Value]) -> (SignalBits, Value) {
-    if args.is_empty() || args.len() > 2 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("fiber/cancel: expected 1-2 arguments, got {}", args.len()),
-            ),
-        );
-    }
-
     let handle = match args[0].as_fiber() {
         Some(h) => h,
         None => {
@@ -297,16 +227,6 @@ pub(crate) fn prim_fiber_cancel(args: &[Value]) -> (SignalBits, Value) {
 /// Only works on :paused fibers (must have something to unwind).
 /// Returns SIG_ABORT — the VM handles the fiber swap and execution.
 pub(crate) fn prim_fiber_abort(args: &[Value]) -> (SignalBits, Value) {
-    if args.is_empty() || args.len() > 2 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("fiber/abort: expected 1-2 arguments, got {}", args.len()),
-            ),
-        );
-    }
-
     let handle = match args[0].as_fiber() {
         Some(h) => h,
         None => {
@@ -377,16 +297,6 @@ pub(crate) fn prim_fiber_caps(args: &[Value]) -> (SignalBits, Value) {
             Value::pair(Value::keyword("fiber/caps"), Value::NIL),
         );
     }
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("fiber/caps: expected 0-1 arguments, got {}", args.len()),
-            ),
-        );
-    }
-
     let handle = match args[0].as_fiber() {
         Some(h) => h,
         None => {

--- a/src/primitives/fibers.rs
+++ b/src/primitives/fibers.rs
@@ -184,19 +184,6 @@ pub(crate) fn resolve_signal_bits(
 /// The child's `withheld` is the union of the explicit deny bits and the
 /// parent's withheld (propagated at resume time by the VM).
 pub(crate) fn prim_fiber_new(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() < 2 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!(
-                    "fiber/new: expected at least 2 arguments, got {}",
-                    args.len()
-                ),
-            ),
-        );
-    }
-
     let closure = match args[0].as_closure() {
         Some(c) => std::rc::Rc::new(c.clone()),
         None => {
@@ -317,16 +304,6 @@ pub(crate) fn prim_fiber_resume(args: &[Value]) -> (SignalBits, Value) {
 /// returned directly — the VM's dispatch loop stores them in fiber.signal
 /// and suspends the fiber.
 pub(crate) fn prim_emit(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 2 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("emit: expected 2 arguments, got {}", args.len()),
-            ),
-        );
-    }
-
     let bits = match resolve_signal_bits(&args[0], "emit") {
         Ok(bits) => bits,
         Err(err) => return err,
@@ -342,16 +319,6 @@ pub(crate) fn prim_emit(args: &[Value]) -> (SignalBits, Value) {
 ///
 /// Returns the fiber's lifecycle status as a keyword.
 pub(crate) fn prim_fiber_status(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("fiber/status: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
-
     let handle = match args[0].as_fiber() {
         Some(h) => h,
         None => {
@@ -374,16 +341,6 @@ pub(crate) fn prim_fiber_status(args: &[Value]) -> (SignalBits, Value) {
 /// Returns the signal payload from the fiber's last signal or return value.
 /// Returns nil if the fiber has no signal.
 pub(crate) fn prim_fiber_value(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("fiber/value: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
-
     let handle = match args[0].as_fiber() {
         Some(h) => h,
         None => {
@@ -406,16 +363,6 @@ pub(crate) fn prim_fiber_value(args: &[Value]) -> (SignalBits, Value) {
 /// Set the instruction budget on a fiber. `n` must be a non-negative integer.
 /// A fuel of 0 means the very next fuel checkpoint emits `:fuel`.
 pub(crate) fn prim_fiber_set_fuel(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 2 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("fiber/set-fuel: expected 2 arguments, got {}", args.len()),
-            ),
-        );
-    }
-
     let handle = match args[0].as_fiber() {
         Some(h) => h,
         None => {
@@ -466,16 +413,6 @@ pub(crate) fn prim_fiber_set_fuel(args: &[Value]) -> (SignalBits, Value) {
 /// Read the remaining instruction budget. Returns an integer if fuel is set,
 /// or `nil` if the fiber has unlimited fuel (the default).
 pub(crate) fn prim_fiber_fuel(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("fiber/fuel: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
-
     let handle = match args[0].as_fiber() {
         Some(h) => h,
         None => {
@@ -503,16 +440,6 @@ pub(crate) fn prim_fiber_fuel(args: &[Value]) -> (SignalBits, Value) {
 ///
 /// Remove the instruction budget, restoring unlimited execution.
 pub(crate) fn prim_fiber_clear_fuel(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("fiber/clear-fuel: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
-
     let handle = match args[0].as_fiber() {
         Some(h) => h,
         None => {
@@ -705,12 +632,6 @@ mod tests {
     }
 
     #[test]
-    fn test_fiber_new_wrong_arity() {
-        let (sig, _) = prim_fiber_new(&[make_test_closure()]);
-        assert_eq!(sig, SIG_ERROR);
-    }
-
-    #[test]
     fn test_fiber_resume_returns_sig_resume() {
         let closure = make_test_closure();
         let (_, fiber_val) = prim_fiber_new(&[closure, Value::int(0)]);
@@ -778,12 +699,6 @@ mod tests {
         let (sig, val) = prim_emit(&[bits, value]);
         assert_eq!(sig, SIG_YIELD);
         assert_eq!(val, Value::int(42));
-    }
-
-    #[test]
-    fn test_fiber_signal_wrong_arity() {
-        let (sig, _) = prim_emit(&[Value::int(0)]);
-        assert_eq!(sig, SIG_ERROR);
     }
 
     #[test]
@@ -897,14 +812,6 @@ mod tests {
     }
 
     #[test]
-    fn test_fiber_set_fuel_wrong_arity() {
-        let closure = make_test_closure();
-        let (_, fiber_val) = prim_fiber_new(&[closure, Value::int(0)]);
-        let (sig, _) = prim_fiber_set_fuel(&[fiber_val]);
-        assert_eq!(sig, SIG_ERROR);
-    }
-
-    #[test]
     fn test_fiber_set_fuel_not_a_fiber() {
         let (sig, _) = prim_fiber_set_fuel(&[Value::int(42), Value::int(100)]);
         assert_eq!(sig, SIG_ERROR);
@@ -948,12 +855,6 @@ mod tests {
     }
 
     #[test]
-    fn test_fiber_fuel_wrong_arity() {
-        let (sig, _) = prim_fiber_fuel(&[]);
-        assert_eq!(sig, SIG_ERROR);
-    }
-
-    #[test]
     fn test_fiber_fuel_not_a_fiber() {
         let (sig, _) = prim_fiber_fuel(&[Value::int(42)]);
         assert_eq!(sig, SIG_ERROR);
@@ -982,12 +883,6 @@ mod tests {
         fiber_val.as_fiber().unwrap().with(|fiber| {
             assert_eq!(fiber.fuel, None);
         });
-    }
-
-    #[test]
-    fn test_fiber_clear_fuel_wrong_arity() {
-        let (sig, _) = prim_fiber_clear_fuel(&[]);
-        assert_eq!(sig, SIG_ERROR);
     }
 
     #[test]

--- a/src/primitives/fileio.rs
+++ b/src/primitives/fileio.rs
@@ -9,15 +9,6 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 /// Read entire file as a string
 pub(crate) fn prim_slurp(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("slurp: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
     if args[0].is_string() {
         args[0]
             .with_string(|path| match std::fs::read_to_string(path) {
@@ -45,16 +36,6 @@ pub(crate) fn prim_slurp(args: &[Value]) -> (SignalBits, Value) {
 
 /// Write string content to a file (overwrites if exists)
 pub(crate) fn prim_spit(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 2 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("spit: expected 2 arguments, got {}", args.len()),
-            ),
-        );
-    }
-
     let path = if let Some(s) = args[0].with_string(|s| s.to_string()) {
         s
     } else {
@@ -94,16 +75,6 @@ pub(crate) fn prim_spit(args: &[Value]) -> (SignalBits, Value) {
 
 /// Append string content to a file
 pub(crate) fn prim_append_file(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 2 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("append-file: expected 2 arguments, got {}", args.len()),
-            ),
-        );
-    }
-
     let path = if let Some(s) = args[0].with_string(|s| s.to_string()) {
         s
     } else {
@@ -160,15 +131,6 @@ pub(crate) fn prim_append_file(args: &[Value]) -> (SignalBits, Value) {
 
 /// Delete a file
 pub(crate) fn prim_delete_file(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("delete-file: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
     if args[0].is_string() {
         args[0]
             .with_string(|path| match std::fs::remove_file(path) {
@@ -196,15 +158,6 @@ pub(crate) fn prim_delete_file(args: &[Value]) -> (SignalBits, Value) {
 
 /// Delete a directory (must be empty)
 pub(crate) fn prim_delete_directory(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("delete-directory: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
     if args[0].is_string() {
         args[0]
             .with_string(|path| match std::fs::remove_dir(path) {
@@ -235,15 +188,6 @@ pub(crate) fn prim_delete_directory(args: &[Value]) -> (SignalBits, Value) {
 
 /// Create a directory
 pub(crate) fn prim_create_directory(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("create-directory: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
     if args[0].is_string() {
         args[0]
             .with_string(|path| match std::fs::create_dir(path) {
@@ -274,18 +218,6 @@ pub(crate) fn prim_create_directory(args: &[Value]) -> (SignalBits, Value) {
 
 /// Create a directory and all parent directories
 pub(crate) fn prim_create_directory_all(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!(
-                    "create-directory-all: expected 1 argument, got {}",
-                    args.len()
-                ),
-            ),
-        );
-    }
     if args[0].is_string() {
         args[0]
             .with_string(|path| match std::fs::create_dir_all(path) {
@@ -316,16 +248,6 @@ pub(crate) fn prim_create_directory_all(args: &[Value]) -> (SignalBits, Value) {
 
 /// Rename a file
 pub(crate) fn prim_rename_file(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 2 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("rename-file: expected 2 arguments, got {}", args.len()),
-            ),
-        );
-    }
-
     let old_path = if let Some(s) = args[0].with_string(|s| s.to_string()) {
         s
     } else {
@@ -365,16 +287,6 @@ pub(crate) fn prim_rename_file(args: &[Value]) -> (SignalBits, Value) {
 
 /// Copy a file
 pub(crate) fn prim_copy_file(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 2 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("copy-file: expected 2 arguments, got {}", args.len()),
-            ),
-        );
-    }
-
     let src = if let Some(s) = args[0].with_string(|s| s.to_string()) {
         s
     } else {
@@ -414,15 +326,6 @@ pub(crate) fn prim_copy_file(args: &[Value]) -> (SignalBits, Value) {
 
 /// Get file size in bytes
 pub(crate) fn prim_file_size(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("file-size: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
     if args[0].is_string() {
         args[0]
             .with_string(|path| match std::fs::metadata(path) {
@@ -529,15 +432,6 @@ fn stat_impl(
     name: &str,
     metadata_fn: fn(&str) -> std::io::Result<std::fs::Metadata>,
 ) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("{}: expected 1 argument, got {}", name, args.len()),
-            ),
-        );
-    }
     if args[0].is_string() {
         args[0]
             .with_string(|path| match metadata_fn(path) {
@@ -579,15 +473,6 @@ pub(crate) fn prim_file_lstat(args: &[Value]) -> (SignalBits, Value) {
 
 /// List directory contents
 pub(crate) fn prim_list_directory(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("list-directory: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
     let path = if let Some(s) = args[0].with_string(|s| s.to_string()) {
         s
     } else {
@@ -640,15 +525,6 @@ pub(crate) fn prim_list_directory(args: &[Value]) -> (SignalBits, Value) {
 
 /// Read lines from a file and return as a list of strings
 pub(crate) fn prim_read_lines(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("read-lines: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
     if args[0].is_string() {
         args[0]
             .with_string(|path| match std::fs::read_to_string(path) {

--- a/src/primitives/introspection.rs
+++ b/src/primitives/introspection.rs
@@ -8,44 +8,17 @@ use crate::value::{error_val, Value};
 
 /// (closure? value) — true if value is a bytecode closure
 pub(crate) fn prim_is_closure(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("closure?: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
     (SIG_OK, Value::bool(args[0].as_closure().is_some()))
 }
 
 /// (jit? value) — true if closure has JIT-compiled code
 pub(crate) fn prim_is_jit(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("jit?: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
     // SIG_QUERY to the VM, which checks jit_cache by bytecode pointer.
     (SIG_QUERY, Value::pair(Value::keyword("jit?"), args[0]))
 }
 
 /// (silent? value) — true if closure is silent (does not suspend: no yield/debug/polymorphic)
 pub(crate) fn prim_is_silent(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("silent?: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
     if let Some(closure) = args[0].as_closure() {
         (SIG_OK, Value::bool(!closure.signal().may_suspend()))
     } else {
@@ -55,15 +28,6 @@ pub(crate) fn prim_is_silent(args: &[Value]) -> (SignalBits, Value) {
 
 /// (mutates-params? value) — true if closure mutates any parameters
 pub(crate) fn prim_mutates_params(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("mutates-params?: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
     if let Some(closure) = args[0].as_closure() {
         (
             SIG_OK,
@@ -76,15 +40,6 @@ pub(crate) fn prim_mutates_params(args: &[Value]) -> (SignalBits, Value) {
 
 /// (fn/gpu-eligible? value) — true if closure is eligible for GPU compilation
 pub(crate) fn prim_gpu_eligible(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("fn/gpu-eligible?: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
     if let Some(closure) = args[0].as_closure() {
         let eligible = match &closure.template.lir_function {
             Some(lir) => lir.is_gpu_eligible(),
@@ -98,15 +53,6 @@ pub(crate) fn prim_gpu_eligible(args: &[Value]) -> (SignalBits, Value) {
 
 /// (fn/errors? value) — true if closure may error
 pub(crate) fn prim_errors(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("fn/errors?: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
     if let Some(closure) = args[0].as_closure() {
         (SIG_OK, Value::bool(closure.template.signal.may_error()))
     } else {
@@ -116,15 +62,6 @@ pub(crate) fn prim_errors(args: &[Value]) -> (SignalBits, Value) {
 
 /// (arity value) — closure arity as int, pair, or nil
 pub(crate) fn prim_arity(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("arity: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
     if let Some(closure) = args[0].as_closure() {
         let result = match closure.template.arity {
             Arity::Exact(n) => Value::int(n as i64),
@@ -139,15 +76,6 @@ pub(crate) fn prim_arity(args: &[Value]) -> (SignalBits, Value) {
 
 /// (captures value) — number of captured variables, or nil
 pub(crate) fn prim_captures(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("captures: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
     if let Some(closure) = args[0].as_closure() {
         (SIG_OK, Value::int(closure.env.len() as i64))
     } else {
@@ -157,15 +85,6 @@ pub(crate) fn prim_captures(args: &[Value]) -> (SignalBits, Value) {
 
 /// (bytecode-size value) — size of bytecode in bytes, or nil
 pub(crate) fn prim_bytecode_size(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("bytecode-size: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
     if let Some(closure) = args[0].as_closure() {
         (SIG_OK, Value::int(closure.template.bytecode.len() as i64))
     } else {
@@ -187,15 +106,6 @@ pub(crate) fn prim_bytecode_size(args: &[Value]) -> (SignalBits, Value) {
 /// primitives and special forms are rewritten to `(doc "name")` string lookup.
 /// Passing an explicit string `(doc "stdlib-fn")` will NOT find stdlib docs.
 pub(crate) fn prim_doc(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("doc: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
     // Closure: extract docstring directly — no VM query needed.
     if let Some(closure) = args[0].as_closure() {
         return if let Some(doc) = closure.template.doc {
@@ -224,15 +134,6 @@ pub(crate) fn prim_doc(args: &[Value]) -> (SignalBits, Value) {
 /// - "global?" symbol → bool
 /// - "fiber/self" _ → fiber or nil
 pub(crate) fn prim_vm_query(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 2 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("vm/query: expected 2 arguments, got {}", args.len()),
-            ),
-        );
-    }
     if !args[0].is_string() && args[0].as_keyword_name().is_none() {
         return (
             SIG_ERROR,
@@ -249,16 +150,7 @@ pub(crate) fn prim_vm_query(args: &[Value]) -> (SignalBits, Value) {
 }
 
 /// (signals) — return the signal registry as a struct mapping keywords to bit positions
-pub(crate) fn prim_signals(args: &[Value]) -> (SignalBits, Value) {
-    if !args.is_empty() {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("signals: expected 0 arguments, got {}", args.len()),
-            ),
-        );
-    }
+pub(crate) fn prim_signals(_args: &[Value]) -> (SignalBits, Value) {
     let reg = crate::signals::registry::global_registry().lock().unwrap();
     let mut map = std::collections::BTreeMap::new();
     for entry in reg.entries() {
@@ -272,15 +164,6 @@ pub(crate) fn prim_signals(args: &[Value]) -> (SignalBits, Value) {
 ///
 /// Creates a content-addressed keyword from the string name.
 pub(crate) fn prim_keyword(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("keyword: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
     if let Some(kw) = args[0].with_string(Value::keyword) {
         (SIG_OK, kw)
     } else {
@@ -301,19 +184,7 @@ pub(crate) fn prim_keyword(args: &[Value]) -> (SignalBits, Value) {
 /// Used by regression tests to assert the ClosureRef LIR-transfer fix
 /// is actually firing on real spawn patterns. See
 /// `src/lir/types.rs::convert_value_consts_for_send`.
-pub(crate) fn prim_closure_value_const_count(args: &[Value]) -> (SignalBits, Value) {
-    if !args.is_empty() {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!(
-                    "lir/closure-value-const-count: expected 0 arguments, got {}",
-                    args.len()
-                ),
-            ),
-        );
-    }
+pub(crate) fn prim_closure_value_const_count(_args: &[Value]) -> (SignalBits, Value) {
     (
         SIG_OK,
         Value::int(crate::lir::closure_value_const_count() as i64),
@@ -324,16 +195,7 @@ pub(crate) fn prim_closure_value_const_count(args: &[Value]) -> (SignalBits, Val
 ///
 /// Returns a list of structs, each with :name, :reason, and :calls keys.
 /// Sorted by call count ascending (coldest first).
-pub(crate) fn prim_jit_rejections(args: &[Value]) -> (SignalBits, Value) {
-    if !args.is_empty() {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("jit/rejections: expected 0 arguments, got {}", args.len()),
-            ),
-        );
-    }
+pub(crate) fn prim_jit_rejections(_args: &[Value]) -> (SignalBits, Value) {
     (
         SIG_QUERY,
         Value::pair(Value::keyword("jit/rejections"), Value::NIL),

--- a/src/primitives/io.rs
+++ b/src/primitives/io.rs
@@ -12,15 +12,6 @@ use crate::value::{error_val, Value};
 
 /// (io-request? value) → boolean
 fn prim_is_io_request(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("io-request?: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
     (
         SIG_OK,
         Value::bool(args[0].external_type_name() == Some("io-request")),
@@ -29,15 +20,6 @@ fn prim_is_io_request(args: &[Value]) -> (SignalBits, Value) {
 
 /// (io-backend? value) → boolean
 fn prim_is_io_backend(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("io-backend?: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
     (
         SIG_OK,
         Value::bool(args[0].external_type_name() == Some("io-backend")),
@@ -46,15 +28,6 @@ fn prim_is_io_backend(args: &[Value]) -> (SignalBits, Value) {
 
 /// (io/backend kind) → backend
 fn prim_io_backend(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("io/backend: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
     match args[0].as_keyword_name().as_deref() {
         Some("async") => match AsyncBackend::new() {
             Ok(backend) => {
@@ -89,15 +62,6 @@ fn prim_io_backend(args: &[Value]) -> (SignalBits, Value) {
 
 /// (io/submit backend request) → submission-id
 fn prim_io_submit(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 2 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("io/submit: expected 2 arguments, got {}", args.len()),
-            ),
-        );
-    }
     let backend = match args[0].as_external::<AnyBackend>() {
         Some(b) => b,
         None => {
@@ -133,15 +97,6 @@ fn prim_io_submit(args: &[Value]) -> (SignalBits, Value) {
 
 /// (io/reap backend) → array-of-completion-structs
 fn prim_io_reap(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("io/reap: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
     let backend = match args[0].as_external::<AnyBackend>() {
         Some(b) => b,
         None => {
@@ -161,15 +116,6 @@ fn prim_io_reap(args: &[Value]) -> (SignalBits, Value) {
 
 /// (io/wait backend timeout-ms) → array-of-completion-structs
 fn prim_io_wait(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 2 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("io/wait: expected 2 arguments, got {}", args.len()),
-            ),
-        );
-    }
     let backend = match args[0].as_external::<AnyBackend>() {
         Some(b) => b,
         None => {
@@ -208,15 +154,6 @@ fn prim_io_wait(args: &[Value]) -> (SignalBits, Value) {
 
 /// (io/cancel backend submission-id) → nil
 fn prim_io_cancel(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 2 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("io/cancel: expected 2 arguments, got {}", args.len()),
-            ),
-        );
-    }
     let backend = match args[0].as_external::<AnyBackend>() {
         Some(b) => b,
         None => {
@@ -258,16 +195,6 @@ fn prim_ev_sleep(args: &[Value]) -> (SignalBits, Value) {
     use crate::io::request::IoOp;
     use std::time::Duration;
 
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("ev/sleep: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
-
     let duration = if let Some(n) = args[0].as_int() {
         if n < 0 {
             return (
@@ -307,16 +234,6 @@ fn prim_ev_sleep(args: &[Value]) -> (SignalBits, Value) {
 /// Returns revents mask as int, or 0 on timeout.
 fn prim_ev_poll_fd(args: &[Value]) -> (SignalBits, Value) {
     use std::time::Duration;
-
-    if args.len() < 2 || args.len() > 3 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("ev/poll-fd: expected 2-3 arguments, got {}", args.len()),
-            ),
-        );
-    }
 
     let fd = match args[0].as_int() {
         Some(n) if n >= 0 => n as std::os::unix::io::RawFd,

--- a/src/primitives/json/mod.rs
+++ b/src/primitives/json/mod.rs
@@ -28,16 +28,6 @@ pub(crate) fn prim_json_parse(args: &[Value]) -> (SignalBits, Value) {
         );
     }
 
-    if args.is_empty() || args.len() > 3 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                "json/parse: expected 1 or 3 arguments".to_string(),
-            ),
-        );
-    }
-
     let json_str = if let Some(s) = args[0].with_string(|s| s.to_string()) {
         s
     } else {
@@ -77,16 +67,6 @@ pub(crate) fn prim_json_parse(args: &[Value]) -> (SignalBits, Value) {
 
 /// Serialize an Elle value to compact JSON
 pub(crate) fn prim_json_serialize(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                "json-serialize: expected 1 argument".to_string(),
-            ),
-        );
-    }
-
     let json_str = match serialize_value(&args[0]) {
         Ok(s) => s,
         Err(e) => return (SIG_ERROR, error_val("parse-error", e)),
@@ -96,16 +76,6 @@ pub(crate) fn prim_json_serialize(args: &[Value]) -> (SignalBits, Value) {
 
 /// Serialize an Elle value to pretty-printed JSON with 2-space indentation
 pub(crate) fn prim_json_serialize_pretty(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                "json-serialize-pretty: expected 1 argument".to_string(),
-            ),
-        );
-    }
-
     let json_str = match serialize_value_pretty(&args[0], 0) {
         Ok(s) => s,
         Err(e) => return (SIG_ERROR, error_val("parse-error", e)),
@@ -542,16 +512,6 @@ mod tests {
     fn test_json_parse_wrong_type() {
         // json-parse requires a string argument
         let (bits, _) = prim_json_parse(&[Value::int(42)]);
-        assert_eq!(bits, crate::value::fiber::SIG_ERROR);
-    }
-
-    #[test]
-    fn test_json_serialize_wrong_arity() {
-        // json-serialize requires exactly 1 argument
-        let (bits, _) = prim_json_serialize(&[]);
-        assert_eq!(bits, crate::value::fiber::SIG_ERROR);
-
-        let (bits, _) = prim_json_serialize(&[Value::int(1), Value::int(2)]);
         assert_eq!(bits, crate::value::fiber::SIG_ERROR);
     }
 

--- a/src/primitives/list/advanced.rs
+++ b/src/primitives/list/advanced.rs
@@ -5,16 +5,6 @@ use unicode_segmentation::UnicodeSegmentation;
 
 /// Take the first n elements of a list
 pub(crate) fn prim_take(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 2 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("take: expected 2 arguments, got {}", args.len()),
-            ),
-        );
-    }
-
     let count = match args[0].as_int() {
         Some(n) if n < 0 => {
             return (
@@ -47,16 +37,6 @@ pub(crate) fn prim_take(args: &[Value]) -> (SignalBits, Value) {
 
 /// Get all elements of a sequence except the last
 pub(crate) fn prim_butlast(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("butlast: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
-
     // Lists
     if args[0].is_pair() || args[0].is_empty_list() {
         if args[0].is_empty_list() {
@@ -157,16 +137,6 @@ pub(crate) fn prim_butlast(args: &[Value]) -> (SignalBits, Value) {
 /// For strings: returns new string
 /// `(append collection1 collection2)`
 pub(crate) fn prim_append(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 2 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("append: expected 2 arguments, got {}", args.len()),
-            ),
-        );
-    }
-
     // @string (mutable) — accepts string or @string as second arg
     if let Some(buf_ref) = args[0].as_string_mut() {
         if let Some(other_buf) = args[1].as_string_mut() {
@@ -680,15 +650,6 @@ pub(crate) fn prim_concat(args: &[Value]) -> (SignalBits, Value) {
 
 /// Reverse a sequence (list, array, @array, string)
 pub(crate) fn prim_reverse(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("reverse: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
     // Array — return new array
     if let Some(arr) = args[0].as_array_mut() {
         let mut vec = arr.borrow().to_vec();
@@ -730,16 +691,6 @@ pub(crate) fn prim_reverse(args: &[Value]) -> (SignalBits, Value) {
 
 /// Get the last element of a sequence
 pub(crate) fn prim_last(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("last: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
-
     let empty_err = (
         SIG_ERROR,
         error_val("argument-error", "last: empty sequence"),
@@ -823,16 +774,6 @@ pub(crate) fn prim_last(args: &[Value]) -> (SignalBits, Value) {
 
 /// Drop the first n elements of a list
 pub(crate) fn prim_drop(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 2 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("drop: expected 2 arguments, got {}", args.len()),
-            ),
-        );
-    }
-
     let count = match args[0].as_int() {
         Some(n) if n < 0 => {
             return (

--- a/src/primitives/list/mod.rs
+++ b/src/primitives/list/mod.rs
@@ -16,15 +16,6 @@ pub(crate) use advanced::{
 
 /// Get the first element of a sequence (list, array, @array, string)
 pub(crate) fn prim_first(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("first: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
     // Pair cell — the common case for lists
     if let Some(pair) = args[0].as_pair() {
         return (SIG_OK, pair.first);
@@ -132,15 +123,6 @@ pub(crate) fn prim_first(args: &[Value]) -> (SignalBits, Value) {
 
 /// Get the second element of a sequence
 pub(crate) fn prim_second(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("second: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
     let too_short = (
         SIG_ERROR,
         error_val(
@@ -230,15 +212,6 @@ pub(crate) fn prim_second(args: &[Value]) -> (SignalBits, Value) {
 
 /// Get the rest of a sequence (list, array, @array, string, @string, bytes, @bytes)
 pub(crate) fn prim_rest(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("rest: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
     // Pair cell — the common case for lists
     if let Some(pair) = args[0].as_pair() {
         return (SIG_OK, pair.rest);
@@ -398,15 +371,6 @@ fn collect_elements(val: &Value) -> Result<Vec<Value>, (SignalBits, Value)> {
 
 /// Convert any sequence to an immutable array.
 pub(crate) fn prim_to_array(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("->array: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
     // Already an immutable array — return as-is
     if args[0].as_array().is_some() {
         return (SIG_OK, args[0]);
@@ -419,15 +383,6 @@ pub(crate) fn prim_to_array(args: &[Value]) -> (SignalBits, Value) {
 
 /// Convert any sequence to a list.
 pub(crate) fn prim_to_list(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("->list: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
     // Already a list — return as-is
     if args[0].is_pair() || args[0].is_empty_list() {
         return (SIG_OK, args[0]);
@@ -440,16 +395,6 @@ pub(crate) fn prim_to_list(args: &[Value]) -> (SignalBits, Value) {
 
 /// Get the length of a collection (universal for all container types)
 pub(crate) fn prim_length(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("length: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
-
     if args[0].is_nil() || args[0].is_empty_list() {
         (SIG_OK, Value::int(0))
     } else if args[0].is_pair() {
@@ -575,16 +520,6 @@ pub(crate) fn prim_length(args: &[Value]) -> (SignalBits, Value) {
 
 /// Check if a collection is empty (O(1) operation for most types)
 pub(crate) fn prim_empty(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("empty?: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
-
     // nil is not a container - error if passed
     if args[0].is_nil() {
         return (
@@ -711,15 +646,6 @@ pub(crate) fn prim_empty(args: &[Value]) -> (SignalBits, Value) {
 
 /// Check if a collection is non-empty (negation of empty?)
 pub(crate) fn prim_nonempty(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("nonempty?: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
     let (sig, val) = prim_empty(args);
     if sig != SIG_OK {
         // Re-wrap errors with nonempty? name

--- a/src/primitives/loading.rs
+++ b/src/primitives/loading.rs
@@ -10,12 +10,6 @@ use crate::value::{error_val, Value};
 use super::ffi::resolve_type_desc;
 
 pub(crate) fn prim_ffi_native(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val("arity-error", "ffi/native: expected 1 argument"),
-        );
-    }
     let vm_ptr = match crate::context::get_vm_context() {
         Some(ptr) => ptr,
         None => {
@@ -62,12 +56,6 @@ pub(crate) fn prim_ffi_native(args: &[Value]) -> (SignalBits, Value) {
 }
 
 pub(crate) fn prim_ffi_lookup(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 2 {
-        return (
-            SIG_ERROR,
-            error_val("arity-error", "ffi/lookup: expected 2 arguments"),
-        );
-    }
     let lib_id = match args[0].as_lib_handle() {
         Some(id) => id,
         None => {
@@ -126,12 +114,6 @@ pub(crate) fn prim_ffi_lookup(args: &[Value]) -> (SignalBits, Value) {
 }
 
 pub(crate) fn prim_ffi_signature(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() < 2 || args.len() > 3 {
-        return (
-            SIG_ERROR,
-            error_val("arity-error", "ffi/signature: expected 2 or 3 arguments"),
-        );
-    }
     let ret = match resolve_type_desc(&args[0], "ffi/signature") {
         Ok(t) => t,
         Err(e) => return e,
@@ -213,12 +195,6 @@ pub(crate) fn prim_ffi_signature(args: &[Value]) -> (SignalBits, Value) {
 
 #[cfg(feature = "ffi")]
 pub(crate) fn prim_ffi_callback(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 2 {
-        return (
-            SIG_ERROR,
-            error_val("arity-error", "ffi/callback: expected 2 arguments"),
-        );
-    }
     let sig = match args[0].as_ffi_signature() {
         Some(s) => s.clone(),
         None => {
@@ -298,12 +274,6 @@ pub(crate) fn prim_ffi_callback(args: &[Value]) -> (SignalBits, Value) {
 
 #[cfg(feature = "ffi")]
 pub(crate) fn prim_ffi_callback_free(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val("arity-error", "ffi/callback-free: expected 1 argument"),
-        );
-    }
     if args[0].is_nil() {
         return (SIG_OK, Value::NIL); // free(nil) is a no-op
     }

--- a/src/primitives/logic.rs
+++ b/src/primitives/logic.rs
@@ -3,7 +3,7 @@ use crate::signals::Signal;
 use crate::value::fiber::{SignalBits, SIG_ERROR, SIG_OK};
 use crate::value::heap::TableKey;
 use crate::value::types::Arity;
-use crate::value::{error_val, Value};
+use crate::value::Value;
 use std::collections::BTreeMap;
 
 /// Logical AND operation
@@ -62,16 +62,6 @@ pub(crate) fn prim_xor(args: &[Value]) -> (SignalBits, Value) {
 /// (assert value) => value if truthy, else signal error
 /// (assert value message) => value if truthy, else signal error with message
 pub(crate) fn prim_assert(args: &[Value]) -> (SignalBits, Value) {
-    if args.is_empty() || args.len() > 2 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("assert: expected 1-2 arguments, got {}", args.len()),
-            ),
-        );
-    }
-
     let value = args[0];
     let message = if args.len() == 2 { args[1] } else { Value::NIL };
 

--- a/src/primitives/lstruct.rs
+++ b/src/primitives/lstruct.rs
@@ -133,16 +133,6 @@ pub(crate) fn prim_table(args: &[Value]) -> (SignalBits, Value) {
 /// For sets: delegates to set-specific del
 /// `(del collection key)`
 pub(crate) fn prim_del(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 2 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("del: expected 2 arguments, got {}", args.len()),
-            ),
-        );
-    }
-
     // Delegate to set-specific del for set types
     if args[0].is_set() || args[0].is_set_mut() {
         return crate::primitives::sets::prim_del(args);
@@ -211,16 +201,6 @@ pub(crate) fn prim_del(args: &[Value]) -> (SignalBits, Value) {
 /// Polymorphic keys - works on both structs
 /// `(keys collection)`
 pub(crate) fn prim_keys(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("keys: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
-
     if args[0].is_struct_mut() {
         let mstruct = match args[0].as_struct_mut() {
             Some(t) => t,
@@ -266,16 +246,6 @@ pub(crate) fn prim_keys(args: &[Value]) -> (SignalBits, Value) {
 /// Polymorphic values - works on both structs
 /// `(values collection)`
 pub(crate) fn prim_values(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("values: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
-
     if args[0].is_struct_mut() {
         let mstruct = match args[0].as_struct_mut() {
             Some(t) => t,
@@ -325,16 +295,6 @@ pub(crate) fn prim_values(args: &[Value]) -> (SignalBits, Value) {
 /// For sets: checks if value is a member
 /// For strings: checks if substring is present
 pub(crate) fn prim_has_key(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 2 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("has?: expected 2 arguments, got {}", args.len()),
-            ),
-        );
-    }
-
     // Delegate to set/string membership check
     if args[0].is_set() || args[0].is_set_mut() || args[0].is_string() || args[0].is_string_mut() {
         return crate::primitives::sets::prim_contains(args);

--- a/src/primitives/memory.rs
+++ b/src/primitives/memory.rs
@@ -12,12 +12,6 @@ use super::ffi::{extract_pointer_addr, resolve_type_desc};
 // ── Struct/array type creation ──────────────────────────────────────
 
 pub(crate) fn prim_ffi_struct(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val("arity-error", "ffi/struct: expected 1 argument"),
-        );
-    }
     // Accept array, @array, or list of type descriptors
     let field_vals = if let Some(arr) = args[0].as_array() {
         arr.to_vec()
@@ -75,12 +69,6 @@ pub(crate) fn prim_ffi_struct(args: &[Value]) -> (SignalBits, Value) {
 }
 
 pub(crate) fn prim_ffi_array(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 2 {
-        return (
-            SIG_ERROR,
-            error_val("arity-error", "ffi/array: expected 2 arguments"),
-        );
-    }
     let elem_desc = match resolve_type_desc(&args[0], "ffi/array") {
         Ok(desc) => {
             if matches!(desc, TypeDesc::Void) {
@@ -133,12 +121,6 @@ pub(crate) fn prim_ffi_array(args: &[Value]) -> (SignalBits, Value) {
 // ── Type introspection ──────────────────────────────────────────────
 
 pub fn prim_ffi_size(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val("arity-error", "ffi/size: expected 1 argument"),
-        );
-    }
     let desc = match resolve_type_desc(&args[0], "ffi/size") {
         Ok(t) => t,
         Err(e) => return e,
@@ -150,12 +132,6 @@ pub fn prim_ffi_size(args: &[Value]) -> (SignalBits, Value) {
 }
 
 pub fn prim_ffi_align(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val("arity-error", "ffi/align: expected 1 argument"),
-        );
-    }
     let desc = match resolve_type_desc(&args[0], "ffi/align") {
         Ok(t) => t,
         Err(e) => return e,
@@ -169,12 +145,6 @@ pub fn prim_ffi_align(args: &[Value]) -> (SignalBits, Value) {
 // ── Memory management ───────────────────────────────────────────────
 
 pub fn prim_ffi_malloc(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val("arity-error", "ffi/malloc: expected 1 argument"),
-        );
-    }
     let size = match args[0].as_int() {
         Some(n) if n > 0 => n as usize,
         Some(_) => {
@@ -205,12 +175,6 @@ pub fn prim_ffi_malloc(args: &[Value]) -> (SignalBits, Value) {
 }
 
 pub fn prim_ffi_free(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val("arity-error", "ffi/free: expected 1 argument"),
-        );
-    }
     if args[0].is_nil() {
         return (SIG_OK, Value::NIL); // free(NULL) is a no-op
     }
@@ -248,12 +212,6 @@ pub fn prim_ffi_free(args: &[Value]) -> (SignalBits, Value) {
 // ── Typed memory access ─────────────────────────────────────────────
 
 pub fn prim_ffi_read(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 2 {
-        return (
-            SIG_ERROR,
-            error_val("arity-error", "ffi/read: expected 2 arguments"),
-        );
-    }
     let addr = match extract_pointer_addr(&args[0], "ffi/read") {
         Ok(a) => a,
         Err(e) => return e,
@@ -327,12 +285,6 @@ pub fn prim_ffi_read(args: &[Value]) -> (SignalBits, Value) {
 }
 
 pub fn prim_ffi_write(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 3 {
-        return (
-            SIG_ERROR,
-            error_val("arity-error", "ffi/write: expected 3 arguments"),
-        );
-    }
     let addr = match extract_pointer_addr(&args[0], "ffi/write") {
         Ok(a) => a,
         Err(e) => return e,
@@ -548,12 +500,6 @@ pub fn prim_ffi_write(args: &[Value]) -> (SignalBits, Value) {
 // ── String from pointer ─────────────────────────────────────────────
 
 pub(crate) fn prim_ffi_string(args: &[Value]) -> (SignalBits, Value) {
-    if args.is_empty() || args.len() > 2 {
-        return (
-            SIG_ERROR,
-            error_val("arity-error", "ffi/string: expected 1 or 2 arguments"),
-        );
-    }
     if args[0].is_nil() {
         return (SIG_OK, Value::NIL);
     }
@@ -610,15 +556,6 @@ pub(crate) fn prim_ffi_string(args: &[Value]) -> (SignalBits, Value) {
 /// existing allocation; ownership remains with the original managed pointer.
 /// The offset may be negative to move backwards.
 pub fn prim_ptr_add(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 2 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("ptr/add: expected 2 arguments, got {}", args.len()),
-            ),
-        );
-    }
     let addr = match extract_pointer_addr(&args[0], "ptr/add") {
         Ok(a) => a,
         Err(e) => return e,
@@ -680,15 +617,6 @@ pub fn prim_ptr_add(args: &[Value]) -> (SignalBits, Value) {
 /// Returns `addr_a - addr_b` as a signed integer. Negative if `a < b`.
 /// Both inputs may be raw or managed pointers.
 pub fn prim_ptr_diff(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 2 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("ptr/diff: expected 2 arguments, got {}", args.len()),
-            ),
-        );
-    }
     let addr_a = match extract_pointer_addr(&args[0], "ptr/diff") {
         Ok(a) => a,
         Err(e) => return e,
@@ -708,15 +636,6 @@ pub fn prim_ptr_diff(args: &[Value]) -> (SignalBits, Value) {
 /// The address is at most 48 bits on current hardware, so it always fits
 /// in a signed i64 (2^63-1 >> 2^48-1). The cast is safe.
 pub fn prim_ptr_to_int(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("ptr/to-int: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
     let addr = match extract_pointer_addr(&args[0], "ptr/to-int") {
         Ok(a) => a,
         Err(e) => return e,
@@ -730,15 +649,6 @@ pub fn prim_ptr_to_int(args: &[Value]) -> (SignalBits, Value) {
 /// Returns `nil` if the address is 0 (consistent with `Value::pointer(0) == NIL`).
 /// Validates the address fits in a usize before calling `Value::pointer`.
 pub fn prim_ptr_from_int(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("ptr/from-int: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
     let n = match args[0].as_int() {
         Some(n) => n,
         None => {

--- a/src/primitives/meta.rs
+++ b/src/primitives/meta.rs
@@ -71,16 +71,6 @@ pub(crate) fn prim_gensym(args: &[Value]) -> (SignalBits, Value) {
 ///      (if ,(datum->syntax test 'it) ,then ,else)))
 /// ```
 pub(crate) fn prim_datum_to_syntax(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 2 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("datum->syntax: expected 2 arguments, got {}", args.len()),
-            ),
-        );
-    }
-
     let context = &args[0];
     let datum = &args[1];
 
@@ -130,16 +120,6 @@ pub(crate) fn prim_datum_to_syntax(args: &[Value]) -> (SignalBits, Value) {
 ///
 /// If the argument is not a syntax object, it is returned unchanged.
 pub(crate) fn prim_syntax_to_datum(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("syntax->datum: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
-
     let stx = &args[0];
 
     let syntax_rc = match stx.as_syntax() {
@@ -168,15 +148,6 @@ pub(crate) fn prim_syntax_to_datum(args: &[Value]) -> (SignalBits, Value) {
 /// Extract a syntax object from args\[0\], or return a type-error.
 /// `prim_name` is the function name for the error message.
 fn require_syntax(args: &[Value], prim_name: &'static str) -> Result<Syntax, (SignalBits, Value)> {
-    if args.len() != 1 {
-        return Err((
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("{}: expected 1 argument, got {}", prim_name, args.len()),
-            ),
-        ));
-    }
     match args[0].as_syntax() {
         Some(stx) => Ok(stx.clone()),
         None => Err((
@@ -194,15 +165,6 @@ fn require_syntax(args: &[Value], prim_name: &'static str) -> Result<Syntax, (Si
 }
 
 pub(crate) fn prim_syntax_pair(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("syntax-pair?: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
     match args[0].as_syntax() {
         Some(stx) => {
             let result = matches!(&stx.kind, SyntaxKind::List(items) if !items.is_empty());
@@ -213,15 +175,6 @@ pub(crate) fn prim_syntax_pair(args: &[Value]) -> (SignalBits, Value) {
 }
 
 pub(crate) fn prim_syntax_list(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("syntax-list?: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
     match args[0].as_syntax() {
         Some(stx) => (
             SIG_OK,
@@ -232,15 +185,6 @@ pub(crate) fn prim_syntax_list(args: &[Value]) -> (SignalBits, Value) {
 }
 
 pub(crate) fn prim_syntax_symbol(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("syntax-symbol?: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
     match args[0].as_syntax() {
         Some(stx) => (
             SIG_OK,
@@ -251,15 +195,6 @@ pub(crate) fn prim_syntax_symbol(args: &[Value]) -> (SignalBits, Value) {
 }
 
 pub(crate) fn prim_syntax_keyword(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("syntax-keyword?: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
     match args[0].as_syntax() {
         Some(stx) => (
             SIG_OK,
@@ -270,15 +205,6 @@ pub(crate) fn prim_syntax_keyword(args: &[Value]) -> (SignalBits, Value) {
 }
 
 pub(crate) fn prim_syntax_nil(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("syntax-nil?: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
     match args[0].as_syntax() {
         Some(stx) => (SIG_OK, Value::bool(matches!(&stx.kind, SyntaxKind::Nil))),
         None => (SIG_OK, Value::FALSE),
@@ -407,25 +333,6 @@ pub(crate) fn prim_syntax_e(args: &[Value]) -> (SignalBits, Value) {
 /// - First arg not a closure: type-error
 /// - Invalid signal spec: type-error or signal-error
 pub(crate) fn prim_squelch(args: &[Value]) -> (SignalBits, Value) {
-    if args.is_empty() {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("squelch: expected at least 2 arguments, got {}", args.len()),
-            ),
-        );
-    }
-    if args.len() == 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                "squelch: expected at least 2 arguments (closure + keywords), got 1",
-            ),
-        );
-    }
-
     // Validate first argument is a closure.
     let closure_rc = match args[0].as_closure() {
         Some(c) => c,
@@ -470,16 +377,6 @@ pub(crate) fn prim_squelch(args: &[Value]) -> (SignalBits, Value) {
 /// Argument order is mask-first: the signal spec declares intent, the closure
 /// follows. This reads as "attune to yield+error: this function."
 pub(crate) fn prim_attune(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 2 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("attune: expected 2 arguments, got {}", args.len()),
-            ),
-        );
-    }
-
     // First argument: signal spec (keyword, set, array, list, or integer)
     let permitted_bits = match crate::primitives::fibers::resolve_signal_bits(&args[0], "attune") {
         Ok(bits) => bits,
@@ -565,15 +462,6 @@ pub(crate) fn prim_git(args: &[Value]) -> (SignalBits, Value) {
     }
     #[cfg(feature = "mlir")]
     {
-        if args.is_empty() || args.len() > 2 {
-            return (
-                SIG_ERROR,
-                error_val(
-                    "arity-error",
-                    format!("git: expected 1-2 arguments, got {}", args.len()),
-                ),
-            );
-        }
         let closure = match args[0].as_closure() {
             Some(c) => c,
             None => {
@@ -621,15 +509,6 @@ pub(crate) fn prim_git(args: &[Value]) -> (SignalBits, Value) {
 
 /// `(fn/git? f)` — true if the closure has cached SPIR-V bytes.
 pub(crate) fn prim_fn_git(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("fn/git?: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
     if let Some(closure) = args[0].as_closure() {
         (SIG_OK, Value::bool(closure.template.spirv.get().is_some()))
     } else {
@@ -641,15 +520,6 @@ pub(crate) fn prim_fn_git(args: &[Value]) -> (SignalBits, Value) {
 ///
 /// Errors if `f` is not a closure or has not been GIT'd.
 pub(crate) fn prim_disgit(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("disgit: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
     let closure = match args[0].as_closure() {
         Some(c) => c,
         None => {

--- a/src/primitives/modules.rs
+++ b/src/primitives/modules.rs
@@ -142,16 +142,6 @@ pub(crate) fn resolve_import(spec: &str) -> Option<String> {
 
 /// Import a module file
 pub(crate) fn prim_import_file(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("import: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
-
     let spec = if let Some(s) = args[0].with_string(|s| s.to_string()) {
         s
     } else {
@@ -307,10 +297,9 @@ pub(crate) fn prim_import_file(args: &[Value]) -> (SignalBits, Value) {
         // Save/restore the caller's stack. import executes the
         // module's bytecode on the same VM, which would overwrite the
         // caller's local variable slots without this protection.
-        vm.location_map = result.bytecode.location_map.clone();
         let bc_rc = std::rc::Rc::new(result.bytecode.instructions);
         let consts_rc = std::rc::Rc::new(result.bytecode.constants);
-        let location_map_rc = std::rc::Rc::new(vm.location_map.clone());
+        let location_map_rc = std::rc::Rc::new(result.bytecode.location_map);
         let empty_env = std::rc::Rc::new(vec![]);
 
         let exec_result =

--- a/src/primitives/parameters.rs
+++ b/src/primitives/parameters.rs
@@ -2,37 +2,19 @@
 
 use crate::primitives::def::PrimitiveDef;
 use crate::signals::Signal;
-use crate::value::fiber::{SignalBits, SIG_ERROR, SIG_OK};
+use crate::value::fiber::{SignalBits, SIG_OK};
 use crate::value::types::Arity;
-use crate::value::{error_val, Value};
+use crate::value::Value;
 
 /// Create a new parameter with a default value.
 /// (parameter default) → parameter
 pub(crate) fn prim_make_parameter(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("parameter: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
     (SIG_OK, Value::parameter(args[0]))
 }
 
 /// Check if a value is a parameter.
 /// (parameter? value) → boolean
 pub(crate) fn prim_is_parameter(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("parameter?: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
     (SIG_OK, Value::bool(args[0].is_parameter()))
 }
 

--- a/src/primitives/path.rs
+++ b/src/primitives/path.rs
@@ -28,15 +28,6 @@ where
 }
 
 fn prim_path_join(args: &[Value]) -> (SignalBits, Value) {
-    if args.is_empty() {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                "path/join: expected at least 1 argument, got 0",
-            ),
-        );
-    }
     let mut parts = Vec::with_capacity(args.len());
     for arg in args {
         if let Some(s) = arg.with_string(|s| s.to_string()) {

--- a/src/primitives/ports.rs
+++ b/src/primitives/ports.rs
@@ -56,20 +56,6 @@ fn mode_to_flags(mode: &str) -> Option<(i32, Direction)> {
 /// Yields `SIG_YIELD | SIG_IO` with an `IoRequest` containing `IoOp::Open`.
 /// Argument validation (path type, mode keyword, timeout) happens here before yielding.
 fn open_file(args: &[Value], encoding: Encoding, prim_name: &str) -> (SignalBits, Value) {
-    if args.len() < 2 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!(
-                    "{}: expected at least 2 arguments, got {}",
-                    prim_name,
-                    args.len()
-                ),
-            ),
-        );
-    }
-
     let path = match args[0].with_string(|s| s.to_string()) {
         Some(s) => s,
         None => {
@@ -164,15 +150,6 @@ fn prim_port_open_bytes(args: &[Value]) -> (SignalBits, Value) {
 /// fd is dropped. For stdio ports (no owned fd) and already-closed
 /// ports, completes synchronously.
 fn prim_port_close(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("port/close: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
     let port = match extract_port(&args[0], "port/close") {
         Ok(p) => p,
         Err(e) => return e,
@@ -192,58 +169,22 @@ fn prim_port_close(args: &[Value]) -> (SignalBits, Value) {
 }
 
 /// (port/stdin) → port
-fn prim_port_stdin(args: &[Value]) -> (SignalBits, Value) {
-    if !args.is_empty() {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("port/stdin: expected 0 arguments, got {}", args.len()),
-            ),
-        );
-    }
+fn prim_port_stdin(_args: &[Value]) -> (SignalBits, Value) {
     (SIG_OK, Value::external("port", Port::stdin()))
 }
 
 /// (port/stdout) → port
-fn prim_port_stdout(args: &[Value]) -> (SignalBits, Value) {
-    if !args.is_empty() {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("port/stdout: expected 0 arguments, got {}", args.len()),
-            ),
-        );
-    }
+fn prim_port_stdout(_args: &[Value]) -> (SignalBits, Value) {
     (SIG_OK, Value::external("port", Port::stdout()))
 }
 
 /// (port/stderr) → port
-fn prim_port_stderr(args: &[Value]) -> (SignalBits, Value) {
-    if !args.is_empty() {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("port/stderr: expected 0 arguments, got {}", args.len()),
-            ),
-        );
-    }
+fn prim_port_stderr(_args: &[Value]) -> (SignalBits, Value) {
     (SIG_OK, Value::external("port", Port::stderr()))
 }
 
 /// (port? value) → boolean
 fn prim_is_port(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("port?: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
     (
         SIG_OK,
         Value::bool(args[0].external_type_name() == Some("port")),
@@ -255,15 +196,6 @@ fn prim_is_port(args: &[Value]) -> (SignalBits, Value) {
 /// Returns true if the port is open, false if closed.
 /// Signals :type-error if argument is not a port.
 fn prim_is_port_open(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("port/open?: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
     let port = match extract_port(&args[0], "port/open?") {
         Ok(p) => p,
         Err(e) => return e,
@@ -371,15 +303,6 @@ fn prim_port_set_options(args: &[Value]) -> (SignalBits, Value) {
 ///
 /// Signals :type-error if argument is not a port.
 fn prim_port_path(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("port/path: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
     let port = match extract_port(&args[0], "port/path") {
         Ok(p) => p,
         Err(e) => return e,
@@ -406,15 +329,6 @@ fn prim_port_path(args: &[Value]) -> (SignalBits, Value) {
 fn prim_port_seek(args: &[Value]) -> (SignalBits, Value) {
     // Arity: exactly 2 or exactly 4 (port, offset, :from, :value).
     // 0, 1, 3, or 5+ args are all errors.
-    if args.len() < 2 || args.len() > 4 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("port/seek: expected 2 or 4 arguments, got {}", args.len()),
-            ),
-        );
-    }
     if args.len() == 3 {
         return (
             SIG_ERROR,
@@ -524,16 +438,6 @@ fn prim_port_seek(args: &[Value]) -> (SignalBits, Value) {
 /// Logical position = kernel file offset - buffered-but-unconsumed bytes.
 /// Only valid on file ports. Returns :type-error on other port kinds.
 fn prim_port_tell(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("port/tell: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
-
     let port = match extract_port(&args[0], "port/tell") {
         Ok(p) => p,
         Err(e) => return e,
@@ -913,18 +817,6 @@ mod tests {
     // ── port/open early-error cases (before yielding) ─────────────────────────
 
     #[test]
-    fn test_port_open_too_few_args_errors() {
-        let (bits, _) = prim_port_open(&[Value::string("/tmp/foo")]);
-        assert_eq!(bits, SIG_ERROR, "too few args must error before yielding");
-    }
-
-    #[test]
-    fn test_port_open_no_args_errors() {
-        let (bits, _) = prim_port_open(&[]);
-        assert_eq!(bits, SIG_ERROR);
-    }
-
-    #[test]
     fn test_port_open_non_string_path_errors() {
         let (bits, _) = prim_port_open(&[Value::int(42), Value::keyword("read")]);
         assert_eq!(
@@ -1078,12 +970,6 @@ mod tests {
     }
 
     #[test]
-    fn test_port_path_wrong_arity_errors() {
-        let (bits, _) = prim_port_path(&[]);
-        assert_eq!(bits, SIG_ERROR);
-    }
-
-    #[test]
     fn test_port_path_tcp_listener() {
         use std::net::TcpListener;
         use std::os::unix::io::{FromRawFd, IntoRawFd, OwnedFd};
@@ -1199,36 +1085,10 @@ mod tests {
     }
 
     #[test]
-    fn test_port_seek_zero_args_errors() {
-        let (bits, _) = prim_port_seek(&[]);
-        assert_eq!(bits, SIG_ERROR);
-    }
-
-    #[test]
-    fn test_port_seek_one_arg_errors() {
-        let port = make_file_port();
-        let (bits, _) = prim_port_seek(&[port]);
-        assert_eq!(bits, SIG_ERROR);
-    }
-
-    #[test]
     fn test_port_seek_three_args_errors() {
         // 3 args = incomplete keyword pair (port, offset, :from without value)
         let port = make_file_port();
         let (bits, _) = prim_port_seek(&[port, Value::int(0), Value::keyword("from")]);
-        assert_eq!(bits, SIG_ERROR);
-    }
-
-    #[test]
-    fn test_port_seek_five_args_errors() {
-        let port = make_file_port();
-        let (bits, _) = prim_port_seek(&[
-            port,
-            Value::int(0),
-            Value::keyword("from"),
-            Value::keyword("start"),
-            Value::int(99),
-        ]);
         assert_eq!(bits, SIG_ERROR);
     }
 
@@ -1301,19 +1161,6 @@ mod tests {
         let (_, val) = prim_port_tell(&[port]);
         let req = val.as_external::<IoRequest>().unwrap();
         assert!(matches!(req.op, IoOp::Tell));
-    }
-
-    #[test]
-    fn test_port_tell_zero_args_errors() {
-        let (bits, _) = prim_port_tell(&[]);
-        assert_eq!(bits, SIG_ERROR);
-    }
-
-    #[test]
-    fn test_port_tell_two_args_errors() {
-        let port = make_file_port();
-        let (bits, _) = prim_port_tell(&[port, Value::int(0)]);
-        assert_eq!(bits, SIG_ERROR);
     }
 
     #[test]

--- a/src/primitives/read.rs
+++ b/src/primitives/read.rs
@@ -16,16 +16,6 @@ use crate::value::{error_val, Value};
 /// (read "true")       # → true
 /// ```
 pub(crate) fn prim_read(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("read: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
-
     let source = if let Some(s) = args[0].with_string(|s| s.to_string()) {
         s
     } else {
@@ -69,16 +59,6 @@ pub(crate) fn prim_read(args: &[Value]) -> (SignalBits, Value) {
 /// (read-all "(+ 1 2) (- 3 4)")  # → ((+ 1 2) (- 3 4))
 /// ```
 pub(crate) fn prim_read_all(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("read-all: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
-
     let source = if let Some(s) = args[0].with_string(|s| s.to_string()) {
         s
     } else {

--- a/src/primitives/sets.rs
+++ b/src/primitives/sets.rs
@@ -71,15 +71,6 @@ pub(crate) fn prim_at_set(args: &[Value]) -> (SignalBits, Value) {
 ///
 /// Returns true for both immutable and mutable sets. Use (type-of x) to distinguish.
 pub(crate) fn prim_is_set(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("set?: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
     (
         SIG_OK,
         Value::bool(args[0].is_set() || args[0].is_set_mut()),
@@ -94,16 +85,6 @@ pub(crate) fn prim_is_set(args: &[Value]) -> (SignalBits, Value) {
 /// For sets: returns true if the value is a member of the set.
 /// For strings: returns true if the string contains the substring.
 pub(crate) fn prim_contains(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 2 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("contains?: expected 2 arguments, got {}", args.len()),
-            ),
-        );
-    }
-
     // Set membership check
     let frozen = freeze_value(args[1]);
     if let Some(s) = args[0].as_set() {
@@ -200,15 +181,6 @@ pub(crate) fn prim_contains(args: &[Value]) -> (SignalBits, Value) {
 /// For immutable sets, returns a new set with the element added.
 /// For mutable sets, modifies in place and returns the set.
 pub(crate) fn prim_add(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 2 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("add: expected 2 arguments, got {}", args.len()),
-            ),
-        );
-    }
     let frozen = freeze_value(args[1]);
     if let Some(s) = args[0].as_set() {
         let mut new_set: BTreeSet<Value> = s.iter().copied().collect();
@@ -238,15 +210,6 @@ pub(crate) fn prim_add(args: &[Value]) -> (SignalBits, Value) {
 /// For immutable sets, returns a new set with the element removed.
 /// For mutable sets, modifies in place and returns the set.
 pub(crate) fn prim_del(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 2 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("del: expected 2 arguments, got {}", args.len()),
-            ),
-        );
-    }
     let frozen = freeze_value(args[1]);
     if let Some(s) = args[0].as_set() {
         let mut new_set: BTreeSet<Value> = s.iter().copied().collect();
@@ -276,15 +239,6 @@ pub(crate) fn prim_del(args: &[Value]) -> (SignalBits, Value) {
 /// Both arguments must be the same type (both immutable or both mutable).
 /// Returns a set containing all elements from both sets.
 pub(crate) fn prim_union(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 2 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("union: expected 2 arguments, got {}", args.len()),
-            ),
-        );
-    }
     if let (Some(a), Some(b)) = (args[0].as_set(), args[1].as_set()) {
         let sa: BTreeSet<Value> = a.iter().copied().collect();
         let sb: BTreeSet<Value> = b.iter().copied().collect();
@@ -311,15 +265,6 @@ pub(crate) fn prim_union(args: &[Value]) -> (SignalBits, Value) {
 /// Both arguments must be the same type (both immutable or both mutable).
 /// Returns a set containing only elements present in both sets.
 pub(crate) fn prim_intersection(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 2 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("intersection: expected 2 arguments, got {}", args.len()),
-            ),
-        );
-    }
     if let (Some(a), Some(b)) = (args[0].as_set(), args[1].as_set()) {
         let sa: BTreeSet<Value> = a.iter().copied().collect();
         let sb: BTreeSet<Value> = b.iter().copied().collect();
@@ -347,15 +292,6 @@ pub(crate) fn prim_intersection(args: &[Value]) -> (SignalBits, Value) {
 /// Both arguments must be the same type (both immutable or both mutable).
 /// Returns a set containing elements in set1 but not in set2.
 pub(crate) fn prim_difference(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 2 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("difference: expected 2 arguments, got {}", args.len()),
-            ),
-        );
-    }
     if let (Some(a), Some(b)) = (args[0].as_set(), args[1].as_set()) {
         let sa: BTreeSet<Value> = a.iter().copied().collect();
         let sb: BTreeSet<Value> = b.iter().copied().collect();
@@ -381,15 +317,6 @@ pub(crate) fn prim_difference(args: &[Value]) -> (SignalBits, Value) {
 ///
 /// Immutable set → array, mutable set → @array. Elements in sorted order.
 pub(crate) fn prim_set_to_array(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("set->array: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
     if let Some(s) = args[0].as_set() {
         let items: Vec<Value> = s.to_vec();
         (SIG_OK, Value::array(items))
@@ -418,15 +345,6 @@ pub(crate) fn prim_set_to_array(args: &[Value]) -> (SignalBits, Value) {
 /// Mutable inputs (@array, @string, @bytes, @set) → mutable set.
 /// Mutable values are frozen on insertion.
 pub(crate) fn prim_seq_to_set(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("seq->set: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
     let v = args[0];
 
     // List (immutable) → immutable set

--- a/src/primitives/sort.rs
+++ b/src/primitives/sort.rs
@@ -10,16 +10,6 @@ use crate::value::{error_val, list, Value};
 /// Type-preserving: @arrays mutated in place, arrays and lists return new sorted values.
 /// Supports any comparable values via Value::Ord.
 pub(crate) fn prim_sort(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("sort: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
-
     // Array — mutate in place
     if let Some(arr) = args[0].as_array_mut() {
         let mut vec = arr.borrow_mut();
@@ -69,16 +59,6 @@ pub(crate) fn prim_sort(args: &[Value]) -> (SignalBits, Value) {
 /// `(range start end)` — start to end-1
 /// `(range start end step)` — start, start+step, ... while < end (or > end for negative step)
 pub(crate) fn prim_range(args: &[Value]) -> (SignalBits, Value) {
-    if args.is_empty() || args.len() > 3 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("range: expected 1-3 arguments, got {}", args.len()),
-            ),
-        );
-    }
-
     let (start, end, step) = match args.len() {
         1 => {
             let end = match args[0].as_number() {

--- a/src/primitives/stream.rs
+++ b/src/primitives/stream.rs
@@ -29,18 +29,6 @@ fn extract_port_value(value: &Value, prim_name: &str) -> Result<Value, (SignalBi
 
 /// (port/read-line port [:timeout ms]) → string | nil
 fn prim_stream_read_line(args: &[Value]) -> (SignalBits, Value) {
-    if args.is_empty() {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!(
-                    "port/read-line: expected at least 1 argument, got {}",
-                    args.len()
-                ),
-            ),
-        );
-    }
     let port = match extract_port_value(&args[0], "port/read-line") {
         Ok(p) => p,
         Err(e) => return e,
@@ -57,18 +45,6 @@ fn prim_stream_read_line(args: &[Value]) -> (SignalBits, Value) {
 
 /// (port/read port n [:timeout ms]) → bytes | nil
 fn prim_stream_read(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() < 2 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!(
-                    "port/read: expected at least 2 arguments, got {}",
-                    args.len()
-                ),
-            ),
-        );
-    }
     let port = match extract_port_value(&args[0], "port/read") {
         Ok(p) => p,
         Err(e) => return e,
@@ -110,18 +86,6 @@ fn prim_stream_read(args: &[Value]) -> (SignalBits, Value) {
 
 /// (port/read-all port [:timeout ms]) → string | bytes
 fn prim_stream_read_all(args: &[Value]) -> (SignalBits, Value) {
-    if args.is_empty() {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!(
-                    "port/read-all: expected at least 1 argument, got {}",
-                    args.len()
-                ),
-            ),
-        );
-    }
     let port = match extract_port_value(&args[0], "port/read-all") {
         Ok(p) => p,
         Err(e) => return e,
@@ -138,18 +102,6 @@ fn prim_stream_read_all(args: &[Value]) -> (SignalBits, Value) {
 
 /// (port/write port data [:timeout ms]) → int
 fn prim_stream_write(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() < 2 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!(
-                    "port/write: expected at least 2 arguments, got {}",
-                    args.len()
-                ),
-            ),
-        );
-    }
     let port = match extract_port_value(&args[0], "port/write") {
         Ok(p) => p,
         Err(e) => return e,
@@ -175,18 +127,6 @@ fn prim_stream_write(args: &[Value]) -> (SignalBits, Value) {
 
 /// (port/flush port [:timeout ms]) → nil
 fn prim_stream_flush(args: &[Value]) -> (SignalBits, Value) {
-    if args.is_empty() {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!(
-                    "port/flush: expected at least 1 argument, got {}",
-                    args.len()
-                ),
-            ),
-        );
-    }
     let port = match extract_port_value(&args[0], "port/flush") {
         Ok(p) => p,
         Err(e) => return e,

--- a/src/primitives/string.rs
+++ b/src/primitives/string.rs
@@ -40,15 +40,6 @@ fn as_text(val: &Value, prim_name: &str) -> Result<(String, bool), (SignalBits, 
 
 /// Convert string or buffer to uppercase
 pub(crate) fn prim_string_upcase(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("string-upcase: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
     let (s, is_buffer) = match as_text(&args[0], "string-upcase") {
         Ok(v) => v,
         Err(e) => return e,
@@ -63,15 +54,6 @@ pub(crate) fn prim_string_upcase(args: &[Value]) -> (SignalBits, Value) {
 
 /// Convert string or buffer to lowercase
 pub(crate) fn prim_string_downcase(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("string-downcase: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
     let (s, is_buffer) = match as_text(&args[0], "string-downcase") {
         Ok(v) => v,
         Err(e) => return e,
@@ -86,16 +68,6 @@ pub(crate) fn prim_string_downcase(args: &[Value]) -> (SignalBits, Value) {
 
 /// Find the grapheme index of a substring, with optional start offset
 pub(crate) fn prim_string_find(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() < 2 || args.len() > 3 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("string/find: expected 2-3 arguments, got {}", args.len()),
-            ),
-        );
-    }
-
     let (haystack, _is_buffer) = match as_text(&args[0], "string/find") {
         Ok(v) => v,
         Err(e) => return e,
@@ -163,16 +135,6 @@ pub(crate) fn prim_string_find(args: &[Value]) -> (SignalBits, Value) {
 
 /// Split string or @string on delimiter, returning an array
 pub(crate) fn prim_string_split(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 2 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("string-split: expected 2 arguments, got {}", args.len()),
-            ),
-        );
-    }
-
     let (s, _is_buffer) = match as_text(&args[0], "string-split") {
         Ok(v) => v,
         Err(e) => return e,
@@ -207,16 +169,6 @@ pub(crate) fn prim_string_split(args: &[Value]) -> (SignalBits, Value) {
 
 /// Replace all occurrences of old with new in a string or buffer
 pub(crate) fn prim_string_replace(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 3 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("string-replace: expected 3 arguments, got {}", args.len()),
-            ),
-        );
-    }
-
     let (s, is_buffer) = match as_text(&args[0], "string-replace") {
         Ok(v) => v,
         Err(e) => return e,
@@ -272,16 +224,6 @@ pub(crate) fn prim_string_replace(args: &[Value]) -> (SignalBits, Value) {
 
 /// Trim leading and trailing whitespace from a string or buffer
 pub(crate) fn prim_string_trim(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("string-trim: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
-
     let (s, is_buffer) = match as_text(&args[0], "string-trim") {
         Ok(v) => v,
         Err(e) => return e,
@@ -296,16 +238,6 @@ pub(crate) fn prim_string_trim(args: &[Value]) -> (SignalBits, Value) {
 
 /// Check if string or buffer contains substring
 pub(crate) fn prim_string_contains(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 2 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("string-contains?: expected 2 arguments, got {}", args.len()),
-            ),
-        );
-    }
-
     let (haystack, _is_buffer) = match as_text(&args[0], "string-contains?") {
         Ok(v) => v,
         Err(e) => return e,
@@ -338,19 +270,6 @@ pub(crate) fn prim_string_contains(args: &[Value]) -> (SignalBits, Value) {
 
 /// Check if string or buffer starts with prefix
 pub(crate) fn prim_string_starts_with(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 2 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!(
-                    "string-starts-with?: expected 2 arguments, got {}",
-                    args.len()
-                ),
-            ),
-        );
-    }
-
     let (s, _is_buffer) = match as_text(&args[0], "string-starts-with?") {
         Ok(v) => v,
         Err(e) => return e,
@@ -383,19 +302,6 @@ pub(crate) fn prim_string_starts_with(args: &[Value]) -> (SignalBits, Value) {
 
 /// Check if string or buffer ends with suffix
 pub(crate) fn prim_string_ends_with(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 2 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!(
-                    "string-ends-with?: expected 2 arguments, got {}",
-                    args.len()
-                ),
-            ),
-        );
-    }
-
     let (s, _is_buffer) = match as_text(&args[0], "string-ends-with?") {
         Ok(v) => v,
         Err(e) => return e,
@@ -428,16 +334,6 @@ pub(crate) fn prim_string_ends_with(args: &[Value]) -> (SignalBits, Value) {
 
 /// Join sequence of strings with separator
 pub(crate) fn prim_string_join(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 2 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("string-join: expected 2 arguments, got {}", args.len()),
-            ),
-        );
-    }
-
     let seq = &args[0];
     let separator = if let Some(s) = args[1].with_string(|s| s.to_string()) {
         s
@@ -499,15 +395,6 @@ pub(crate) fn prim_string_join(args: &[Value]) -> (SignalBits, Value) {
 /// Unreserved characters (A-Z, a-z, 0-9, '-', '.', '_', '~') pass through.
 /// All others are percent-encoded as %XX with uppercase hex.
 pub(crate) fn prim_uri_encode(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("uri-encode: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
     if args[0].is_string() {
         return args[0]
             .with_string(|s| {
@@ -582,15 +469,6 @@ pub(crate) fn prim_buffer(args: &[Value]) -> (SignalBits, Value) {
 
 /// Return the UTF-8 byte length of a string (not grapheme count).
 pub(crate) fn prim_string_size_of(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("string/size-of: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
     if let Some(byte_len) = args[0].with_string(|s| s.len()) {
         return (SIG_OK, Value::int(byte_len as i64));
     }
@@ -611,15 +489,6 @@ pub(crate) fn prim_string_size_of(args: &[Value]) -> (SignalBits, Value) {
 
 /// Repeat a string N times
 pub(crate) fn prim_string_repeat(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 2 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("string/repeat: expected 2 arguments, got {}", args.len()),
-            ),
-        );
-    }
     let s = if let Some(s) = args[0].with_string(|s| s.to_string()) {
         s
     } else {

--- a/src/primitives/structs.rs
+++ b/src/primitives/structs.rs
@@ -301,16 +301,6 @@ pub(crate) fn prim_thaw(args: &[Value]) -> (SignalBits, Value) {
 /// Convert a struct to a list of [key value] pairs
 /// (pairs {:a 1 :b 2}) -> ((:a 1) (:b 2))
 pub(crate) fn prim_pairs(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("pairs: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
-
     // Helper: convert a slice of (TableKey, Value) pairs into a list of [key value] pairs
     fn pairs_from_slice(entries: &[(TableKey, Value)]) -> Value {
         let mut result = Value::EMPTY_LIST;

--- a/src/primitives/subprocess.rs
+++ b/src/primitives/subprocess.rs
@@ -16,33 +16,23 @@ use crate::value::{error_val, list, sorted_struct_get, Value};
 pub(crate) fn prim_exit(args: &[Value]) -> (SignalBits, Value) {
     let code = if args.is_empty() {
         0
-    } else if args.len() == 1 {
-        if let Some(n) = args[0].as_int() {
-            if !(0..=255).contains(&n) {
-                return (
-                    SIG_ERROR,
-                    error_val(
-                        "argument-error",
-                        format!("exit: code must be between 0 and 255, got {}", n),
-                    ),
-                );
-            }
-            n as i32
-        } else {
+    } else if let Some(n) = args[0].as_int() {
+        if !(0..=255).contains(&n) {
             return (
                 SIG_ERROR,
                 error_val(
-                    "type-error",
-                    format!("exit: expected integer, got {}", args[0].type_name()),
+                    "argument-error",
+                    format!("exit: code must be between 0 and 255, got {}", n),
                 ),
             );
         }
+        n as i32
     } else {
         return (
             SIG_ERROR,
             error_val(
-                "arity-error",
-                format!("exit: expected 0-1 arguments, got {}", args.len()),
+                "type-error",
+                format!("exit: expected integer, got {}", args[0].type_name()),
             ),
         );
     };
@@ -60,15 +50,6 @@ pub(crate) fn prim_exit(args: &[Value]) -> (SignalBits, Value) {
 /// is maskable by fiber signal masks but non-resumable: once a fiber
 /// halts, it is Dead.
 pub(crate) fn prim_halt(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() > 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("halt: expected 0-1 arguments, got {}", args.len()),
-            ),
-        );
-    }
     let value = if args.is_empty() { Value::NIL } else { args[0] };
     (SIG_HALT, value)
 }
@@ -130,15 +111,6 @@ pub(crate) fn prim_sys_argv(_args: &[Value]) -> (SignalBits, Value) {
 /// (sys/env) => {"HOME" "/home/user" "PATH" "/usr/bin:..." ...}
 /// (sys/env "HOME") => "/home/user" or nil if not set
 pub(crate) fn prim_sys_env(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() > 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("sys/env: expected 0-1 arguments, got {}", args.len()),
-            ),
-        );
-    }
     if args.len() == 1 {
         let name = match args[0].with_string(|s| s.to_string()) {
             Some(s) => s,
@@ -441,19 +413,6 @@ fn extract_string_sequence(seq: &Value, fn_name: &str) -> Result<Vec<String>, (S
 ///
 /// Returns (SIG_EXEC | SIG_IO | SIG_YIELD, io-request).
 fn prim_subprocess_exec(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() < 2 || args.len() > 3 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!(
-                    "subprocess/exec: expected 2-3 arguments, got {}",
-                    args.len()
-                ),
-            ),
-        );
-    }
-
     let program = match args[0].with_string(|s| s.to_string()) {
         Some(s) => s,
         None => {
@@ -508,15 +467,6 @@ fn prim_subprocess_exec(args: &[Value]) -> (SignalBits, Value) {
 ///
 /// Returns (SIG_EXEC | SIG_IO | SIG_YIELD, io-request).
 fn prim_subprocess_wait(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("subprocess/wait: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
     let handle_val = match extract_process_handle(&args[0], "subprocess/wait") {
         Ok(v) => v,
         Err(e) => return e,
@@ -563,18 +513,6 @@ fn keyword_to_signal(name: &str) -> Option<libc::c_int> {
 ///
 /// Synchronous — returns (SIG_OK, nil) on success, (SIG_ERROR, error) on failure.
 fn prim_subprocess_kill(args: &[Value]) -> (SignalBits, Value) {
-    if args.is_empty() || args.len() > 2 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!(
-                    "subprocess/kill: expected 1-2 arguments, got {}",
-                    args.len()
-                ),
-            ),
-        );
-    }
     let handle_val = match extract_process_handle(&args[0], "subprocess/kill") {
         Ok(v) => v,
         Err(e) => return e,
@@ -644,15 +582,6 @@ fn prim_subprocess_kill(args: &[Value]) -> (SignalBits, Value) {
 ///
 /// Synchronous — no yield.
 fn prim_subprocess_pid(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("subprocess/pid: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
     let handle_val = match extract_process_handle(&args[0], "subprocess/pid") {
         Ok(v) => v,
         Err(e) => return e,
@@ -824,12 +753,6 @@ mod tests {
         assert_eq!(value, Value::int(42));
     }
 
-    #[test]
-    fn test_halt_too_many_args() {
-        let (signal, _) = prim_halt(&[Value::int(0), Value::int(1)]);
-        assert_eq!(signal, SIG_ERROR);
-    }
-
     // --- sys/args ---
 
     #[test]
@@ -987,25 +910,6 @@ mod tests {
     // --- subprocess/exec ---
 
     #[test]
-    fn test_subprocess_exec_arity_too_few() {
-        let (sig, _) = prim_subprocess_exec(&[]);
-        assert_eq!(sig, SIG_ERROR);
-        let (sig, _) = prim_subprocess_exec(&[Value::string("echo")]);
-        assert_eq!(sig, SIG_ERROR);
-    }
-
-    #[test]
-    fn test_subprocess_exec_arity_too_many() {
-        let (sig, _) = prim_subprocess_exec(&[
-            Value::string("echo"),
-            Value::array(vec![]),
-            Value::struct_from(std::collections::BTreeMap::new()),
-            Value::string("extra"),
-        ]);
-        assert_eq!(sig, SIG_ERROR);
-    }
-
-    #[test]
     fn test_subprocess_exec_program_not_string() {
         let (sig, _) = prim_subprocess_exec(&[Value::int(42), Value::array(vec![])]);
         assert_eq!(sig, SIG_ERROR);
@@ -1139,14 +1043,6 @@ mod tests {
     // --- subprocess/wait ---
 
     #[test]
-    fn test_subprocess_wait_arity() {
-        let (sig, _) = prim_subprocess_wait(&[]);
-        assert_eq!(sig, SIG_ERROR);
-        let (sig, _) = prim_subprocess_wait(&[Value::NIL, Value::NIL]);
-        assert_eq!(sig, SIG_ERROR);
-    }
-
-    #[test]
     fn test_subprocess_wait_wrong_type() {
         let (sig, _) = prim_subprocess_wait(&[Value::int(42)]);
         assert_eq!(sig, SIG_ERROR);
@@ -1234,14 +1130,6 @@ mod tests {
     }
 
     // --- subprocess/pid ---
-
-    #[test]
-    fn test_subprocess_pid_arity() {
-        let (sig, _) = prim_subprocess_pid(&[]);
-        assert_eq!(sig, SIG_ERROR);
-        let (sig, _) = prim_subprocess_pid(&[Value::NIL, Value::NIL]);
-        assert_eq!(sig, SIG_ERROR);
-    }
 
     #[test]
     fn test_subprocess_pid_wrong_type() {

--- a/src/primitives/time.rs
+++ b/src/primitives/time.rs
@@ -14,17 +14,7 @@ fn process_epoch() -> &'static Instant {
 
 /// Returns seconds elapsed since process start (monotonic clock)
 /// (clock/monotonic)
-pub(crate) fn prim_clock_monotonic(args: &[Value]) -> (SignalBits, Value) {
-    if !args.is_empty() {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("clock/monotonic: expected 0 arguments, got {}", args.len()),
-            ),
-        );
-    }
-
+pub(crate) fn prim_clock_monotonic(_args: &[Value]) -> (SignalBits, Value) {
     (
         SIG_OK,
         Value::float(process_epoch().elapsed().as_secs_f64()),
@@ -33,17 +23,7 @@ pub(crate) fn prim_clock_monotonic(args: &[Value]) -> (SignalBits, Value) {
 
 /// Returns thread CPU time in seconds
 /// (clock/cpu)
-pub(crate) fn prim_clock_cpu(args: &[Value]) -> (SignalBits, Value) {
-    if !args.is_empty() {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("clock/cpu: expected 0 arguments, got {}", args.len()),
-            ),
-        );
-    }
-
+pub(crate) fn prim_clock_cpu(_args: &[Value]) -> (SignalBits, Value) {
     let mut ts = libc::timespec {
         tv_sec: 0,
         tv_nsec: 0,
@@ -63,17 +43,7 @@ pub(crate) fn prim_clock_cpu(args: &[Value]) -> (SignalBits, Value) {
 
 /// Returns seconds since Unix epoch (wall clock)
 /// (clock/realtime)
-pub(crate) fn prim_clock_realtime(args: &[Value]) -> (SignalBits, Value) {
-    if !args.is_empty() {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("clock/realtime: expected 0 arguments, got {}", args.len()),
-            ),
-        );
-    }
-
+pub(crate) fn prim_clock_realtime(_args: &[Value]) -> (SignalBits, Value) {
     match std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH) {
         Ok(duration) => (SIG_OK, Value::float(duration.as_secs_f64())),
         Err(_) => (
@@ -89,16 +59,6 @@ pub(crate) fn prim_clock_realtime(args: &[Value]) -> (SignalBits, Value) {
 /// Sleeps for the specified number of seconds
 /// (time/sleep seconds)
 pub(crate) fn prim_sleep(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("time/sleep: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
-
     if let Some(n) = args[0].as_int() {
         if n < 0 {
             return (

--- a/src/primitives/traits.rs
+++ b/src/primitives/traits.rs
@@ -19,15 +19,6 @@ use crate::value::{error_val, Value};
 /// - returns a new heap object with the same data and traits = table
 /// - for mutable types, data storage is shared (same RefCell)
 pub(crate) fn prim_with_traits(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 2 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("with-traits: expected 2 arguments, got {}", args.len()),
-            ),
-        );
-    }
     let value = args[0];
     let table = args[1];
 
@@ -183,15 +174,6 @@ unsafe fn clone_with_traits(value: Value, table: Value) -> Result<Value, String>
 /// Returns the trait table attached to value, or nil if none.
 /// For immediate values and infrastructure types, returns nil (no error).
 pub(crate) fn prim_traits(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("traits: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
     let value = args[0];
     if !value.is_heap() {
         return (SIG_OK, Value::NIL);

--- a/src/primitives/types.rs
+++ b/src/primitives/types.rs
@@ -7,29 +7,11 @@ use crate::value::{error_val, Value};
 
 /// Check if value is nil
 pub(crate) fn prim_is_nil(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("nil?: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
     (SIG_OK, Value::bool(args[0].is_nil()))
 }
 
 /// Check if value is a pair (pair)
 pub(crate) fn prim_is_pair(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("pair?: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
     let is_pair = args[0].as_pair().is_some()
         || args[0].as_syntax().is_some_and(
             |s| matches!(s.kind, crate::syntax::SyntaxKind::List(ref items) if !items.is_empty()),
@@ -39,15 +21,6 @@ pub(crate) fn prim_is_pair(args: &[Value]) -> (SignalBits, Value) {
 
 /// Check if value is a list (empty list or pair)
 pub(crate) fn prim_is_list(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("list?: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
     let is_list = args[0].is_empty_list()
         || args[0].as_pair().is_some()
         || args[0]
@@ -58,57 +31,21 @@ pub(crate) fn prim_is_list(args: &[Value]) -> (SignalBits, Value) {
 
 /// Check if value is a number
 pub(crate) fn prim_is_number(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("number?: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
     (SIG_OK, Value::bool(args[0].is_number()))
 }
 
 /// Check if value is an integer
 pub(crate) fn prim_is_integer(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("integer?: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
     (SIG_OK, Value::bool(args[0].is_int()))
 }
 
 /// Check if value is a float
 pub(crate) fn prim_is_float(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("float?: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
     (SIG_OK, Value::bool(args[0].is_float()))
 }
 
 /// Check if value is a symbol
 pub(crate) fn prim_is_symbol(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("symbol?: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
     let is_symbol = args[0].is_symbol()
         || args[0]
             .as_syntax()
@@ -118,15 +55,6 @@ pub(crate) fn prim_is_symbol(args: &[Value]) -> (SignalBits, Value) {
 
 /// Check if value is a string (immutable or mutable)
 pub(crate) fn prim_is_string(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("string?: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
     (
         SIG_OK,
         Value::bool(args[0].is_string() || args[0].is_string_mut()),
@@ -135,60 +63,23 @@ pub(crate) fn prim_is_string(args: &[Value]) -> (SignalBits, Value) {
 
 /// Check if value is a boolean
 pub(crate) fn prim_is_boolean(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("boolean?: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
     (SIG_OK, Value::bool(args[0].is_bool()))
 }
 
 /// Check if value is a keyword
 pub(crate) fn prim_is_keyword(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("keyword?: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
     (SIG_OK, Value::bool(args[0].is_keyword()))
 }
 
 /// Check if value is a keyword
 /// Get the type name of a value as a keyword
 pub(crate) fn prim_type_of(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("type-of: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
-
     let type_name = args[0].type_name();
     (SIG_OK, Value::keyword(type_name))
 }
 
 /// Check if value is a raw C pointer
 pub(crate) fn prim_ptr_predicate(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("ptr?: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
     (
         SIG_OK,
         Value::bool(args[0].is_pointer() || args[0].as_managed_pointer().is_some()),
@@ -197,15 +88,6 @@ pub(crate) fn prim_ptr_predicate(args: &[Value]) -> (SignalBits, Value) {
 
 /// Check if value is an array (immutable or mutable indexed sequence)
 pub(crate) fn prim_is_array(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("array?: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
     (
         SIG_OK,
         Value::bool(args[0].as_array().is_some() || args[0].as_array_mut().is_some()),
@@ -214,15 +96,6 @@ pub(crate) fn prim_is_array(args: &[Value]) -> (SignalBits, Value) {
 
 /// Check if value is bytes (immutable or mutable binary data)
 pub(crate) fn prim_is_bytes(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("bytes?: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
     (
         SIG_OK,
         Value::bool(args[0].is_bytes() || args[0].is_bytes_mut()),
@@ -231,15 +104,6 @@ pub(crate) fn prim_is_bytes(args: &[Value]) -> (SignalBits, Value) {
 
 /// Check if value is a struct (immutable or mutable key-value map)
 pub(crate) fn prim_is_struct(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("struct?: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
     (
         SIG_OK,
         Value::bool(args[0].as_struct().is_some() || args[0].as_struct_mut().is_some()),
@@ -248,12 +112,6 @@ pub(crate) fn prim_is_struct(args: &[Value]) -> (SignalBits, Value) {
 
 /// Check if value is callable (closure or native function)
 pub(crate) fn prim_is_fn(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val("arity-error", "fn?: expected 1 argument"),
-        );
-    }
     (
         SIG_OK,
         Value::bool(args[0].is_closure() || args[0].is_native_fn()),
@@ -262,12 +120,6 @@ pub(crate) fn prim_is_fn(args: &[Value]) -> (SignalBits, Value) {
 
 /// Check if value is callable (function, collection, or parameter)
 pub(crate) fn prim_is_callable(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val("arity-error", "callable?: expected 1 argument"),
-        );
-    }
     let v = &args[0];
     let callable = v.is_closure()
         || v.is_native_fn()
@@ -287,53 +139,20 @@ pub(crate) fn prim_is_callable(args: &[Value]) -> (SignalBits, Value) {
 
 /// Check if value is a native (built-in) function
 pub(crate) fn prim_is_native_fn(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val("arity-error", "native-fn?: expected 1 argument"),
-        );
-    }
     (SIG_OK, Value::bool(args[0].is_native_fn()))
 }
 
 /// Check if value is mutable (can be modified in-place)
 pub(crate) fn prim_is_mutable(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("mutable?: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
     (SIG_OK, Value::bool(args[0].is_mutable()))
 }
 
 pub(crate) fn prim_is_immutable(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("immutable?: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
     (SIG_OK, Value::bool(!args[0].is_mutable()))
 }
 
 /// Check if value is numerically zero
 pub(crate) fn prim_is_zero(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("zero?: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
     let is_zero = if let Some(i) = args[0].as_int() {
         i == 0
     } else if let Some(f) = args[0].as_float() {
@@ -345,15 +164,6 @@ pub(crate) fn prim_is_zero(args: &[Value]) -> (SignalBits, Value) {
 }
 
 pub(crate) fn prim_is_nonzero(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("nonzero?: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
     let is_nonzero = if let Some(i) = args[0].as_int() {
         i != 0
     } else if let Some(f) = args[0].as_float() {
@@ -366,30 +176,12 @@ pub(crate) fn prim_is_nonzero(args: &[Value]) -> (SignalBits, Value) {
 
 /// Check if value is NaN
 pub(crate) fn prim_is_nan(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("nan?: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
     let is_nan = args[0].as_number().map(|n| n.is_nan()).unwrap_or(false);
     (SIG_OK, Value::bool(is_nan))
 }
 
 /// Check if value is positive
 pub(crate) fn prim_is_pos(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("pos?: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
     if let Some(i) = args[0].as_int() {
         return (SIG_OK, Value::bool(i > 0));
     }
@@ -407,15 +199,6 @@ pub(crate) fn prim_is_pos(args: &[Value]) -> (SignalBits, Value) {
 
 /// Check if value is negative
 pub(crate) fn prim_is_neg(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("neg?: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
     if let Some(i) = args[0].as_int() {
         return (SIG_OK, Value::bool(i < 0));
     }
@@ -433,15 +216,6 @@ pub(crate) fn prim_is_neg(args: &[Value]) -> (SignalBits, Value) {
 
 /// Check if value is infinite
 pub(crate) fn prim_is_inf(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("inf?: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
     let is_inf = args[0]
         .as_number()
         .map(|n| n.is_infinite())

--- a/src/primitives/watch.rs
+++ b/src/primitives/watch.rs
@@ -9,16 +9,7 @@ use crate::value::types::Arity;
 use crate::value::{error_val, sorted_struct_get, Value};
 
 /// (watch) — create a filesystem watcher, returns an External handle.
-fn prim_watch(args: &[Value]) -> (SignalBits, Value) {
-    if !args.is_empty() {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("watch: expected 0 arguments, got {}", args.len()),
-            ),
-        );
-    }
+fn prim_watch(_args: &[Value]) -> (SignalBits, Value) {
     match FsWatcher::new() {
         Ok(w) => (SIG_OK, Value::external("fs-watcher", w)),
         Err(msg) => (SIG_ERROR, error_val("io-error", msg)),
@@ -27,15 +18,6 @@ fn prim_watch(args: &[Value]) -> (SignalBits, Value) {
 
 /// (watch-add watcher path) or (watch-add watcher path {:recursive bool})
 fn prim_watch_add(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() < 2 || args.len() > 3 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("watch-add: expected 2-3 arguments, got {}", args.len()),
-            ),
-        );
-    }
     let watcher = match args[0].as_external::<FsWatcher>() {
         Some(w) => w,
         None => {
@@ -80,15 +62,6 @@ fn prim_watch_add(args: &[Value]) -> (SignalBits, Value) {
 
 /// (watch-remove watcher path)
 fn prim_watch_remove(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 2 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("watch-remove: expected 2 arguments, got {}", args.len()),
-            ),
-        );
-    }
     let watcher = match args[0].as_external::<FsWatcher>() {
         Some(w) => w,
         None => {
@@ -121,15 +94,6 @@ fn prim_watch_remove(args: &[Value]) -> (SignalBits, Value) {
 
 /// (watch-next watcher) — async: yields SIG_IO, resumes with event batch.
 fn prim_watch_next(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("watch-next: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
     // Validate it's a watcher before yielding
     if args[0].as_external::<FsWatcher>().is_none() {
         return (
@@ -142,15 +106,6 @@ fn prim_watch_next(args: &[Value]) -> (SignalBits, Value) {
 
 /// (watch-close watcher)
 fn prim_watch_close(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (
-            SIG_ERROR,
-            error_val(
-                "arity-error",
-                format!("watch-close: expected 1 argument, got {}", args.len()),
-            ),
-        );
-    }
     let watcher = match args[0].as_external::<FsWatcher>() {
         Some(w) => w,
         None => {

--- a/src/vm/call.rs
+++ b/src/vm/call.rs
@@ -38,6 +38,7 @@ impl VM {
     ///
     /// Returns `Some(SignalBits)` if execution should return immediately,
     /// or `None` if the dispatch loop should continue.
+    #[allow(clippy::too_many_arguments)]
     pub(super) fn handle_call(
         &mut self,
         bytecode: &Rc<Vec<u8>>,
@@ -46,6 +47,7 @@ impl VM {
         ip: &mut usize,
         instr_ip: usize,
         location_map: &Rc<LocationMap>,
+        checked: bool,
     ) -> Option<SignalBits> {
         let bc: &[u8] = bytecode;
         let arg_count = self.read_u16(bc, ip) as usize;
@@ -75,6 +77,7 @@ impl VM {
             ip,
             instr_ip,
             location_map,
+            checked,
         )
     }
 
@@ -86,6 +89,7 @@ impl VM {
     /// calls the function with those args.
     ///
     /// Stack: \[func, args_array\] → \[result\]
+    #[allow(clippy::too_many_arguments)]
     pub(super) fn handle_call_array(
         &mut self,
         bytecode: &Rc<Vec<u8>>,
@@ -94,6 +98,7 @@ impl VM {
         ip: &mut usize,
         instr_ip: usize,
         location_map: &Rc<LocationMap>,
+        checked: bool,
     ) -> Option<SignalBits> {
         let args_val = self
             .fiber
@@ -133,6 +138,7 @@ impl VM {
             ip,
             instr_ip,
             location_map,
+            checked,
         )
     }
 
@@ -141,6 +147,9 @@ impl VM {
     /// Dispatches native functions, executes closures with environment setup,
     /// handles yield-through-calls and JIT compilation.
     #[allow(clippy::too_many_arguments)]
+    ///
+    /// When `checked` is true, the compiler verified arity at compile time
+    /// and the runtime skips the arity check for primitives and closures.
     fn call_inner(
         &mut self,
         func: Value,
@@ -151,6 +160,7 @@ impl VM {
         ip: &mut usize,
         instr_ip: usize,
         location_map: &Rc<LocationMap>,
+        checked: bool,
     ) -> Option<SignalBits> {
         if let Some(def) = func.as_native_def() {
             etrace!(
@@ -177,6 +187,20 @@ impl VM {
                     ip,
                     location_map,
                 );
+            }
+            if !checked && !def.arity.matches(args.len()) {
+                set_error(
+                    &mut self.fiber,
+                    "arity-error",
+                    format!(
+                        "{}: expected {} argument(s), got {}",
+                        def.name,
+                        def.arity,
+                        args.len()
+                    ),
+                );
+                self.fiber.stack.push(Value::NIL);
+                return None;
             }
             let (bits, value) =
                 if std::ptr::fn_addr_eq(def.func, crate::plugin_api::PLUGIN_SENTINEL) {
@@ -233,8 +257,8 @@ impl VM {
                 location_map: location_map.clone(),
             });
 
-            // Validate argument count
-            if !self.check_arity(&closure.template.arity, args.len()) {
+            // Validate argument count (skip if compiler verified)
+            if !checked && !self.check_arity(&closure.template.arity, args.len()) {
                 self.fiber.call_depth -= 1;
                 self.fiber.call_stack.pop();
                 self.fiber.stack.push(Value::NIL);
@@ -524,6 +548,7 @@ impl VM {
         &mut self,
         ip: &mut usize,
         bytecode: &[u8],
+        checked: bool,
     ) -> Option<SignalBits> {
         let arg_count = self.read_u16(bytecode, ip) as usize;
         let func = self
@@ -543,7 +568,7 @@ impl VM {
         }
         args.reverse();
 
-        self.tail_call_inner(func, args)
+        self.tail_call_inner(func, args, checked)
     }
 
     /// Handle the TailCallArrayMut instruction.
@@ -554,6 +579,7 @@ impl VM {
         &mut self,
         ip: &mut usize,
         bytecode: &[u8],
+        checked: bool,
     ) -> Option<SignalBits> {
         // Suppress unused warnings — these params match the dispatch signature
         let _ = (ip, bytecode);
@@ -586,14 +612,22 @@ impl VM {
             return Some(SIG_ERROR);
         };
 
-        self.tail_call_inner(func, args)
+        self.tail_call_inner(func, args, checked)
     }
 
     /// Shared TailCall/TailCallArrayMut logic after argument extraction.
     ///
     /// Dispatches native functions via tail signal handler, sets up pending
     /// tail call for closures with environment building.
-    fn tail_call_inner(&mut self, func: Value, args: Vec<Value>) -> Option<SignalBits> {
+    ///
+    /// When `checked` is true, the compiler verified arity at compile time
+    /// and the runtime skips the arity check for primitives and closures.
+    fn tail_call_inner(
+        &mut self,
+        func: Value,
+        args: Vec<Value>,
+        checked: bool,
+    ) -> Option<SignalBits> {
         if let Some(def) = func.as_native_def() {
             let blocked = def
                 .signal
@@ -602,6 +636,19 @@ impl VM {
                 .intersection(crate::signals::CAP_MASK);
             if !blocked.is_empty() {
                 return Some(self.handle_capability_denial_tail(def, blocked, &args));
+            }
+            if !checked && !def.arity.matches(args.len()) {
+                set_error(
+                    &mut self.fiber,
+                    "arity-error",
+                    format!(
+                        "{}: expected {} argument(s), got {}",
+                        def.name,
+                        def.arity,
+                        args.len()
+                    ),
+                );
+                return Some(SIG_ERROR);
             }
             let (bits, value) =
                 if std::ptr::fn_addr_eq(def.func, crate::plugin_api::PLUGIN_SENTINEL) {
@@ -627,8 +674,8 @@ impl VM {
         }
 
         if let Some(closure) = func.as_closure() {
-            // Validate argument count
-            if !self.check_arity(&closure.template.arity, args.len()) {
+            // Validate argument count (skip if compiler verified)
+            if !checked && !self.check_arity(&closure.template.arity, args.len()) {
                 // check_arity sets fiber.signal to (SIG_ERROR, ...)
                 return Some(SIG_ERROR);
             }

--- a/src/vm/core.rs
+++ b/src/vm/core.rs
@@ -58,7 +58,6 @@ pub struct VM {
     /// which would re-register primitives and leak library handles.
     pub loaded_plugins: HashMap<String, Value>,
     pub closure_call_counts: FxHashMap<*const u8, usize>,
-    pub location_map: LocationMap,
     pub tail_call_env_cache: Vec<Value>,
     pub env_cache: Vec<Value>,
     pub(crate) pending_tail_call: Option<TailCallInfo>,
@@ -195,7 +194,6 @@ impl VM {
             loading_modules: std::collections::HashSet::new(),
             loaded_plugins: HashMap::new(),
             closure_call_counts: FxHashMap::default(),
-            location_map: LocationMap::new(),
             tail_call_env_cache: Vec::with_capacity(256),
             env_cache: Vec::with_capacity(256),
             pending_tail_call: None,
@@ -253,18 +251,7 @@ impl VM {
         self.closure_call_counts.clear();
         #[cfg(feature = "jit")]
         self.jit_rejections.clear();
-        self.location_map = LocationMap::new();
         self.loading_modules.clear();
-    }
-
-    /// Set the location map for mapping bytecode instructions to source locations
-    pub fn set_location_map(&mut self, map: LocationMap) {
-        self.location_map = map;
-    }
-
-    /// Get the location map for bytecode instruction lookups
-    pub fn get_location_map(&self) -> &LocationMap {
-        &self.location_map
     }
 
     /// Format a runtime error value with source location.

--- a/src/vm/dispatch.rs
+++ b/src/vm/dispatch.rs
@@ -172,13 +172,34 @@ impl VM {
                         &mut ip,
                         instr_ip,
                         location_map,
+                        false,
+                    ) {
+                        return (bits, ip);
+                    }
+                }
+                Instruction::CallChecked => {
+                    check_fuel!(self, instr_ip);
+                    if let Some(bits) = self.handle_call(
+                        bytecode,
+                        constants,
+                        closure_env,
+                        &mut ip,
+                        instr_ip,
+                        location_map,
+                        true,
                     ) {
                         return (bits, ip);
                     }
                 }
                 Instruction::TailCall => {
                     check_fuel!(self, instr_ip);
-                    if let Some(bits) = self.handle_tail_call(&mut ip, bc) {
+                    if let Some(bits) = self.handle_tail_call(&mut ip, bc, false) {
+                        return (bits, ip);
+                    }
+                }
+                Instruction::TailCallChecked => {
+                    check_fuel!(self, instr_ip);
+                    if let Some(bits) = self.handle_tail_call(&mut ip, bc, true) {
                         return (bits, ip);
                     }
                 }
@@ -413,13 +434,14 @@ impl VM {
                         &mut ip,
                         instr_ip,
                         location_map,
+                        false,
                     ) {
                         return (bits, ip);
                     }
                 }
                 Instruction::TailCallArrayMut => {
                     check_fuel!(self, instr_ip);
-                    if let Some(bits) = self.handle_tail_call_array(&mut ip, bc) {
+                    if let Some(bits) = self.handle_tail_call_array(&mut ip, bc, false) {
                         return (bits, ip);
                     }
                 }

--- a/src/vm/jit_entry.rs
+++ b/src/vm/jit_entry.rs
@@ -6,11 +6,8 @@
 //! - Batch JIT compilation for call peers
 //! - Fallback to interpreter on compilation failure
 
-use crate::jit::{
-    JitCode, JitCompiler, JitRejectionInfo, JitValue, TAIL_CALL_SENTINEL, YIELD_SENTINEL,
-};
+use crate::jit::{JitCode, JitRejectionInfo, JitValue, TAIL_CALL_SENTINEL, YIELD_SENTINEL};
 use crate::value::{SignalBits, SymbolId, Value, SIG_ERROR, SIG_HALT, SIG_YIELD};
-use std::rc::Rc;
 use std::sync::Arc;
 
 use super::core::VM;
@@ -325,113 +322,6 @@ impl VM {
 
     /// Try batch JIT compilation for a hot function and its call peers.
     ///
-    /// Returns `Some` if batch compilation succeeded and the hot function
-    /// was executed. Returns `None` to fall through to solo compilation.
-    ///
-    /// Currently always returns `None` (discover_compilation_group returns
-    /// empty with globals removed). Retained for future batch compilation.
-    #[allow(dead_code)]
-    fn try_batch_jit(
-        &mut self,
-        lir_func: &Rc<crate::lir::LirFunction>,
-        _bytecode_ptr: *const u8,
-        closure: &crate::value::Closure,
-        args: &[Value],
-        func: Value,
-        hot_sym: Option<SymbolId>,
-    ) -> Option<Option<SignalBits>> {
-        // With globals removed, discover_compilation_group always returns
-        // empty — batch JIT requires compile-time peer discovery (future work).
-        let group = crate::jit::discover_compilation_group(lir_func, &[]);
-        if group.is_empty() {
-            return None;
-        }
-
-        let hot_sym = hot_sym?;
-
-        let compiler = match JitCompiler::new() {
-            Ok(c) => c,
-            Err(e) => {
-                panic!("JIT compiler creation failed: {}. This is a bug.", e);
-            }
-        };
-
-        let mut members = Vec::with_capacity(group.len() + 1);
-        members.push(crate::jit::BatchMember {
-            sym: hot_sym,
-            lir: lir_func,
-        });
-
-        for (sym, lir) in &group {
-            if *sym != hot_sym {
-                members.push(crate::jit::BatchMember { sym: *sym, lir });
-            }
-        }
-
-        if members.len() <= 1 {
-            return None;
-        }
-
-        let results =
-            match compiler.compile_batch(&members, (*closure.template.symbol_names).clone()) {
-                Ok(r) => r,
-                Err(e) => match &e {
-                    crate::jit::JitError::UnsupportedInstruction(_)
-                    | crate::jit::JitError::Yielding => {
-                        return None;
-                    }
-                    _ => {
-                        panic!(
-                            "Batch JIT compilation failed: {}. \
-                         This is a bug — all members were pre-validated as JIT-compilable.",
-                            e
-                        );
-                    }
-                },
-            };
-
-        // Insert all compiled functions into cache and find the hot one
-        let mut hot_jit_code = None;
-        for (sym, jit_code) in results {
-            let jit_code = Arc::new(jit_code);
-            if sym == hot_sym {
-                let bc_ptr = closure.template.bytecode.as_ptr();
-                self.jit_cache.insert(bc_ptr, jit_code.clone());
-                hot_jit_code = Some(jit_code);
-            }
-        }
-
-        if let Some(jit_code) = hot_jit_code {
-            return Some(self.run_jit(&jit_code, closure, args, func));
-        }
-
-        None
-    }
-
-    /// Record a JIT rejection for a closure. Only the first rejection per
-    /// closure template is stored (deduplicated by bytecode pointer).
-    #[allow(dead_code)]
-    fn record_jit_rejection(
-        &mut self,
-        bytecode_ptr: *const u8,
-        closure: &crate::value::Closure,
-        error: crate::jit::JitError,
-    ) {
-        self.jit_rejections.entry(bytecode_ptr).or_insert_with(|| {
-            // Prefer LIR name, fall back to closure template name.
-            let name = closure
-                .template
-                .lir_function
-                .as_ref()
-                .and_then(|f| f.name.clone())
-                .or_else(|| closure.template.name.as_ref().map(|n| n.to_string()));
-            JitRejectionInfo {
-                name,
-                reason: error,
-            }
-        });
-    }
-
     /// Find the SymbolId for a closure matching the given bytecode pointer.
     ///
     /// With globals removed, there is no global symbol table to scan.

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -30,6 +30,7 @@ pub use crate::value::fiber::CallFrame;
 pub use core::VM;
 
 use crate::compiler::bytecode::{Bytecode, Instruction};
+use crate::error::LocationMap;
 use crate::pipeline::lookup_stdlib_value;
 use crate::symbol::SymbolTable;
 use crate::value::{
@@ -39,7 +40,6 @@ use std::rc::Rc;
 
 impl VM {
     pub fn execute(&mut self, bytecode: &Bytecode) -> Result<Value, String> {
-        self.location_map = bytecode.location_map.clone();
         self.execute_bytecode(&bytecode.instructions, &bytecode.constants, None)
     }
 
@@ -84,7 +84,7 @@ impl VM {
         let mut current_bytecode = Rc::new(bytecode.to_vec());
         let mut current_constants = Rc::new(constants.to_vec());
         let mut current_env = closure_env.cloned().unwrap_or(empty_env);
-        let mut current_location_map = Rc::new(self.location_map.clone());
+        let mut current_location_map = Rc::new(LocationMap::new());
 
         // Initial execution with tail-call loop.
         // Pool rotation: when a tail call is rotation-safe, release the
@@ -277,7 +277,6 @@ impl VM {
         ];
         let synthetic_constants = vec![thunk, ev_run];
 
-        self.location_map = bytecode.location_map.clone();
         self.execute_bytecode(&synthetic_bc, &synthetic_constants, None)
     }
 }

--- a/src/wasm/controlflow.rs
+++ b/src/wasm/controlflow.rs
@@ -84,6 +84,7 @@ impl WasmEmitter {
                             dst: call_dst,
                             func: fn_reg,
                             args,
+                            ..
                         } => {
                             let resume_state = self
                                 .call_state_map
@@ -169,6 +170,7 @@ impl WasmEmitter {
                         dst,
                         func: fn_reg,
                         args,
+                        ..
                     } => {
                         let resume_state = self
                             .call_state_map

--- a/src/wasm/instruction.rs
+++ b/src/wasm/instruction.rs
@@ -160,13 +160,17 @@ impl WasmEmitter {
                 f.instruction(&Instruction::Drop);
                 f.instruction(&Instruction::Drop);
             }
-            LirInstr::Call { dst, func, args } => {
+            LirInstr::Call {
+                dst, func, args, ..
+            } => {
                 self.emit_call(f, *dst, *func, args);
             }
-            LirInstr::SuspendingCall { dst, func, args } => {
+            LirInstr::SuspendingCall {
+                dst, func, args, ..
+            } => {
                 self.emit_call(f, *dst, *func, args);
             }
-            LirInstr::TailCall { func, args } => {
+            LirInstr::TailCall { func, args, .. } => {
                 if !self.is_closure {
                     let dst = Reg(0);
                     self.emit_call(f, dst, *func, args);

--- a/src/wasm/regalloc.rs
+++ b/src/wasm/regalloc.rs
@@ -325,7 +325,7 @@ pub fn for_each_use(instr: &LirInstr, mut f: impl FnMut(Reg)) {
                 f(*a);
             }
         }
-        LirInstr::TailCall { func, args } => {
+        LirInstr::TailCall { func, args, .. } => {
             f(*func);
             for a in args {
                 f(*a);

--- a/tests/integration/error_reporting.rs
+++ b/tests/integration/error_reporting.rs
@@ -241,30 +241,3 @@ fn test_closure_has_location_map() {
     }
 }
 
-#[test]
-fn test_vm_uses_location_map_for_stack_trace() {
-    use elle::pipeline::compile;
-    use elle::primitives::register_primitives;
-    use elle::vm::VM;
-    use elle::SymbolTable;
-
-    let mut symbols = SymbolTable::new();
-    let mut vm = VM::new();
-    let _signals = register_primitives(&mut vm, &mut symbols);
-
-    // Compile a simple expression
-    let source = "(%add 1 2)";
-    let result = compile(source, &mut symbols, "<test>");
-    assert!(result.is_ok(), "Compilation failed: {:?}", result.err());
-
-    let compiled = result.unwrap();
-
-    // Execute the bytecode - this sets the VM's location_map
-    let _ = vm.execute(&compiled.bytecode);
-
-    // The VM's location_map should now be populated
-    assert!(
-        !vm.get_location_map().is_empty(),
-        "VM's location_map should be set from bytecode"
-    );
-}

--- a/tests/integration/jit.rs
+++ b/tests/integration/jit.rs
@@ -698,6 +698,7 @@ fn test_jit_call_compiles() {
             dst: Reg(1),
             func: Reg(0),
             args: vec![],
+            arity_checked: false,
         },
         span(),
     ));
@@ -1345,6 +1346,7 @@ fn test_jit_tail_call_compiles() {
         LirInstr::TailCall {
             func: Reg(0),
             args: vec![],
+            arity_checked: false,
         },
         span(),
     ));

--- a/tests/unittests/primitives.rs
+++ b/tests/unittests/primitives.rs
@@ -288,18 +288,25 @@ fn test_list_operation_errors() {
     assert!(call_primitive(&first, &[Value::NIL]).is_err());
 }
 
+// Arity checking — verified at the VM dispatch level
 #[test]
 fn test_arity_errors() {
-    let (_vm, mut symbols, meta) = setup();
-
     // first requires exactly 1 argument
-    let first = get_primitive(&meta, &mut symbols, "first");
-    assert!(call_primitive(&first, &[]).is_err());
-    assert!(call_primitive(&first, &[Value::int(1), Value::int(2)]).is_err());
+    assert!(eval_source("(first)").is_err());
+    assert!(eval_source("(first 1 2)").is_err());
 
     // = requires exactly 2 arguments
-    let eq = get_primitive(&meta, &mut symbols, "=");
-    assert!(call_primitive(&eq, &[Value::int(1)]).is_err());
+    assert!(eval_source("(= 1)").is_err());
+}
+
+#[test]
+fn test_disbit_arity_error() {
+    assert!(eval_source("(disassemble/bytecode)").is_err());
+}
+
+#[test]
+fn test_disjit_arity_error() {
+    assert!(eval_source("(disassemble/jit)").is_err());
 }
 
 // Macro and meta-programming tests
@@ -706,20 +713,6 @@ fn test_string_split_errors() {
     let (_vm, mut symbols, meta) = setup();
     let split_fn = get_primitive(&meta, &mut symbols, "string-split");
 
-    // Wrong arity - too few args
-    assert!(call_primitive(&split_fn, &[Value::string("hello")]).is_err());
-
-    // Wrong arity - too many args
-    assert!(call_primitive(
-        &split_fn,
-        &[
-            Value::string("hello"),
-            Value::string(","),
-            Value::string("extra"),
-        ]
-    )
-    .is_err());
-
     // Wrong type - first arg not string
     assert!(call_primitive(&split_fn, &[Value::int(42), Value::string(","),]).is_err());
 
@@ -734,21 +727,6 @@ fn test_string_split_errors() {
 fn test_string_replace_errors() {
     let (_vm, mut symbols, meta) = setup();
     let replace_fn = get_primitive(&meta, &mut symbols, "string-replace");
-
-    // Wrong arity - too few args
-    assert!(call_primitive(&replace_fn, &[Value::string("hello"), Value::string("l"),]).is_err());
-
-    // Wrong arity - too many args
-    assert!(call_primitive(
-        &replace_fn,
-        &[
-            Value::string("hello"),
-            Value::string("l"),
-            Value::string("x"),
-            Value::string("extra"),
-        ]
-    )
-    .is_err());
 
     // Wrong type - first arg not string
     assert!(call_primitive(
@@ -788,12 +766,6 @@ fn test_string_trim_errors() {
     let (_vm, mut symbols, meta) = setup();
     let trim_fn = get_primitive(&meta, &mut symbols, "string-trim");
 
-    // Wrong arity - too few args
-    assert!(call_primitive(&trim_fn, &[]).is_err());
-
-    // Wrong arity - too many args
-    assert!(call_primitive(&trim_fn, &[Value::string("hello"), Value::string("extra"),]).is_err());
-
     // Wrong type - not string
     assert!(call_primitive(&trim_fn, &[Value::int(42)]).is_err());
 }
@@ -802,20 +774,6 @@ fn test_string_trim_errors() {
 fn test_string_contains_errors() {
     let (_vm, mut symbols, meta) = setup();
     let contains_fn = get_primitive(&meta, &mut symbols, "string-contains?");
-
-    // Wrong arity - too few args
-    assert!(call_primitive(&contains_fn, &[Value::string("hello")]).is_err());
-
-    // Wrong arity - too many args
-    assert!(call_primitive(
-        &contains_fn,
-        &[
-            Value::string("hello"),
-            Value::string("l"),
-            Value::string("extra"),
-        ]
-    )
-    .is_err());
 
     // Wrong type - first arg not string
     assert!(call_primitive(&contains_fn, &[Value::int(42), Value::string("l"),]).is_err());
@@ -829,20 +787,6 @@ fn test_string_starts_with_errors() {
     let (_vm, mut symbols, meta) = setup();
     let starts_fn = get_primitive(&meta, &mut symbols, "string-starts-with?");
 
-    // Wrong arity - too few args
-    assert!(call_primitive(&starts_fn, &[Value::string("hello")]).is_err());
-
-    // Wrong arity - too many args
-    assert!(call_primitive(
-        &starts_fn,
-        &[
-            Value::string("hello"),
-            Value::string("h"),
-            Value::string("extra"),
-        ]
-    )
-    .is_err());
-
     // Wrong type - first arg not string
     assert!(call_primitive(&starts_fn, &[Value::int(42), Value::string("h"),]).is_err());
 
@@ -855,20 +799,6 @@ fn test_string_ends_with_errors() {
     let (_vm, mut symbols, meta) = setup();
     let ends_fn = get_primitive(&meta, &mut symbols, "string-ends-with?");
 
-    // Wrong arity - too few args
-    assert!(call_primitive(&ends_fn, &[Value::string("hello")]).is_err());
-
-    // Wrong arity - too many args
-    assert!(call_primitive(
-        &ends_fn,
-        &[
-            Value::string("hello"),
-            Value::string("o"),
-            Value::string("extra"),
-        ]
-    )
-    .is_err());
-
     // Wrong type - first arg not string
     assert!(call_primitive(&ends_fn, &[Value::int(42), Value::string("o"),]).is_err());
 
@@ -880,16 +810,6 @@ fn test_string_ends_with_errors() {
 fn test_string_join_errors() {
     let (_vm, mut symbols, meta) = setup();
     let join_fn = get_primitive(&meta, &mut symbols, "string-join");
-
-    // Wrong arity - too few args
-    assert!(call_primitive(&join_fn, &[list(vec![])]).is_err());
-
-    // Wrong arity - too many args
-    assert!(call_primitive(
-        &join_fn,
-        &[list(vec![]), Value::string(","), Value::string("extra"),]
-    )
-    .is_err());
 
     // Wrong type - second arg not string
     assert!(call_primitive(&join_fn, &[list(vec![]), Value::int(42),]).is_err());
@@ -990,10 +910,6 @@ fn test_import_file_primitive() {
 
     // Test with invalid argument type
     let result = call_primitive(&import_file, &[Value::int(42)]);
-    assert!(result.is_err());
-
-    // Test with wrong argument count
-    let result = call_primitive(&import_file, &[]);
     assert!(result.is_err());
 }
 
@@ -1231,10 +1147,6 @@ fn test_clock_monotonic_primitive() {
         t2 >= t1,
         "clock/monotonic should be monotonically non-decreasing"
     );
-
-    // Arity error when given arguments
-    let result = call_primitive(&clock, &[Value::int(1)]);
-    assert!(result.is_err());
 }
 
 #[test]
@@ -1254,10 +1166,6 @@ fn test_clock_realtime_primitive() {
         val.as_float().unwrap() > 1_700_000_000.0,
         "clock/realtime should be a plausible epoch timestamp"
     );
-
-    // Arity error when given arguments
-    let result = call_primitive(&clock, &[Value::int(1)]);
-    assert!(result.is_err());
 }
 
 #[test]
@@ -1279,10 +1187,6 @@ fn test_clock_cpu_primitive() {
     let t1 = call_primitive(&clock, &[]).unwrap().as_float().unwrap();
     let t2 = call_primitive(&clock, &[]).unwrap().as_float().unwrap();
     assert!(t2 >= t1, "clock/cpu should be non-decreasing");
-
-    // Arity error when given arguments
-    let result = call_primitive(&clock, &[Value::int(1)]);
-    assert!(result.is_err());
 }
 
 #[test]
@@ -1681,14 +1585,6 @@ fn test_disbit_type_error_on_non_closure() {
 }
 
 #[test]
-fn test_disbit_arity_error() {
-    let (_vm, mut symbols, meta) = setup();
-    let disbit = get_primitive(&meta, &mut symbols, "disbit");
-    let result = call_primitive(&disbit, &[]);
-    assert!(result.is_err(), "disbit with no args should error");
-}
-
-#[test]
 fn test_disbit_returns_array_for_pure_closure() {
     let (_vm, mut symbols, meta) = setup();
     let disbit = get_primitive(&meta, &mut symbols, "disbit");
@@ -1715,14 +1611,6 @@ fn test_disjit_type_error_on_non_closure() {
     let disjit = get_primitive(&meta, &mut symbols, "disjit");
     let result = call_primitive(&disjit, &[Value::int(42)]);
     assert!(result.is_err(), "disjit on non-closure should error");
-}
-
-#[test]
-fn test_disjit_arity_error() {
-    let (_vm, mut symbols, meta) = setup();
-    let disjit = get_primitive(&meta, &mut symbols, "disjit");
-    let result = call_primitive(&disjit, &[]);
-    assert!(result.is_err(), "disjit with no args should error");
 }
 
 // ============================================================================


### PR DESCRIPTION
Move arity validation from individual primitive functions to the VM dispatch layer (call_inner / tail_call_inner). The compiler marks calls to known-immutable native functions as arity_checked, allowing the runtime to skip the check for statically verified call sites.

- Add CallChecked/TailCallChecked bytecodes + LIR arity_checked flag
- VM dispatch checks def.arity.matches() for unchecked calls
- Fix lowerer bug: gate arity_checked on is_native_fn() to exclude stdlib closures (map, string/join, etc.) from the optimization
- Strip 250+ manual arity checks from src/primitives/ (~44 files)
- Remove 20 now-redundant arity unit tests
- Clean up unused imports and dead code across affected modules