### PR TITLE
Accept all immutable non-float values as struct keys

### DIFF
--- a/src/lir/emit/stack.rs
+++ b/src/lir/emit/stack.rs
@@ -73,7 +73,7 @@ impl super::Emitter {
     /// leaving different stack depths at the merge point.  This causes
     /// DupN offsets in the merge block to be wrong, shifting operands and
     /// producing incorrect results (e.g. a struct value in a hash-key
-    /// slot → "expected hashable value, got struct").
+    /// slot → "struct keys must be immutable (got struct)").
     ///
     /// Call this before saving stack state to `yield_stack_state` in
     /// terminators so that all predecessors of a merge block agree on

--- a/src/primitives/access.rs
+++ b/src/primitives/access.rs
@@ -261,7 +261,10 @@ pub(crate) fn prim_get(args: &[Value]) -> (SignalBits, Value) {
                     SIG_ERROR,
                     error_val(
                         "type-error",
-                        format!("expected hashable value, got {}", args[1].type_name()),
+                        format!(
+                            "struct keys must be immutable (got {})",
+                            args[1].type_name()
+                        ),
                     ),
                 )
             }
@@ -291,7 +294,10 @@ pub(crate) fn prim_get(args: &[Value]) -> (SignalBits, Value) {
                     SIG_ERROR,
                     error_val(
                         "type-error",
-                        format!("expected hashable value, got {}", args[1].type_name()),
+                        format!(
+                            "struct keys must be immutable (got {})",
+                            args[1].type_name()
+                        ),
                     ),
                 )
             }
@@ -670,7 +676,10 @@ pub(crate) fn prim_put(args: &[Value]) -> (SignalBits, Value) {
                 SIG_ERROR,
                 error_val(
                     "type-error",
-                    format!("expected hashable value, got {}", args[1].type_name()),
+                    format!(
+                        "struct keys must be immutable (got {})",
+                        args[1].type_name()
+                    ),
                 ),
             )
         }

--- a/src/primitives/collection.rs
+++ b/src/primitives/collection.rs
@@ -185,7 +185,7 @@ pub fn coll_has(coll: &Value, needle: &Value) -> Result<bool, Value> {
         let key = TableKey::from_value(needle).ok_or_else(|| {
             error_val(
                 "type-error",
-                format!("expected hashable value, got {}", needle.type_name()),
+                format!("struct keys must be immutable (got {})", needle.type_name()),
             )
         })?;
         if let Some(s) = coll.as_struct() {

--- a/src/primitives/lstruct.rs
+++ b/src/primitives/lstruct.rs
@@ -115,7 +115,10 @@ pub(crate) fn prim_table(args: &[Value]) -> (SignalBits, Value) {
                     SIG_ERROR,
                     error_val(
                         "type-error",
-                        format!("expected hashable value, got {}", args[i].type_name()),
+                        format!(
+                            "struct keys must be immutable (got {})",
+                            args[i].type_name()
+                        ),
                     ),
                 )
             }
@@ -146,7 +149,10 @@ pub(crate) fn prim_del(args: &[Value]) -> (SignalBits, Value) {
                 SIG_ERROR,
                 error_val(
                     "type-error",
-                    format!("expected hashable value, got {}", args[1].type_name()),
+                    format!(
+                        "struct keys must be immutable (got {})",
+                        args[1].type_name()
+                    ),
                 ),
             )
         }

--- a/src/primitives/structs.rs
+++ b/src/primitives/structs.rs
@@ -87,7 +87,10 @@ pub(crate) fn prim_struct(args: &[Value]) -> (SignalBits, Value) {
                     SIG_ERROR,
                     error_val(
                         "type-error",
-                        format!("expected hashable value, got {}", args[i].type_name()),
+                        format!(
+                            "struct keys must be immutable (got {})",
+                            args[i].type_name()
+                        ),
                     ),
                 )
             }
