### PR TITLE
Look through DerefCell in escape analysis for letrec-bound callees

### DIFF
--- a/src/lir/lower/escape.rs
+++ b/src/lir/lower/escape.rs
@@ -97,6 +97,11 @@ impl<'a> Lowerer<'a> {
                     }
                 }
             }
+            // DerefCell: functionalize wraps letrec bindings in cells.
+            // Treat like Var — the cell holds a pre-existing value.
+            HirKind::DerefCell { cell } => {
+                self.result_is_safe_impl(cell, scope_bindings, trust_return_safe)
+            }
 
             // Control flow: recurse into all result positions
             HirKind::If {
@@ -197,8 +202,17 @@ impl<'a> Lowerer<'a> {
                 // Extended mode: also trust calls to callee_return_safe functions.
                 // These are user functions proven (by fixpoint) to never return
                 // freshly heap-allocated values.
+                // Look through DerefCell (functionalize wraps letrec bindings).
                 if trust_return_safe {
-                    if let HirKind::Var(binding) = &func.kind {
+                    let binding = match &func.kind {
+                        HirKind::Var(b) => Some(b),
+                        HirKind::DerefCell { cell } => match &cell.kind {
+                            HirKind::Var(b) => Some(b),
+                            _ => None,
+                        },
+                        _ => None,
+                    };
+                    if let Some(binding) = binding {
                         if self
                             .callee_return_safe
                             .get(binding)
@@ -300,7 +314,15 @@ impl<'a> Lowerer<'a> {
         }
         // For Call expressions: check callee_result_immediate
         if let HirKind::Call { func, .. } = &hir.kind {
-            if let HirKind::Var(binding) = &func.kind {
+            let binding = match &func.kind {
+                HirKind::Var(b) => Some(b),
+                HirKind::DerefCell { cell } => match &cell.kind {
+                    HirKind::Var(b) => Some(b),
+                    _ => None,
+                },
+                _ => None,
+            };
+            if let Some(binding) = binding {
                 if self
                     .callee_result_immediate
                     .get(binding)
@@ -384,7 +406,16 @@ impl<'a> Lowerer<'a> {
                 if self.call_result_is_safe(func, args) {
                     return true;
                 }
-                if let HirKind::Var(binding) = &func.kind {
+                // Look through DerefCell (functionalize wraps letrec bindings)
+                let binding = match &func.kind {
+                    HirKind::Var(b) => Some(b),
+                    HirKind::DerefCell { cell } => match &cell.kind {
+                        HirKind::Var(b) => Some(b),
+                        _ => None,
+                    },
+                    _ => None,
+                };
+                if let Some(binding) = binding {
                     if self
                         .callee_result_immediate
                         .get(binding)

--- a/src/lir/lower/mod.rs
+++ b/src/lir/lower/mod.rs
@@ -1566,8 +1566,29 @@ impl<'a> Lowerer<'a> {
             HirKind::While { .. } | HirKind::Recur { .. } => true, // returns nil
             HirKind::Loop { body, .. } => self.body_result_is_immediate(body),
 
-            // ALL calls (tail or not): check if callee returns immediate
-            HirKind::Call { func, args, .. } => self.call_result_is_safe(func, args),
+            // ALL calls (tail or not): check if callee returns immediate.
+            // Look through DerefCell (functionalize wraps letrec bindings).
+            HirKind::Call { func, args, .. } => {
+                if self.call_result_is_safe(func, args) {
+                    return true;
+                }
+                let binding = match &func.kind {
+                    HirKind::Var(b) => Some(b),
+                    HirKind::DerefCell { cell } => match &cell.kind {
+                        HirKind::Var(b) => Some(b),
+                        _ => None,
+                    },
+                    _ => None,
+                };
+                if let Some(binding) = binding {
+                    return self
+                        .callee_result_immediate
+                        .get(binding)
+                        .copied()
+                        .unwrap_or(false);
+                }
+                false
+            }
 
             // Cell ops: MakeCell creates a heap cell, DerefCell/SetCell
             // may return heap values — conservatively not immediate.


### PR DESCRIPTION
Functionalize wraps letrec bindings in cells, so all calls to mutually-recursive functions appear as (deref-cell Var) rather than plain Var. Multiple escape analysis checks only matched plain Var, causing them to conservatively reject all letrec-bound calls:

- result_is_safe_impl: DerefCell fell to _ => false
- body_result_is_immediate: only checked call_result_is_safe (Var-only)
- result_is_safe_extended (callee_return_safe lookup): Var-only
- tail_arg_is_safe / tail_arg_is_safe_extended: Var-only

Fix: look through DerefCell consistently in all four sites.

Impact: nqueens(12) goes from >6GB (70K+ leaked pairs per call tree) to bounded allocation — rotation now fires for mutually-recursive backtracking patterns.