### PR TITLE
Collection + Seq protocol: centralize 8-way type dispatch (#834)

### DIFF
--- a/src/primitives/array.rs
+++ b/src/primitives/array.rs
@@ -1,5 +1,6 @@
 //! Array operations primitives
 use crate::primitives::def::PrimitiveDef;
+use crate::primitives::seq::{seq_pop, seq_push};
 use crate::signals::Signal;
 use crate::value::fiber::{SignalBits, SIG_ERROR, SIG_OK};
 use crate::value::fiberheap;
@@ -60,222 +61,18 @@ pub(crate) fn prim_array_new(args: &[Value]) -> (SignalBits, Value) {
 
 /// Push a value onto the end of an array or @string (mutates in place, returns the collection)
 pub(crate) fn prim_push(args: &[Value]) -> (SignalBits, Value) {
-    if let Some(vec_ref) = args[0].as_array_mut() {
-        fiberheap::incref(args[1]);
-        let mut vec = vec_ref.borrow_mut();
-        vec.push(args[1]);
-        drop(vec);
-        return (SIG_OK, args[0]);
+    match seq_push(&args[0], args[1]) {
+        Ok(v) => (SIG_OK, v),
+        Err(e) => (SIG_ERROR, e),
     }
-
-    if let Some(buf_ref) = args[0].as_string_mut() {
-        let s = match args[1].with_string(|s| s.to_string()) {
-            Some(s) => s,
-            None => {
-                return (
-                    SIG_ERROR,
-                    error_val(
-                        "type-error",
-                        format!(
-                            "push: @string value must be string, got {}",
-                            args[1].type_name()
-                        ),
-                    ),
-                )
-            }
-        };
-        buf_ref.borrow_mut().extend_from_slice(s.as_bytes());
-        return (SIG_OK, args[0]);
-    }
-
-    if let Some(blob_ref) = args[0].as_bytes_mut() {
-        let byte = match args[1].as_int() {
-            Some(n) if (0..=255).contains(&n) => n as u8,
-            Some(n) => {
-                return (
-                    SIG_ERROR,
-                    error_val(
-                        "argument-error",
-                        format!("push: byte value out of range 0-255: {}", n),
-                    ),
-                )
-            }
-            None => {
-                return (
-                    SIG_ERROR,
-                    error_val(
-                        "type-error",
-                        format!(
-                            "push: @bytes value must be integer, got {}",
-                            args[1].type_name()
-                        ),
-                    ),
-                )
-            }
-        };
-        blob_ref.borrow_mut().push(byte);
-        return (SIG_OK, args[0]);
-    }
-
-    // Immutable array — return new array with element appended
-    if let Some(elems) = args[0].as_array() {
-        let mut new = elems.to_vec();
-        new.push(args[1]);
-        return (SIG_OK, Value::array(new));
-    }
-
-    // Immutable string — return new string with value appended
-    if args[0].is_string() {
-        let s = match args[1].with_string(|s| s.to_string()) {
-            Some(s) => s,
-            None => {
-                return (
-                    SIG_ERROR,
-                    error_val(
-                        "type-error",
-                        format!(
-                            "push: string value must be string, got {}",
-                            args[1].type_name()
-                        ),
-                    ),
-                )
-            }
-        };
-        return args[0]
-            .with_string(|base| {
-                let mut new = base.to_string();
-                new.push_str(&s);
-                (SIG_OK, Value::string(new))
-            })
-            .unwrap_or_else(|| {
-                (
-                    SIG_ERROR,
-                    error_val("type-error", "push: unreachable string case".to_string()),
-                )
-            });
-    }
-
-    // Immutable bytes — return new bytes with byte appended
-    if let Some(b) = args[0].as_bytes() {
-        let byte = match args[1].as_int() {
-            Some(n) if (0..=255).contains(&n) => n as u8,
-            Some(n) => {
-                return (
-                    SIG_ERROR,
-                    error_val(
-                        "argument-error",
-                        format!("push: byte value out of range 0-255: {}", n),
-                    ),
-                )
-            }
-            None => {
-                return (
-                    SIG_ERROR,
-                    error_val(
-                        "type-error",
-                        format!(
-                            "push: bytes value must be integer, got {}",
-                            args[1].type_name()
-                        ),
-                    ),
-                )
-            }
-        };
-        let mut new = b.to_vec();
-        new.push(byte);
-        return (SIG_OK, Value::bytes(new));
-    }
-
-    (
-        SIG_ERROR,
-        error_val(
-            "type-error",
-            format!(
-                "push: expected array, @array, string, @string, bytes, or @bytes, got {}",
-                args[0].type_name()
-            ),
-        ),
-    )
 }
 
 /// Pop a value from the end of an @array or @string (mutates in place, returns the removed element)
 pub(crate) fn prim_pop(args: &[Value]) -> (SignalBits, Value) {
-    if let Some(vec_ref) = args[0].as_array_mut() {
-        let mut vec = vec_ref.borrow_mut();
-        match vec.pop() {
-            Some(v) => {
-                drop(vec);
-                // Decref: value leaves a durable collection reference.
-                fiberheap::decref(v);
-                return (SIG_OK, v);
-            }
-            None => {
-                drop(vec);
-                return (
-                    SIG_ERROR,
-                    error_val("argument-error", "pop: empty array".to_string()),
-                );
-            }
-        }
+    match seq_pop(&args[0]) {
+        Ok(v) => (SIG_OK, v),
+        Err(e) => (SIG_ERROR, e),
     }
-
-    if let Some(buf_ref) = args[0].as_string_mut() {
-        let mut buf = buf_ref.borrow_mut();
-        if buf.is_empty() {
-            drop(buf);
-            return (
-                SIG_ERROR,
-                error_val("argument-error", "pop: empty @string".to_string()),
-            );
-        }
-        let s = match std::str::from_utf8(&buf) {
-            Ok(s) => s,
-            Err(_) => {
-                drop(buf);
-                return (
-                    SIG_ERROR,
-                    error_val(
-                        "encoding-error",
-                        "pop: @string contains invalid UTF-8".to_string(),
-                    ),
-                );
-            }
-        };
-        use unicode_segmentation::UnicodeSegmentation;
-        let cluster = s.graphemes(true).next_back().unwrap().to_string();
-        let new_len = buf.len() - cluster.len();
-        buf.truncate(new_len);
-        drop(buf);
-        return (SIG_OK, Value::string(cluster));
-    }
-
-    if let Some(blob_ref) = args[0].as_bytes_mut() {
-        let mut blob = blob_ref.borrow_mut();
-        match blob.pop() {
-            Some(byte) => {
-                drop(blob);
-                return (SIG_OK, Value::int(byte as i64));
-            }
-            None => {
-                drop(blob);
-                return (
-                    SIG_ERROR,
-                    error_val("argument-error", "pop: empty @bytes".to_string()),
-                );
-            }
-        }
-    }
-
-    (
-        SIG_ERROR,
-        error_val(
-            "type-error",
-            format!(
-                "pop: expected @array, @string, or @bytes, got {}",
-                args[0].type_name()
-            ),
-        ),
-    )
 }
 
 /// Pop n values from the end of an @array or @string and return them as a new collection
@@ -361,12 +158,9 @@ pub(crate) fn prim_insert(args: &[Value]) -> (SignalBits, Value) {
 
     if let Some(vec_ref) = args[0].as_array_mut() {
         let mut vec = vec_ref.borrow_mut();
-        // insert allows index == len (append), so try resolve_index first,
-        // then also accept len exactly for non-negative raw_index
         let index = match resolve_index(raw_index, vec.len()) {
             Some(i) => i,
             None => {
-                // Allow index == len for append (only when non-negative or resolved == len)
                 if raw_index >= 0 && raw_index as usize <= vec.len() {
                     raw_index as usize
                 } else if raw_index < 0 {
@@ -382,11 +176,10 @@ pub(crate) fn prim_insert(args: &[Value]) -> (SignalBits, Value) {
                         ),
                     );
                 } else {
-                    vec.len() // clamp to append
+                    vec.len()
                 }
             }
         };
-        // Incref: value enters a durable collection reference.
         fiberheap::incref(args[2]);
         vec.insert(index, args[2]);
         drop(vec);
@@ -508,7 +301,6 @@ pub(crate) fn prim_remove(args: &[Value]) -> (SignalBits, Value) {
         if let Some(index) = resolve_index(raw_index, vec.len()) {
             let remove_count = std::cmp::min(count, vec.len() - index);
             for j in 0..remove_count {
-                // Decref: value leaves a durable collection reference.
                 fiberheap::decref(vec[index + j]);
             }
             for _ in 0..remove_count {

--- a/src/primitives/bytes.rs
+++ b/src/primitives/bytes.rs
@@ -1,10 +1,10 @@
 //! Bytes and @bytes primitives (binary data)
 use crate::primitives::def::PrimitiveDef;
+use crate::primitives::seq::seq_slice;
 use crate::signals::Signal;
 use crate::value::fiber::{SignalBits, SIG_ERROR, SIG_OK};
 use crate::value::types::Arity;
 use crate::value::{error_val, Value};
-use unicode_segmentation::UnicodeSegmentation;
 
 /// Create immutable bytes from integer arguments, or from a single string/keyword.
 ///
@@ -264,8 +264,6 @@ pub(crate) fn prim_seq_to_hex(args: &[Value]) -> (SignalBits, Value) {
 /// Supports: bytes, @bytes, array, @array, list, string, @string.
 /// Indices are 0-based, clamped to length. start >= end returns empty.
 pub(crate) fn prim_slice(args: &[Value]) -> (SignalBits, Value) {
-    use crate::primitives::access::resolve_slice_index;
-
     let raw_start = match args[1].as_int() {
         Some(i) => i,
         None => {
@@ -297,127 +295,9 @@ pub(crate) fn prim_slice(args: &[Value]) -> (SignalBits, Value) {
         }
     };
 
-    // Bytes (immutable)
-    if let Some(b) = args[0].as_bytes() {
-        let start = resolve_slice_index(raw_start, b.len());
-        let end = resolve_slice_index(raw_end, b.len());
-        if start >= end {
-            return (SIG_OK, Value::bytes(vec![]));
-        }
-        return (SIG_OK, Value::bytes(b[start..end].to_vec()));
-    }
-
-    // @bytes (mutable)
-    if let Some(blob_ref) = args[0].as_bytes_mut() {
-        let borrowed = blob_ref.borrow();
-        let start = resolve_slice_index(raw_start, borrowed.len());
-        let end = resolve_slice_index(raw_end, borrowed.len());
-        if start >= end {
-            return (SIG_OK, Value::bytes_mut(vec![]));
-        }
-        return (SIG_OK, Value::bytes_mut(borrowed[start..end].to_vec()));
-    }
-
-    // Array (immutable)
-    if let Some(elems) = args[0].as_array() {
-        let start = resolve_slice_index(raw_start, elems.len());
-        let end = resolve_slice_index(raw_end, elems.len());
-        if start >= end {
-            return (SIG_OK, Value::array(vec![]));
-        }
-        return (SIG_OK, Value::array(elems[start..end].to_vec()));
-    }
-
-    // Array (mutable)
-    if let Some(arr_ref) = args[0].as_array_mut() {
-        let borrowed = arr_ref.borrow();
-        let start = resolve_slice_index(raw_start, borrowed.len());
-        let end = resolve_slice_index(raw_end, borrowed.len());
-        if start >= end {
-            return (SIG_OK, Value::array_mut(vec![]));
-        }
-        return (SIG_OK, Value::array_mut(borrowed[start..end].to_vec()));
-    }
-
-    // String (immutable, grapheme-aware)
-    if args[0].is_string() {
-        return args[0]
-            .with_string(|s| {
-                let grapheme_count = s.graphemes(true).count();
-                let start = resolve_slice_index(raw_start, grapheme_count);
-                let end = resolve_slice_index(raw_end, grapheme_count);
-                slice_graphemes(s, start, end, false)
-            })
-            .unwrap();
-    }
-
-    // @string (mutable, grapheme-aware)
-    if let Some(buf_ref) = args[0].as_string_mut() {
-        let borrowed = buf_ref.borrow();
-        // @string is valid UTF-8 by construction
-        let s = unsafe { std::str::from_utf8_unchecked(&borrowed) };
-        let grapheme_count = s.graphemes(true).count();
-        let start = resolve_slice_index(raw_start, grapheme_count);
-        let end = resolve_slice_index(raw_end, grapheme_count);
-        return slice_graphemes(s, start, end, true);
-    }
-
-    // List
-    if args[0].is_empty_list() || args[0].is_pair() {
-        match args[0].list_to_vec() {
-            Ok(elems) => {
-                let clamped_start = resolve_slice_index(raw_start, elems.len());
-                let clamped_end = resolve_slice_index(raw_end, elems.len());
-                if clamped_start >= clamped_end {
-                    return (SIG_OK, Value::EMPTY_LIST);
-                }
-                let mut result = Value::EMPTY_LIST;
-                for v in elems[clamped_start..clamped_end].iter().rev() {
-                    result = Value::pair(*v, result);
-                }
-                return (SIG_OK, result);
-            }
-            Err(_) => {
-                return (
-                    SIG_ERROR,
-                    error_val(
-                        "type-error",
-                        format!("slice: expected proper list, got {}", args[0].type_name()),
-                    ),
-                );
-            }
-        }
-    }
-
-    (
-        SIG_ERROR,
-        error_val(
-            "type-error",
-            format!(
-                "slice: expected sequence (bytes, @bytes, array, @array, list, string, or @string), got {}",
-                args[0].type_name()
-            ),
-        ),
-    )
-}
-
-/// Grapheme-aware slicing for strings and @strings.
-fn slice_graphemes(s: &str, start: usize, end: usize, is_buffer: bool) -> (SignalBits, Value) {
-    let graphemes: Vec<&str> = s.graphemes(true).collect();
-    let clamped_start = start.min(graphemes.len());
-    let clamped_end = end.min(graphemes.len());
-    if clamped_start >= clamped_end {
-        if is_buffer {
-            return (SIG_OK, Value::string_mut(vec![]));
-        } else {
-            return (SIG_OK, Value::string(""));
-        }
-    }
-    let result: String = graphemes[clamped_start..clamped_end].concat();
-    if is_buffer {
-        (SIG_OK, Value::string_mut(result.into_bytes()))
-    } else {
-        (SIG_OK, Value::string(result))
+    match seq_slice(&args[0], raw_start, raw_end) {
+        Ok(v) => (SIG_OK, v),
+        Err(e) => (SIG_ERROR, e),
     }
 }
 

--- a/src/primitives/collection.rs
+++ b/src/primitives/collection.rs
@@ -1,0 +1,367 @@
+//! Collection protocol: centralized dispatch for all container types.
+//!
+//! Every container in Elle (list, (), array, @array, string, @string,
+//! bytes, @bytes, set, @set, struct, @struct) implements these operations.
+//! Each function dispatches once; primitives delegate here instead of
+//! repeating the 12-way type match.
+use crate::value::{error_val, sorted_struct_contains, TableKey, Value};
+use unicode_segmentation::UnicodeSegmentation;
+
+use super::sets::freeze_value;
+
+/// Is the collection empty?
+pub fn coll_empty(val: &Value) -> Result<bool, Value> {
+    if val.is_nil() {
+        return Err(error_val("type-error", "expected collection type, got nil"));
+    }
+    if val.is_empty_list() {
+        return Ok(true);
+    }
+    if val.is_pair() {
+        return Ok(false);
+    }
+    if let Some(elems) = val.as_array() {
+        return Ok(elems.is_empty());
+    }
+    if let Some(arr) = val.as_array_mut() {
+        return Ok(arr.borrow().is_empty());
+    }
+    if let Some(r) = val.with_string(|s| s.is_empty()) {
+        return Ok(r);
+    }
+    if let Some(buf_ref) = val.as_string_mut() {
+        return Ok(buf_ref.borrow().is_empty());
+    }
+    if let Some(b) = val.as_bytes() {
+        return Ok(b.is_empty());
+    }
+    if let Some(blob_ref) = val.as_bytes_mut() {
+        return Ok(blob_ref.borrow().is_empty());
+    }
+    if let Some(s) = val.as_set() {
+        return Ok(s.is_empty());
+    }
+    if let Some(s) = val.as_set_mut() {
+        return Ok(s.borrow().is_empty());
+    }
+    if let Some(s) = val.as_struct() {
+        return Ok(s.is_empty());
+    }
+    if let Some(t) = val.as_struct_mut() {
+        return Ok(t.borrow().is_empty());
+    }
+    if let Some(syntax) = val.as_syntax() {
+        use crate::syntax::SyntaxKind;
+        if let SyntaxKind::List(items) | SyntaxKind::Array(items) = &syntax.kind {
+            return Ok(items.is_empty());
+        }
+    }
+    Err(error_val(
+        "type-error",
+        format!("expected collection type, got {}", val.type_name()),
+    ))
+}
+
+/// Element/key/grapheme/byte count.
+pub fn coll_len(val: &Value) -> Result<usize, Value> {
+    if val.is_nil() || val.is_empty_list() {
+        return Ok(0);
+    }
+    if val.is_pair() {
+        let vec = val
+            .list_to_vec()
+            .map_err(|e| error_val("type-error", e.to_string()))?;
+        return Ok(vec.len());
+    }
+    if let Some(elems) = val.as_array() {
+        return Ok(elems.len());
+    }
+    if let Some(arr) = val.as_array_mut() {
+        return Ok(arr.borrow().len());
+    }
+    if let Some(r) = val.with_string(|s| s.graphemes(true).count()) {
+        return Ok(r);
+    }
+    if let Some(buf_ref) = val.as_string_mut() {
+        let borrowed = buf_ref.borrow();
+        match std::str::from_utf8(&borrowed) {
+            Ok(s) => return Ok(s.graphemes(true).count()),
+            Err(e) => {
+                return Err(error_val(
+                    "encoding-error",
+                    format!("@string contains invalid UTF-8: {}", e),
+                ))
+            }
+        }
+    }
+    if let Some(b) = val.as_bytes() {
+        return Ok(b.len());
+    }
+    if let Some(blob_ref) = val.as_bytes_mut() {
+        return Ok(blob_ref.borrow().len());
+    }
+    if let Some(s) = val.as_set() {
+        return Ok(s.len());
+    }
+    if let Some(s) = val.as_set_mut() {
+        return Ok(s.borrow().len());
+    }
+    if let Some(s) = val.as_struct() {
+        return Ok(s.len());
+    }
+    if let Some(t) = val.as_struct_mut() {
+        return Ok(t.borrow().len());
+    }
+    if let Some(sid) = val.as_symbol() {
+        if let Some(name) = crate::context::resolve_symbol_name(sid) {
+            return Ok(name.graphemes(true).count());
+        }
+        return Err(error_val(
+            "internal-error",
+            format!("unable to resolve symbol name for id {:?}", sid),
+        ));
+    }
+    if let Some(name) = val.as_keyword_name() {
+        return Ok(name.graphemes(true).count());
+    }
+    if let Some(syntax) = val.as_syntax() {
+        use crate::syntax::SyntaxKind;
+        if let SyntaxKind::List(items) | SyntaxKind::Array(items) = &syntax.kind {
+            return Ok(items.len());
+        }
+    }
+    Err(error_val(
+        "type-error",
+        format!("expected collection type, got {}", val.type_name()),
+    ))
+}
+
+/// Membership test: element in seq/set, key in struct, substring in string.
+pub fn coll_has(coll: &Value, needle: &Value) -> Result<bool, Value> {
+    // Sets
+    let frozen = freeze_value(*needle);
+    if let Some(s) = coll.as_set() {
+        return Ok(s.binary_search(&frozen).is_ok());
+    }
+    if let Some(s) = coll.as_set_mut() {
+        return Ok(s.borrow().contains(&frozen));
+    }
+    // Strings — substring check
+    if coll.is_string() {
+        let needle_str = needle.with_string(|s| s.to_string()).ok_or_else(|| {
+            error_val(
+                "type-error",
+                format!(
+                    "has?: expected string as substring, got {}",
+                    needle.type_name()
+                ),
+            )
+        })?;
+        return coll
+            .with_string(|haystack| haystack.contains(&*needle_str))
+            .ok_or_else(|| error_val("internal-error", "has?: unreachable string case"));
+    }
+    if let Some(buf_ref) = coll.as_string_mut() {
+        let needle_str = needle.with_string(|s| s.to_string()).ok_or_else(|| {
+            error_val(
+                "type-error",
+                format!(
+                    "has?: expected string as substring, got {}",
+                    needle.type_name()
+                ),
+            )
+        })?;
+        let borrowed = buf_ref.borrow();
+        let haystack = String::from_utf8(borrowed.clone()).map_err(|e| {
+            error_val(
+                "encoding-error",
+                format!("has?: buffer contains invalid UTF-8: {}", e),
+            )
+        })?;
+        return Ok(haystack.contains(&*needle_str));
+    }
+    // Structs — key lookup
+    if coll.is_struct() || coll.is_struct_mut() {
+        let key = TableKey::from_value(needle).ok_or_else(|| {
+            error_val(
+                "type-error",
+                format!("expected hashable value, got {}", needle.type_name()),
+            )
+        })?;
+        if let Some(s) = coll.as_struct() {
+            return Ok(sorted_struct_contains(s, &key));
+        }
+        if let Some(t) = coll.as_struct_mut() {
+            return Ok(t.borrow().contains_key(&key));
+        }
+    }
+    Err(error_val(
+        "type-error",
+        format!(
+            "has?: expected struct, set, or string, got {}",
+            coll.type_name()
+        ),
+    ))
+}
+
+/// Collect all elements as `Vec<Value>`.
+pub fn coll_to_vec(val: &Value) -> Result<Vec<Value>, Value> {
+    // List
+    if val.is_pair() || val.is_empty_list() {
+        let mut elements = Vec::new();
+        let mut cur = *val;
+        while let Some(c) = cur.as_pair() {
+            elements.push(c.first);
+            cur = c.rest;
+        }
+        return Ok(elements);
+    }
+    // Array / @array
+    if let Some(elems) = val.as_array() {
+        return Ok(elems.to_vec());
+    }
+    if let Some(data) = val.as_array_mut() {
+        return Ok(data.borrow().clone());
+    }
+    // Set / @set
+    if let Some(set) = val.as_set() {
+        return Ok(set.to_vec());
+    }
+    if let Some(set) = val.as_set_mut() {
+        return Ok(set.borrow().iter().copied().collect());
+    }
+    // String — grapheme clusters
+    if val.is_string() {
+        return val
+            .with_string(|s| Ok(s.graphemes(true).map(Value::string).collect()))
+            .unwrap_or_else(|| Ok(vec![]));
+    }
+    // @string — grapheme clusters
+    if val.is_string_mut() {
+        if let Some(data) = val.as_string_mut() {
+            let bytes = data.borrow();
+            if let Ok(s) = std::str::from_utf8(&bytes) {
+                return Ok(s.graphemes(true).map(Value::string).collect());
+            }
+        }
+        return Ok(vec![]);
+    }
+    // Bytes — each byte as integer
+    if let Some(b) = val.as_bytes() {
+        return Ok(b.iter().map(|&byte| Value::int(byte as i64)).collect());
+    }
+    // @bytes
+    if let Some(data) = val.as_bytes_mut() {
+        return Ok(data
+            .borrow()
+            .iter()
+            .map(|&byte| Value::int(byte as i64))
+            .collect());
+    }
+    // Struct — key-value pairs as 2-element arrays
+    if let Some(s) = val.as_struct() {
+        return Ok(s
+            .iter()
+            .map(|(k, v)| Value::array(vec![k.to_value(), *v]))
+            .collect());
+    }
+    if let Some(t) = val.as_struct_mut() {
+        return Ok(t
+            .borrow()
+            .iter()
+            .map(|(k, v)| Value::array(vec![k.to_value(), *v]))
+            .collect());
+    }
+    Err(error_val(
+        "type-error",
+        format!("expected collection, got {}", val.type_name()),
+    ))
+}
+
+/// Combine two collections (concat for seqs, union for sets, merge for structs).
+pub fn coll_combine(a: &Value, b: &Value) -> Result<Value, Value> {
+    // Sets — union
+    if let (Some(sa), Some(sb)) = (a.as_set(), b.as_set()) {
+        let mut result: std::collections::BTreeSet<Value> = sa.iter().copied().collect();
+        result.extend(sb.iter().copied());
+        return Ok(Value::set(result));
+    }
+    if let (Some(sa), Some(sb)) = (a.as_set_mut(), b.as_set_mut()) {
+        let result: std::collections::BTreeSet<Value> =
+            sa.borrow().union(&*sb.borrow()).copied().collect();
+        return Ok(Value::set_mut(result));
+    }
+
+    // Structs — merge (right wins)
+    if let (Some(sa), Some(sb)) = (a.as_struct(), b.as_struct()) {
+        let mut result = std::collections::BTreeMap::new();
+        result.extend(sa.iter().map(|(k, v)| (k.clone(), *v)));
+        result.extend(sb.iter().map(|(k, v)| (k.clone(), *v)));
+        return Ok(Value::struct_from(result));
+    }
+    if let (Some(ta), Some(tb)) = (a.as_struct_mut(), b.as_struct_mut()) {
+        let mut result = std::collections::BTreeMap::new();
+        result.extend(ta.borrow().iter().map(|(k, v)| (k.clone(), *v)));
+        result.extend(tb.borrow().iter().map(|(k, v)| (k.clone(), *v)));
+        return Ok(Value::struct_mut_from(result));
+    }
+
+    // Lists
+    if (a.is_pair() || a.is_empty_list()) && (b.is_pair() || b.is_empty_list()) {
+        let mut first = a
+            .list_to_vec()
+            .map_err(|e| error_val("type-error", e.to_string()))?;
+        let second = b
+            .list_to_vec()
+            .map_err(|e| error_val("type-error", e.to_string()))?;
+        first.extend(second);
+        let mut result = Value::EMPTY_LIST;
+        for val in first.into_iter().rev() {
+            result = Value::pair(val, result);
+        }
+        return Ok(result);
+    }
+
+    // Arrays
+    if let (Some(ea), Some(eb)) = (a.as_array(), b.as_array()) {
+        let mut result = ea.to_vec();
+        result.extend(eb.iter().cloned());
+        return Ok(Value::array(result));
+    }
+    if let (Some(ra), Some(rb)) = (a.as_array_mut(), b.as_array_mut()) {
+        let mut result = ra.borrow().clone();
+        result.extend(rb.borrow().iter().cloned());
+        return Ok(Value::array_mut(result));
+    }
+
+    // Strings
+    if a.is_string() && b.is_string() {
+        let mut sa = a.with_string(|s| s.to_string()).unwrap();
+        b.with_string(|s| sa.push_str(s));
+        return Ok(Value::string(sa.as_str()));
+    }
+    if a.as_string_mut().is_some() && b.as_string_mut().is_some() {
+        let ba = a.as_string_mut().unwrap();
+        let bb = b.as_string_mut().unwrap();
+        let mut result = ba.borrow().clone();
+        result.extend(bb.borrow().iter());
+        return Ok(Value::string_mut(result));
+    }
+
+    // Bytes
+    if let (Some(ba), Some(bb)) = (a.as_bytes(), b.as_bytes()) {
+        let mut result = ba.to_vec();
+        result.extend(bb.iter());
+        return Ok(Value::bytes(result));
+    }
+    if let (Some(ra), Some(rb)) = (a.as_bytes_mut(), b.as_bytes_mut()) {
+        let mut result = ra.borrow().clone();
+        result.extend(rb.borrow().iter());
+        return Ok(Value::bytes_mut(result));
+    }
+
+    Err(error_val(
+        "type-error",
+        format!("cannot combine {} and {}", a.type_name(), b.type_name()),
+    ))
+}

--- a/src/primitives/list/advanced.rs
+++ b/src/primitives/list/advanced.rs
@@ -1,7 +1,8 @@
 //! Advanced list operations: append, concat, take, drop, butlast, reverse, last
+use crate::primitives::collection::coll_combine;
+use crate::primitives::seq::{seq_butlast, seq_last, seq_reverse};
 use crate::value::fiber::{SignalBits, SIG_ERROR, SIG_OK};
 use crate::value::{error_val, list, Value};
-use unicode_segmentation::UnicodeSegmentation;
 
 /// Take the first n elements of a list
 pub(crate) fn prim_take(args: &[Value]) -> (SignalBits, Value) {
@@ -37,107 +38,17 @@ pub(crate) fn prim_take(args: &[Value]) -> (SignalBits, Value) {
 
 /// Get all elements of a sequence except the last
 pub(crate) fn prim_butlast(args: &[Value]) -> (SignalBits, Value) {
-    // Lists
-    if args[0].is_pair() || args[0].is_empty_list() {
-        if args[0].is_empty_list() {
-            return (SIG_OK, Value::EMPTY_LIST);
-        }
-        let vec = match args[0].list_to_vec() {
-            Ok(v) => v,
-            Err(e) => {
-                return (
-                    SIG_ERROR,
-                    error_val("type-error", format!("butlast: {}", e)),
-                )
-            }
-        };
-        if vec.is_empty() {
-            return (SIG_OK, Value::EMPTY_LIST);
-        }
-        return (SIG_OK, list(vec[..vec.len() - 1].to_vec()));
+    match seq_butlast(&args[0]) {
+        Ok(v) => (SIG_OK, v),
+        Err(e) => (SIG_ERROR, e),
     }
-    // Array
-    if let Some(elems) = args[0].as_array() {
-        if elems.is_empty() {
-            return (SIG_OK, Value::array(vec![]));
-        }
-        return (SIG_OK, Value::array(elems[..elems.len() - 1].to_vec()));
-    }
-    // @array
-    if let Some(arr) = args[0].as_array_mut() {
-        let borrowed = arr.borrow();
-        if borrowed.is_empty() {
-            return (SIG_OK, Value::array_mut(vec![]));
-        }
-        return (
-            SIG_OK,
-            Value::array_mut(borrowed[..borrowed.len() - 1].to_vec()),
-        );
-    }
-    // String — all but last grapheme
-    if let Some(result) = args[0].with_string(|s| {
-        let graphemes: Vec<&str> = s.graphemes(true).collect();
-        if graphemes.is_empty() {
-            (SIG_OK, Value::string(""))
-        } else {
-            let init: String = graphemes[..graphemes.len() - 1].concat();
-            (SIG_OK, Value::string(init))
-        }
-    }) {
-        return result;
-    }
-    // @string — all but last grapheme
-    if let Some(buf_ref) = args[0].as_string_mut() {
-        let borrowed = buf_ref.borrow();
-        if let Ok(s) = std::str::from_utf8(&borrowed) {
-            let graphemes: Vec<&str> = s.graphemes(true).collect();
-            if graphemes.is_empty() {
-                return (SIG_OK, Value::string_mut(vec![]));
-            }
-            let init: String = graphemes[..graphemes.len() - 1].concat();
-            return (SIG_OK, Value::string_mut(init.into_bytes()));
-        }
-        return (SIG_OK, Value::string_mut(vec![]));
-    }
-    // Bytes — all but last byte
-    if let Some(b) = args[0].as_bytes() {
-        if b.is_empty() {
-            return (SIG_OK, Value::bytes(vec![]));
-        }
-        return (SIG_OK, Value::bytes(b[..b.len() - 1].to_vec()));
-    }
-    // @bytes — all but last byte
-    if let Some(blob_ref) = args[0].as_bytes_mut() {
-        let borrowed = blob_ref.borrow();
-        if borrowed.is_empty() {
-            return (SIG_OK, Value::bytes_mut(vec![]));
-        }
-        return (
-            SIG_OK,
-            Value::bytes_mut(borrowed[..borrowed.len() - 1].to_vec()),
-        );
-    }
-
-    (
-        SIG_ERROR,
-        error_val(
-            "type-error",
-            format!(
-                "butlast: expected sequence (list, array, string, bytes), got {}",
-                args[0].type_name()
-            ),
-        ),
-    )
 }
 
-/// Append multiple lists
-/// Polymorphic append - works on arrays and strings
-/// For arrays: mutates first arg in place, returns it
-/// For arrays: returns new array
-/// For strings: returns new string
-/// `(append collection1 collection2)`
+/// Append two collections
 pub(crate) fn prim_append(args: &[Value]) -> (SignalBits, Value) {
     // @string (mutable) — accepts string or @string as second arg
+    // append has special mutation semantics for mutable types that
+    // coll_combine doesn't handle (mutate first arg in place).
     if let Some(buf_ref) = args[0].as_string_mut() {
         if let Some(other_buf) = args[1].as_string_mut() {
             let other = other_buf.borrow();
@@ -181,56 +92,6 @@ pub(crate) fn prim_append(args: &[Value]) -> (SignalBits, Value) {
         return (SIG_OK, args[0]);
     }
 
-    // array (immutable) — accepts array or @array
-    if let Some(elems) = args[0].as_array() {
-        let other = if let Some(other) = args[1].as_array() {
-            other.to_vec()
-        } else if let Some(other_ref) = args[1].as_array_mut() {
-            other_ref.borrow().clone()
-        } else {
-            return (
-                SIG_ERROR,
-                error_val(
-                    "type-error",
-                    format!(
-                        "append: expected array or @array, got {}",
-                        args[1].type_name()
-                    ),
-                ),
-            );
-        };
-        let mut result = elems.to_vec();
-        result.extend(other);
-        return (SIG_OK, Value::array(result));
-    }
-
-    // string (immutable) — accepts string or @string
-    if args[0].is_string() {
-        let s = args[0].with_string(|s| s.as_bytes().to_vec()).unwrap();
-        let other = if let Some(o) = args[1].with_string(|s| s.as_bytes().to_vec()) {
-            o
-        } else if let Some(o) = args[1].as_string_mut() {
-            o.borrow().clone()
-        } else {
-            return (
-                SIG_ERROR,
-                error_val(
-                    "type-error",
-                    format!(
-                        "append: expected string or @string, got {}",
-                        args[1].type_name()
-                    ),
-                ),
-            );
-        };
-        let mut result = s;
-        result.extend(other);
-        return (
-            SIG_OK,
-            Value::string(std::str::from_utf8(&result).unwrap_or("")),
-        );
-    }
-
     // @bytes (mutable) — accepts bytes or @bytes
     if let Some(blob_ref) = args[0].as_bytes_mut() {
         if let Some(other) = args[1].as_bytes_mut() {
@@ -253,32 +114,8 @@ pub(crate) fn prim_append(args: &[Value]) -> (SignalBits, Value) {
         return (SIG_OK, args[0]);
     }
 
-    // bytes (immutable) — accepts bytes or @bytes
-    if let Some(b) = args[0].as_bytes() {
-        let other = if let Some(other) = args[1].as_bytes() {
-            other.to_vec()
-        } else if let Some(other_ref) = args[1].as_bytes_mut() {
-            other_ref.borrow().clone()
-        } else {
-            return (
-                SIG_ERROR,
-                error_val(
-                    "type-error",
-                    format!(
-                        "append: expected bytes or @bytes, got {}",
-                        args[1].type_name()
-                    ),
-                ),
-            );
-        };
-        let mut result = b.to_vec();
-        result.extend(other);
-        return (SIG_OK, Value::bytes(result));
-    }
-
     // List (or syntax list — used during macro expansion)
     if args[0].is_pair() || args[0].is_empty_list() || args[0].as_syntax().is_some() {
-        // list_to_vec handles both cons lists and syntax lists
         let mut first = match args[0].list_to_vec() {
             Ok(v) => v,
             Err(e) => return (SIG_ERROR, error_val("type-error", format!("append: {}", e))),
@@ -299,7 +136,6 @@ pub(crate) fn prim_append(args: &[Value]) -> (SignalBits, Value) {
             }
         };
         first.extend(second);
-        // Rebuild as a proper list
         let mut result = Value::EMPTY_LIST;
         for val in first.into_iter().rev() {
             result = Value::pair(val, result);
@@ -307,17 +143,11 @@ pub(crate) fn prim_append(args: &[Value]) -> (SignalBits, Value) {
         return (SIG_OK, result);
     }
 
-    // Unsupported type
-    (
-        SIG_ERROR,
-        error_val(
-            "type-error",
-            format!(
-                "append: expected collection (list, array, or string), got {}",
-                args[0].type_name()
-            ),
-        ),
-    )
+    // Remaining immutable types — delegate to coll_combine
+    match coll_combine(&args[0], &args[1]) {
+        Ok(v) => (SIG_OK, v),
+        Err(e) => (SIG_ERROR, e),
+    }
 }
 
 /// Concatenate one or more collections of the same type.
@@ -336,7 +166,6 @@ pub(crate) fn prim_concat(args: &[Value]) -> (SignalBits, Value) {
     // Dispatch on the type of the first argument
     // @string
     if args[0].as_string_mut().is_some() {
-        // Pre-calculate total length
         let mut total_len = 0usize;
         for (i, arg) in args.iter().enumerate() {
             match arg.as_string_mut() {
@@ -650,126 +479,18 @@ pub(crate) fn prim_concat(args: &[Value]) -> (SignalBits, Value) {
 
 /// Reverse a sequence (list, array, @array, string)
 pub(crate) fn prim_reverse(args: &[Value]) -> (SignalBits, Value) {
-    // Array — return new array
-    if let Some(arr) = args[0].as_array_mut() {
-        let mut vec = arr.borrow().to_vec();
-        vec.reverse();
-        return (SIG_OK, Value::array_mut(vec));
+    match seq_reverse(&args[0]) {
+        Ok(v) => (SIG_OK, v),
+        Err(e) => (SIG_ERROR, e),
     }
-    // Array — return new array
-    if let Some(elems) = args[0].as_array() {
-        let mut vec = elems.to_vec();
-        vec.reverse();
-        return (SIG_OK, Value::array(vec));
-    }
-    // String — reverse grapheme clusters
-    if let Some(result) = args[0].with_string(|s| {
-        let reversed: String = s.graphemes(true).rev().collect();
-        (SIG_OK, Value::string(reversed))
-    }) {
-        return result;
-    }
-    // List — existing behavior (fallback via list_to_vec)
-    let mut vec = match args[0].list_to_vec() {
-        Ok(v) => v,
-        Err(_) => {
-            return (
-                SIG_ERROR,
-                error_val(
-                    "type-error",
-                    format!(
-                        "reverse: expected sequence (list, array, or string), got {}",
-                        args[0].type_name()
-                    ),
-                ),
-            )
-        }
-    };
-    vec.reverse();
-    (SIG_OK, list(vec))
 }
 
 /// Get the last element of a sequence
 pub(crate) fn prim_last(args: &[Value]) -> (SignalBits, Value) {
-    let empty_err = (
-        SIG_ERROR,
-        error_val("argument-error", "last: empty sequence"),
-    );
-    // Pair cell — walk to end
-    if args[0].is_pair() || args[0].is_empty_list() {
-        if args[0].is_empty_list() {
-            return empty_err;
-        }
-        let mut current = args[0];
-        let mut last = Value::NIL;
-        while let Some(pair) = current.as_pair() {
-            last = pair.first;
-            current = pair.rest;
-        }
-        return (SIG_OK, last);
+    match seq_last(&args[0]) {
+        Ok(v) => (SIG_OK, v),
+        Err(e) => (SIG_ERROR, e),
     }
-    // Array
-    if let Some(elems) = args[0].as_array() {
-        return match elems.last() {
-            Some(v) => (SIG_OK, *v),
-            None => empty_err,
-        };
-    }
-    // @array
-    if let Some(arr) = args[0].as_array_mut() {
-        let borrowed = arr.borrow();
-        return match borrowed.last() {
-            Some(v) => (SIG_OK, *v),
-            None => empty_err,
-        };
-    }
-    // String — last grapheme
-    if let Some(result) = args[0].with_string(|s| match s.graphemes(true).next_back() {
-        Some(g) => (SIG_OK, Value::string(g)),
-        None => (
-            SIG_ERROR,
-            error_val("argument-error", "last: empty sequence"),
-        ),
-    }) {
-        return result;
-    }
-    // @string — last grapheme
-    if let Some(buf_ref) = args[0].as_string_mut() {
-        let borrowed = buf_ref.borrow();
-        if let Ok(s) = std::str::from_utf8(&borrowed) {
-            return match s.graphemes(true).next_back() {
-                Some(g) => (SIG_OK, Value::string(g)),
-                None => empty_err,
-            };
-        }
-        return empty_err;
-    }
-    // Bytes — last byte as integer
-    if let Some(b) = args[0].as_bytes() {
-        return match b.last() {
-            Some(&byte) => (SIG_OK, Value::int(byte as i64)),
-            None => empty_err,
-        };
-    }
-    // @bytes — last byte as integer
-    if let Some(blob_ref) = args[0].as_bytes_mut() {
-        let borrowed = blob_ref.borrow();
-        return match borrowed.last() {
-            Some(&byte) => (SIG_OK, Value::int(byte as i64)),
-            None => empty_err,
-        };
-    }
-
-    (
-        SIG_ERROR,
-        error_val(
-            "type-error",
-            format!(
-                "last: expected sequence (list, array, string, bytes), got {}",
-                args[0].type_name()
-            ),
-        ),
-    )
 }
 
 /// Drop the first n elements of a list

--- a/src/primitives/list/mod.rs
+++ b/src/primitives/list/mod.rs
@@ -1,13 +1,14 @@
 //! List manipulation primitives
 mod advanced;
 
+use crate::primitives::collection::{coll_empty, coll_len, coll_to_vec};
 use crate::primitives::def::PrimitiveDef;
+use crate::primitives::seq::{seq_first, seq_nth, seq_rest};
 use crate::signals::Signal;
 use crate::syntax::SyntaxKind;
 use crate::value::fiber::{SignalBits, SIG_ERROR, SIG_OK};
 use crate::value::types::Arity;
 use crate::value::{error_val, list, Value};
-use unicode_segmentation::UnicodeSegmentation;
 
 // Re-export advanced functions for use in PRIMITIVES array
 pub(crate) use advanced::{
@@ -16,90 +17,6 @@ pub(crate) use advanced::{
 
 /// Get the first element of a sequence (list, array, @array, string)
 pub(crate) fn prim_first(args: &[Value]) -> (SignalBits, Value) {
-    // Pair cell — the common case for lists
-    if let Some(pair) = args[0].as_pair() {
-        return (SIG_OK, pair.first);
-    }
-    // Empty list → error
-    if args[0].is_empty_list() {
-        return (
-            SIG_ERROR,
-            error_val("argument-error", "first: empty sequence"),
-        );
-    }
-    // Array
-    if let Some(elems) = args[0].as_array() {
-        return if elems.is_empty() {
-            (
-                SIG_ERROR,
-                error_val("argument-error", "first: empty sequence"),
-            )
-        } else {
-            (SIG_OK, elems[0])
-        };
-    }
-    // @array
-    if let Some(arr) = args[0].as_array_mut() {
-        let borrowed = arr.borrow();
-        return if borrowed.is_empty() {
-            (
-                SIG_ERROR,
-                error_val("argument-error", "first: empty sequence"),
-            )
-        } else {
-            (SIG_OK, borrowed[0])
-        };
-    }
-    // String — first grapheme cluster
-    if let Some(result) = args[0].with_string(|s| match s.graphemes(true).next() {
-        Some(g) => (SIG_OK, Value::string(g)),
-        None => (
-            SIG_ERROR,
-            error_val("argument-error", "first: empty sequence"),
-        ),
-    }) {
-        return result;
-    }
-    // @string — first grapheme cluster
-    if let Some(buf_ref) = args[0].as_string_mut() {
-        let borrowed = buf_ref.borrow();
-        if let Ok(s) = std::str::from_utf8(&borrowed) {
-            return match s.graphemes(true).next() {
-                Some(g) => (SIG_OK, Value::string(g)),
-                None => (
-                    SIG_ERROR,
-                    error_val("argument-error", "first: empty sequence"),
-                ),
-            };
-        }
-        return (
-            SIG_ERROR,
-            error_val("argument-error", "first: empty sequence"),
-        );
-    }
-    // Bytes — first byte as integer
-    if let Some(b) = args[0].as_bytes() {
-        return if b.is_empty() {
-            (
-                SIG_ERROR,
-                error_val("argument-error", "first: empty sequence"),
-            )
-        } else {
-            (SIG_OK, Value::int(b[0] as i64))
-        };
-    }
-    // @bytes — first byte as integer
-    if let Some(blob_ref) = args[0].as_bytes_mut() {
-        let borrowed = blob_ref.borrow();
-        return if borrowed.is_empty() {
-            (
-                SIG_ERROR,
-                error_val("argument-error", "first: empty sequence"),
-            )
-        } else {
-            (SIG_OK, Value::int(borrowed[0] as i64))
-        };
-    }
     // Syntax (existing behavior, preserved)
     if let Some(syntax) = args[0].as_syntax() {
         if let SyntaxKind::List(items) | SyntaxKind::Array(items) = &syntax.kind {
@@ -109,167 +26,29 @@ pub(crate) fn prim_first(args: &[Value]) -> (SignalBits, Value) {
             return (SIG_OK, Value::syntax(items[0].clone()));
         }
     }
-    (
-        SIG_ERROR,
-        error_val(
-            "type-error",
-            format!(
-                "first: expected sequence (list, array, string, bytes), got {}",
-                args[0].type_name()
-            ),
-        ),
-    )
+    match seq_first(&args[0]) {
+        Ok(v) => (SIG_OK, v),
+        Err(e) => (SIG_ERROR, e),
+    }
 }
 
 /// Get the second element of a sequence
 pub(crate) fn prim_second(args: &[Value]) -> (SignalBits, Value) {
-    let too_short = (
-        SIG_ERROR,
-        error_val(
-            "argument-error",
-            "second: sequence has fewer than 2 elements",
-        ),
-    );
-    // Pair cell — walk to second
-    if let Some(pair) = args[0].as_pair() {
-        if let Some(c2) = pair.rest.as_pair() {
-            return (SIG_OK, c2.first);
-        }
-        return too_short;
-    }
-    if args[0].is_empty_list() {
-        return too_short;
-    }
-    // Array
-    if let Some(elems) = args[0].as_array() {
-        return if elems.len() < 2 {
-            too_short
-        } else {
-            (SIG_OK, elems[1])
-        };
-    }
-    // @array
-    if let Some(arr) = args[0].as_array_mut() {
-        let borrowed = arr.borrow();
-        return if borrowed.len() < 2 {
-            too_short
-        } else {
-            (SIG_OK, borrowed[1])
-        };
-    }
-    // String — second grapheme cluster
-    if let Some(result) = args[0].with_string(|s| match s.graphemes(true).nth(1) {
-        Some(g) => (SIG_OK, Value::string(g)),
-        None => (
+    // Syntax is not a seq type, handle it inline
+    match seq_nth(&args[0], 1) {
+        Ok(v) => (SIG_OK, v),
+        Err(_) => (
             SIG_ERROR,
             error_val(
                 "argument-error",
                 "second: sequence has fewer than 2 elements",
             ),
         ),
-    }) {
-        return result;
     }
-    // @string — second grapheme cluster
-    if let Some(buf_ref) = args[0].as_string_mut() {
-        let borrowed = buf_ref.borrow();
-        if let Ok(s) = std::str::from_utf8(&borrowed) {
-            return match s.graphemes(true).nth(1) {
-                Some(g) => (SIG_OK, Value::string(g)),
-                None => too_short,
-            };
-        }
-        return too_short;
-    }
-    // Bytes — second byte as integer
-    if let Some(b) = args[0].as_bytes() {
-        return if b.len() < 2 {
-            too_short
-        } else {
-            (SIG_OK, Value::int(b[1] as i64))
-        };
-    }
-    // @bytes — second byte as integer
-    if let Some(blob_ref) = args[0].as_bytes_mut() {
-        let borrowed = blob_ref.borrow();
-        return if borrowed.len() < 2 {
-            too_short
-        } else {
-            (SIG_OK, Value::int(borrowed[1] as i64))
-        };
-    }
-    (
-        SIG_ERROR,
-        error_val(
-            "type-error",
-            format!(
-                "second: expected sequence (list, array, string, bytes), got {}",
-                args[0].type_name()
-            ),
-        ),
-    )
 }
 
 /// Get the rest of a sequence (list, array, @array, string, @string, bytes, @bytes)
 pub(crate) fn prim_rest(args: &[Value]) -> (SignalBits, Value) {
-    // Pair cell — the common case for lists
-    if let Some(pair) = args[0].as_pair() {
-        return (SIG_OK, pair.rest);
-    }
-    // Empty list → empty list
-    if args[0].is_empty_list() {
-        return (SIG_OK, Value::EMPTY_LIST);
-    }
-    // Array — return array
-    if let Some(elems) = args[0].as_array() {
-        return if elems.len() <= 1 {
-            (SIG_OK, Value::array(vec![]))
-        } else {
-            (SIG_OK, Value::array(elems[1..].to_vec()))
-        };
-    }
-    // Array — return array
-    if let Some(arr) = args[0].as_array_mut() {
-        let borrowed = arr.borrow();
-        return if borrowed.len() <= 1 {
-            (SIG_OK, Value::array_mut(vec![]))
-        } else {
-            (SIG_OK, Value::array_mut(borrowed[1..].to_vec()))
-        };
-    }
-    // String — skip first grapheme, return string
-    if let Some(result) = args[0].with_string(|s| {
-        let rest: String = s.graphemes(true).skip(1).collect();
-        (SIG_OK, Value::string(rest))
-    }) {
-        return result;
-    }
-    // @string — skip first grapheme, return new @string
-    if let Some(buf_ref) = args[0].as_string_mut() {
-        let borrowed = buf_ref.borrow();
-        if let Ok(s) = std::str::from_utf8(&borrowed) {
-            let rest: String = s.graphemes(true).skip(1).collect();
-            return (SIG_OK, Value::string_mut(rest.into_bytes()));
-        }
-        return (SIG_OK, Value::string_mut(vec![]));
-    }
-    // Bytes — return bytes from index 1 onward
-    if let Some(b) = args[0].as_bytes() {
-        return if b.len() <= 1 {
-            (SIG_OK, Value::bytes(vec![]))
-        } else {
-            (SIG_OK, Value::bytes(b[1..].to_vec()))
-        };
-    }
-    // @bytes — return new @bytes from index 1 onward
-    if let Some(blob_ref) = args[0].as_bytes_mut() {
-        let borrowed = blob_ref.borrow();
-        return if borrowed.len() <= 1 {
-            (SIG_OK, Value::bytes_mut(vec![]))
-        } else {
-            (SIG_OK, Value::bytes_mut(borrowed[1..].to_vec()))
-        };
-    }
     // Syntax (existing behavior, preserved)
     if let Some(syntax) = args[0].as_syntax() {
         if let SyntaxKind::List(items) | SyntaxKind::Array(items) = &syntax.kind {
@@ -285,88 +64,15 @@ pub(crate) fn prim_rest(args: &[Value]) -> (SignalBits, Value) {
             return (SIG_OK, Value::syntax(rest));
         }
     }
-    (
-        SIG_ERROR,
-        error_val(
-            "type-error",
-            format!(
-                "rest: expected sequence (list, array, string, bytes), got {}",
-                args[0].type_name()
-            ),
-        ),
-    )
+    match seq_rest(&args[0]) {
+        Ok(v) => (SIG_OK, v),
+        Err(e) => (SIG_ERROR, e),
+    }
 }
 
 /// Create a list from arguments
 pub(crate) fn prim_list(args: &[Value]) -> (SignalBits, Value) {
     (SIG_OK, list(args.to_vec()))
-}
-
-/// Collect elements of any sequence into a `Vec<Value>`.
-fn collect_elements(val: &Value) -> Result<Vec<Value>, (SignalBits, Value)> {
-    // List — walk cons cells
-    if val.is_pair() || val.is_empty_list() {
-        let mut elements = Vec::new();
-        let mut cur = *val;
-        while let Some(c) = cur.as_pair() {
-            elements.push(c.first);
-            cur = c.rest;
-        }
-        return Ok(elements);
-    }
-    // Array / @array
-    if let Some(elems) = val.as_array() {
-        return Ok(elems.to_vec());
-    }
-    if let Some(data) = val.as_array_mut() {
-        return Ok(data.borrow().clone());
-    }
-    // Set / @set
-    if let Some(set) = val.as_set() {
-        return Ok(set.to_vec());
-    }
-    if let Some(set) = val.as_set_mut() {
-        return Ok(set.borrow().iter().copied().collect());
-    }
-    // String — grapheme clusters as single-char strings
-    if val.is_string() {
-        return val
-            .with_string(|s| {
-                use unicode_segmentation::UnicodeSegmentation;
-                Ok(s.graphemes(true).map(Value::string).collect())
-            })
-            .unwrap_or_else(|| Ok(vec![]));
-    }
-    // @string — grapheme clusters
-    if val.is_string_mut() {
-        if let Some(data) = val.as_string_mut() {
-            let bytes = data.borrow();
-            if let Ok(s) = std::str::from_utf8(&bytes) {
-                use unicode_segmentation::UnicodeSegmentation;
-                return Ok(s.graphemes(true).map(Value::string).collect());
-            }
-        }
-        return Ok(vec![]);
-    }
-    // Bytes — each byte as integer
-    if let Some(b) = val.as_bytes() {
-        return Ok(b.iter().map(|&byte| Value::int(byte as i64)).collect());
-    }
-    // @bytes — each byte as integer
-    if let Some(data) = val.as_bytes_mut() {
-        return Ok(data
-            .borrow()
-            .iter()
-            .map(|&byte| Value::int(byte as i64))
-            .collect());
-    }
-    Err((
-        SIG_ERROR,
-        error_val(
-            "type-error",
-            format!("expected sequence, got {}", val.type_name()),
-        ),
-    ))
 }
 
 /// Convert any sequence to an immutable array.
@@ -375,9 +81,9 @@ pub(crate) fn prim_to_array(args: &[Value]) -> (SignalBits, Value) {
     if args[0].as_array().is_some() {
         return (SIG_OK, args[0]);
     }
-    match collect_elements(&args[0]) {
+    match coll_to_vec(&args[0]) {
         Ok(elements) => (SIG_OK, Value::array(elements)),
-        Err(e) => e,
+        Err(e) => (SIG_ERROR, e),
     }
 }
 
@@ -387,275 +93,33 @@ pub(crate) fn prim_to_list(args: &[Value]) -> (SignalBits, Value) {
     if args[0].is_pair() || args[0].is_empty_list() {
         return (SIG_OK, args[0]);
     }
-    match collect_elements(&args[0]) {
+    match coll_to_vec(&args[0]) {
         Ok(elements) => (SIG_OK, list(elements)),
-        Err(e) => e,
+        Err(e) => (SIG_ERROR, e),
     }
 }
 
 /// Get the length of a collection (universal for all container types)
 pub(crate) fn prim_length(args: &[Value]) -> (SignalBits, Value) {
-    if args[0].is_nil() || args[0].is_empty_list() {
-        (SIG_OK, Value::int(0))
-    } else if args[0].is_pair() {
-        let vec = match args[0].list_to_vec() {
-            Ok(v) => v,
-            Err(e) => return (SIG_ERROR, error_val("type-error", format!("length: {}", e))),
-        };
-        (SIG_OK, Value::int(vec.len() as i64))
-    } else if let Some(syntax) = args[0].as_syntax() {
-        if let SyntaxKind::List(items) | SyntaxKind::Array(items) = &syntax.kind {
-            (SIG_OK, Value::int(items.len() as i64))
-        } else {
-            (
-                SIG_ERROR,
-                error_val(
-                    "type-error",
-                    "length: expected collection type, got syntax object (non-list)",
-                ),
-            )
-        }
-    } else if let Some(buf_ref) = args[0].as_string_mut() {
-        let borrowed = buf_ref.borrow();
-        match std::str::from_utf8(&borrowed) {
-            Ok(s) => (SIG_OK, Value::int(s.graphemes(true).count() as i64)),
-            Err(e) => (
-                SIG_ERROR,
-                error_val(
-                    "encoding-error",
-                    format!("length: @string contains invalid UTF-8: {}", e),
-                ),
-            ),
-        }
-    } else if let Some(b) = args[0].as_bytes() {
-        (SIG_OK, Value::int(b.len() as i64))
-    } else if let Some(blob_ref) = args[0].as_bytes_mut() {
-        (SIG_OK, Value::int(blob_ref.borrow().len() as i64))
-    } else if let Some(r) =
-        args[0].with_string(|s| (SIG_OK, Value::int(s.graphemes(true).count() as i64)))
-    {
-        r
-    } else if let Some(elems) = args[0].as_array() {
-        (SIG_OK, Value::int(elems.len() as i64))
-    } else if args[0].is_array_mut() {
-        let vec = match args[0].as_array_mut() {
-            Some(v) => v,
-            None => {
-                return (
-                    SIG_ERROR,
-                    error_val("internal-error", "length: failed to get array".to_string()),
-                )
-            }
-        };
-        (SIG_OK, Value::int(vec.borrow().len() as i64))
-    } else if args[0].is_struct_mut() {
-        let table = match args[0].as_struct_mut() {
-            Some(t) => t,
-            None => {
-                return (
-                    SIG_ERROR,
-                    error_val("internal-error", "length: failed to get table".to_string()),
-                )
-            }
-        };
-        (SIG_OK, Value::int(table.borrow().len() as i64))
-    } else if args[0].is_struct() {
-        let s = match args[0].as_struct() {
-            Some(st) => st,
-            None => {
-                return (
-                    SIG_ERROR,
-                    error_val("internal-error", "length: failed to get struct".to_string()),
-                )
-            }
-        };
-        (SIG_OK, Value::int(s.len() as i64))
-    } else if let Some(sid) = args[0].as_symbol() {
-        // Get the symbol name from the symbol table context
-        if let Some(name) = crate::context::resolve_symbol_name(sid) {
-            (SIG_OK, Value::int(name.graphemes(true).count() as i64))
-        } else {
-            (
-                SIG_ERROR,
-                error_val(
-                    "internal-error",
-                    format!("length: unable to resolve symbol name for id {:?}", sid),
-                ),
-            )
-        }
-    } else if let Some(name) = args[0].as_keyword_name() {
-        (SIG_OK, Value::int(name.graphemes(true).count() as i64))
-    } else if args[0].is_set() {
-        let set = match args[0].as_set() {
-            Some(s) => s,
-            None => {
-                return (
-                    SIG_ERROR,
-                    error_val("internal-error", "length: failed to get set".to_string()),
-                )
-            }
-        };
-        (SIG_OK, Value::int(set.len() as i64))
-    } else if args[0].is_set_mut() {
-        let set = match args[0].as_set_mut() {
-            Some(s) => s,
-            None => {
-                return (
-                    SIG_ERROR,
-                    error_val(
-                        "internal-error",
-                        "length: failed to get mutable set".to_string(),
-                    ),
-                )
-            }
-        };
-        (SIG_OK, Value::int(set.borrow().len() as i64))
-    } else {
-        (SIG_ERROR, error_val("type-error", format!(
-            "length: expected collection type (list, string, array, @array, @struct, struct, set, symbol, or keyword), got {}",
-            args[0].type_name()
-        )))
+    match coll_len(&args[0]) {
+        Ok(n) => (SIG_OK, Value::int(n as i64)),
+        Err(e) => (SIG_ERROR, e),
     }
 }
 
 /// Check if a collection is empty (O(1) operation for most types)
 pub(crate) fn prim_empty(args: &[Value]) -> (SignalBits, Value) {
-    // nil is not a container - error if passed
-    if args[0].is_nil() {
-        return (
-            SIG_ERROR,
-            error_val(
-                "type-error",
-                "empty?: expected collection type (list, string, array, @array, @string, @struct, struct, or set), got nil"
-                    .to_string(),
-            ),
-        );
+    match coll_empty(&args[0]) {
+        Ok(empty) => (SIG_OK, if empty { Value::TRUE } else { Value::FALSE }),
+        Err(e) => (SIG_ERROR, e),
     }
-
-    let result = if let Some(syntax) = args[0].as_syntax() {
-        if let SyntaxKind::List(items) | SyntaxKind::Array(items) = &syntax.kind {
-            items.is_empty()
-        } else {
-            return (
-                SIG_ERROR,
-                error_val(
-                    "type-error",
-                    format!(
-                        "empty?: expected collection type (list, string, array, @array, @string, @struct, struct, or set), got {}",
-                        args[0].type_name()
-                    ),
-                ),
-            );
-        }
-    } else if args[0].is_empty_list() {
-        true
-    } else if args[0].is_pair() {
-        false
-    } else if let Some(buf_ref) = args[0].as_string_mut() {
-        buf_ref.borrow().is_empty()
-    } else if let Some(r) = args[0].with_string(|s| s.is_empty()) {
-        r
-    } else if args[0].is_array_mut() {
-        let vec = match args[0].as_array_mut() {
-            Some(v) => v,
-            None => {
-                return (
-                    SIG_ERROR,
-                    error_val("internal-error", "empty?: failed to get array".to_string()),
-                )
-            }
-        };
-        vec.borrow().is_empty()
-    } else if let Some(b) = args[0].as_bytes() {
-        b.is_empty()
-    } else if let Some(blob_ref) = args[0].as_bytes_mut() {
-        blob_ref.borrow().is_empty()
-    } else if args[0].is_array() {
-        let elems = match args[0].as_array() {
-            Some(e) => e,
-            None => {
-                return (
-                    SIG_ERROR,
-                    error_val("internal-error", "empty?: failed to get array".to_string()),
-                )
-            }
-        };
-        elems.is_empty()
-    } else if args[0].is_struct_mut() {
-        let table = match args[0].as_struct_mut() {
-            Some(t) => t,
-            None => {
-                return (
-                    SIG_ERROR,
-                    error_val("internal-error", "empty?: failed to get table".to_string()),
-                )
-            }
-        };
-        table.borrow().is_empty()
-    } else if args[0].is_struct() {
-        let s = match args[0].as_struct() {
-            Some(st) => st,
-            None => {
-                return (
-                    SIG_ERROR,
-                    error_val("internal-error", "empty?: failed to get struct".to_string()),
-                )
-            }
-        };
-        s.is_empty()
-    } else if args[0].is_set() {
-        let set = match args[0].as_set() {
-            Some(s) => s,
-            None => {
-                return (
-                    SIG_ERROR,
-                    error_val("internal-error", "empty?: failed to get set".to_string()),
-                )
-            }
-        };
-        set.is_empty()
-    } else if args[0].is_set_mut() {
-        let set = match args[0].as_set_mut() {
-            Some(s) => s,
-            None => {
-                return (
-                    SIG_ERROR,
-                    error_val(
-                        "internal-error",
-                        "empty?: failed to get mutable set".to_string(),
-                    ),
-                )
-            }
-        };
-        set.borrow().is_empty()
-    } else {
-        return (
-            SIG_ERROR,
-            error_val(
-                "type-error",
-                format!(
-                "empty?: expected collection type (list, string, array, @array, @string, @struct, struct, set, or @set), got {}",
-                args[0].type_name()
-            ),
-            ),
-        );
-    };
-
-    (SIG_OK, if result { Value::TRUE } else { Value::FALSE })
 }
 
 /// Check if a collection is non-empty (negation of empty?)
 pub(crate) fn prim_nonempty(args: &[Value]) -> (SignalBits, Value) {
-    let (sig, val) = prim_empty(args);
-    if sig != SIG_OK {
-        // Re-wrap errors with nonempty? name
-        return (sig, val);
-    }
-    // Negate the boolean result
-    if val == Value::TRUE {
-        (SIG_OK, Value::FALSE)
-    } else {
-        (SIG_OK, Value::TRUE)
+    match coll_empty(&args[0]) {
+        Ok(empty) => (SIG_OK, if empty { Value::FALSE } else { Value::TRUE }),
+        Err(e) => (SIG_ERROR, e),
     }
 }
 

--- a/src/primitives/lstruct.rs
+++ b/src/primitives/lstruct.rs
@@ -1,12 +1,13 @@
 //! Struct operations primitives (mutable hash tables)
 //!
 //! Polymorphic collection access (get, put) is in `access.rs`.
+use crate::primitives::collection::coll_has;
 use crate::primitives::def::PrimitiveDef;
 use crate::signals::Signal;
 use crate::value::fiber::{SignalBits, SIG_ERROR, SIG_OK};
 use crate::value::fiberheap;
 use crate::value::types::Arity;
-use crate::value::{error_val, sorted_struct_contains, sorted_struct_remove, TableKey, Value};
+use crate::value::{error_val, sorted_struct_remove, TableKey, Value};
 use std::collections::BTreeMap;
 
 use super::access::{prim_get, prim_put};
@@ -290,67 +291,9 @@ pub(crate) fn prim_values(args: &[Value]) -> (SignalBits, Value) {
 
 /// Polymorphic has? - works on structs, sets, and strings
 /// `(has? collection key-or-value)`
-///
-/// For structs: checks if key exists
-/// For sets: checks if value is a member
-/// For strings: checks if substring is present
 pub(crate) fn prim_has_key(args: &[Value]) -> (SignalBits, Value) {
-    // Delegate to set/string membership check
-    if args[0].is_set() || args[0].is_set_mut() || args[0].is_string() || args[0].is_string_mut() {
-        return crate::primitives::sets::prim_contains(args);
-    }
-
-    let key = match TableKey::from_value(&args[1]) {
-        Some(k) => k,
-        None => {
-            return (
-                SIG_ERROR,
-                error_val(
-                    "type-error",
-                    format!("expected hashable value, got {}", args[1].type_name()),
-                ),
-            )
-        }
-    };
-
-    if args[0].is_struct_mut() {
-        let mstruct = match args[0].as_struct_mut() {
-            Some(t) => t,
-            None => {
-                return (
-                    SIG_ERROR,
-                    error_val(
-                        "type-error",
-                        format!("has?: expected struct, got {}", args[0].type_name()),
-                    ),
-                )
-            }
-        };
-        (SIG_OK, Value::bool(mstruct.borrow().contains_key(&key)))
-    } else if args[0].is_struct() {
-        let s = match args[0].as_struct() {
-            Some(st) => st,
-            None => {
-                return (
-                    SIG_ERROR,
-                    error_val(
-                        "type-error",
-                        format!("has?: expected struct, got {}", args[0].type_name()),
-                    ),
-                )
-            }
-        };
-        (SIG_OK, Value::bool(sorted_struct_contains(s, &key)))
-    } else {
-        (
-            SIG_ERROR,
-            error_val(
-                "type-error",
-                format!(
-                    "has?: expected struct, set, or string, got {}",
-                    args[0].type_name()
-                ),
-            ),
-        )
+    match coll_has(&args[0], &args[1]) {
+        Ok(found) => (SIG_OK, if found { Value::TRUE } else { Value::FALSE }),
+        Err(e) => (SIG_ERROR, e),
     }
 }

--- a/src/primitives/mod.rs
+++ b/src/primitives/mod.rs
@@ -7,6 +7,8 @@ pub mod bitwise;
 pub mod r#box;
 pub mod bytes;
 pub mod chan;
+pub mod collection;
+
 pub mod comparison;
 pub mod compile;
 pub mod concurrency;
@@ -44,6 +46,7 @@ pub mod path;
 pub mod ports;
 pub mod read;
 pub mod registration;
+pub mod seq;
 pub mod sets;
 pub mod sort;
 pub mod stream;

--- a/src/primitives/seq.rs
+++ b/src/primitives/seq.rs
@@ -1,0 +1,721 @@
+//! Seq protocol: centralized dispatch for ordered, indexable sequences.
+//!
+//! Seq extends Collection — these operations apply only to types with a
+//! defined element order: list, (), array, @array, string, @string,
+//! bytes, @bytes.  Not sets or structs (unordered).
+use crate::value::fiberheap;
+use crate::value::{error_val, list, Value};
+use unicode_segmentation::UnicodeSegmentation;
+
+use super::access::{resolve_index, resolve_slice_index};
+
+const SEQ_TYPES: &str = "sequence (list, array, string, bytes)";
+
+fn seq_type_error(op: &str, val: &Value) -> Value {
+    error_val(
+        "type-error",
+        format!("{}: expected {}, got {}", op, SEQ_TYPES, val.type_name()),
+    )
+}
+
+/// Get the first element of a sequence.
+pub fn seq_first(val: &Value) -> Result<Value, Value> {
+    if let Some(pair) = val.as_pair() {
+        return Ok(pair.first);
+    }
+    if val.is_empty_list() {
+        return Err(error_val("argument-error", "first: empty sequence"));
+    }
+    if let Some(elems) = val.as_array() {
+        return elems
+            .first()
+            .copied()
+            .ok_or_else(|| error_val("argument-error", "first: empty sequence"));
+    }
+    if let Some(arr) = val.as_array_mut() {
+        let borrowed = arr.borrow();
+        return borrowed
+            .first()
+            .copied()
+            .ok_or_else(|| error_val("argument-error", "first: empty sequence"));
+    }
+    if let Some(result) = val.with_string(|s| match s.graphemes(true).next() {
+        Some(g) => Ok(Value::string(g)),
+        None => Err(error_val("argument-error", "first: empty sequence")),
+    }) {
+        return result;
+    }
+    if let Some(buf_ref) = val.as_string_mut() {
+        let borrowed = buf_ref.borrow();
+        if let Ok(s) = std::str::from_utf8(&borrowed) {
+            return match s.graphemes(true).next() {
+                Some(g) => Ok(Value::string(g)),
+                None => Err(error_val("argument-error", "first: empty sequence")),
+            };
+        }
+        return Err(error_val("argument-error", "first: empty sequence"));
+    }
+    if let Some(b) = val.as_bytes() {
+        return if b.is_empty() {
+            Err(error_val("argument-error", "first: empty sequence"))
+        } else {
+            Ok(Value::int(b[0] as i64))
+        };
+    }
+    if let Some(blob_ref) = val.as_bytes_mut() {
+        let borrowed = blob_ref.borrow();
+        return if borrowed.is_empty() {
+            Err(error_val("argument-error", "first: empty sequence"))
+        } else {
+            Ok(Value::int(borrowed[0] as i64))
+        };
+    }
+    Err(seq_type_error("first", val))
+}
+
+/// Get the rest of a sequence (type-preserving).
+pub fn seq_rest(val: &Value) -> Result<Value, Value> {
+    if let Some(pair) = val.as_pair() {
+        return Ok(pair.rest);
+    }
+    if val.is_empty_list() {
+        return Ok(Value::EMPTY_LIST);
+    }
+    if let Some(elems) = val.as_array() {
+        return Ok(if elems.len() <= 1 {
+            Value::array(vec![])
+        } else {
+            Value::array(elems[1..].to_vec())
+        });
+    }
+    if let Some(arr) = val.as_array_mut() {
+        let borrowed = arr.borrow();
+        return Ok(if borrowed.len() <= 1 {
+            Value::array_mut(vec![])
+        } else {
+            Value::array_mut(borrowed[1..].to_vec())
+        });
+    }
+    if let Some(result) = val.with_string(|s| {
+        let rest: String = s.graphemes(true).skip(1).collect();
+        Value::string(rest)
+    }) {
+        return Ok(result);
+    }
+    if let Some(buf_ref) = val.as_string_mut() {
+        let borrowed = buf_ref.borrow();
+        if let Ok(s) = std::str::from_utf8(&borrowed) {
+            let rest: String = s.graphemes(true).skip(1).collect();
+            return Ok(Value::string_mut(rest.into_bytes()));
+        }
+        return Ok(Value::string_mut(vec![]));
+    }
+    if let Some(b) = val.as_bytes() {
+        return Ok(if b.len() <= 1 {
+            Value::bytes(vec![])
+        } else {
+            Value::bytes(b[1..].to_vec())
+        });
+    }
+    if let Some(blob_ref) = val.as_bytes_mut() {
+        let borrowed = blob_ref.borrow();
+        return Ok(if borrowed.len() <= 1 {
+            Value::bytes_mut(vec![])
+        } else {
+            Value::bytes_mut(borrowed[1..].to_vec())
+        });
+    }
+    Err(seq_type_error("rest", val))
+}
+
+/// Get the last element of a sequence.
+pub fn seq_last(val: &Value) -> Result<Value, Value> {
+    if val.is_empty_list() {
+        return Err(error_val("argument-error", "last: empty sequence"));
+    }
+    if val.is_pair() {
+        let mut current = *val;
+        let mut last = Value::NIL;
+        while let Some(pair) = current.as_pair() {
+            last = pair.first;
+            current = pair.rest;
+        }
+        return Ok(last);
+    }
+    if let Some(elems) = val.as_array() {
+        return elems
+            .last()
+            .copied()
+            .ok_or_else(|| error_val("argument-error", "last: empty sequence"));
+    }
+    if let Some(arr) = val.as_array_mut() {
+        let borrowed = arr.borrow();
+        return borrowed
+            .last()
+            .copied()
+            .ok_or_else(|| error_val("argument-error", "last: empty sequence"));
+    }
+    if let Some(result) = val.with_string(|s| match s.graphemes(true).next_back() {
+        Some(g) => Ok(Value::string(g)),
+        None => Err(error_val("argument-error", "last: empty sequence")),
+    }) {
+        return result;
+    }
+    if let Some(buf_ref) = val.as_string_mut() {
+        let borrowed = buf_ref.borrow();
+        if let Ok(s) = std::str::from_utf8(&borrowed) {
+            return match s.graphemes(true).next_back() {
+                Some(g) => Ok(Value::string(g)),
+                None => Err(error_val("argument-error", "last: empty sequence")),
+            };
+        }
+        return Err(error_val("argument-error", "last: empty sequence"));
+    }
+    if let Some(b) = val.as_bytes() {
+        return b
+            .last()
+            .map(|&byte| Value::int(byte as i64))
+            .ok_or_else(|| error_val("argument-error", "last: empty sequence"));
+    }
+    if let Some(blob_ref) = val.as_bytes_mut() {
+        let borrowed = blob_ref.borrow();
+        return borrowed
+            .last()
+            .map(|&byte| Value::int(byte as i64))
+            .ok_or_else(|| error_val("argument-error", "last: empty sequence"));
+    }
+    Err(seq_type_error("last", val))
+}
+
+/// Get element at index n.
+pub fn seq_nth(val: &Value, n: i64) -> Result<Value, Value> {
+    if val.is_pair() {
+        // Positive index: walk forward
+        if n >= 0 {
+            let mut current = *val;
+            let mut i = 0usize;
+            loop {
+                if current.is_empty_list() || current.is_nil() {
+                    return Err(error_val(
+                        "argument-error",
+                        format!("nth: index {} out of bounds", n),
+                    ));
+                }
+                if let Some(p) = current.as_pair() {
+                    if i == n as usize {
+                        return Ok(p.first);
+                    }
+                    current = p.rest;
+                    i += 1;
+                } else {
+                    return Err(error_val(
+                        "argument-error",
+                        format!("nth: index {} out of bounds", n),
+                    ));
+                }
+            }
+        } else {
+            // Negative: need length
+            let mut len = 0usize;
+            let mut cur = *val;
+            while let Some(c) = cur.as_pair() {
+                len += 1;
+                cur = c.rest;
+            }
+            let resolved = n + len as i64;
+            if resolved < 0 {
+                return Err(error_val(
+                    "argument-error",
+                    format!("nth: index {} out of bounds (length {})", n, len),
+                ));
+            }
+            return seq_nth(val, resolved);
+        }
+    }
+    if val.is_empty_list() {
+        return Err(error_val(
+            "argument-error",
+            format!("nth: index {} out of bounds (empty list)", n),
+        ));
+    }
+    if let Some(elems) = val.as_array() {
+        return resolve_index(n, elems.len())
+            .map(|i| elems[i])
+            .ok_or_else(|| {
+                error_val(
+                    "argument-error",
+                    format!("nth: index {} out of bounds (length {})", n, elems.len()),
+                )
+            });
+    }
+    if let Some(arr) = val.as_array_mut() {
+        let borrowed = arr.borrow();
+        return resolve_index(n, borrowed.len())
+            .map(|i| borrowed[i])
+            .ok_or_else(|| {
+                error_val(
+                    "argument-error",
+                    format!("nth: index {} out of bounds (length {})", n, borrowed.len()),
+                )
+            });
+    }
+    if let Some(result) = val.with_string(|s| {
+        let graphemes: Vec<&str> = s.graphemes(true).collect();
+        resolve_index(n, graphemes.len())
+            .map(|i| Value::string(graphemes[i]))
+            .ok_or_else(|| {
+                error_val(
+                    "argument-error",
+                    format!(
+                        "nth: index {} out of bounds (length {})",
+                        n,
+                        graphemes.len()
+                    ),
+                )
+            })
+    }) {
+        return result;
+    }
+    if let Some(buf_ref) = val.as_string_mut() {
+        let borrowed = buf_ref.borrow();
+        if let Ok(s) = std::str::from_utf8(&borrowed) {
+            let graphemes: Vec<&str> = s.graphemes(true).collect();
+            return resolve_index(n, graphemes.len())
+                .map(|i| Value::string(graphemes[i]))
+                .ok_or_else(|| {
+                    error_val(
+                        "argument-error",
+                        format!(
+                            "nth: index {} out of bounds (length {})",
+                            n,
+                            graphemes.len()
+                        ),
+                    )
+                });
+        }
+        return Err(error_val(
+            "argument-error",
+            format!("nth: index {} out of bounds (empty @string)", n),
+        ));
+    }
+    if let Some(b) = val.as_bytes() {
+        return resolve_index(n, b.len())
+            .map(|i| Value::int(b[i] as i64))
+            .ok_or_else(|| {
+                error_val(
+                    "argument-error",
+                    format!("nth: index {} out of bounds (length {})", n, b.len()),
+                )
+            });
+    }
+    if let Some(blob_ref) = val.as_bytes_mut() {
+        let borrowed = blob_ref.borrow();
+        return resolve_index(n, borrowed.len())
+            .map(|i| Value::int(borrowed[i] as i64))
+            .ok_or_else(|| {
+                error_val(
+                    "argument-error",
+                    format!("nth: index {} out of bounds (length {})", n, borrowed.len()),
+                )
+            });
+    }
+    Err(seq_type_error("nth", val))
+}
+
+/// All elements except the last (type-preserving).
+pub fn seq_butlast(val: &Value) -> Result<Value, Value> {
+    if val.is_empty_list() {
+        return Ok(Value::EMPTY_LIST);
+    }
+    if val.is_pair() {
+        let vec = val
+            .list_to_vec()
+            .map_err(|e| error_val("type-error", e.to_string()))?;
+        if vec.is_empty() {
+            return Ok(Value::EMPTY_LIST);
+        }
+        return Ok(list(vec[..vec.len() - 1].to_vec()));
+    }
+    if let Some(elems) = val.as_array() {
+        return Ok(if elems.is_empty() {
+            Value::array(vec![])
+        } else {
+            Value::array(elems[..elems.len() - 1].to_vec())
+        });
+    }
+    if let Some(arr) = val.as_array_mut() {
+        let borrowed = arr.borrow();
+        return Ok(if borrowed.is_empty() {
+            Value::array_mut(vec![])
+        } else {
+            Value::array_mut(borrowed[..borrowed.len() - 1].to_vec())
+        });
+    }
+    if let Some(result) = val.with_string(|s| {
+        let graphemes: Vec<&str> = s.graphemes(true).collect();
+        if graphemes.is_empty() {
+            Value::string("")
+        } else {
+            Value::string(graphemes[..graphemes.len() - 1].concat())
+        }
+    }) {
+        return Ok(result);
+    }
+    if let Some(buf_ref) = val.as_string_mut() {
+        let borrowed = buf_ref.borrow();
+        if let Ok(s) = std::str::from_utf8(&borrowed) {
+            let graphemes: Vec<&str> = s.graphemes(true).collect();
+            return Ok(if graphemes.is_empty() {
+                Value::string_mut(vec![])
+            } else {
+                Value::string_mut(graphemes[..graphemes.len() - 1].concat().into_bytes())
+            });
+        }
+        return Ok(Value::string_mut(vec![]));
+    }
+    if let Some(b) = val.as_bytes() {
+        return Ok(if b.is_empty() {
+            Value::bytes(vec![])
+        } else {
+            Value::bytes(b[..b.len() - 1].to_vec())
+        });
+    }
+    if let Some(blob_ref) = val.as_bytes_mut() {
+        let borrowed = blob_ref.borrow();
+        return Ok(if borrowed.is_empty() {
+            Value::bytes_mut(vec![])
+        } else {
+            Value::bytes_mut(borrowed[..borrowed.len() - 1].to_vec())
+        });
+    }
+    Err(seq_type_error("butlast", val))
+}
+
+/// Reverse a sequence (type-preserving).
+pub fn seq_reverse(val: &Value) -> Result<Value, Value> {
+    if val.is_empty_list() {
+        return Ok(Value::EMPTY_LIST);
+    }
+    if val.is_pair() {
+        let mut vec = val
+            .list_to_vec()
+            .map_err(|e| error_val("type-error", e.to_string()))?;
+        vec.reverse();
+        return Ok(list(vec));
+    }
+    if let Some(elems) = val.as_array() {
+        let mut vec = elems.to_vec();
+        vec.reverse();
+        return Ok(Value::array(vec));
+    }
+    if let Some(arr) = val.as_array_mut() {
+        let mut vec = arr.borrow().to_vec();
+        vec.reverse();
+        return Ok(Value::array_mut(vec));
+    }
+    if let Some(result) = val.with_string(|s| {
+        let reversed: String = s.graphemes(true).rev().collect();
+        Value::string(reversed)
+    }) {
+        return Ok(result);
+    }
+    if let Some(buf_ref) = val.as_string_mut() {
+        let borrowed = buf_ref.borrow();
+        if let Ok(s) = std::str::from_utf8(&borrowed) {
+            let reversed: String = s.graphemes(true).rev().collect();
+            return Ok(Value::string_mut(reversed.into_bytes()));
+        }
+        return Ok(Value::string_mut(vec![]));
+    }
+    if let Some(b) = val.as_bytes() {
+        let mut vec = b.to_vec();
+        vec.reverse();
+        return Ok(Value::bytes(vec));
+    }
+    if let Some(blob_ref) = val.as_bytes_mut() {
+        let mut vec = blob_ref.borrow().to_vec();
+        vec.reverse();
+        return Ok(Value::bytes_mut(vec));
+    }
+    Err(seq_type_error("reverse", val))
+}
+
+/// Slice a sequence from start to end (type-preserving).
+pub fn seq_slice(val: &Value, start: i64, end: i64) -> Result<Value, Value> {
+    // Bytes
+    if let Some(b) = val.as_bytes() {
+        let s = resolve_slice_index(start, b.len());
+        let e = resolve_slice_index(end, b.len());
+        return Ok(if s >= e {
+            Value::bytes(vec![])
+        } else {
+            Value::bytes(b[s..e].to_vec())
+        });
+    }
+    if let Some(blob_ref) = val.as_bytes_mut() {
+        let borrowed = blob_ref.borrow();
+        let s = resolve_slice_index(start, borrowed.len());
+        let e = resolve_slice_index(end, borrowed.len());
+        return Ok(if s >= e {
+            Value::bytes_mut(vec![])
+        } else {
+            Value::bytes_mut(borrowed[s..e].to_vec())
+        });
+    }
+    // Arrays
+    if let Some(elems) = val.as_array() {
+        let s = resolve_slice_index(start, elems.len());
+        let e = resolve_slice_index(end, elems.len());
+        return Ok(if s >= e {
+            Value::array(vec![])
+        } else {
+            Value::array(elems[s..e].to_vec())
+        });
+    }
+    if let Some(arr_ref) = val.as_array_mut() {
+        let borrowed = arr_ref.borrow();
+        let s = resolve_slice_index(start, borrowed.len());
+        let e = resolve_slice_index(end, borrowed.len());
+        return Ok(if s >= e {
+            Value::array_mut(vec![])
+        } else {
+            Value::array_mut(borrowed[s..e].to_vec())
+        });
+    }
+    // Strings (grapheme-aware)
+    if val.is_string() {
+        return val
+            .with_string(|str_val| {
+                let count = str_val.graphemes(true).count();
+                let s = resolve_slice_index(start, count);
+                let e = resolve_slice_index(end, count);
+                Ok(slice_graphemes_immut(str_val, s, e))
+            })
+            .unwrap();
+    }
+    if let Some(buf_ref) = val.as_string_mut() {
+        let borrowed = buf_ref.borrow();
+        let str_val = unsafe { std::str::from_utf8_unchecked(&borrowed) };
+        let count = str_val.graphemes(true).count();
+        let s = resolve_slice_index(start, count);
+        let e = resolve_slice_index(end, count);
+        return Ok(slice_graphemes_mut(str_val, s, e));
+    }
+    // Lists
+    if val.is_empty_list() || val.is_pair() {
+        let elems = val
+            .list_to_vec()
+            .map_err(|e| error_val("type-error", e.to_string()))?;
+        let s = resolve_slice_index(start, elems.len());
+        let e = resolve_slice_index(end, elems.len());
+        if s >= e {
+            return Ok(Value::EMPTY_LIST);
+        }
+        let mut result = Value::EMPTY_LIST;
+        for v in elems[s..e].iter().rev() {
+            result = Value::pair(*v, result);
+        }
+        return Ok(result);
+    }
+    Err(seq_type_error("slice", val))
+}
+
+fn slice_graphemes_immut(s: &str, start: usize, end: usize) -> Value {
+    let graphemes: Vec<&str> = s.graphemes(true).collect();
+    let cs = start.min(graphemes.len());
+    let ce = end.min(graphemes.len());
+    if cs >= ce {
+        Value::string("")
+    } else {
+        Value::string(graphemes[cs..ce].concat())
+    }
+}
+
+fn slice_graphemes_mut(s: &str, start: usize, end: usize) -> Value {
+    let graphemes: Vec<&str> = s.graphemes(true).collect();
+    let cs = start.min(graphemes.len());
+    let ce = end.min(graphemes.len());
+    if cs >= ce {
+        Value::string_mut(vec![])
+    } else {
+        Value::string_mut(graphemes[cs..ce].concat().into_bytes())
+    }
+}
+
+/// Sort a sequence (type-preserving).
+pub fn seq_sort(val: &Value) -> Result<Value, Value> {
+    if let Some(arr) = val.as_array_mut() {
+        arr.borrow_mut().sort();
+        return Ok(*val);
+    }
+    if let Some(elems) = val.as_array() {
+        let mut vec = elems.to_vec();
+        vec.sort();
+        return Ok(Value::array(vec));
+    }
+    if val.is_empty_list() {
+        return Ok(Value::EMPTY_LIST);
+    }
+    if val.is_pair() {
+        let mut vec = val
+            .list_to_vec()
+            .map_err(|e| error_val("type-error", e.to_string()))?;
+        vec.sort();
+        return Ok(list(vec));
+    }
+    Err(error_val(
+        "type-error",
+        format!(
+            "sort: expected list, array, or @array, got {}",
+            val.type_name()
+        ),
+    ))
+}
+
+/// Push an element onto the end of a sequence (type-aware).
+pub fn seq_push(val: &Value, elem: Value) -> Result<Value, Value> {
+    // @array — mutate in place
+    if let Some(vec_ref) = val.as_array_mut() {
+        fiberheap::incref(elem);
+        vec_ref.borrow_mut().push(elem);
+        return Ok(*val);
+    }
+    // @string — append string
+    if let Some(buf_ref) = val.as_string_mut() {
+        let s = elem.with_string(|s| s.to_string()).ok_or_else(|| {
+            error_val(
+                "type-error",
+                format!(
+                    "push: @string value must be string, got {}",
+                    elem.type_name()
+                ),
+            )
+        })?;
+        buf_ref.borrow_mut().extend_from_slice(s.as_bytes());
+        return Ok(*val);
+    }
+    // @bytes — append byte
+    if let Some(blob_ref) = val.as_bytes_mut() {
+        let byte = match elem.as_int() {
+            Some(n) if (0..=255).contains(&n) => n as u8,
+            Some(n) => {
+                return Err(error_val(
+                    "argument-error",
+                    format!("push: byte value out of range 0-255: {}", n),
+                ))
+            }
+            None => {
+                return Err(error_val(
+                    "type-error",
+                    format!(
+                        "push: @bytes value must be integer, got {}",
+                        elem.type_name()
+                    ),
+                ))
+            }
+        };
+        blob_ref.borrow_mut().push(byte);
+        return Ok(*val);
+    }
+    // Immutable array
+    if let Some(elems) = val.as_array() {
+        let mut new = elems.to_vec();
+        new.push(elem);
+        return Ok(Value::array(new));
+    }
+    // Immutable string
+    if val.is_string() {
+        let s = elem.with_string(|s| s.to_string()).ok_or_else(|| {
+            error_val(
+                "type-error",
+                format!(
+                    "push: string value must be string, got {}",
+                    elem.type_name()
+                ),
+            )
+        })?;
+        return val
+            .with_string(|base| {
+                let mut new = base.to_string();
+                new.push_str(&s);
+                Ok(Value::string(new))
+            })
+            .unwrap();
+    }
+    // Immutable bytes
+    if let Some(b) = val.as_bytes() {
+        let byte = match elem.as_int() {
+            Some(n) if (0..=255).contains(&n) => n as u8,
+            Some(n) => {
+                return Err(error_val(
+                    "argument-error",
+                    format!("push: byte value out of range 0-255: {}", n),
+                ))
+            }
+            None => {
+                return Err(error_val(
+                    "type-error",
+                    format!(
+                        "push: bytes value must be integer, got {}",
+                        elem.type_name()
+                    ),
+                ))
+            }
+        };
+        let mut new = b.to_vec();
+        new.push(byte);
+        return Ok(Value::bytes(new));
+    }
+    Err(error_val(
+        "type-error",
+        format!(
+            "push: expected array, @array, string, @string, bytes, or @bytes, got {}",
+            val.type_name()
+        ),
+    ))
+}
+
+/// Pop the last element from a mutable sequence.
+pub fn seq_pop(val: &Value) -> Result<Value, Value> {
+    if let Some(vec_ref) = val.as_array_mut() {
+        let mut vec = vec_ref.borrow_mut();
+        match vec.pop() {
+            Some(v) => {
+                drop(vec);
+                fiberheap::decref(v);
+                return Ok(v);
+            }
+            None => return Err(error_val("argument-error", "pop: empty array")),
+        }
+    }
+    if let Some(buf_ref) = val.as_string_mut() {
+        let mut buf = buf_ref.borrow_mut();
+        if buf.is_empty() {
+            return Err(error_val("argument-error", "pop: empty @string"));
+        }
+        let s = std::str::from_utf8(&buf)
+            .map_err(|_| error_val("encoding-error", "pop: @string contains invalid UTF-8"))?;
+        let cluster = s.graphemes(true).next_back().unwrap().to_string();
+        let new_len = buf.len() - cluster.len();
+        buf.truncate(new_len);
+        drop(buf);
+        return Ok(Value::string(cluster));
+    }
+    if let Some(blob_ref) = val.as_bytes_mut() {
+        let mut blob = blob_ref.borrow_mut();
+        match blob.pop() {
+            Some(byte) => {
+                drop(blob);
+                return Ok(Value::int(byte as i64));
+            }
+            None => return Err(error_val("argument-error", "pop: empty @bytes")),
+        }
+    }
+    Err(error_val(
+        "type-error",
+        format!(
+            "pop: expected @array, @string, or @bytes, got {}",
+            val.type_name()
+        ),
+    ))
+}

--- a/src/primitives/sets.rs
+++ b/src/primitives/sets.rs
@@ -1,6 +1,7 @@
 //! Set primitives for immutable and mutable sets
 use std::collections::BTreeSet;
 
+use crate::primitives::collection::{coll_combine, coll_has};
 use crate::primitives::def::PrimitiveDef;
 use crate::signals::Signal;
 use crate::value::fiber::{SignalBits, SIG_ERROR, SIG_OK};
@@ -85,93 +86,10 @@ pub(crate) fn prim_is_set(args: &[Value]) -> (SignalBits, Value) {
 /// For sets: returns true if the value is a member of the set.
 /// For strings: returns true if the string contains the substring.
 pub(crate) fn prim_contains(args: &[Value]) -> (SignalBits, Value) {
-    // Set membership check
-    let frozen = freeze_value(args[1]);
-    if let Some(s) = args[0].as_set() {
-        return (SIG_OK, Value::bool(s.binary_search(&frozen).is_ok()));
-    } else if let Some(s) = args[0].as_set_mut() {
-        return (SIG_OK, Value::bool(s.borrow().contains(&frozen)));
+    match coll_has(&args[0], &args[1]) {
+        Ok(found) => (SIG_OK, if found { Value::TRUE } else { Value::FALSE }),
+        Err(e) => (SIG_ERROR, e),
     }
-
-    // String substring check (immutable string)
-    if args[0].is_string() {
-        let needle = if let Some(n) = args[1].with_string(|s| s.to_string()) {
-            n
-        } else {
-            return (
-                SIG_ERROR,
-                error_val(
-                    "type-error",
-                    format!(
-                        "contains?: expected string as substring, got {}",
-                        args[1].type_name()
-                    ),
-                ),
-            );
-        };
-        return args[0]
-            .with_string(|haystack| {
-                (
-                    SIG_OK,
-                    if haystack.contains(&*needle) {
-                        Value::TRUE
-                    } else {
-                        Value::FALSE
-                    },
-                )
-            })
-            .unwrap();
-    }
-
-    // Mutable @string substring check
-    if let Some(buf_ref) = args[0].as_string_mut() {
-        let needle = if let Some(n) = args[1].with_string(|s| s.to_string()) {
-            n
-        } else {
-            return (
-                SIG_ERROR,
-                error_val(
-                    "type-error",
-                    format!(
-                        "contains?: expected string as substring, got {}",
-                        args[1].type_name()
-                    ),
-                ),
-            );
-        };
-        let borrowed = buf_ref.borrow();
-        let haystack = match String::from_utf8(borrowed.clone()) {
-            Ok(s) => s,
-            Err(e) => {
-                return (
-                    SIG_ERROR,
-                    error_val(
-                        "encoding-error",
-                        format!("contains?: buffer contains invalid UTF-8: {}", e),
-                    ),
-                )
-            }
-        };
-        return (
-            SIG_OK,
-            if haystack.contains(&*needle) {
-                Value::TRUE
-            } else {
-                Value::FALSE
-            },
-        );
-    }
-
-    (
-        SIG_ERROR,
-        error_val(
-            "type-error",
-            format!(
-                "contains?: expected set, string, or @string, got {}",
-                args[0].type_name()
-            ),
-        ),
-    )
 }
 
 /// Add an element to a set
@@ -239,22 +157,9 @@ pub(crate) fn prim_del(args: &[Value]) -> (SignalBits, Value) {
 /// Both arguments must be the same type (both immutable or both mutable).
 /// Returns a set containing all elements from both sets.
 pub(crate) fn prim_union(args: &[Value]) -> (SignalBits, Value) {
-    if let (Some(a), Some(b)) = (args[0].as_set(), args[1].as_set()) {
-        let sa: BTreeSet<Value> = a.iter().copied().collect();
-        let sb: BTreeSet<Value> = b.iter().copied().collect();
-        let result: BTreeSet<Value> = sa.union(&sb).copied().collect();
-        (SIG_OK, Value::set(result))
-    } else if let (Some(a), Some(b)) = (args[0].as_set_mut(), args[1].as_set_mut()) {
-        let result: BTreeSet<Value> = a.borrow().union(&*b.borrow()).copied().collect();
-        (SIG_OK, Value::set_mut(result))
-    } else {
-        (
-            SIG_ERROR,
-            error_val(
-                "type-error",
-                "union: both arguments must be sets or both must be mutable sets".to_string(),
-            ),
-        )
+    match coll_combine(&args[0], &args[1]) {
+        Ok(v) => (SIG_OK, v),
+        Err(e) => (SIG_ERROR, e),
     }
 }
 

--- a/src/primitives/sort.rs
+++ b/src/primitives/sort.rs
@@ -1,56 +1,20 @@
 //! Sort and range primitives
 use crate::primitives::def::PrimitiveDef;
+use crate::primitives::seq::seq_sort;
 use crate::signals::Signal;
 use crate::value::fiber::{SignalBits, SIG_ERROR, SIG_OK};
 use crate::value::types::Arity;
-use crate::value::{error_val, list, Value};
+use crate::value::{error_val, Value};
 
 /// Sort a collection in ascending order using the built-in value ordering.
 ///
 /// Type-preserving: @arrays mutated in place, arrays and lists return new sorted values.
 /// Supports any comparable values via Value::Ord.
 pub(crate) fn prim_sort(args: &[Value]) -> (SignalBits, Value) {
-    // Array — mutate in place
-    if let Some(arr) = args[0].as_array_mut() {
-        let mut vec = arr.borrow_mut();
-        vec.sort();
-        drop(vec);
-        return (SIG_OK, args[0]);
+    match seq_sort(&args[0]) {
+        Ok(v) => (SIG_OK, v),
+        Err(e) => (SIG_ERROR, e),
     }
-
-    // Array — return new sorted array
-    if let Some(elems) = args[0].as_array() {
-        let mut vec = elems.to_vec();
-        vec.sort();
-        return (SIG_OK, Value::array(vec));
-    }
-
-    // Empty list
-    if args[0].is_empty_list() {
-        return (SIG_OK, Value::EMPTY_LIST);
-    }
-
-    // List — collect, sort, rebuild
-    if args[0].is_pair() {
-        let vec = match args[0].list_to_vec() {
-            Ok(v) => v,
-            Err(e) => return (SIG_ERROR, error_val("type-error", format!("sort: {}", e))),
-        };
-        let mut sorted = vec;
-        sorted.sort();
-        return (SIG_OK, list(sorted));
-    }
-
-    (
-        SIG_ERROR,
-        error_val(
-            "type-error",
-            format!(
-                "sort: expected list, array, or tuple, got {}",
-                args[0].type_name()
-            ),
-        ),
-    )
 }
 
 /// Generate a range of numbers as an array.


### PR DESCRIPTION
Two new protocol modules consolidate repeated type dispatch across 20+ primitives into single-dispatch-point functions:

- collection.rs: coll_empty, coll_len, coll_has, coll_to_vec, coll_combine
- seq.rs: seq_first, seq_rest, seq_last, seq_nth, seq_butlast, seq_reverse, seq_slice, seq_sort, seq_push, seq_pop

Converted primitives delegate to protocol functions instead of repeating the 8-12 way type match inline. Net reduction of ~700 lines. Stepping stone for future trait-based dispatch via heap object trait tables.