@@ -312,8 +315,9 @@ pub(crate) fn prim_pairs(args: &[Value]) -> (SignalBits, Value) {
                 TableKey::Symbol(sym) => Value::symbol(sym.0),
                 TableKey::String(s) => Value::string(s.as_str()),
                 TableKey::Keyword(kw) => Value::keyword(kw.as_str()),
+                TableKey::EmptyList => Value::EMPTY_LIST,
                 TableKey::Array(keys) => Value::array(keys.iter().map(|k| k.to_value()).collect()),
-                TableKey::Identity(v) => *v,
+                TableKey::Heap(v) => *v,
             };
             let pair = Value::array(vec![key_val, *value]);
             result = Value::pair(pair, result);

--- a/src/syntax/convert.rs
+++ b/src/syntax/convert.rs
@@ -45,6 +45,7 @@ fn table_key_to_syntax(
         }
         TableKey::String(s) => SyntaxKind::String(s.clone()),
         TableKey::Keyword(s) => SyntaxKind::Keyword(s.clone()),
+        TableKey::EmptyList => SyntaxKind::List(vec![]),
         TableKey::Array(keys) => {
             let elements: Result<Vec<_>, _> = keys
                 .iter()
@@ -52,8 +53,8 @@ fn table_key_to_syntax(
                 .collect();
             return Ok(Syntax::new(SyntaxKind::Array(elements?), span.clone()));
         }
-        TableKey::Identity(_) => {
-            return Err("Cannot convert identity key to Syntax".to_string());
+        TableKey::Heap(_) => {
+            return Err("Cannot convert heap key to Syntax".to_string());
         }
     };
     Ok(Syntax::new(kind, span.clone()))

--- a/src/value/types.rs
+++ b/src/value/types.rs
@@ -3,8 +3,23 @@
 //! This module contains fundamental types used throughout the value system:
 //! - `SymbolId` - Interned symbol identifier
 //! - `Arity` - Function arity specification
-//! - `TableKey` - Keys for tables and structs
+//! - `TableKey` - Keys for structs (accepts all immutable non-float types)
 //! - `NativeFn` - Unified primitive function type
+//!
+//! ## TableKey design
+//!
+//! `TableKey` accepts any immutable, non-float value as a struct key:
+//! - **Scalar**: nil, bool, int, symbol, keyword, string, empty list
+//! - **Compound immutable**: arrays, cons cells, empty list, bytes, sets, structs
+//! - **Identity types**: fiber, closure, external (compared by pointer identity)
+//!
+//! Mutable types (@array, @struct, @set, @bytes, @string, box) and floats are
+//! rejected. Mutable values could change after insertion, breaking hash invariants.
+//! Floats are rejected because NaN violates Eq/Hash.
+//!
+//! Compound immutable keys store the original `Value` directly in the `Heap`
+//! variant; `from_value()` recursively validates sub-elements but always stores
+//! the original value, not a reconstructed copy.
 
 use crate::value::heap::HeapTag;
 use crate::value::Value;
@@ -101,21 +116,21 @@ pub enum TableKey {
     Symbol(SymbolId),
     String(String),
     Keyword(String),
+    EmptyList,
     /// Immutable array key. All elements must themselves be valid TableKeys.
     /// Mutable arrays are rejected — mutation after insertion would break
     /// the hash invariant.
     Array(Vec<TableKey>),
-    /// Identity-compared key for reference types (fiber, closure, external).
+    /// Any non-scalar immutable heap value used as a struct key.
     ///
-    /// **Invariant**: Only constructed via `from_value()`. The stored `Value`
-    /// must be a type where `identical?` uses pointer identity (currently: fiber,
-    /// closure, external). Storing a value-compared type here would silently
-    /// use bit-pattern comparison instead of value comparison.
+    /// Stores the original `Value` directly. `from_value()` recursively validates
+    /// that all sub-elements are themselves valid keys (immutable, non-float) but
+    /// always stores the original `*val`, not a reconstructed copy.
     ///
-    /// Hash/Eq/Ord compare by tag+payload equality, which
-    /// encodes the heap pointer. This gives the same identity semantics as
-    /// `identical?` for these types.
-    Identity(Value),
+    /// `Hash`/`Eq`/`Ord` delegate to `Value`'s implementations, which give:
+    /// - **Identity semantics** for fiber, closure, external (compared by pointer)
+    /// - **Structural semantics** for cons, set, struct, bytes, empty list
+    Heap(Value),
 }
 
 impl TableKey {
@@ -142,8 +157,29 @@ impl TableKey {
                 keys.push(TableKey::from_value(elem)?);
             }
             Some(TableKey::Array(keys))
+        } else if val.is_empty_list() {
+            Some(TableKey::EmptyList)
+        } else if val.is_pair() {
+            let pair = val.as_pair().unwrap();
+            Self::from_value(&pair.first)?;
+            Self::from_value(&pair.rest)?;
+            Some(TableKey::Heap(*val))
+        } else if val.is_bytes() {
+            Some(TableKey::Heap(*val))
+        } else if val.is_set() {
+            let set = val.as_set().unwrap();
+            for elem in set {
+                Self::from_value(elem)?;
+            }
+            Some(TableKey::Heap(*val))
+        } else if val.is_struct() {
+            let entries = val.as_struct().unwrap();
+            for (_key, value) in entries {
+                Self::from_value(value)?;
+            }
+            Some(TableKey::Heap(*val))
         } else if val.is_fiber() || val.is_closure() || val.heap_tag() == Some(HeapTag::External) {
-            Some(TableKey::Identity(*val))
+            Some(TableKey::Heap(*val))
         } else {
             None
         }
@@ -160,19 +196,20 @@ impl TableKey {
             TableKey::Symbol(sid) => Value::symbol(sid.0),
             TableKey::String(s) => Value::string(s.as_str()),
             TableKey::Keyword(s) => Value::keyword(s.as_str()),
+            TableKey::EmptyList => Value::EMPTY_LIST,
             TableKey::Array(keys) => Value::array(keys.iter().map(|k| k.to_value()).collect()),
-            TableKey::Identity(v) => *v,
+            TableKey::Heap(v) => *v,
         }
     }
 
     /// Whether this key can be safely sent across thread boundaries.
     ///
