### PR TITLE
Value-flow propagation for closure properties in escape analysis

### DIFF
--- a/docs/memory.md
+++ b/docs/memory.md
@@ -1,68 +1,55 @@
 # Memory
 
 Elle has no garbage collector. Memory is managed deterministically through
-per-fiber tracked pools, compiler-directed scope reclamation, and tail-call
-pool rotation. These mechanisms are derived from the same static analysis that
-drives signal inference — the compiler knows at every allocation site whether
-the value can escape its scope, whether the containing function is a tail call,
+per-fiber tracked pools, compiler-directed scope reclamation, tail-call
+pool rotation, flip rotation, and deferred reference counting. These
+mechanisms are derived from the same static analysis that drives signal
+inference — the compiler knows at every allocation site whether the value
+can escape its scope, whether the containing function is a tail call,
 and whether the fiber will yield.
 
 ## How to write leak-free code
 
 Most Elle code is naturally leak-free. The three rules:
 
-### 1. Don't assign heap values to outer mutable bindings in a loop
+### 1. Don't push heap values into unbounded collections in a loop
 
 ```lisp
-# BAD: struct escapes to outer @var — linear growth
+# BAD: push stores heap structs into growing array — linear growth
+(def @acc @[])
+(def @i 0)
+(while (< i 100)
+  (push acc {:x i})
+  (assign i (+ i 1)))
+# the array grows without bound
+```
+
+Overwriting patterns (assign, put) are bounded thanks to deferred
+reference counting — the old value is decref'd and freed at scope exit:
+
+```lisp
+# OK: assign overwrites — old value freed via refcount decrement
 (def @last nil)
 (def @i 0)
 (while (< i 100)
   (assign last {:x i})
   (assign i (+ i 1)))
-# each iteration's struct stays alive — the old value of last is never freed
+# bounded: each old struct is freed when its refcount drops to zero
 
-# GOOD: let-bind the struct — scope reclamation frees it
-(def @i 0)
-(while (< i 100)
-  (let [x {:x i}]
-    x)
-  (assign i (+ i 1)))
-# the struct is reclaimed at each iteration's scope exit
-```
-
-```lisp
-# BAD: strings accumulate via concat to outer @var
-(def @s "")
-(def @i 0)
-(while (< i 100)
-  (assign s (concat s "x"))
-  (assign i (+ i 1)))
-
-# BAD: push stores heap structs into outer mutable array
-(def @acc [])
-(def @i 0)
-(while (< i 100)
-  (push acc {:x i})
-  (assign i (+ i 1)))
-
-# BAD: put stores heap strings into outer mutable struct
-(def @s {:x 0})
+# OK: put overwrites — old string freed via refcount decrement
+(def @s @{:x 0})
 (def @i 0)
 (while (< i 100)
   (put s :x (string "v" i))
   (assign i (+ i 1)))
+# bounded: each old string is freed on overwrite
 ```
-
-These patterns are inherently leaky — the value genuinely escapes the scope
-and must stay alive because something still references it. Fixing them requires
-drop-on-overwrite semantics (not yet implemented).
 
 ### 2. Prefer tail calls for loops with heap allocation
 
 ```lisp
 # Tail-recursive loop: trampoline rotation keeps memory bounded
-(defn process-all (n)
+(defn process-all [n]
   (if (= n 0)
     :done
     (begin
@@ -78,11 +65,11 @@ doesn't outlive the iteration:
 
 ```lisp
 # Mutual tail recursion — also bounded