-    /// Identity keys contain heap pointers (`Rc`) that are not thread-safe.
+    /// Heap keys contain `Rc` data that is not thread-safe.
     /// Value-based keys (nil, bool, int, symbol, string, keyword) are always
     /// sendable.
     pub fn is_sendable(&self) -> bool {
         match self {
-            TableKey::Identity(_) => false,
+            TableKey::Heap(_) => false,
             TableKey::Array(keys) => keys.iter().all(|k| k.is_sendable()),
             _ => true,
         }
@@ -186,8 +223,9 @@ impl TableKey {
             TableKey::Symbol(_) => 3,
             TableKey::String(_) => 4,
             TableKey::Keyword(_) => 5,
-            TableKey::Array(_) => 6,
-            TableKey::Identity(_) => 7,
+            TableKey::EmptyList => 6,
+            TableKey::Array(_) => 7,
+            TableKey::Heap(_) => 8,
         }
     }
 }
@@ -197,6 +235,7 @@ impl std::hash::Hash for TableKey {
         std::mem::discriminant(self).hash(state);
         match self {
             TableKey::Nil => {}
+            TableKey::EmptyList => {}
             TableKey::Bool(b) => b.hash(state),
             TableKey::Int(i) => i.hash(state),
             TableKey::Symbol(id) => id.hash(state),
@@ -207,7 +246,9 @@ impl std::hash::Hash for TableKey {
             // that encodes a stable Rc/Arc-backed identity rather than
             // the slot pointer, so outbox relocation on fiber yield
             // doesn't turn the same fiber into a different map key.
-            TableKey::Identity(v) => v.hash(state),
+            // For cons/set/struct/bytes/empty-list, gives structural
+            // hashing based on the value's content.
+            TableKey::Heap(v) => v.hash(state),
         }
     }
 }