-(defn ping (n)
+(defn ping [n]
   (if (= n 0) :done
     (begin (string "ping " n) (pong (- n 1)))))
 
-(defn pong (n)
+(defn pong [n]
   (if (= n 0) :done
     (begin (string "pong " n) (ping (- n 1)))))
 
@@ -97,7 +84,7 @@ pools each iteration:
 
 ```lisp
 # Yielding fiber — flip rotation keeps memory bounded
-(defn yield-items (n)
+(defn yield-items [n]
   (fiber/new (fn []
     (def @i 0)
     (while (< i n)
@@ -144,6 +131,32 @@ The escape analysis is conservative but handles common patterns:
 - `fiber/new` + `fiber/resume` within the same scope
 - `protect` expressions
 - `map`, `filter`, `each` over known-safe collections
+- Factory-returned closures (`(def proc (make-proc))`)
+- Binding aliases (`(def f existing-fn)`)
+- Conditional closures (`(def f (if ... (fn ...) (fn ...)))`)
+
+### Deferred reference counting
+
+The slab tracks a per-slot reference count for durable references — mutable
+collection entries and mutable bindings. Transient references (stack values,
+let bindings, function parameters) are handled by scope marks without
+refcount overhead.
+
+When a mutable binding is overwritten (`assign`) or a mutable collection
+entry is replaced (`put`), the old value's refcount is decremented. At
+scope exit, `RegionExitRefcounted` skips objects whose refcount is still
+positive (they're referenced by something outside the scope) and frees
+everything else. This makes overwrite-heavy patterns bounded:
+
+```lisp
+# Overwrite in a loop — bounded via refcounting
+(def @v (string "init"))
+(def @i 0)
+(while (< i 10000)
+  (assign v (string "val-" i))     # old string decref'd → freed
+  (assign i (+ i 1)))
+# net allocs: bounded (~30)
+```
 
 ### Tail-call rotation
 
@@ -177,8 +190,8 @@ tracked pool owned by the fiber.
 
 Each fiber owns a `FiberHeap` containing a `SlabPool` — a slab allocator for
 HeapObjects plus a bump arena for inline slice data, both backed by `mmap`
-pages. The slab allocates fixed-size HeapObject slots from 18KB chunks (256
-slots each). The bump arena allocates variable-size data (string bytes, array
+pages. The slab allocates fixed-size HeapObject slots from chunks of 256
+slots each. The bump arena allocates variable-size data (string bytes, array
 elements) sequentially into 64KB pages. Both use `munmap` to return pages to
 the OS on fiber death — no process-allocator caching, no RSS hoarding.
 
@@ -189,21 +202,16 @@ owned shared allocators and outboxes, and returns all mmap'd pages to the OS.
 
 The slab manages HeapObject slots:
 
-- **Chunks**: `mmap`'d regions of 256 HeapObject slots (~18KB each)
+- **Chunks**: `mmap`'d regions of 256 HeapObject slots each
 - **Allocation**: check free list first, then bump cursor within last chunk
-- **Deallocation**: write intrusive `Option<u32>` free-list link into the
-  dead slot's bytes, return to free list for reuse
+- **Deallocation**: write intrusive free-list link into the dead slot's bytes,
+  return to free list for reuse
+- **Reference counting**: per-slot `u32` refcount for durable references
+  (mutable bindings and collection entries). `incref`/`decref` manage the
+  count; `release_refcounted` skips pinned slots during scope exit
 - **Pointer stability**: chunk addresses never move; `Value` payloads are
   raw pointers into chunk slots
 - **OS return**: `munmap` on `Drop` returns chunk pages immediately
-
-Slot recycling via the free list is the target mechanism for drop-on-overwrite
-(assign frees the old slot) and scope reclamation (RegionExit frees batches).
-`dealloc_slot` is currently gated — scope eligibility for while/loop forms
-needs to be routed through the region inference system before enabling it.
-Rotation paths use `dealloc_slot_deferred()` (no-op) until Phase 2A enables
-rotation slot recycling. Until then, memory is reclaimed only on fiber death
-(teardown).
 
 ### Bump arena
 
@@ -225,7 +233,7 @@ elements):
 - `allocs: Vec<*mut HeapObject>` — every allocation in order (for rotation
   and scope release)
 - `dtors: Vec<*mut HeapObject>` — objects that need `Drop` (closures,
-  fibers, mutable types with `Rc<RefCell<...>>`)
+  fibers, mutable types)
 - `alloc_count` — running total for `arena/count` introspection
 
 `alloc(obj)` routes to the slab. `alloc_inline_slice(items)` routes to the
@@ -235,8 +243,10 @@ bump arena. `teardown()` clears both.
 
 `RegionEnter` pushes an `ArenaMark` recording the pool's position and destructor
 count. `RegionExit` pops the mark, runs destructors for objects allocated since
-the mark, and rewinds the pool. This is transparent to user code — it's
-entirely compiler-directed.
+the mark, and rewinds the pool. `RegionExitRefcounted` does the same but skips
+objects whose refcount is positive (they're referenced by durable bindings or
+collection entries). This is transparent to user code — it's entirely
+compiler-directed.
 
 ### Inter-fiber value exchange
 
@@ -248,12 +258,12 @@ inference:
 allocations to a `SharedAllocator` owned by the parent's `FiberHeap`. The
 parent reads yielded values directly — zero copy, zero serialization.
 
-**Outbox mechanism** (newer path): The parent installs an outbox `SlabPool`
-before child execution. Between `OutboxEnter`/`OutboxExit` bytecodes,
-allocations go to the outbox. At yield time, values in the private pool are
-deep-copied to the outbox; values already in the outbox are returned directly.
-Previous outboxes are preserved so the parent can read values from earlier
-yields. All outboxes are freed in bulk on fiber death.
+**Outbox mechanism**: The parent installs an outbox `SlabPool` before child
+execution. Between `OutboxEnter`/`OutboxExit` bytecodes, allocations go to
+the outbox. At yield time, values in the private pool are deep-copied to the
+outbox; values already in the outbox are returned directly. Previous outboxes
+are preserved so the parent can read values from earlier yields. All outboxes
+are freed in bulk on fiber death.
 
 **Silent fibers** (no yields): neither mechanism is needed. The fiber allocates
 exclusively into its own private pool with no indirection overhead.
@@ -297,8 +307,8 @@ The memory model exploits two properties that the compiler guarantees:
 
 Together, these give deterministic memory management with no GC pauses, no
 write barriers, no card tables, and no stop-the-world collection. Memory is
-reclaimed at four granularities: scope exit, tail-call rotation, flip
-rotation, and fiber death — all in bounded time.
+reclaimed at five granularities: scope exit, refcount-aware scope exit,
+tail-call rotation, flip rotation, and fiber death — all in bounded time.
 
 ## Introspection
 
@@ -370,19 +380,16 @@ For loop patterns, measure at two scales to detect linear leaks:
 
 ## Known leak patterns
 
-These patterns leak linearly and cannot be fixed without drop-on-overwrite
-semantics or reference counting:
+These patterns leak linearly because the value genuinely escapes to an
+unbounded accumulator:
 
 | Pattern | Why it leaks |
 |---------|-------------|
-| `(assign var (struct ...))` in a loop | Old value referenced by `var` |
-| `(assign s (concat s "x"))` in a loop | Old string referenced by `s` |
-| `(push arr (struct ...))` in a loop | Struct stored in growing array |
-| `(put s :key (string ...))` in a loop | Old string stored in struct |
+| `(push arr {:x i})` in a loop | Struct stored in growing array — every pushed value is kept alive |
+| `(assign acc (append acc [i]))` in a loop | Functional append creates new arrays; old array freed by refcount, but the new array grows without bound |
 
-These are inherent — the value genuinely escapes its scope. If you must
-accumulate, be aware that the accumulated data lives until the containing
-fiber dies.
+Overwrite patterns (`assign`, `put`) are **not** leaky — deferred reference
+counting frees old values at scope exit.
 
 ---
 

--- a/src/lir/lower/AGENTS.md
+++ b/src/lir/lower/AGENTS.md
@@ -133,6 +133,17 @@ checks `callee_result_immediate` or `callee_return_safe` for Call expressions
 at any depth. Used by `body_escapes_heap_values` (rotation safety) when the
 standard flat check fails.
 
+**Value-flow propagation (`callee_returns_*` + widen passes):**
+
+`precompute_returns_rotation_safe()` and `precompute_returns_param_safe()` determine
+whether each function's return positions always produce rotation-safe or param-safe
+closures. `widen_rotation_safety()` and `widen_param_safety()` then extend the
+`callee_rotation_safe` / `callee_param_safe` maps to cover non-Lambda bindings:
+factory returns (`(def proc (make-proc))`), aliases (`(def f g)`), conditional
+construction (`(def f (if ... (fn ...) (fn ...)))`), and nested factories.
+Uses `collect_all_bindings` to find all Define/Let/Letrec bindings regardless of
+init type, then resolves each through value-flow analysis with fixpoint iteration.
+
 **Known limitations and why they exist:**
 
 - **`suspends` (condition 2)**: Any let body that calls a polymorphic-signal

--- a/src/lir/lower/escape.rs
+++ b/src/lir/lower/escape.rs
@@ -1958,6 +1958,278 @@ impl<'a> Lowerer<'a> {
         false
     }
 
+    /// Walk a function body's return positions to check whether all
+    /// returned closures are rotation-safe.
+    ///
+    /// At each return position:
+    /// - Lambda: check `!body_escapes_heap_values(body)`
+    /// - Call: check `callee_returns_rotation_safe` for the callee
+    /// - Var: check `callee_rotation_safe` for the binding
+    /// - Control flow: all branches must satisfy
+    pub(super) fn body_returns_rotation_safe_closures(&self, hir: &Hir) -> bool {
+        match &hir.kind {
+            HirKind::Lambda { body, .. } => !self.body_escapes_heap_values(body),
+            HirKind::Call { func, .. } => {
+                let binding = self.extract_callee_binding(func);
+                match binding {
+                    Some(b) => self
+                        .callee_returns_rotation_safe
+                        .get(b)
+                        .copied()
+                        .unwrap_or(false),
+                    None => false,
+                }
+            }
+            HirKind::Var(b) => self.callee_rotation_safe.get(b).copied().unwrap_or(false),
+            HirKind::DerefCell { cell } => self.body_returns_rotation_safe_closures(cell),
+            HirKind::If {
+                then_branch,
+                else_branch,
+                ..
+            } => {
+                self.body_returns_rotation_safe_closures(then_branch)
+                    && self.body_returns_rotation_safe_closures(else_branch)
+            }
+            HirKind::Begin(exprs) => exprs
+                .last()
+                .is_none_or(|e| self.body_returns_rotation_safe_closures(e)),
+            HirKind::Let { body, .. } | HirKind::Letrec { body, .. } => {
+                self.body_returns_rotation_safe_closures(body)
+            }
+            HirKind::Cond {
+                clauses,
+                else_branch,
+            } => {
+                clauses
+                    .iter()
+                    .all(|(_, b)| self.body_returns_rotation_safe_closures(b))
+                    && else_branch
+                        .as_ref()
+                        .is_none_or(|b| self.body_returns_rotation_safe_closures(b))
+            }
+            HirKind::Match { arms, .. } => arms
+                .iter()
+                .all(|(_, _, body)| self.body_returns_rotation_safe_closures(body)),
+            HirKind::Block { body, .. } => body
+                .last()
+                .is_none_or(|e| self.body_returns_rotation_safe_closures(e)),
+            _ => false, // conservative
+        }
+    }
+
+    /// Walk a function body's return positions to check whether all
+    /// returned closures are param-safe.
+    pub(super) fn body_returns_param_safe_closures(&self, hir: &Hir) -> bool {
+        match &hir.kind {
+            HirKind::Lambda { body, params, .. } => {
+                !self.body_stores_params_externally(body, params)
+            }
+            HirKind::Call { func, .. } => {
+                let binding = self.extract_callee_binding(func);
+                match binding {
+                    Some(b) => self
+                        .callee_returns_param_safe
+                        .get(b)
+                        .copied()
+                        .unwrap_or(false),
+                    None => false,
+                }
+            }
+            HirKind::Var(b) => self.callee_param_safe.get(b).copied().unwrap_or(false),
+            HirKind::DerefCell { cell } => self.body_returns_param_safe_closures(cell),
+            HirKind::If {
+                then_branch,
+                else_branch,
+                ..
+            } => {
+                self.body_returns_param_safe_closures(then_branch)
+                    && self.body_returns_param_safe_closures(else_branch)
+            }
+            HirKind::Begin(exprs) => exprs
+                .last()
+                .is_none_or(|e| self.body_returns_param_safe_closures(e)),
+            HirKind::Let { body, .. } | HirKind::Letrec { body, .. } => {
+                self.body_returns_param_safe_closures(body)
+            }
+            HirKind::Cond {
+                clauses,
+                else_branch,
+            } => {
+                clauses
+                    .iter()
+                    .all(|(_, b)| self.body_returns_param_safe_closures(b))
+                    && else_branch
+                        .as_ref()
+                        .is_none_or(|b| self.body_returns_param_safe_closures(b))
+            }
+            HirKind::Match { arms, .. } => arms
+                .iter()
+                .all(|(_, _, body)| self.body_returns_param_safe_closures(body)),
+            HirKind::Block { body, .. } => body
+                .last()
+                .is_none_or(|e| self.body_returns_param_safe_closures(e)),
+            _ => false, // conservative
+        }
+    }
+
+    /// Resolve the rotation-safety of a non-Lambda init expression.
+    /// Returns `Some(true/false)` if resolvable, `None` if dependencies
+    /// haven't been resolved yet.
+    pub(super) fn resolve_value_rotation_safe(&self, hir: &Hir) -> Option<bool> {
+        match &hir.kind {
+            HirKind::Lambda { body, .. } => Some(!self.body_escapes_heap_values(body)),
+            HirKind::Call { func, .. } => {
+                let binding = self.extract_callee_binding(func);
+                match binding {
+                    Some(b) => self
+                        .callee_returns_rotation_safe
+                        .get(b)
+                        .copied()
+                        .map(Some)?,
+                    None => Some(false),
+                }
+            }
+            HirKind::Var(b) => self
+                .callee_rotation_safe
+                .get(b)
+                .copied()
+                .map(Some)
+                .or(Some(None))?,
+            HirKind::DerefCell { cell } => self.resolve_value_rotation_safe(cell),
+            HirKind::If {
+                then_branch,
+                else_branch,
+                ..
+            } => {
+                let t = self.resolve_value_rotation_safe(then_branch)?;
+                let e = self.resolve_value_rotation_safe(else_branch)?;
+                Some(t && e)
+            }
+            HirKind::Begin(exprs) => exprs
+                .last()
+                .map_or(Some(true), |e| self.resolve_value_rotation_safe(e)),
+            HirKind::Let { body, .. } | HirKind::Letrec { body, .. } => {
+                self.resolve_value_rotation_safe(body)
+            }
+            HirKind::Cond {
+                clauses,
+                else_branch,
+            } => {
+                let mut all = true;
+                for (_, b) in clauses {
+                    match self.resolve_value_rotation_safe(b) {
+                        Some(v) => all = all && v,
+                        None => return None,
+                    }
+                }
+                if let Some(e) = else_branch {
+                    match self.resolve_value_rotation_safe(e) {
+                        Some(v) => all = all && v,
+                        None => return None,
+                    }
+                }
+                Some(all)
+            }
+            HirKind::Match { arms, .. } => {
+                let mut all = true;
+                for (_, _, body) in arms {
+                    match self.resolve_value_rotation_safe(body) {
+                        Some(v) => all = all && v,
+                        None => return None,
+                    }
+                }
+                Some(all)
+            }
+            HirKind::Block { body, .. } => body
+                .last()
+                .map_or(Some(true), |e| self.resolve_value_rotation_safe(e)),
+            _ => None, // can't determine
+        }
+    }
+
+    /// Resolve the param-safety of a non-Lambda init expression.
+    pub(super) fn resolve_value_param_safe(&self, hir: &Hir) -> Option<bool> {
+        match &hir.kind {
+            HirKind::Lambda { body, params, .. } => {
+                Some(!self.body_stores_params_externally(body, params))
+            }
+            HirKind::Call { func, .. } => {
+                let binding = self.extract_callee_binding(func);
+                match binding {
+                    Some(b) => self.callee_returns_param_safe.get(b).copied().map(Some)?,
+                    None => Some(false),
+                }
+            }
+            HirKind::Var(b) => self
+                .callee_param_safe
+                .get(b)
+                .copied()
+                .map(Some)
+                .or(Some(None))?,
+            HirKind::DerefCell { cell } => self.resolve_value_param_safe(cell),
+            HirKind::If {
+                then_branch,
+                else_branch,
+                ..
+            } => {
+                let t = self.resolve_value_param_safe(then_branch)?;
+                let e = self.resolve_value_param_safe(else_branch)?;
+                Some(t && e)
+            }
+            HirKind::Begin(exprs) => exprs
+                .last()
+                .map_or(Some(true), |e| self.resolve_value_param_safe(e)),
+            HirKind::Let { body, .. } | HirKind::Letrec { body, .. } => {
+                self.resolve_value_param_safe(body)
+            }
+            HirKind::Cond {
+                clauses,
+                else_branch,
+            } => {
+                let mut all = true;
+                for (_, b) in clauses {
+                    match self.resolve_value_param_safe(b) {
+                        Some(v) => all = all && v,
+                        None => return None,
+                    }
+                }
+                if let Some(e) = else_branch {
+                    match self.resolve_value_param_safe(e) {
+                        Some(v) => all = all && v,
+                        None => return None,
+                    }
+                }
+                Some(all)
+            }
+            HirKind::Match { arms, .. } => {
+                let mut all = true;
+                for (_, _, body) in arms {
+                    match self.resolve_value_param_safe(body) {
+                        Some(v) => all = all && v,
+                        None => return None,
+                    }
+                }
+                Some(all)
+            }
+            HirKind::Block { body, .. } => body
+                .last()
+                .map_or(Some(true), |e| self.resolve_value_param_safe(e)),
+            _ => None, // can't determine
+        }
+    }
+
+    /// Extract the Binding from a callee expression (Var or DerefCell{Var}).
+    fn extract_callee_binding<'h>(&self, func: &'h Hir) -> Option<&'h Binding> {
+        match &func.kind {
+            HirKind::Var(b) => Some(b),
+            HirKind::DerefCell { cell } => match &cell.kind {
+                HirKind::Var(b) => Some(b),
+                _ => None,
+            },
+            _ => None,
+        }
+    }
+
     /// Check if an expression is statically proven to produce an immediate
     /// (non-heap) Value. Conservative: returns false if we cannot prove it.
     ///

--- a/src/lir/lower/mod.rs
+++ b/src/lir/lower/mod.rs
@@ -307,6 +307,14 @@ pub struct Lowerer<'a> {
     /// to see through call boundaries that `call_result_is_safe` rejects
     /// (e.g. letrec-bound functions).
     callee_return_safe: HashMap<Binding, bool>,
+    /// Binding → returns_rotation_safe for function definitions.
+    /// A function returns-rotation-safe if all closures it returns are
+    /// rotation-safe (their bodies don't escape heap values).
+    callee_returns_rotation_safe: HashMap<Binding, bool>,
+    /// Binding → returns_param_safe for function definitions.
+    /// A function returns-param-safe if all closures it returns are
+    /// param-safe (their bodies don't store params externally).
+    callee_returns_param_safe: HashMap<Binding, bool>,
     /// Binding → result_is_immediate for function definitions.
     /// Precomputed via fixpoint iteration so that `call_result_is_safe`
     /// can identify user functions that always return immediates.
@@ -389,6 +397,8 @@ impl<'a> Lowerer<'a> {
             callee_rotation_safe: HashMap::new(),
             callee_param_safe: HashMap::new(),
             callee_return_safe: HashMap::new(),
+            callee_returns_rotation_safe: HashMap::new(),
+            callee_returns_param_safe: HashMap::new(),
             callee_result_immediate: HashMap::new(),
             callee_return_params: HashMap::new(),
             callee_rest_index: HashMap::new(),
@@ -525,6 +535,10 @@ impl<'a> Lowerer<'a> {
         self.precompute_return_safe(hir);
         self.precompute_param_safety(hir);
         self.precompute_rotation_safety(hir);
+        self.precompute_returns_rotation_safe(hir);
+        self.precompute_returns_param_safe(hir);
+        self.widen_rotation_safety(hir);
+        self.widen_param_safety(hir);
 
         let result_reg = self.lower_expr(hir)?;
         self.terminate(Terminator::Return(result_reg));
@@ -1692,6 +1706,246 @@ impl<'a> Lowerer<'a> {
         // Record stats
         self.scope_stats.rotation_analyzed = defs.len();
         self.scope_stats.rotation_safe = self.callee_rotation_safe.values().filter(|&&v| v).count();
+    }
+
+    /// Precompute `callee_returns_rotation_safe` for all function definitions.
+    ///
+    /// A function returns-rotation-safe if every closure it returns (in all
+    /// return positions) is itself rotation-safe. This enables the widen pass
+    /// to resolve `(def proc (factory))` — if `factory` returns-rotation-safe,
+    /// then `proc` is rotation-safe.
+    fn precompute_returns_rotation_safe(&mut self, hir: &Hir) {
+        let mut defs: Vec<(Binding, &Hir)> = Vec::new();
+        Self::collect_lambda_defs(hir, &mut defs);
+        if defs.is_empty() {
+            return;
+        }
+
+        // Seed: all functions optimistically return rotation-safe closures.
+        for &(binding, _) in &defs {
+            self.callee_returns_rotation_safe.insert(binding, true);
+        }
+
+        // Iterate until stable.
+        loop {
+            let mut changed = false;
+            for &(binding, body) in &defs {
+                if !self.callee_returns_rotation_safe[&binding] {
+                    continue;
+                }
+                if !self.body_returns_rotation_safe_closures(body) {
+                    self.callee_returns_rotation_safe.insert(binding, false);
+                    changed = true;
+                }
+            }
+            if !changed {
+                break;
+            }
+        }
+    }
+
+    /// Precompute `callee_returns_param_safe` for all function definitions.
+    fn precompute_returns_param_safe(&mut self, hir: &Hir) {
+        let mut defs: Vec<(Binding, &Hir)> = Vec::new();
+        Self::collect_lambda_defs(hir, &mut defs);
+        if defs.is_empty() {
+            return;
+        }
+
+        // Seed: all functions optimistically return param-safe closures.
+        for &(binding, _) in &defs {
+            self.callee_returns_param_safe.insert(binding, true);
+        }
+
+        // Iterate until stable.
+        loop {
+            let mut changed = false;
+            for &(binding, body) in &defs {
+                if !self.callee_returns_param_safe[&binding] {
+                    continue;
+                }
+                if !self.body_returns_param_safe_closures(body) {
+                    self.callee_returns_param_safe.insert(binding, false);
+                    changed = true;
+                }
+            }
+            if !changed {
+                break;
+            }
+        }
+    }
+
+    /// Widen `callee_rotation_safe` to cover non-Lambda bindings.
+    ///
+    /// After the Lambda-only fixpoints and returns_* fixpoints have run,
+    /// this pass iterates over ALL bindings (including those with Call,
+    /// Var, If, etc. inits) and resolves their rotation-safety using
+    /// value-flow analysis.
+    fn widen_rotation_safety(&mut self, hir: &Hir) {
+        let mut all_bindings: Vec<(Binding, &Hir)> = Vec::new();
+        Self::collect_all_bindings(hir, &mut all_bindings);
+
+        loop {
+            let mut changed = false;
+            for &(binding, init) in &all_bindings {
+                if self.callee_rotation_safe.contains_key(&binding) {
+                    continue; // already resolved
+                }
+                if let Some(safe) = self.resolve_value_rotation_safe(init) {
+                    self.callee_rotation_safe.insert(binding, safe);
+                    changed = true;
+                }
+            }
+            if !changed {
+                break;
+            }
+        }
+    }
+
+    /// Widen `callee_param_safe` to cover non-Lambda bindings.
+    fn widen_param_safety(&mut self, hir: &Hir) {
+        let mut all_bindings: Vec<(Binding, &Hir)> = Vec::new();
+        Self::collect_all_bindings(hir, &mut all_bindings);
+
+        loop {
+            let mut changed = false;
+            for &(binding, init) in &all_bindings {
+                if self.callee_param_safe.contains_key(&binding) {
+                    continue; // already resolved
+                }
+                if let Some(safe) = self.resolve_value_param_safe(init) {
+                    self.callee_param_safe.insert(binding, safe);
+                    changed = true;
+                }
+            }
+            if !changed {
+                break;
+            }
+        }
+    }
+
+    /// Collect ALL `(binding, init_expr)` pairs from Define/Let/Letrec,
+    /// regardless of whether the init is a Lambda. Used by widen passes.
+    fn collect_all_bindings<'b>(hir: &'b Hir, out: &mut Vec<(Binding, &'b Hir)>) {
+        match &hir.kind {
+            HirKind::Define { binding, value } => {
+                out.push((*binding, value));
+                Self::collect_all_bindings(value, out);
+            }
+            HirKind::Begin(exprs) => {
+                for e in exprs {
+                    Self::collect_all_bindings(e, out);
+                }
+            }
+            HirKind::Let { bindings, body } | HirKind::Letrec { bindings, body } => {
+                for (binding, init) in bindings {
+                    out.push((*binding, init));
+                    Self::collect_all_bindings(init, out);
+                }
+                Self::collect_all_bindings(body, out);
+            }
+            HirKind::Lambda { body, .. } => {
+                Self::collect_all_bindings(body, out);
+            }
+            HirKind::While { cond, body } => {
+                Self::collect_all_bindings(cond, out);
+                Self::collect_all_bindings(body, out);
+            }
+            HirKind::Loop { bindings, body } => {
+                for (binding, init) in bindings {
+                    out.push((*binding, init));
+                    Self::collect_all_bindings(init, out);
+                }
+                Self::collect_all_bindings(body, out);
+            }
+            HirKind::Recur { args } => {
+                for a in args {
+                    Self::collect_all_bindings(a, out);
+                }
+            }
+            HirKind::If {
+                cond,
+                then_branch,
+                else_branch,
+            } => {
+                Self::collect_all_bindings(cond, out);
+                Self::collect_all_bindings(then_branch, out);
+                Self::collect_all_bindings(else_branch, out);
+            }
+            HirKind::Cond {
+                clauses,
+                else_branch,
+            } => {
+                for (c, b) in clauses {
+                    Self::collect_all_bindings(c, out);
+                    Self::collect_all_bindings(b, out);
+                }
+                if let Some(e) = else_branch {
+                    Self::collect_all_bindings(e, out);
+                }
+            }
+            HirKind::Block { body, .. } => {
+                for e in body {
+                    Self::collect_all_bindings(e, out);
+                }
+            }
+            HirKind::Break { value, .. } => Self::collect_all_bindings(value, out),
+            HirKind::Match { value, arms } => {
+                Self::collect_all_bindings(value, out);
+                for (_, guard, body) in arms {
+                    if let Some(g) = guard {
+                        Self::collect_all_bindings(g, out);
+                    }
+                    Self::collect_all_bindings(body, out);
+                }
+            }
+            HirKind::Call { func, args, .. } => {
+                Self::collect_all_bindings(func, out);
+                for a in args {
+                    Self::collect_all_bindings(&a.expr, out);
+                }
+            }
+            HirKind::Assign { value, .. } => Self::collect_all_bindings(value, out),
+            HirKind::And(exprs) | HirKind::Or(exprs) => {
+                for e in exprs {
+                    Self::collect_all_bindings(e, out);
+                }
+            }
+            HirKind::Emit { value, .. } => Self::collect_all_bindings(value, out),
+            HirKind::Destructure { value, .. } => Self::collect_all_bindings(value, out),
+            HirKind::Eval { expr, env } => {
+                Self::collect_all_bindings(expr, out);
+                Self::collect_all_bindings(env, out);
+            }
+            HirKind::Parameterize { bindings, body } => {
+                for (k, v) in bindings {
+                    Self::collect_all_bindings(k, out);
+                    Self::collect_all_bindings(v, out);
+                }
+                Self::collect_all_bindings(body, out);
+            }
+            HirKind::MakeCell { value } => Self::collect_all_bindings(value, out),
+            HirKind::DerefCell { cell } => Self::collect_all_bindings(cell, out),
+            HirKind::SetCell { cell, value } => {
+                Self::collect_all_bindings(cell, out);
+                Self::collect_all_bindings(value, out);
+            }
+            HirKind::Intrinsic { args, .. } => {
+                for a in args {
+                    Self::collect_all_bindings(a, out);
+                }
+            }
+            HirKind::Nil
+            | HirKind::EmptyList
+            | HirKind::Bool(_)
+            | HirKind::Int(_)
+            | HirKind::Float(_)
+            | HirKind::String(_)
+            | HirKind::Keyword(_)
+            | HirKind::Var(_)
+            | HirKind::Quote(_)
+            | HirKind::Error => {}
+        }
     }
 
     /// Collect all `(binding, lambda_body)` pairs from Define nodes.

--- a/tests/elle/leak.lisp
+++ b/tests/elle/leak.lisp
@@ -1291,3 +1291,94 @@
       d10k (t12-wrap-map 10000)]
   (assert (or checked? (bounded? d100 d10k 30))
           (string "t12 wrap-map: d100=" d100 " d10k=" d10k)))
+
+# ── Tier 13: value-flow propagation ───────────────────────────
+# Closures obtained through non-Lambda value paths (factory calls,
+# aliases, conditional construction) should be recognized as
+# rotation-safe / param-safe so the caller's while loop can reclaim.
+
+# 13a: factory function returning a closure
+(defn make-proc []
+  (fn [i] {:x i}))
+
+(defn t13-factory [n]
+  (def proc (make-proc))
+  (def before (arena/count))
+  (def @i 0)
+  (while (%lt i n)
+    (proc i)
+    (assign i (%add i 1)))
+  (%sub (arena/count) before))
+
+(let [d100 (t13-factory 100)
+      d10k (t13-factory 10000)]
+  (assert (or checked? (bounded? d100 d10k 30))
+          (string "t13 factory: d100=" d100 " d10k=" d10k)))
+
+# 13b: conditional factory — both branches return closures
+(defn make-thing [mode]
+  (if (= mode :fast) (fn [x] {:fast x}) (fn [x] {:slow x})))
+
+(defn t13-cond-factory [n]
+  (def proc (make-thing :fast))
+  (def before (arena/count))
+  (def @i 0)
+  (while (%lt i n)
+    (proc i)
+    (assign i (%add i 1)))
+  (%sub (arena/count) before))
+
+(let [d100 (t13-cond-factory 100)
+      d10k (t13-cond-factory 10000)]
+  (assert (or checked? (bounded? d100 d10k 30))
+          (string "t13 cond-factory: d100=" d100 " d10k=" d10k)))
+
+# 13c: alias to a known-safe function
+(defn t13-alias [n]
+  (def f make-struct)
+  (def before (arena/count))
+  (def @i 0)
+  (while (%lt i n)
+    (f i)
+    (assign i (%add i 1)))
+  (%sub (arena/count) before))
+
+(let [d100 (t13-alias 100)
+      d10k (t13-alias 10000)]
+  (assert (or checked? (bounded? d100 d10k 30))
+          (string "t13 alias: d100=" d100 " d10k=" d10k)))
+
+# 13d: nested factory — factory calls another factory
+(defn make-inner []
+  (fn [x] {:x x}))
+(defn make-outer []
+  (make-inner))
+
+(defn t13-nested-factory [n]
+  (def proc (make-outer))
+  (def before (arena/count))
+  (def @i 0)
+  (while (%lt i n)
+    (proc i)
+    (assign i (%add i 1)))
+  (%sub (arena/count) before))
+
+(let [d100 (t13-nested-factory 100)
+      d10k (t13-nested-factory 10000)]
+  (assert (or checked? (bounded? d100 d10k 30))
+          (string "t13 nested-factory: d100=" d100 " d10k=" d10k)))
+
+# 13e: let-bound alias
+(defn t13-let-alias [n]
+  (let [f make-struct]
+    (def before (arena/count))
+    (def @i 0)
+    (while (%lt i n)
+      (f i)
+      (assign i (%add i 1)))
+    (%sub (arena/count) before)))
+
+(let [d100 (t13-let-alias 100)
+      d10k (t13-let-alias 10000)]
+  (assert (or checked? (bounded? d100 d10k 30))
+          (string "t13 let-alias: d100=" d100 " d10k=" d10k)))


### PR DESCRIPTION
Escape analysis previously only recognized rotation-safe and param-safe properties for bindings directly assigned to Lambda nodes. Bindings whose closures arrive through factory calls, aliases, conditional branches, or nested factories were invisible — causing scope marks to be rejected and memory to grow linearly.

Add returns_rotation_safe / returns_param_safe fixpoints that determine what properties a function's returned closures have, then widen passes that extend the property maps to all non-Lambda bindings via value-flow analysis (Call → returns_*, Var → direct lookup, If/Cond/Match → all branches). Update docs/memory.md to reflect refcounting and current reclamation capabilities.