@@ -221,10 +262,12 @@ impl PartialEq for TableKey {
             (TableKey::Symbol(a), TableKey::Symbol(b)) => a == b,
             (TableKey::String(a), TableKey::String(b)) => a == b,
             (TableKey::Keyword(a), TableKey::Keyword(b)) => a == b,
+            (TableKey::EmptyList, TableKey::EmptyList) => true,
             (TableKey::Array(a), TableKey::Array(b)) => a == b,
             // Delegate to Value's PartialEq (stable identity for Fiber
-            // and friends — see Hash impl above).
-            (TableKey::Identity(a), TableKey::Identity(b)) => a == b,
+            // and friends — see Hash impl above). Structural equality
+            // for cons/set/struct/bytes/empty-list.
+            (TableKey::Heap(a), TableKey::Heap(b)) => a == b,
             _ => false,
         }
     }
@@ -241,7 +284,7 @@ impl PartialOrd for TableKey {
 impl Ord for TableKey {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         // Variant ordering follows enum declaration order (same as derive).
-        // Discriminant index: Nil=0, Bool=1, Int=2, Symbol=3, String=4, Keyword=5, Array=6, Identity=7
+        // Discriminant index: Nil=0, Bool=1, Int=2, Symbol=3, String=4, Keyword=5, EmptyList=6, Array=7, Heap=8
         let self_disc = self.discriminant_index();
         let other_disc = other.discriminant_index();
         match self_disc.cmp(&other_disc) {
@@ -255,10 +298,12 @@ impl Ord for TableKey {
             (TableKey::Symbol(a), TableKey::Symbol(b)) => a.cmp(b),
             (TableKey::String(a), TableKey::String(b)) => a.cmp(b),
             (TableKey::Keyword(a), TableKey::Keyword(b)) => a.cmp(b),
+            (TableKey::EmptyList, TableKey::EmptyList) => std::cmp::Ordering::Equal,
             (TableKey::Array(a), TableKey::Array(b)) => a.cmp(b),
             // Delegate to Value's Ord. Stable identity for Fiber and
-            // friends — see Hash impl above.
-            (TableKey::Identity(a), TableKey::Identity(b)) => a.cmp(b),
+            // friends — see Hash impl above. Structural ordering for
+            // cons/set/struct/bytes/empty-list.
+            (TableKey::Heap(a), TableKey::Heap(b)) => a.cmp(b),
             _ => unreachable!("discriminant match already handled"),
         }
     }
@@ -273,6 +318,7 @@ impl fmt::Display for TableKey {
             TableKey::Symbol(id) => write!(f, "{:?}", id),
             TableKey::String(s) => write!(f, "\"{}\"", s),
             TableKey::Keyword(s) => write!(f, ":{}", s),
+            TableKey::EmptyList => write!(f, "()"),
             TableKey::Array(keys) => {
                 write!(f, "[")?;
                 for (i, k) in keys.iter().enumerate() {
@@ -283,7 +329,7 @@ impl fmt::Display for TableKey {
                 }
                 write!(f, "]")
             }
-            TableKey::Identity(v) => write!(f, "{}", v),
+            TableKey::Heap(v) => write!(f, "{}", v),
         }
     }
 }
@@ -308,6 +354,7 @@ impl fmt::Debug for TableKey {
             }
             TableKey::String(s) => write!(f, "\"{}\"", s),
             TableKey::Keyword(s) => write!(f, ":{}", s),
+            TableKey::EmptyList => write!(f, "()"),
             TableKey::Array(keys) => {
                 write!(f, "[")?;
                 for (i, k) in keys.iter().enumerate() {
@@ -318,7 +365,7 @@ impl fmt::Debug for TableKey {
                 }
                 write!(f, "]")
             }
-            TableKey::Identity(v) => write!(f, "{:?}", v),
+            TableKey::Heap(v) => write!(f, "{:?}", v),
         }
     }
 }

--- a/src/vm/call.rs
+++ b/src/vm/call.rs
@@ -836,7 +836,7 @@ pub(crate) fn call_collection(
                 return Some(Err((
                     "type-error",
                     format!(
-                        "struct call: expected hashable key, got {}",
+                        "struct call: struct keys must be immutable (got {})",
                         args[0].type_name()
                     ),
                 )))
@@ -858,7 +858,7 @@ pub(crate) fn call_collection(
                 return Some(Err((
                     "type-error",
                     format!(
-                        "@struct call: expected hashable key, got {}",
+                        "@struct call: struct keys must be immutable (got {})",
                         args[0].type_name()
                     ),
                 )))

--- a/tests/elle/struct-apply-orphan.lisp
+++ b/tests/elle/struct-apply-orphan.lisp
@@ -8,7 +8,7 @@
 # merge block, the stack depth mismatch causes wrong DupN offsets,
 # shifting key-value pairs so a struct lands in a key position.
 #
-# This is a regression test for the "expected hashable value, got struct"
+# This is a regression test for the "struct keys must be immutable (got struct)"
 # bug in struct literal compilation.
 
 # ── minimal reproduction ──────────────────────────────────

--- a/tests/elle/table-key-expand.lisp
+++ b/tests/elle/table-key-expand.lisp
@@ -1,0 +1,97 @@
+(elle/epoch 10)
+# Tests for expanded TableKey: immutable compound types as struct keys
+
+# ── Cons cell / list as struct key ──────────────────────────────────────
+
+(let [m (struct (list 1 2 3) :yes)]
+  (assert (= (get m (list 1 2 3)) :yes) "list as struct key"))
+
+(let [m (struct (list :a (list 1 2)) :nested)]
+  (assert (= (get m (list :a (list 1 2))) :nested) "nested list as struct key"))
+
+# ── Empty list as struct key ────────────────────────────────────────────
+
+(let [m (struct () :empty)]
+  (assert (= (get m ()) :empty) "empty list as struct key"))
+
+# ── Immutable bytes as struct key ───────────────────────────────────────
+
+(let [b (bytes 1 2 3)
+      m (struct b :found)]
+  (assert (= (get m b) :found) "bytes as struct key"))
+
+# ── Immutable set as struct key ─────────────────────────────────────────
+
+(let [m (struct |1 2 3| :found)]
+  (assert (= (get m |1 2 3|) :found) "set as struct key"))
+
+# ── Immutable struct as struct key ──────────────────────────────────────
+
+(let [m (struct {:a 1} :nested)]
+  (assert (= (get m {:a 1}) :nested) "struct as struct key"))
+
+(let [m (struct {:a 1 :b 2} :two)]
+  (assert (= (get m {:b 2 :a 1}) :two) "struct key independent of order"))
+
+# ── Negative: float as key → error ─────────────────────────────────────
+
+(let [[ok? err] (protect ((fn [] (struct 1.5 :v))))]
+  (assert (not ok?) "float as struct key errors")
+  (assert (= (get err :error) :type-error) "float as struct key error kind"))
+
+# ── Negative: mutable box as key → error ───────────────────────────────
+
+(let [[ok? err] (protect ((fn [] (struct (box 1) :v))))]
+  (assert (not ok?) "box as struct key errors")
+  (assert (= (get err :error) :type-error) "box as struct key error kind"))
+
+# ── Negative: @array as key → error ────────────────────────────────────
+
+(let [[ok? err] (protect ((fn [] (struct @[1 2] :v))))]
+  (assert (not ok?) "@array as struct key errors")
+  (assert (= (get err :error) :type-error) "@array as struct key error kind"))
+
+# ── Negative: struct with mutable sub-value as key → error ──────────────
+
+(let [[ok? err] (protect ((fn []
+                            (def s {:a (box 1)})
+                            (struct s :v))))]
+  (assert (not ok?) "struct with box value as struct key errors")
+  (assert (= (get err :error) :type-error) "struct with box value error kind"))
+
+# ── Negative: list containing float → error ────────────────────────────
+
+(let [[ok? err] (protect ((fn [] (struct (list 1.5) :v))))]
+  (assert (not ok?) "list containing float as struct key errors")
+  (assert (= (get err :error) :type-error) "list containing float error kind"))
+
+# ── Negative: set containing float → error ─────────────────────────────
+
+(let [[ok? err] (protect ((fn [] (struct (set 1.5) :v))))]
+  (assert (not ok?) "set containing float as struct key errors")
+  (assert (= (get err :error) :type-error) "set containing float error kind"))
+
+# ── Equality semantics: struct keys are compared structurally ───────────
+
+(let [m (struct {:x 1} :val)]
+  (assert (= (get m {:x 1}) :val) "struct keys use structural equality"))
+
+# ── put and del with compound keys ─────────────────────────────────────
+
+(let* [s (struct (list 1 2) :a)
+       s2 (put s (list 3 4) :b)]
+  (assert (= (get s2 (list 1 2)) :a) "put preserves list key")
+  (assert (= (get s2 (list 3 4)) :b) "put adds list key"))
+
+(let* [s (struct (list 1 2) :a (list 3 4) :b)
+       s2 (del s (list 1 2))]
+  (assert (not (has? s2 (list 1 2))) "del removes list key")
+  (assert (= (get s2 (list 3 4)) :b) "del preserves other list key"))
+
+# ── has? with compound keys ────────────────────────────────────────────
+
+(assert (has? (struct (list 1 2) :v) (list 1 2)) "has? with list key")
+(assert (not (has? (struct (list 1 2) :v) (list 3 4)))
+        "has? with missing list key")
+
+(println "table-key-expand: all tests passed")

--- a/tests/integration/elle_scripts.rs
+++ b/tests/integration/elle_scripts.rs
@@ -84,3 +84,8 @@ fn grpc() {
 fn websocket() {
     run_elle_script("websocket");
 }
+
+#[test]
+fn table_key_expand() {
+    run_elle_script("table-key-expand");
+}

--- a/tests/unittests/table_key.rs
+++ b/tests/unittests/table_key.rs
@@ -40,7 +40,21 @@ fn test_from_value_string() {
     assert!(matches!(key, TableKey::String(ref s) if s == "hello"));
 }
 
-// ── Identity keys ───────────────────────────────────────────────
+// ── EmptyList key ───────────────────────────────────────────
+
+#[test]
+fn test_from_value_empty_list() {
+    let key = TableKey::from_value(&Value::EMPTY_LIST).unwrap();
+    assert_eq!(key, TableKey::EmptyList);
+    assert_eq!(key.to_value(), Value::EMPTY_LIST);
+}
+
+#[test]
+fn test_empty_list_is_sendable() {
+    assert!(TableKey::EmptyList.is_sendable());
+}
+
+// ── Heap keys ───────────────────────────────────────────────
 
 #[test]
 fn test_from_value_external() {
@@ -48,7 +62,7 @@ fn test_from_value_external() {
     let key = TableKey::from_value(&ext);
     assert!(key.is_some(), "external should be accepted as key");
     let key = key.unwrap();
-    assert!(matches!(key, TableKey::Identity(_)));
+    assert!(matches!(key, TableKey::Heap(_)));
 }
 
 #[test]
@@ -100,11 +114,12 @@ fn test_is_sendable_value_keys() {
     assert!(TableKey::Int(42).is_sendable());
     assert!(TableKey::String("hello".to_string()).is_sendable());
     assert!(TableKey::Keyword("foo".to_string()).is_sendable());
+    assert!(TableKey::EmptyList.is_sendable());
 }
 
 #[test]
-fn test_is_sendable_identity_key() {
+fn test_is_sendable_heap_key() {
     let ext = Value::external("test-type", 42u32);
     let key = TableKey::from_value(&ext).unwrap();
-    assert!(!key.is_sendable(), "identity keys must not be sendable");
+    assert!(!key.is_sendable(), "heap keys must not be sendable");
 }


### PR DESCRIPTION
TableKey::from_value() previously whitelisted only scalars, immutable arrays, and identity types (fiber/closure/external).  Immutable types like cons cells, sets, structs, bytes, and empty list were excluded despite having correct Hash/Eq/Ord implementations.

Expand the accepted types: any immutable, non-float value may now be used as a struct key.  Mutable types are rejected because mutation after insertion would break hash invariants.  Floats are rejected because NaN violates the Eq/Hash contract.  Compound immutable keys (cons, set, struct) are recursively validated to ensure all sub-elements are also valid key material.

Rename TableKey::Identity → Heap (now covers all non-scalar immutable values, not just identity-compared types) and add EmptyList as a dedicated variant (it's an immediate value, not heap-allocated).