### PR TITLE
Hammer time: dead code removal, bug fixes, and simplification

### DIFF
--- a/docs/memory.md
+++ b/docs/memory.md
@@ -1,55 +1,68 @@
 # Memory
 
 Elle has no garbage collector. Memory is managed deterministically through
-per-fiber tracked pools, compiler-directed scope reclamation, tail-call
-pool rotation, flip rotation, and deferred reference counting. These
-mechanisms are derived from the same static analysis that drives signal
-inference — the compiler knows at every allocation site whether the value
-can escape its scope, whether the containing function is a tail call,
+per-fiber tracked pools, compiler-directed scope reclamation, and tail-call
+pool rotation. These mechanisms are derived from the same static analysis that
+drives signal inference — the compiler knows at every allocation site whether
+the value can escape its scope, whether the containing function is a tail call,
 and whether the fiber will yield.
 
 ## How to write leak-free code
 
 Most Elle code is naturally leak-free. The three rules:
 
-### 1. Don't push heap values into unbounded collections in a loop
+### 1. Don't assign heap values to outer mutable bindings in a loop
 
 ```lisp
-# BAD: push stores heap structs into growing array — linear growth
-(def @acc @[])
-(def @i 0)
-(while (< i 100)
-  (push acc {:x i})
-  (assign i (+ i 1)))
-# the array grows without bound
-```
-
-Overwriting patterns (assign, put) are bounded thanks to deferred
-reference counting — the old value is decref'd and freed at scope exit:
-
-```lisp
-# OK: assign overwrites — old value freed via refcount decrement
+# BAD: struct escapes to outer @var — linear growth
 (def @last nil)
 (def @i 0)
 (while (< i 100)
   (assign last {:x i})
   (assign i (+ i 1)))
-# bounded: each old struct is freed when its refcount drops to zero
+# each iteration's struct stays alive — the old value of last is never freed
 
-# OK: put overwrites — old string freed via refcount decrement
-(def @s @{:x 0})
+# GOOD: let-bind the struct — scope reclamation frees it
+(def @i 0)
+(while (< i 100)
+  (let [x {:x i}]
+    x)
+  (assign i (+ i 1)))
+# the struct is reclaimed at each iteration's scope exit
+```
+
+```lisp
+# BAD: strings accumulate via concat to outer @var
+(def @s "")
+(def @i 0)
+(while (< i 100)
+  (assign s (concat s "x"))
+  (assign i (+ i 1)))
+
+# BAD: push stores heap structs into outer mutable array
+(def @acc [])
+(def @i 0)
+(while (< i 100)
+  (push acc {:x i})
+  (assign i (+ i 1)))
+
+# BAD: put stores heap strings into outer mutable struct
+(def @s {:x 0})
 (def @i 0)
 (while (< i 100)
   (put s :x (string "v" i))
   (assign i (+ i 1)))
-# bounded: each old string is freed on overwrite
 ```
+
+These patterns are inherently leaky — the value genuinely escapes the scope
+and must stay alive because something still references it. Fixing them requires
+drop-on-overwrite semantics (not yet implemented).
 
 ### 2. Prefer tail calls for loops with heap allocation
 
 ```lisp
 # Tail-recursive loop: trampoline rotation keeps memory bounded
-(defn process-all [n]
+(defn process-all (n)
   (if (= n 0)
     :done
     (begin
@@ -65,11 +78,11 @@ doesn't outlive the iteration:
 
 ```lisp
 # Mutual tail recursion — also bounded
-(defn ping [n]
+(defn ping (n)
   (if (= n 0) :done
     (begin (string "ping " n) (pong (- n 1)))))
 
-(defn pong [n]
+(defn pong (n)
   (if (= n 0) :done
     (begin (string "pong " n) (ping (- n 1)))))
 
@@ -84,7 +97,7 @@ pools each iteration:
 
 ```lisp
 # Yielding fiber — flip rotation keeps memory bounded
-(defn yield-items [n]
+(defn yield-items (n)
   (fiber/new (fn []
     (def @i 0)
     (while (< i n)
@@ -131,32 +144,6 @@ The escape analysis is conservative but handles common patterns:
 - `fiber/new` + `fiber/resume` within the same scope
 - `protect` expressions
 - `map`, `filter`, `each` over known-safe collections
-- Factory-returned closures (`(def proc (make-proc))`)
-- Binding aliases (`(def f existing-fn)`)
-- Conditional closures (`(def f (if ... (fn ...) (fn ...)))`)
-
-### Deferred reference counting
-
-The slab tracks a per-slot reference count for durable references — mutable
-collection entries and mutable bindings. Transient references (stack values,
-let bindings, function parameters) are handled by scope marks without
-refcount overhead.
-
-When a mutable binding is overwritten (`assign`) or a mutable collection
-entry is replaced (`put`), the old value's refcount is decremented. At
-scope exit, `RegionExitRefcounted` skips objects whose refcount is still
-positive (they're referenced by something outside the scope) and frees
-everything else. This makes overwrite-heavy patterns bounded:
-
-```lisp
-# Overwrite in a loop — bounded via refcounting
-(def @v (string "init"))
-(def @i 0)
-(while (< i 10000)
-  (assign v (string "val-" i))     # old string decref'd → freed
-  (assign i (+ i 1)))
-# net allocs: bounded (~30)
-```
 
 ### Tail-call rotation
 
@@ -190,8 +177,8 @@ tracked pool owned by the fiber.
 
 Each fiber owns a `FiberHeap` containing a `SlabPool` — a slab allocator for
 HeapObjects plus a bump arena for inline slice data, both backed by `mmap`
-pages. The slab allocates fixed-size HeapObject slots from chunks of 256
-slots each. The bump arena allocates variable-size data (string bytes, array
+pages. The slab allocates fixed-size HeapObject slots from 18KB chunks (256
+slots each). The bump arena allocates variable-size data (string bytes, array
 elements) sequentially into 64KB pages. Both use `munmap` to return pages to
 the OS on fiber death — no process-allocator caching, no RSS hoarding.
 
@@ -202,16 +189,21 @@ owned shared allocators and outboxes, and returns all mmap'd pages to the OS.
 
 The slab manages HeapObject slots:
 
-- **Chunks**: `mmap`'d regions of 256 HeapObject slots each
+- **Chunks**: `mmap`'d regions of 256 HeapObject slots (~18KB each)
 - **Allocation**: check free list first, then bump cursor within last chunk
-- **Deallocation**: write intrusive free-list link into the dead slot's bytes,
-  return to free list for reuse
-- **Reference counting**: per-slot `u32` refcount for durable references
-  (mutable bindings and collection entries). `incref`/`decref` manage the
-  count; `release_refcounted` skips pinned slots during scope exit
+- **Deallocation**: write intrusive `Option<u32>` free-list link into the
+  dead slot's bytes, return to free list for reuse
 - **Pointer stability**: chunk addresses never move; `Value` payloads are
   raw pointers into chunk slots
 - **OS return**: `munmap` on `Drop` returns chunk pages immediately
+
+Slot recycling via the free list is the target mechanism for drop-on-overwrite
+(assign frees the old slot) and scope reclamation (RegionExit frees batches).
+`dealloc_slot` is currently gated — scope eligibility for while/loop forms
+needs to be routed through the region inference system before enabling it.
+Rotation paths use `dealloc_slot_deferred()` (no-op) until Phase 2A enables
+rotation slot recycling. Until then, memory is reclaimed only on fiber death
+(teardown).
 
 ### Bump arena
 
@@ -233,7 +225,7 @@ elements):
 - `allocs: Vec<*mut HeapObject>` — every allocation in order (for rotation
   and scope release)
 - `dtors: Vec<*mut HeapObject>` — objects that need `Drop` (closures,
-  fibers, mutable types)
+  fibers, mutable types with `Rc<RefCell<...>>`)
 - `alloc_count` — running total for `arena/count` introspection
 
 `alloc(obj)` routes to the slab. `alloc_inline_slice(items)` routes to the
@@ -243,10 +235,8 @@ bump arena. `teardown()` clears both.
 
 `RegionEnter` pushes an `ArenaMark` recording the pool's position and destructor
 count. `RegionExit` pops the mark, runs destructors for objects allocated since
-the mark, and rewinds the pool. `RegionExitRefcounted` does the same but skips
-objects whose refcount is positive (they're referenced by durable bindings or
-collection entries). This is transparent to user code — it's entirely
-compiler-directed.
+the mark, and rewinds the pool. This is transparent to user code — it's
+entirely compiler-directed.
 
 ### Inter-fiber value exchange
 
@@ -258,12 +248,12 @@ inference:
 allocations to a `SharedAllocator` owned by the parent's `FiberHeap`. The
 parent reads yielded values directly — zero copy, zero serialization.
 
-**Outbox mechanism**: The parent installs an outbox `SlabPool` before child
-execution. Between `OutboxEnter`/`OutboxExit` bytecodes, allocations go to
-the outbox. At yield time, values in the private pool are deep-copied to the
-outbox; values already in the outbox are returned directly. Previous outboxes
-are preserved so the parent can read values from earlier yields. All outboxes
-are freed in bulk on fiber death.
+**Outbox mechanism** (newer path): The parent installs an outbox `SlabPool`
+before child execution. Between `OutboxEnter`/`OutboxExit` bytecodes,
+allocations go to the outbox. At yield time, values in the private pool are
+deep-copied to the outbox; values already in the outbox are returned directly.
+Previous outboxes are preserved so the parent can read values from earlier
+yields. All outboxes are freed in bulk on fiber death.
 
 **Silent fibers** (no yields): neither mechanism is needed. The fiber allocates
 exclusively into its own private pool with no indirection overhead.
@@ -307,8 +297,8 @@ The memory model exploits two properties that the compiler guarantees:
 
 Together, these give deterministic memory management with no GC pauses, no
 write barriers, no card tables, and no stop-the-world collection. Memory is
-reclaimed at five granularities: scope exit, refcount-aware scope exit,
-tail-call rotation, flip rotation, and fiber death — all in bounded time.
+reclaimed at four granularities: scope exit, tail-call rotation, flip
+rotation, and fiber death — all in bounded time.
 
 ## Introspection
 
@@ -380,16 +370,19 @@ For loop patterns, measure at two scales to detect linear leaks:
 
 ## Known leak patterns
 
-These patterns leak linearly because the value genuinely escapes to an
-unbounded accumulator:
+These patterns leak linearly and cannot be fixed without drop-on-overwrite
+semantics or reference counting:
 
 | Pattern | Why it leaks |
 |---------|-------------|
-| `(push arr {:x i})` in a loop | Struct stored in growing array — every pushed value is kept alive |
-| `(assign acc (append acc [i]))` in a loop | Functional append creates new arrays; old array freed by refcount, but the new array grows without bound |
+| `(assign var (struct ...))` in a loop | Old value referenced by `var` |
+| `(assign s (concat s "x"))` in a loop | Old string referenced by `s` |
+| `(push arr (struct ...))` in a loop | Struct stored in growing array |
+| `(put s :key (string ...))` in a loop | Old string stored in struct |
 
-Overwrite patterns (`assign`, `put`) are **not** leaky — deferred reference
-counting frees old values at scope exit.
+These are inherent — the value genuinely escapes its scope. If you must
+accumulate, be aware that the accumulated data lives until the containing
+fiber dies.
 
 ---
 

--- a/lib/resource.lisp
+++ b/lib/resource.lisp
@@ -1,7 +1,7 @@
 (elle/epoch 10)
 ## lib/resource.lisp — Deterministic resource consumption measurement.
 ##
-## Measures discrete, deterministic counters (allocation counts, intern table
+## Measures discrete, deterministic counters (allocation counts, symbol table
 ## sizes, etc.) — not wall-clock time. Same program always gives same numbers,
 ## making these ideal for CI regression detection.
 ##
@@ -24,7 +24,6 @@
     "Capture all resource counters at a point in time."
     {:objects (arena/count)
      :bytes (arena/bytes)
-     :interns (debug/intern-count)
      :symbols (debug/symbol-count)
      :keywords (debug/keyword-count)})
 
@@ -48,7 +47,6 @@
      Before-snapshot uses raw scalars (no struct) to avoid tainting peak."
     (let* [b-objects (arena/count)
            b-bytes (arena/bytes)
-           b-interns (debug/intern-count)
            b-symbols (debug/symbol-count)
            b-keywords (debug/keyword-count)
            _ (arena/reset-peak)
@@ -58,7 +56,6 @@
        :allocs (rest pair)
        :peak peak
        :bytes (- (arena/bytes) b-bytes)
-       :interns (- (debug/intern-count) b-interns)
        :symbols (- (debug/symbol-count) b-symbols)
        :keywords (- (debug/keyword-count) b-keywords)}))
 
@@ -79,8 +76,7 @@
     "Format a measurement as a tab-separated key=value line."
     (let [n (pad-right name 24)]
       (string n "\tallocs=" (m :allocs) "\tpeak=" (m :peak) "\tbytes="
-              (m :bytes) "\tinterns=" (m :interns) "\tsymbols=" (m :symbols)
-              "\tkeywords=" (m :keywords))))
+              (m :bytes) "\tsymbols=" (m :symbols) "\tkeywords=" (m :keywords))))
 
   ## ── Suite ───────────────────────────────────────────────────────────
 

--- a/src/arithmetic.rs
+++ b/src/arithmetic.rs
@@ -137,6 +137,27 @@ pub(crate) fn abs_value(a: &Value) -> Result<Value, Value> {
     }
 }
 
+/// Numeric-aware equality: int-int stays exact, mixed promotes to f64.
+/// Returns true if both values are bitwise equal or numerically equal.
+/// Used by both the VM's Eq instruction and the `=` primitive.
+#[inline]
+pub(crate) fn values_eq(a: &Value, b: &Value) -> bool {
+    // Fast path: bitwise identical (covers same-type immediates)
+    if *a == *b {
+        return true;
+    }
+    // Numeric coercion: int-int stays exact, mixed promotes to f64
+    if a.is_number() && b.is_number() {
+        if let (Some(x), Some(y)) = (a.as_int(), b.as_int()) {
+            return x == y;
+        }
+        if let (Some(x), Some(y)) = (a.as_number(), b.as_number()) {
+            return x == y;
+        }
+    }
+    false
+}
+
 /// Get minimum of two numeric values
 pub(crate) fn min_values(a: &Value, b: &Value) -> Value {
     match (a.as_int(), b.as_int()) {

--- a/src/config.rs
+++ b/src/config.rs
@@ -63,8 +63,6 @@ pub enum JitPolicy {
     Eager,
     /// Compile after N calls (default: threshold=10).
     Adaptive { threshold: usize },
-    /// Only compile silent, capture-free functions.
-    Conservative,
     /// Defer to an Elle closure stored on the VM (see `vm/config`).
     Custom,
 }
@@ -82,7 +80,6 @@ impl JitPolicy {
             JitPolicy::Off => usize::MAX,
             JitPolicy::Eager => 0,
             JitPolicy::Adaptive { threshold } => *threshold,
-            JitPolicy::Conservative => 10,
             JitPolicy::Custom => 0,
         }
     }
@@ -93,7 +90,6 @@ impl JitPolicy {
             JitPolicy::Off => "off",
             JitPolicy::Eager => "eager",
             JitPolicy::Adaptive { .. } => "adaptive",
-            JitPolicy::Conservative => "conservative",
             JitPolicy::Custom => "custom",
         }
     }
@@ -104,7 +100,6 @@ impl JitPolicy {
             "off" => Some(JitPolicy::Off),
             "eager" => Some(JitPolicy::Eager),
             "adaptive" => Some(JitPolicy::Adaptive { threshold: 10 }),
-            "conservative" => Some(JitPolicy::Conservative),
             "custom" => Some(JitPolicy::Custom),
             _ => None,
         }
@@ -122,8 +117,6 @@ pub enum WasmPolicy {
     Full,
     /// Per-function lazy compilation after N calls.
     Lazy { threshold: usize },
-    /// Per-module WASM compilation (future).
-    Modular,
 }
 
 impl WasmPolicy {
@@ -132,7 +125,6 @@ impl WasmPolicy {
             WasmPolicy::Off => "off",
             WasmPolicy::Full => "full",
             WasmPolicy::Lazy { .. } => "lazy",
-            WasmPolicy::Modular => "modular",
         }
     }
 
@@ -141,7 +133,6 @@ impl WasmPolicy {
             "off" => Some(WasmPolicy::Off),
             "full" => Some(WasmPolicy::Full),
             "lazy" => Some(WasmPolicy::Lazy { threshold: 10 }),
-            "modular" => Some(WasmPolicy::Modular),
             _ => None,
         }
     }
@@ -322,89 +313,28 @@ pub struct RuntimeConfig {
     pub mlir: MlirPolicy,
     /// Print bytecode before execution.
     pub debug_bytecode: bool,
-    /// Active compiler-stage dumps (see `DUMP_KEYWORDS`).
-    pub dump: HashSet<String>,
-    /// Bitfield cache mirroring `dump`.
-    pub dump_bits: u32,
     /// Print compilation stats on exit.
     pub stats: bool,
-    /// Whether flip instructions are enabled.
-    pub flip: bool,
 }
 
 impl RuntimeConfig {
     /// Build a RuntimeConfig from the static global Config.
     pub fn from_static_config(config: &Config) -> Self {
-        let jit = if config.jit == 0 {
-            JitPolicy::Off
-        } else if config.jit == 1 {
-            JitPolicy::Eager
-        } else {
-            JitPolicy::Adaptive {
-                threshold: (config.jit - 1) as usize,
-            }
-        };
-
-        let wasm = if config.wasm_full {
-            WasmPolicy::Full
-        } else if config.wasm > 0 {
-            WasmPolicy::Lazy {
-                threshold: (config.wasm - 1) as usize,
-            }
-        } else {
-            WasmPolicy::Off
-        };
-
-        let mlir = if config.mlir == 0 {
-            MlirPolicy::Off
-        } else if config.mlir == 1 {
-            MlirPolicy::Eager
-        } else {
-            MlirPolicy::Adaptive {
-                threshold: (config.mlir - 1) as usize,
-            }
-        };
-
-        // Map old debug_* flags to trace keywords
         let mut trace = HashSet::new();
         let mut bits = 0u32;
-        if config.debug {
-            trace.insert("bytecode".to_string());
-            bits |= trace_bits::BYTECODE;
-        }
-        if config.debug_jit {
-            trace.insert("jit".to_string());
-            bits |= trace_bits::JIT;
-        }
-        if config.debug_resume {
-            trace.insert("fiber".to_string());
-            bits |= trace_bits::FIBER;
-        }
-        if config.debug_stack {
-            trace.insert("call".to_string());
-            bits |= trace_bits::CALL;
-        }
-        if config.debug_wasm {
-            trace.insert("wasm".to_string());
-            bits |= trace_bits::WASM;
-        }
-
-        let mut dump_bits_u = 0u32;
-        for kw in &config.dump {
-            dump_bits_u |= dump_bits::from_name(kw);
+        for kw in &config.trace_keywords {
+            trace.insert(kw.clone());
+            bits |= trace_bits::from_name(kw);
         }
 
         RuntimeConfig {
             trace,
             trace_bits: bits,
-            jit,
-            wasm,
-            mlir,
-            debug_bytecode: config.debug,
-            dump: config.dump.clone(),
-            dump_bits: dump_bits_u,
+            jit: config.jit.clone(),
+            wasm: config.wasm.clone(),
+            mlir: config.mlir.clone(),
+            debug_bytecode: bits & trace_bits::BYTECODE != 0,
             stats: config.stats,
-            flip: config.flip_instructions,
         }
     }
 
@@ -423,12 +353,6 @@ impl RuntimeConfig {
     pub fn has_trace_bit(&self, bit: u32) -> bool {
         self.trace_bits & bit != 0
     }
-
-    /// Check if a dump bit is set.
-    #[inline(always)]
-    pub fn has_dump_bit(&self, bit: u32) -> bool {
-        self.dump_bits & bit != 0
-    }
 }
 
 impl Default for RuntimeConfig {
@@ -440,10 +364,7 @@ impl Default for RuntimeConfig {
             wasm: WasmPolicy::Off,
             mlir: MlirPolicy::Adaptive { threshold: 10 },
             debug_bytecode: false,
-            dump: HashSet::new(),
-            dump_bits: 0,
             stats: false,
-            flip: true,
         }
     }
 }
@@ -471,24 +392,17 @@ impl Default for RuntimeConfig {
 /// Default: 0 (disabled).
 #[derive(Debug, Clone)]
 pub struct Config {
-    // -- JIT --
-    /// JIT hotness value from `--jit=N`. 0 = disabled, N = threshold is N-1.
-    pub jit: u32,
+    /// JIT compilation policy.
+    pub jit: JitPolicy,
 
     /// Print compilation stats on exit.
     pub stats: bool,
 
-    // -- MLIR --
-    /// MLIR tier value from `--mlir=N`. 0 = disabled, 1 = eager, N = threshold is N-1.
-    /// Default: 11 (threshold 10, same as JIT).
-    pub mlir: u32,
+    /// MLIR compilation policy for GPU-eligible functions.
+    pub mlir: MlirPolicy,
 
-    // -- WASM --
-    /// WASM tier value from `--wasm=N`. 0 = disabled, N = threshold is N-1.
-    pub wasm: u32,
-
-    /// Full-module WASM mode (`--wasm=full`).
-    pub wasm_full: bool,
+    /// WASM compilation policy.
+    pub wasm: WasmPolicy,
 
     /// Skip stdlib in full-module WASM mode.
     pub wasm_no_stdlib: bool,
@@ -512,22 +426,6 @@ pub struct Config {
     // -- Output --
     /// JSON output on stderr (errors, stats, timing).
     pub json: bool,
-
-    // -- Debug (old flags, mapped to RuntimeConfig on VM init) --
-    /// Print bytecode before execution.
-    pub debug: bool,
-
-    /// Print JIT compilation decisions.
-    pub debug_jit: bool,
-
-    /// Print fiber resume traces.
-    pub debug_resume: bool,
-
-    /// Print stack operations.
-    pub debug_stack: bool,
-
-    /// Print WASM host call traces.
-    pub debug_wasm: bool,
 
     /// Dump WASM module bytes to /tmp/elle-wasm-dump.wasm.
     pub wasm_dump: bool,
@@ -568,22 +466,16 @@ pub struct Config {
 impl Default for Config {
     fn default() -> Self {
         Config {
-            jit: 11,
+            jit: JitPolicy::Adaptive { threshold: 10 },
             stats: false,
-            mlir: 11,
-            wasm: 0,
-            wasm_full: false,
+            mlir: MlirPolicy::Adaptive { threshold: 10 },
+            wasm: WasmPolicy::Off,
             wasm_no_stdlib: false,
             cache: default_cache_dir(),
             no_uring: false,
             home: std::env::var("ELLE_HOME").ok(),
             path: std::env::var("ELLE_PATH").ok(),
             json: false,
-            debug: false,
-            debug_jit: false,
-            debug_resume: false,
-            debug_stack: false,
-            debug_wasm: false,
             wasm_dump: false,
             wasm_lir: false,
             wasm_chunk: false,
@@ -597,24 +489,24 @@ impl Default for Config {
 }
 
 impl Config {
+    /// Check if a trace keyword is set.
+    pub fn has_trace(&self, keyword: &str) -> bool {
+        self.trace_keywords.iter().any(|k| k == keyword)
+    }
+
     /// Whether JIT compilation is enabled.
     pub fn jit_enabled(&self) -> bool {
-        self.jit > 0
+        self.jit.enabled()
     }
 
-    /// JIT hotness threshold (calls before compilation).
-    pub fn jit_threshold(&self) -> usize {
-        self.jit.saturating_sub(1) as usize
-    }
-
-    /// Whether WASM tiered compilation is enabled.
+    /// Whether WASM tiered compilation is enabled (lazy mode).
     pub fn wasm_tier_enabled(&self) -> bool {
-        self.wasm > 0
+        matches!(self.wasm, WasmPolicy::Lazy { .. })
     }
 
-    /// WASM tier hotness threshold.
-    pub fn wasm_threshold(&self) -> usize {
-        self.wasm.saturating_sub(1) as usize
+    /// Whether full-module WASM mode is enabled.
+    pub fn wasm_full(&self) -> bool {
+        matches!(self.wasm, WasmPolicy::Full)
     }
 
     /// Parse CLI arguments into a Config and remaining positional args.
@@ -639,57 +531,78 @@ impl Config {
 
             // --key=value style
             if let Some(rest) = arg.strip_prefix("--jit=") {
-                // Named policies: off, eager, adaptive
-                match rest {
-                    "off" => config.jit = 0,
-                    "eager" => config.jit = 1,
-                    "adaptive" => config.jit = 11,
+                config.jit = match rest {
+                    "off" => JitPolicy::Off,
+                    "eager" => JitPolicy::Eager,
+                    "adaptive" => JitPolicy::Adaptive { threshold: 10 },
                     _ => {
-                        config.jit = rest.parse::<u32>().map_err(|_| {
+                        let n: u32 = rest.parse().map_err(|_| {
                             format!(
                                 "--jit: expected integer or policy name (off/eager/adaptive), got '{}'",
                                 rest
                             )
                         })?;
+                        if n == 0 {
+                            JitPolicy::Off
+                        } else if n == 1 {
+                            JitPolicy::Eager
+                        } else {
+                            JitPolicy::Adaptive {
+                                threshold: (n - 1) as usize,
+                            }
+                        }
                     }
-                }
+                };
                 i += 1;
                 continue;
             }
             if let Some(rest) = arg.strip_prefix("--mlir=") {
-                match rest {
-                    "off" => config.mlir = 0,
-                    "eager" => config.mlir = 1,
-                    "adaptive" => config.mlir = 11,
+                config.mlir = match rest {
+                    "off" => MlirPolicy::Off,
+                    "eager" => MlirPolicy::Eager,
+                    "adaptive" => MlirPolicy::Adaptive { threshold: 10 },
                     _ => {
-                        config.mlir = rest.parse::<u32>().map_err(|_| {
+                        let n: u32 = rest.parse().map_err(|_| {
                             format!(
                                 "--mlir: expected integer or policy name (off/eager/adaptive), got '{}'",
                                 rest
                             )
                         })?;
+                        if n == 0 {
+                            MlirPolicy::Off
+                        } else if n == 1 {
+                            MlirPolicy::Eager
+                        } else {
+                            MlirPolicy::Adaptive {
+                                threshold: (n - 1) as usize,
+                            }
+                        }
                     }
-                }
+                };
                 i += 1;
                 continue;
             }
             if let Some(rest) = arg.strip_prefix("--wasm=") {
-                match rest {
-                    "off" => {
-                        config.wasm = 0;
-                        config.wasm_full = false;
-                    }
-                    "full" => config.wasm_full = true,
-                    "lazy" => config.wasm = 11,
+                config.wasm = match rest {
+                    "off" => WasmPolicy::Off,
+                    "full" => WasmPolicy::Full,
+                    "lazy" => WasmPolicy::Lazy { threshold: 10 },
                     _ => {
-                        config.wasm = rest.parse::<u32>().map_err(|_| {
+                        let n: u32 = rest.parse().map_err(|_| {
                             format!(
                                 "--wasm: expected integer or policy name (off/full/lazy), got '{}'",
                                 rest
                             )
                         })?;
+                        if n == 0 {
+                            WasmPolicy::Off
+                        } else {
+                            WasmPolicy::Lazy {
+                                threshold: (n - 1) as usize,
+                            }
+                        }
                     }
-                }
+                };
                 i += 1;
                 continue;
             }
@@ -715,18 +628,6 @@ impl Config {
                         if !kw.is_empty() {
                             config.trace_keywords.push(kw.to_string());
                         }
-                    }
-                }
-                // Also set old debug_* flags for backward compat with code
-                // that still checks them directly (wasm paths, etc.)
-                for kw in &config.trace_keywords {
-                    match kw.as_str() {
-                        "jit" => config.debug_jit = true,
-                        "fiber" => config.debug_resume = true,
-                        "call" => config.debug_stack = true,
-                        "wasm" => config.debug_wasm = true,
-                        "bytecode" => config.debug = true,
-                        _ => {}
                     }
                 }
                 i += 1;
@@ -782,35 +683,20 @@ impl Config {
                 "--stats" => config.stats = true,
                 "--wasm-no-stdlib" => config.wasm_no_stdlib = true,
                 "--no-uring" => config.no_uring = true,
-                // Old debug flags — kept as aliases
-                "--debug" => {
-                    config.debug = true;
-                    config.trace_keywords.push("bytecode".into());
-                }
-                "--debug-jit" => {
-                    config.debug_jit = true;
-                    config.trace_keywords.push("jit".into());
-                }
-                "--debug-resume" => {
-                    config.debug_resume = true;
-                    config.trace_keywords.push("fiber".into());
-                }
-                "--debug-stack" => {
-                    config.debug_stack = true;
-                    config.trace_keywords.push("call".into());
-                }
-                "--debug-wasm" => {
-                    config.debug_wasm = true;
-                    config.trace_keywords.push("wasm".into());
-                }
+                // Old debug flags — kept as aliases for --trace=<kw>
+                "--debug" => config.trace_keywords.push("bytecode".into()),
+                "--debug-jit" => config.trace_keywords.push("jit".into()),
+                "--debug-resume" => config.trace_keywords.push("fiber".into()),
+                "--debug-stack" => config.trace_keywords.push("call".into()),
+                "--debug-wasm" => config.trace_keywords.push("wasm".into()),
                 "--wasm-dump" => config.wasm_dump = true,
                 "--wasm-lir" => config.wasm_lir = true,
                 "--wasm-chunk" => config.wasm_chunk = true,
                 "--wasm-no-sparse-spill" => config.wasm_sparse_spill = false,
                 "--checked-intrinsics" => {
                     config.checked_intrinsics = true;
-                    config.jit = 0;
-                    config.mlir = 0;
+                    config.jit = JitPolicy::Off;
+                    config.mlir = MlirPolicy::Off;
                 }
                 "--eval" | "-e" => {
                     i += 1;
@@ -835,13 +721,13 @@ impl Config {
         }
 
         // --checked-intrinsics requires JIT and MLIR off
-        if config.checked_intrinsics && config.jit > 0 {
+        if config.checked_intrinsics && config.jit.enabled() {
             return Err(
                 "--checked-intrinsics is incompatible with --jit (JIT would bypass type checks)"
                     .to_string(),
             );
         }
-        if config.checked_intrinsics && config.mlir > 0 {
+        if config.checked_intrinsics && config.mlir.enabled() {
             return Err(
                 "--checked-intrinsics is incompatible with --mlir (MLIR would bypass type checks)"
                     .to_string(),

--- a/src/context.rs
+++ b/src/context.rs
@@ -54,3 +54,59 @@ pub fn resolve_symbol_name(sym_id: u32) -> Option<String> {
             .map(|s| s.to_string())
     }
 }
+
+// ── RAII guards ─────────────────────────────────────────────────────
+//
+// Scoped guards that save the previous TLS value on construction and
+// restore it on drop.  This prevents:
+//  - forgetting to clear (use-after-free on stack unwind)
+//  - forgetting to restore after nested set/clear (subprocess pattern)
+
+/// RAII guard for the VM context TLS slot.
+/// On drop, restores the previous value (which may be None).
+pub struct VmContextGuard {
+    prev: Option<*mut VM>,
+}
+
+impl VmContextGuard {
+    /// Set the VM context for the current scope.  The previous value
+    /// is saved and restored when the guard is dropped.
+    pub fn new(vm: &mut VM) -> Self {
+        let prev = get_vm_context();
+        set_vm_context(vm as *mut VM);
+        VmContextGuard { prev }
+    }
+}
+
+impl Drop for VmContextGuard {
+    fn drop(&mut self) {
+        match self.prev {
+            Some(ptr) => set_vm_context(ptr),
+            None => clear_vm_context(),
+        }
+    }
+}
+
+/// RAII guard for the symbol table TLS slot.
+/// On drop, restores the previous value (which may be None).
+pub struct SymbolTableGuard {
+    prev: Option<*mut SymbolTable>,
+}
+
+impl SymbolTableGuard {
+    /// Set the symbol table context for the current scope.
+    pub fn new(symbols: &mut SymbolTable) -> Self {
+        let prev = unsafe { get_symbol_table() };
+        set_symbol_table(symbols as *mut SymbolTable);
+        SymbolTableGuard { prev }
+    }
+}
+
+impl Drop for SymbolTableGuard {
+    fn drop(&mut self) {
+        match self.prev {
+            Some(ptr) => set_symbol_table(ptr),
+            None => clear_symbol_table(),
+        }
+    }
+}

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -12,6 +12,28 @@ pub use types::{ErrorKind, LError, LResult, StackFrame, TraceSource};
 /// Mapping from bytecode instruction index to source location
 pub type LocationMap = HashMap<usize, SourceLoc>;
 
+/// Parse a "file:line:col: message" error string into components.
+/// Returns `Some((file, line, col, message))` on success, `None` if the
+/// string doesn't match the expected format.
+pub fn parse_located_error(error: &str) -> Option<(&str, usize, usize, &str)> {
+    let colon_idx = error.find(": ")?;
+    let loc_part = &error[..colon_idx];
+    let parts: Vec<&str> = loc_part.rsplitn(3, ':').collect();
+    if parts.len() >= 2 {
+        let col = parts[0].parse::<usize>().ok()?;
+        let line = parts[1].parse::<usize>().ok()?;
+        let file = if parts.len() == 3 {
+            parts[2]
+        } else {
+            "<unknown>"
+        };
+        let message = &error[colon_idx + 2..];
+        Some((file, line, col, message))
+    } else {
+        None
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/hir/lint.rs
+++ b/src/hir/lint.rs
@@ -5,7 +5,6 @@
 
 use crate::hir::arena::BindingArena;
 use crate::hir::expr::{Hir, HirKind};
-use crate::hir::pattern::is_exhaustive_match;
 use crate::lint::diagnostics::{Diagnostic, Severity};
 use crate::lint::rules;
 use crate::reader::SourceLoc;
@@ -31,11 +30,6 @@ impl HirLinter {
     /// Get all diagnostics
     pub fn diagnostics(&self) -> &[Diagnostic] {
         &self.diagnostics
-    }
-
-    /// Get mutable diagnostics
-    pub fn diagnostics_mut(&mut self) -> &mut Vec<Diagnostic> {
-        &mut self.diagnostics
     }
 
     /// Check if there are any errors
@@ -82,23 +76,7 @@ impl HirLinter {
             }
 
             HirKind::Letrec { bindings, body } => {
-                for (binding, init) in bindings {
-                    // Check naming convention on file-level def/var bindings.
-                    // Skip gensyms (__file_expr_N) and primitive bindings
-                    // (identified by their initializer being a quoted NativeFn).
-                    let is_primitive = matches!(&init.kind, HirKind::Quote(v) if v.is_native_fn());
-                    if !is_primitive {
-                        if let Some(sym_name) = symbols.name(arena.get(*binding).name) {
-                            if !sym_name.starts_with("__") {
-                                let binding_loc = Self::span_to_loc(&init.span);
-                                rules::check_naming_convention(
-                                    sym_name,
-                                    &binding_loc,
-                                    &mut self.diagnostics,
-                                );
-                            }
-                        }
-                    }
+                for (_, init) in bindings {
                     self.check(init, symbols, arena);
                 }
                 self.check(body, symbols, arena);
@@ -171,11 +149,7 @@ impl HirLinter {
                 self.check(value, symbols, arena);
             }
 
-            HirKind::Define { binding, value } => {
-                // Check naming convention
-                if let Some(sym_name) = symbols.name(arena.get(*binding).name) {
-                    rules::check_naming_convention(sym_name, &loc, &mut self.diagnostics);
-                }
+            HirKind::Define { binding: _, value } => {
                 self.check(value, symbols, arena);
             }
 
@@ -208,17 +182,6 @@ impl HirLinter {
                         self.check(g, symbols, arena);
                     }
                     self.check(body, symbols, arena);
-                }
-
-                // Check for non-exhaustive match
-                if !arms.is_empty() && !is_exhaustive_match(arms) {
-                    self.diagnostics.push(Diagnostic::new(
-                        Severity::Warning,
-                        "W003",
-                        "non-exhaustive-match",
-                        "match expression may not cover all cases; consider adding a wildcard (_) or variable pattern as the last arm",
-                        loc.clone(),
-                    ));
                 }
             }
 
@@ -295,40 +258,6 @@ mod tests {
         assert_eq!(linter.diagnostics().len(), 0);
         assert!(!linter.has_errors());
         assert!(!linter.has_warnings());
-    }
-
-    #[test]
-    fn test_hir_linter_naming_convention() {
-        let (mut symbols, mut vm) = setup();
-        let result = analyze("(var camelCase 42)", &mut symbols, &mut vm, "<test>");
-        assert!(result.is_ok());
-        let analysis = result.unwrap();
-
-        let mut linter = HirLinter::new();
-        linter.lint(&analysis.hir, &symbols, &analysis.arena);
-
-        assert!(linter.has_warnings());
-        assert!(linter
-            .diagnostics()
-            .iter()
-            .any(|d| d.rule == "naming-kebab-case"));
-    }
-
-    #[test]
-    fn test_hir_linter_valid_naming() {
-        let (mut symbols, mut vm) = setup();
-        let result = analyze("(var valid-name 42)", &mut symbols, &mut vm, "<test>");
-        assert!(result.is_ok());
-        let analysis = result.unwrap();
-
-        let mut linter = HirLinter::new();
-        linter.lint(&analysis.hir, &symbols, &analysis.arena);
-
-        // Should have no naming warnings
-        assert!(!linter
-            .diagnostics()
-            .iter()
-            .any(|d| d.rule == "naming-kebab-case"));
     }
 
     #[test]

--- a/src/lint/cli.rs
+++ b/src/lint/cli.rs
@@ -1,6 +1,6 @@
 //! Lint CLI wrapper — configuration, output formatting, and the Linter type.
 
-use crate::context::set_symbol_table;
+use crate::context::SymbolTableGuard;
 use crate::hir::HirLinter;
 use crate::lint::diagnostics::{Diagnostic, Severity};
 use crate::symbol::SymbolTable;
@@ -47,7 +47,7 @@ impl Linter {
         let mut symbols = SymbolTable::new();
         let mut vm = VM::new();
         let _signals = register_primitives(&mut vm, &mut symbols);
-        set_symbol_table(&mut symbols as *mut SymbolTable);
+        let _sym_guard = SymbolTableGuard::new(&mut symbols);
         init_stdlib(&mut vm, &mut symbols);
 
         // Use pipeline: parse -> expand -> analyze -> HIR
@@ -99,34 +99,24 @@ impl Linter {
         Diagnostic::new(Severity::Error, code, rule, error.description(), Some(loc))
     }
 
-    /// Convert a String error (from fatal analysis failure) to a Diagnostic
     fn error_to_diagnostic(error: &str, file: &str) -> Diagnostic {
-        // Try to parse location from "file:line:col: message" format
-        if let Some(colon_idx) = error.find(": ") {
-            let loc_part = &error[..colon_idx];
-            let parts: Vec<&str> = loc_part.rsplitn(3, ':').collect();
-            if parts.len() >= 2 {
-                if let (Ok(col), Ok(line)) = (parts[0].parse::<usize>(), parts[1].parse::<usize>())
-                {
-                    let file_part = if parts.len() == 3 { parts[2] } else { file };
-                    let message = &error[colon_idx + 2..];
-                    return Diagnostic::new(
-                        Severity::Error,
-                        "E000",
-                        "analysis-error",
-                        message,
-                        Some(crate::reader::SourceLoc::new(file_part, line, col)),
-                    );
-                }
-            }
+        if let Some((f, line, col, message)) = crate::error::parse_located_error(error) {
+            Diagnostic::new(
+                Severity::Error,
+                "E000",
+                "analysis-error",
+                message,
+                Some(crate::reader::SourceLoc::new(f, line, col)),
+            )
+        } else {
+            Diagnostic::new(
+                Severity::Error,
+                "E000",
+                "analysis-error",
+                error,
+                Some(crate::reader::SourceLoc::new(file, 0, 0)),
+            )
         }
-        Diagnostic::new(
-            Severity::Error,
-            "E000",
-            "analysis-error",
-            error,
-            Some(crate::reader::SourceLoc::new(file, 0, 0)),
-        )
     }
 
     /// Lint a file

--- a/src/lint/diagnostics.rs
+++ b/src/lint/diagnostics.rs
@@ -3,11 +3,6 @@
 use crate::reader::SourceLoc;
 use std::fmt;
 
-/// Optional source code for displaying diagnostics with context
-pub struct DiagnosticContext {
-    pub source: String,
-}
-
 /// Severity level of a diagnostic
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Severity {
@@ -53,11 +48,6 @@ impl Diagnostic {
             location,
             suggestions: Vec::new(),
         }
-    }
-
-    pub fn with_suggestions(mut self, suggestions: Vec<String>) -> Self {
-        self.suggestions = suggestions;
-        self
     }
 
     /// Format as human-readable output
@@ -161,14 +151,14 @@ mod tests {
         let loc = SourceLoc::from_line_col(5, 2);
         let diag = Diagnostic::new(
             Severity::Warning,
-            "W001",
-            "naming-kebab-case",
-            "identifier should use kebab-case",
+            "W002",
+            "arity-mismatch",
+            "function expects 1 argument but got 2",
             Some(loc),
         );
 
         assert_eq!(diag.severity, Severity::Warning);
-        assert_eq!(diag.rule, "naming-kebab-case");
+        assert_eq!(diag.rule, "arity-mismatch");
     }
 
     #[test]

--- a/src/lint/mod.rs
+++ b/src/lint/mod.rs
@@ -8,5 +8,4 @@ pub mod rules;
 pub mod run;
 
 pub use cli::{LintConfig, Linter, OutputFormat};
-pub use diagnostics::{Diagnostic, DiagnosticContext, Severity};
-pub use rules::check_naming_convention;
+pub use diagnostics::{Diagnostic, Severity};

--- a/src/lint/rules.rs
+++ b/src/lint/rules.rs
@@ -6,49 +6,6 @@ use crate::reader::SourceLoc;
 use crate::value::types::Arity;
 use crate::value::SymbolId;
 
-/// Check naming conventions for a symbol
-pub fn check_naming_convention(
-    name: &str,
-    location: &Option<SourceLoc>,
-    diagnostics: &mut Vec<Diagnostic>,
-) {
-    // Allow single letter variables and built-in functions
-    if name.len() == 1 {
-        return;
-    }
-
-    // Check for kebab-case requirement
-    // Allowed suffixes: ? (predicate), ! (mutation)
-    let base_name = if name.ends_with('?') || name.ends_with('!') {
-        &name[..name.len() - 1]
-    } else {
-        name
-    };
-
-    // Check if it's valid kebab-case
-    if !is_valid_kebab_case(base_name) {
-        let suggestion = to_kebab_case(base_name);
-        let suggested_name = if name.ends_with('?') {
-            format!("{}?", suggestion)
-        } else if name.ends_with('!') {
-            format!("{}!", suggestion)
-        } else {
-            suggestion
-        };
-
-        let diag = Diagnostic::new(
-            Severity::Warning,
-            "W001",
-            "naming-kebab-case",
-            format!("identifier '{}' should use kebab-case", name),
-            location.clone(),
-        )
-        .with_suggestions(vec![format!("rename to '{}'", suggested_name)]);
-
-        diagnostics.push(diag);
-    }
-}
-
 /// Check arity of a function call
 pub(crate) fn check_call_arity(
     func_sym: SymbolId,
@@ -76,39 +33,6 @@ pub(crate) fn check_call_arity(
     }
 }
 
-/// Check if a name is valid kebab-case
-fn is_valid_kebab_case(s: &str) -> bool {
-    if s.is_empty() {
-        return false;
-    }
-
-    // Must be all lowercase letters, numbers, and hyphens
-    // Cannot start or end with hyphen
-    if s.starts_with('-') || s.ends_with('-') {
-        return false;
-    }
-
-    // Must contain only lowercase, digits, and hyphens
-    s.chars()
-        .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
-}
-
-/// Convert a string to kebab-case
-fn to_kebab_case(s: &str) -> String {
-    let mut result = String::new();
-
-    for (i, c) in s.chars().enumerate() {
-        if i > 0 && c.is_ascii_uppercase() {
-            result.push('-');
-            result.push(c.to_ascii_lowercase());
-        } else {
-            result.push(c.to_ascii_lowercase());
-        }
-    }
-
-    result
-}
-
 /// Get arity of a built-in function by looking up `PrimitiveDef::PRIMITIVES` tables.
 pub(crate) fn builtin_arity(name: &str) -> Option<Arity> {
     for table in ALL_TABLES {
@@ -124,31 +48,6 @@ pub(crate) fn builtin_arity(name: &str) -> Option<Arity> {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_valid_kebab_case() {
-        assert!(is_valid_kebab_case("square"));
-        assert!(is_valid_kebab_case("square-number"));
-        assert!(is_valid_kebab_case("add-two-numbers"));
-        assert!(is_valid_kebab_case("foo1"));
-        assert!(is_valid_kebab_case("foo-1-bar"));
-    }
-
-    #[test]
-    fn test_invalid_kebab_case() {
-        assert!(!is_valid_kebab_case("camelCase"));
-        assert!(!is_valid_kebab_case("PascalCase"));
-        assert!(!is_valid_kebab_case("snake_case"));
-        assert!(!is_valid_kebab_case("-leading"));
-        assert!(!is_valid_kebab_case("trailing-"));
-    }
-
-    #[test]
-    fn test_to_kebab_case() {
-        assert_eq!(to_kebab_case("squareNumber"), "square-number");
-        assert_eq!(to_kebab_case("myVariable"), "my-variable");
-        assert_eq!(to_kebab_case("FOO"), "f-o-o");
-    }
 
     #[test]
     fn test_builtin_arity() {

--- a/src/lir/lower/AGENTS.md
+++ b/src/lir/lower/AGENTS.md
@@ -133,17 +133,6 @@ checks `callee_result_immediate` or `callee_return_safe` for Call expressions
 at any depth. Used by `body_escapes_heap_values` (rotation safety) when the
 standard flat check fails.
 
-**Value-flow propagation (`callee_returns_*` + widen passes):**
-
-`precompute_returns_rotation_safe()` and `precompute_returns_param_safe()` determine
-whether each function's return positions always produce rotation-safe or param-safe
-closures. `widen_rotation_safety()` and `widen_param_safety()` then extend the
-`callee_rotation_safe` / `callee_param_safe` maps to cover non-Lambda bindings:
-factory returns (`(def proc (make-proc))`), aliases (`(def f g)`), conditional
-construction (`(def f (if ... (fn ...) (fn ...)))`), and nested factories.
-Uses `collect_all_bindings` to find all Define/Let/Letrec bindings regardless of
-init type, then resolves each through value-flow analysis with fixpoint iteration.
-
 **Known limitations and why they exist:**
 
 - **`suspends` (condition 2)**: Any let body that calls a polymorphic-signal

--- a/src/lir/lower/mod.rs
+++ b/src/lir/lower/mod.rs
@@ -20,35 +20,6 @@ use crate::value::{Arity, SymbolId, Value};
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::collections::HashMap;
 use std::fmt;
-use std::sync::Mutex;
-
-static GLOBAL_SCOPE_STATS: Mutex<ScopeStats> = Mutex::new(ScopeStats {
-    scopes_analyzed: 0,
-    scopes_qualified: 0,
-    rejected_captured: 0,
-    rejected_suspends: 0,
-    rejected_unsafe_result: 0,
-    rejected_outward_set: 0,
-    rejected_break: 0,
-    calls_scoped: 0,
-    rotation_analyzed: 0,
-    rotation_safe: 0,
-});
-
-/// Merge local scope stats into the global accumulator.
-pub fn accumulate_scope_stats(stats: &ScopeStats) {
-    if let Ok(mut global) = GLOBAL_SCOPE_STATS.lock() {
-        global.merge(stats);
-    }
-}
-
-/// Read the global scope stats.
-pub fn global_scope_stats() -> ScopeStats {
-    GLOBAL_SCOPE_STATS
-        .lock()
-        .map(|g| g.clone())
-        .unwrap_or_default()
-}
 
 /// Wrap `func`'s body with `FlipEnter`/`FlipExit` and insert `FlipSwap`
 /// before every tail call. Used by Phase 4b auto-insertion

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use elle::context::{clear_vm_context, set_symbol_table, set_vm_context};
+use elle::context::{SymbolTableGuard, VmContextGuard};
 use elle::pipeline::compile_file;
 use elle::repl::Repl;
 use elle::{init_stdlib, register_primitives, SymbolTable, VM};
@@ -78,26 +78,14 @@ fn format_runtime_error(error: &str, symbols: &SymbolTable) -> String {
 /// Uses Generic kind so `description()` returns just the message without
 /// an extra "Compile error:" prefix (the caller provides context).
 fn parse_compilation_error(error: &str) -> elle::error::LError {
-    // Try to extract location from "file:line:col: message" pattern
-    if let Some(colon_idx) = error.find(": ") {
-        let loc_part = &error[..colon_idx];
-        let parts: Vec<&str> = loc_part.rsplitn(3, ':').collect();
-        if parts.len() >= 2 {
-            if let (Ok(col), Ok(line)) = (parts[0].parse::<usize>(), parts[1].parse::<usize>()) {
-                let file = if parts.len() == 3 {
-                    parts[2]
-                } else {
-                    "<unknown>"
-                };
-                let message = &error[colon_idx + 2..];
-                return elle::error::LError::new(elle::error::ErrorKind::CompileError {
-                    message: message.to_string(),
-                })
-                .with_location(elle::error::SourceLoc::new(file, line, col));
-            }
-        }
+    if let Some((file, line, col, message)) = elle::error::parse_located_error(error) {
+        elle::error::LError::new(elle::error::ErrorKind::CompileError {
+            message: message.to_string(),
+        })
+        .with_location(elle::error::SourceLoc::new(file, line, col))
+    } else {
+        elle::error::LError::compile_error(error)
     }
-    elle::error::LError::compile_error(error)
 }
 
 /// Format a compilation error as JSON for --json mode
@@ -462,7 +450,7 @@ fn run_source(
 
     // WASM backend: compile and run through Wasmtime instead of bytecode VM
     #[cfg(feature = "wasm")]
-    if elle::config::get().wasm_full {
+    if elle::config::get().wasm_full() {
         let no_stdlib = elle::config::get().wasm_no_stdlib;
         let eval_fn = if no_stdlib {
             elle::wasm::eval_wasm
@@ -492,8 +480,13 @@ fn run_source(
         }
     };
 
+    // Print scope stats if --stats is set
+    if elle::config::get().stats && result.scope_stats.scopes_analyzed > 0 {
+        eprint!("{}", result.scope_stats);
+    }
+
     // Debug: print bytecode if --debug is set
-    if elle::config::get().debug {
+    if elle::config::get().has_trace("bytecode") {
         eprintln!(
             "{}",
             elle::compiler::format_bytecode_with_constants(
@@ -612,11 +605,11 @@ fn main() {
 
     let _signals = register_primitives(&mut vm, &mut symbols);
 
-    set_symbol_table(&mut symbols as *mut SymbolTable);
+    let _sym_guard = SymbolTableGuard::new(&mut symbols);
 
     init_stdlib(&mut vm, &mut symbols);
 
-    set_vm_context(&mut vm as *mut VM);
+    let _vm_guard = VmContextGuard::new(&mut vm);
 
     let mut had_errors = false;
     let mut files: Vec<String> = Vec::new();
@@ -670,13 +663,11 @@ fn main() {
         had_errors = true;
     }
 
-    clear_vm_context();
+    // VM and symbol table guards drop here (or at function exit),
+    // clearing the TLS pointers automatically.
+    drop(_vm_guard);
 
     if elle::config::get().stats {
-        let scope_stats = elle::lir::lower::global_scope_stats();
-        if scope_stats.scopes_analyzed > 0 {
-            eprint!("{}", scope_stats);
-        }
         #[cfg(feature = "jit")]
         print_jit_stats(&mut vm);
         let cvc = elle::lir::closure_value_const_count();

--- a/src/pipeline/cache.rs
+++ b/src/pipeline/cache.rs
@@ -27,6 +27,28 @@ struct CompilationCache {
     expander: Expander,
     /// Primitive metadata from register_primitives.
     meta: PrimitiveMeta,
+    /// Signal projection cache: maps resolved file paths to their
+    /// keyword→signal projections. Populated lazily when the analyzer
+    /// encounters `(import "...")` with a literal string argument.
+    projections: HashMap<String, Option<HashMap<String, Signal>>>,
+}
+
+impl CompilationCache {
+    fn new() -> Self {
+        let mut vm = VM::new();
+        let mut init_symbols = SymbolTable::new();
+        let meta = register_primitives(&mut vm, &mut init_symbols);
+        let mut expander = Expander::new();
+        expander
+            .load_prelude(&mut init_symbols, &mut vm)
+            .expect("prelude loading must succeed");
+        CompilationCache {
+            vm,
+            expander,
+            meta,
+            projections: HashMap::new(),
+        }
+    }
 }
 
 thread_local! {
@@ -57,19 +79,7 @@ where
 {
     COMPILATION_CACHE.with(|cache| {
         let mut cache_ref = cache.borrow_mut();
-        let c = cache_ref.get_or_insert_with(|| {
-            let mut vm = VM::new();
-            let mut init_symbols = SymbolTable::new();
-            let meta = register_primitives(&mut vm, &mut init_symbols);
-            let mut expander = Expander::new();
-            // Prelude loading needs the VM for macro body evaluation.
-            // The init_symbols is throwaway — prelude is 100% defmacro,
-            // so handle_defmacro doesn't touch SymbolTable.
-            expander
-                .load_prelude(&mut init_symbols, &mut vm)
-                .expect("prelude loading must succeed");
-            CompilationCache { vm, expander, meta }
-        });
+        let c = cache_ref.get_or_insert_with(CompilationCache::new);
 
         // Always reset fiber before use
         c.vm.reset_fiber();
@@ -86,16 +96,7 @@ where
 pub(super) fn get_cached_expander_and_meta() -> (Expander, PrimitiveMeta) {
     COMPILATION_CACHE.with(|cache| {
         let mut cache_ref = cache.borrow_mut();
-        let c = cache_ref.get_or_insert_with(|| {
-            let mut vm = VM::new();
-            let mut init_symbols = SymbolTable::new();
-            let meta = register_primitives(&mut vm, &mut init_symbols);
-            let mut expander = Expander::new();
-            expander
-                .load_prelude(&mut init_symbols, &mut vm)
-                .expect("prelude loading must succeed");
-            CompilationCache { vm, expander, meta }
-        });
+        let c = cache_ref.get_or_insert_with(CompilationCache::new);
         (c.expander.clone(), c.meta.clone())
     })
 }
@@ -162,16 +163,7 @@ pub fn update_cache_with_stdlib(
 ) {
     COMPILATION_CACHE.with(|cache| {
         let mut cache_ref = cache.borrow_mut();
-        let c = cache_ref.get_or_insert_with(|| {
-            let mut vm = VM::new();
-            let mut init_symbols = SymbolTable::new();
-            let meta = register_primitives(&mut vm, &mut init_symbols);
-            let mut expander = Expander::new();
-            expander
-                .load_prelude(&mut init_symbols, &mut vm)
-                .expect("prelude loading must succeed");
-            CompilationCache { vm, expander, meta }
-        });
+        let c = cache_ref.get_or_insert_with(CompilationCache::new);
         for (sym_id, (value, signal)) in &exports {
             c.meta.signals.insert(*sym_id, *signal);
             c.meta.functions.insert(*sym_id, *value);
@@ -188,7 +180,12 @@ pub fn update_cache_with_stdlib(
 /// Returns `None` if the file's return value is not a projectable struct.
 pub fn get_or_compile_projection(resolved_path: &str) -> Option<HashMap<String, Signal>> {
     // Check cache first (outside the compilation cache borrow)
-    let cached = PROJECTION_CACHE.with(|pc| pc.borrow().get(resolved_path).cloned());
+    let cached = COMPILATION_CACHE.with(|cache| {
+        cache
+            .borrow()
+            .as_ref()
+            .and_then(|c| c.projections.get(resolved_path).cloned())
+    });
     if let Some(proj) = cached {
         return proj;
     }
@@ -200,9 +197,12 @@ pub fn get_or_compile_projection(resolved_path: &str) -> Option<HashMap<String, 
     let projection = result.bytecode.signal_projection;
 
     // Cache the result (even if None, to avoid re-compiling)
-    PROJECTION_CACHE.with(|pc| {
-        pc.borrow_mut()
-            .insert(resolved_path.to_string(), projection.clone());
+    COMPILATION_CACHE.with(|cache| {
+        let mut cache_ref = cache.borrow_mut();
+        if let Some(c) = cache_ref.as_mut() {
+            c.projections
+                .insert(resolved_path.to_string(), projection.clone());
+        }
     });
 
     projection

--- a/src/pipeline/compile.rs
+++ b/src/pipeline/compile.rs
@@ -12,54 +12,6 @@ use crate::symbol::SymbolTable;
 use crate::syntax::{Span, Syntax, SyntaxKind};
 use std::collections::HashSet;
 
-/// Compile source code to LIR (for the WASM backend).
-///
-/// Runs phases 1-4 (parse, expand, analyze, lower) and returns the
-/// LirModule before bytecode emission.
-pub fn compile_to_lir(
-    source: &str,
-    symbols: &mut SymbolTable,
-    source_name: &str,
-) -> Result<crate::lir::LirModule, String> {
-    intern_primitive_names(symbols);
-
-    let syntax = read_syntax(source, source_name)?;
-
-    let (expanded, meta) = cache::with_compilation_cache(|macro_vm, mut expander, meta| {
-        let expanded = expander.expand(syntax, symbols, macro_vm)?;
-        Ok::<_, String>((expanded, meta))
-    })?;
-
-    let mut arena = crate::hir::BindingArena::new();
-    let mut analyzer = crate::hir::Analyzer::new_with_primitives(
-        symbols,
-        &mut arena,
-        meta.signals.clone(),
-        meta.arities.clone(),
-    );
-    analyzer.bind_primitives(&meta);
-    let mut analysis = analyzer.analyze(&expanded)?;
-    let prim_values = analyzer.primitive_values().clone();
-    drop(analyzer);
-
-    mark_tail_calls(&mut analysis.hir);
-    functionalize(&mut analysis.hir, &mut arena);
-    crate::hir::typeinfer::infer_and_rewrite(&mut analysis.hir, &arena, symbols);
-
-    let pc = crate::lir::intrinsics::PrimitiveClassification::new(symbols);
-    let region_info =
-        crate::hir::analyze_regions_with(&analysis.hir, &arena, pc.call_classification.clone());
-    let symbol_names = symbols.all_names();
-    let mut lowerer = Lowerer::new(&arena)
-        .with_primitive_classification(pc)
-        .with_primitive_values(prim_values)
-        .with_symbol_names(symbol_names)
-        .with_region_info(region_info);
-    let result = lowerer.lower(&analysis.hir);
-    crate::lir::lower::accumulate_scope_stats(lowerer.scope_stats());
-    result
-}
-
 /// Compile source code to bytecode.
 ///
 /// Creates an internal VM for macro expansion. Macro side effects
@@ -111,12 +63,16 @@ pub fn compile(
         .with_symbol_names(symbol_names.clone())
         .with_region_info(region_info);
     let lir_module = lowerer.lower(&analysis.hir)?;
+    let scope_stats = lowerer.scope_stats().clone();
 
     // Phase 5: Emit bytecode with symbol names for cross-thread portability
     let mut emitter = Emitter::new_with_symbols(symbol_names);
     let (bytecode, _yield_points, _call_sites) = emitter.emit_module(&lir_module);
 
-    Ok(CompileResult { bytecode })
+    Ok(CompileResult {
+        bytecode,
+        scope_stats,
+    })
 }
 
 /// Classify an expanded top-level form into a `FileForm`.
@@ -176,33 +132,12 @@ pub fn compile_file_to_lir(
         let mut expanded_forms = Vec::new();
         let mut included: HashSet<String> = HashSet::from([source_name.to_string()]);
         while let Some(syntax) = pending.pop_front() {
-            if let Some((spec, is_include)) = extract_include(&syntax) {
-                let path = if is_include {
-                    crate::primitives::modules::resolve_import(&spec)
-                } else {
-                    resolve_include_file(&spec, source_name)
-                };
-                let path =
-                    path.ok_or_else(|| format!("{}: include: '{}' not found", syntax.span, spec))?;
-                if !included.insert(path.clone()) {
-                    return Err(format!(
-                        "{}: include: circular dependency on '{}'",
-                        syntax.span, path
-                    ));
-                }
-                let contents = std::fs::read_to_string(&path).map_err(|e| {
-                    format!("{}: include: failed to read '{}': {}", syntax.span, path, e)
-                })?;
-                let forms = read_syntax_all_for(&contents, &path)?;
-                for (i, form) in forms.into_iter().enumerate() {
-                    pending.insert(i, form);
-                }
+            if resolve_and_splice_include(&syntax, source_name, &mut pending, &mut included)? {
                 continue;
             }
-            let expanded = expander.expand(syntax, symbols, macro_vm)?;
-            expanded_forms.push(expanded);
+            expanded_forms.push(expander.expand(syntax, symbols, macro_vm)?);
         }
-        Ok((expanded_forms, meta))
+        Ok::<_, String>((expanded_forms, meta))
     })?;
 
     let forms: Vec<FileForm> = expanded_forms.iter().map(classify_form).collect();
@@ -263,9 +198,7 @@ pub fn compile_file_to_lir(
         .with_primitive_values(prim_values)
         .with_symbol_names(symbol_names)
         .with_region_info(region_info);
-    let result = lowerer.lower(&hir);
-    crate::lir::lower::accumulate_scope_stats(lowerer.scope_stats());
-    result
+    lowerer.lower(&hir)
 }
 
 /// Shared front-end for file compilation: parse, epoch migration, macro
@@ -312,33 +245,12 @@ fn compile_file_frontend(
             let mut expanded_forms = Vec::new();
             let mut included: HashSet<String> = HashSet::from([source_name.to_string()]);
             while let Some(syntax) = pending.pop_front() {
-                if let Some((spec, is_include)) = extract_include(&syntax) {
-                    let path = if is_include {
-                        crate::primitives::modules::resolve_import(&spec)
-                    } else {
-                        resolve_include_file(&spec, source_name)
-                    };
-                    let path = path
-                        .ok_or_else(|| format!("{}: include: '{}' not found", syntax.span, spec))?;
-                    if !included.insert(path.clone()) {
-                        return Err(format!(
-                            "{}: include: circular dependency on '{}'",
-                            syntax.span, path
-                        ));
-                    }
-                    let contents = std::fs::read_to_string(&path).map_err(|e| {
-                        format!("{}: include: failed to read '{}': {}", syntax.span, path, e)
-                    })?;
-                    let forms = read_syntax_all_for(&contents, &path)?;
-                    for (i, form) in forms.into_iter().enumerate() {
-                        pending.insert(i, form);
-                    }
+                if resolve_and_splice_include(&syntax, source_name, &mut pending, &mut included)? {
                     continue;
                 }
-                let expanded = expander.expand(syntax, symbols, macro_vm)?;
-                expanded_forms.push(expanded);
+                expanded_forms.push(expander.expand(syntax, symbols, macro_vm)?);
             }
-            Ok((expanded_forms, expander, meta))
+            Ok::<_, String>((expanded_forms, expander, meta))
         })?;
 
     let forms: Vec<FileForm> = expanded_forms.iter().map(classify_form).collect();
@@ -466,6 +378,7 @@ fn compile_file_inner(
 
     let lir_module = lowerer.lower(&hir)?;
     let escape_projection = lowerer.take_escape_projection();
+    let scope_stats = lowerer.scope_stats().clone();
 
     // Emit bytecode
     let signal = lir_module.entry.signal;
@@ -475,7 +388,13 @@ fn compile_file_inner(
     bytecode.signal_projection = signal_projection;
     bytecode.escape_projection = escape_projection;
 
-    Ok((CompileResult { bytecode }, expander))
+    Ok((
+        CompileResult {
+            bytecode,
+            scope_stats,
+        },
+        expander,
+    ))
 }
 
 /// Splice include/include-file directives in source text.
@@ -490,34 +409,47 @@ pub fn splice_includes(source: &str, source_name: &str) -> Result<String, String
     let mut parts: Vec<String> = Vec::new();
 
     while let Some(syntax) = pending.pop_front() {
-        if let Some((spec, is_include)) = extract_include(&syntax) {
-            let path = if is_include {
-                crate::primitives::modules::resolve_import(&spec)
-            } else {
-                resolve_include_file(&spec, source_name)
-            };
-            let path =
-                path.ok_or_else(|| format!("{}: include: '{}' not found", syntax.span, spec))?;
-            if !included.insert(path.clone()) {
-                return Err(format!(
-                    "{}: include: circular dependency on '{}'",
-                    syntax.span, path
-                ));
-            }
-            let contents = std::fs::read_to_string(&path).map_err(|e| {
-                format!("{}: include: failed to read '{}': {}", syntax.span, path, e)
-            })?;
-            let forms = read_syntax_all_for(&contents, &path)?;
-            for (i, form) in forms.into_iter().enumerate() {
-                pending.insert(i, form);
-            }
+        if resolve_and_splice_include(&syntax, source_name, &mut pending, &mut included)? {
             continue;
         }
-        // Preserve the original source text for this form
         parts.push(format!("{}", syntax));
     }
 
     Ok(parts.join("\n"))
+}
+
+/// Resolve and splice a single include directive into the pending queue.
+/// Returns `Ok(true)` if the syntax was an include (resolved and spliced),
+/// `Ok(false)` if it was not an include, or `Err` on resolution failure.
+fn resolve_and_splice_include(
+    syntax: &Syntax,
+    source_name: &str,
+    pending: &mut std::collections::VecDeque<Syntax>,
+    included: &mut HashSet<String>,
+) -> Result<bool, String> {
+    let (spec, is_include) = match extract_include(syntax) {
+        Some(pair) => pair,
+        None => return Ok(false),
+    };
+    let path = if is_include {
+        crate::primitives::modules::resolve_import(&spec)
+    } else {
+        resolve_include_file(&spec, source_name)
+    };
+    let path = path.ok_or_else(|| format!("{}: include: '{}' not found", syntax.span, spec))?;
+    if !included.insert(path.clone()) {
+        return Err(format!(
+            "{}: include: circular dependency on '{}'",
+            syntax.span, path
+        ));
+    }
+    let contents = std::fs::read_to_string(&path)
+        .map_err(|e| format!("{}: include: failed to read '{}': {}", syntax.span, path, e))?;
+    let forms = read_syntax_all_for(&contents, &path)?;
+    for (i, form) in forms.into_iter().enumerate() {
+        pending.insert(i, form);
+    }
+    Ok(true)
 }
 
 /// Extract the spec from `(include-file "path")` or `(include "spec")`.

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -15,7 +15,7 @@ pub use cache::{
 };
 pub use compile::{
     compile, compile_file, compile_file_repl, compile_file_to_fhir, compile_file_to_lir,
-    compile_to_lir, splice_includes,
+    splice_includes,
 };
 pub use eval::{eval, eval_all, eval_file, eval_syntax};
 
@@ -23,6 +23,7 @@ pub use eval::{eval, eval_all, eval_file, eval_syntax};
 #[derive(Debug)]
 pub struct CompileResult {
     pub bytecode: crate::compiler::Bytecode,
+    pub scope_stats: crate::lir::lower::ScopeStats,
 }
 
 /// Analysis-only result (no bytecode generation)

--- a/src/primitives/access.rs
+++ b/src/primitives/access.rs
@@ -241,19 +241,7 @@ pub(crate) fn prim_get(args: &[Value]) -> (SignalBits, Value) {
     }
 
     // Struct (mutable keyed collection)
-    if args[0].is_struct_mut() {
-        let mstruct = match args[0].as_struct_mut() {
-            Some(t) => t,
-            None => {
-                return (
-                    SIG_ERROR,
-                    error_val(
-                        "type-error",
-                        format!("get: expected struct, got {}", args[0].type_name()),
-                    ),
-                )
-            }
-        };
+    if let Some(mstruct) = args[0].as_struct_mut() {
         let key = match TableKey::from_value(&args[1]) {
             Some(k) => k,
             None => {
@@ -274,19 +262,7 @@ pub(crate) fn prim_get(args: &[Value]) -> (SignalBits, Value) {
     }
 
     // Struct (immutable keyed collection)
-    if args[0].is_struct() {
-        let s = match args[0].as_struct() {
-            Some(st) => st,
-            None => {
-                return (
-                    SIG_ERROR,
-                    error_val(
-                        "type-error",
-                        format!("get: expected struct, got {}", args[0].type_name()),
-                    ),
-                )
-            }
-        };
+    if let Some(s) = args[0].as_struct() {
         let key = match TableKey::from_value(&args[1]) {
             Some(k) => k,
             None => {
@@ -686,19 +662,7 @@ pub(crate) fn prim_put(args: &[Value]) -> (SignalBits, Value) {
     };
     let value = args[2];
 
-    if args[0].is_struct_mut() {
-        let mstruct = match args[0].as_struct_mut() {
-            Some(t) => t,
-            None => {
-                return (
-                    SIG_ERROR,
-                    error_val(
-                        "type-error",
-                        format!("put: expected struct, got {}", args[0].type_name()),
-                    ),
-                )
-            }
-        };
+    if let Some(mstruct) = args[0].as_struct_mut() {
         // Decref old value, incref new value.
         if let Some(&old_val) = mstruct.borrow().get(&key) {
             fiberheap::decref_and_free(old_val);
@@ -709,19 +673,7 @@ pub(crate) fn prim_put(args: &[Value]) -> (SignalBits, Value) {
     }
 
     // Struct (immutable keyed collection) - return new struct
-    if args[0].is_struct() {
-        let s = match args[0].as_struct() {
-            Some(st) => st,
-            None => {
-                return (
-                    SIG_ERROR,
-                    error_val(
-                        "type-error",
-                        format!("put: expected struct, got {}", args[0].type_name()),
-                    ),
-                )
-            }
-        };
+    if let Some(s) = args[0].as_struct() {
         return (
             SIG_OK,
             Value::struct_from_sorted(sorted_struct_insert(s, key, value)),

--- a/src/primitives/arithmetic.rs
+++ b/src/primitives/arithmetic.rs
@@ -13,6 +13,15 @@ pub(crate) fn prim_abs(args: &[Value]) -> (SignalBits, Value) {
 }
 
 pub(crate) fn prim_min(args: &[Value]) -> (SignalBits, Value) {
+    if !args[0].is_number() {
+        return (
+            SIG_ERROR,
+            error_val(
+                "type-error",
+                format!("min: expected number, got {}", args[0].type_name()),
+            ),
+        );
+    }
     let mut min = args[0];
     for arg in &args[1..] {
         if !arg.is_number() {
@@ -30,6 +39,15 @@ pub(crate) fn prim_min(args: &[Value]) -> (SignalBits, Value) {
 }
 
 pub(crate) fn prim_max(args: &[Value]) -> (SignalBits, Value) {
+    if !args[0].is_number() {
+        return (
+            SIG_ERROR,
+            error_val(
+                "type-error",
+                format!("max: expected number, got {}", args[0].type_name()),
+            ),
+        );
+    }
     let mut max = args[0];
     for arg in &args[1..] {
         if !arg.is_number() {

--- a/src/primitives/bitwise.rs
+++ b/src/primitives/bitwise.rs
@@ -33,55 +33,32 @@ fn coerce_to_int(val: &Value, name: &str) -> Result<i64, (SignalBits, Value)> {
     ))
 }
 
-/// Bitwise AND: fold all arguments with &
+/// Fold arguments with a bitwise operation.
+fn fold_bitwise(args: &[Value], name: &str, op: fn(i64, i64) -> i64) -> (SignalBits, Value) {
+    let mut result = match coerce_to_int(&args[0], name) {
+        Ok(n) => n,
+        Err(e) => return e,
+    };
+    for arg in &args[1..] {
+        let n = match coerce_to_int(arg, name) {
+            Ok(n) => n,
+            Err(e) => return e,
+        };
+        result = op(result, n);
+    }
+    (SIG_OK, Value::int(result))
+}
+
 pub(crate) fn prim_bit_and(args: &[Value]) -> (SignalBits, Value) {
-    let mut result = match coerce_to_int(&args[0], "bit/and") {
-        Ok(n) => n,
-        Err(e) => return e,
-    };
-
-    for arg in &args[1..] {
-        let n = match coerce_to_int(arg, "bit/and") {
-            Ok(n) => n,
-            Err(e) => return e,
-        };
-        result &= n;
-    }
-    (SIG_OK, Value::int(result))
+    fold_bitwise(args, "bit/and", |a, b| a & b)
 }
 
-/// Bitwise OR: fold all arguments with |
 pub(crate) fn prim_bit_or(args: &[Value]) -> (SignalBits, Value) {
-    let mut result = match coerce_to_int(&args[0], "bit/or") {
-        Ok(n) => n,
-        Err(e) => return e,
-    };
-
-    for arg in &args[1..] {
-        let n = match coerce_to_int(arg, "bit/or") {
-            Ok(n) => n,
-            Err(e) => return e,
-        };
-        result |= n;
-    }
-    (SIG_OK, Value::int(result))
+    fold_bitwise(args, "bit/or", |a, b| a | b)
 }
 
-/// Bitwise XOR: fold all arguments with ^
 pub(crate) fn prim_bit_xor(args: &[Value]) -> (SignalBits, Value) {
-    let mut result = match coerce_to_int(&args[0], "bit/xor") {
-        Ok(n) => n,
-        Err(e) => return e,
-    };
-
-    for arg in &args[1..] {
-        let n = match coerce_to_int(arg, "bit/xor") {
-            Ok(n) => n,
-            Err(e) => return e,
-        };
-        result ^= n;
-    }
-    (SIG_OK, Value::int(result))
+    fold_bitwise(args, "bit/xor", |a, b| a ^ b)
 }
 
 /// Bitwise NOT: apply ! to single integer argument

--- a/src/primitives/comparison.rs
+++ b/src/primitives/comparison.rs
@@ -1,4 +1,5 @@
 //! Comparison primitives
+use crate::arithmetic::values_eq;
 use crate::primitives::def::PrimitiveDef;
 use crate::signals::Signal;
 use crate::value::fiber::{SignalBits, SIG_OK};
@@ -14,28 +15,9 @@ use std::hash::{Hash, Hasher};
 /// Chained: (= a b c) means all pairs are equal.
 pub(crate) fn prim_eq(args: &[Value]) -> (SignalBits, Value) {
     for i in 0..args.len() - 1 {
-        // Fast path: bitwise identical (covers same-type immediates)
-        if args[i] == args[i + 1] {
-            continue;
+        if !values_eq(&args[i], &args[i + 1]) {
+            return (SIG_OK, Value::FALSE);
         }
-        // Numeric coercion: int-int stays exact, mixed promotes to f64
-        if args[i].is_number() && args[i + 1].is_number() {
-            if let (Some(a), Some(b)) = (args[i].as_int(), args[i + 1].as_int()) {
-                if a == b {
-                    continue;
-                } else {
-                    return (SIG_OK, Value::FALSE);
-                }
-            }
-            if let (Some(a), Some(b)) = (args[i].as_number(), args[i + 1].as_number()) {
-                if a == b {
-                    continue;
-                } else {
-                    return (SIG_OK, Value::FALSE);
-                }
-            }
-        }
-        return (SIG_OK, Value::FALSE);
     }
     (SIG_OK, Value::TRUE)
 }
@@ -43,19 +25,14 @@ pub(crate) fn prim_eq(args: &[Value]) -> (SignalBits, Value) {
 /// Inequality comparison — negation of `=`.
 /// Numeric-aware: (not= 1 1.0) is false. Accepts exactly 2 arguments.
 pub(crate) fn prim_not_eq(args: &[Value]) -> (SignalBits, Value) {
-    // Fast path: bitwise identical
-    if args[0] == args[1] {
-        return (SIG_OK, Value::FALSE);
-    }
-    // Numeric coercion: if both are numbers, compare as f64
-    if args[0].is_number() && args[1].is_number() {
-        if let (Some(a), Some(b)) = (args[0].as_number(), args[1].as_number()) {
-            if a == b {
-                return (SIG_OK, Value::FALSE);
-            }
-        }
-    }
-    (SIG_OK, Value::TRUE)
+    (
+        SIG_OK,
+        if values_eq(&args[0], &args[1]) {
+            Value::FALSE
+        } else {
+            Value::TRUE
+        },
+    )
 }
 
 /// Strict identity comparison — bitwise/structural equality with no coercion.

--- a/src/primitives/concurrency.rs
+++ b/src/primitives/concurrency.rs
@@ -72,11 +72,8 @@ fn spawn_closure_impl(closure: &crate::value::Closure) -> LResult<Value> {
         }
     });
 
-    let thread_handle_data = ThreadHandle {
-        result: result_holder,
-    };
     Ok(alloc(HeapObject::ThreadHandle {
-        handle: thread_handle_data,
+        handle: ThreadHandle::new(result_holder),
         traits: Value::NIL,
     }))
 }

--- a/src/primitives/debug.rs
+++ b/src/primitives/debug.rs
@@ -163,13 +163,6 @@ fn get_memory_usage() -> (u64, u64) {
     (0, 0)
 }
 
-/// Returns the number of interned strings in the thread-local table.
-/// (debug/intern-count)
-pub(crate) fn prim_intern_count(_args: &[Value]) -> (SignalBits, Value) {
-    let count = crate::value::intern::intern_string_count();
-    (SIG_OK, Value::int(count as i64))
-}
-
 /// Returns the number of interned symbols in the thread-local symbol table.
 /// (debug/symbol-count)
 pub(crate) fn prim_symbol_count(_args: &[Value]) -> (SignalBits, Value) {
@@ -223,17 +216,6 @@ pub(crate) const PRIMITIVES: &[PrimitiveDef] = &[
         category: "debug",
         example: "(debug/memory)",
         aliases: &["memory-usage"],
-    },
-    PrimitiveDef {
-        name: "debug/intern-count",
-        func: prim_intern_count,
-        signal: Signal::silent(),
-        arity: Arity::Exact(0),
-        doc: "Returns the number of interned strings in the thread-local table",
-        params: &[],
-        category: "debug",
-        example: "(debug/intern-count)",
-        aliases: &[],
     },
     PrimitiveDef {
         name: "debug/symbol-count",

--- a/src/primitives/display.rs
+++ b/src/primitives/display.rs
@@ -229,9 +229,6 @@ fn pretty_print_impl(val: Value, indent: usize, remaining_width: usize, depth: u
 
 /// (pp value) — Pretty-print a value with indentation, returns the value
 pub(crate) fn prim_pp(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (SIG_OK, Value::NIL);
-    }
     let val = args[0];
 
     const DEFAULT_WIDTH: usize = 80;
@@ -243,10 +240,6 @@ pub(crate) fn prim_pp(args: &[Value]) -> (SignalBits, Value) {
 
 /// (describe value) — Return a string describing a value's type and content
 pub(crate) fn prim_describe(args: &[Value]) -> (SignalBits, Value) {
-    if args.len() != 1 {
-        return (SIG_OK, Value::string("<error>"));
-    }
-
     let val = args[0];
 
     if val.is_nil() {

--- a/src/primitives/logic.rs
+++ b/src/primitives/logic.rs
@@ -1,10 +1,8 @@
 use crate::primitives::def::PrimitiveDef;
 use crate::signals::Signal;
 use crate::value::fiber::{SignalBits, SIG_ERROR, SIG_OK};
-use crate::value::heap::TableKey;
 use crate::value::types::Arity;
-use crate::value::Value;
-use std::collections::BTreeMap;
+use crate::value::{error_val, Value};
 
 /// Logical AND operation
 /// (and) => true
@@ -66,17 +64,16 @@ pub(crate) fn prim_assert(args: &[Value]) -> (SignalBits, Value) {
     let message = if args.len() == 2 { args[1] } else { Value::NIL };
 
     if value.is_truthy() {
-        // Pass through the value
         (SIG_OK, value)
     } else {
-        // Signal error with {:error :failed-assertion :message msg}
-        let mut fields = BTreeMap::new();
-        fields.insert(
-            TableKey::Keyword("error".into()),
-            Value::keyword("failed-assertion"),
-        );
-        fields.insert(TableKey::Keyword("message".into()), message);
-        (SIG_ERROR, Value::struct_from(fields))
+        let msg_str = if message.is_nil() {
+            "assertion failed".to_string()
+        } else if let Some(s) = message.with_string(|s| s.to_string()) {
+            s
+        } else {
+            format!("{}", message)
+        };
+        (SIG_ERROR, error_val("failed-assertion", msg_str))
     }
 }
 

--- a/src/primitives/seq.rs
+++ b/src/primitives/seq.rs
@@ -18,6 +18,90 @@ fn seq_type_error(op: &str, val: &Value) -> Value {
     )
 }
 
+// ── Mutable/immutable dispatch helpers ──────────────────────────────
+//
+// These collapse the 2-way branch (immut vs @mut) into a single call
+// for each container family.  The `mutable` flag lets callers preserve
+// mutability in the result when needed.
+
+/// Run `f` over an array's elements, whether immutable or @mutable.
+fn with_array<F, R>(val: &Value, f: F) -> Option<R>
+where
+    F: FnOnce(&[Value], bool) -> R,
+{
+    if let Some(elems) = val.as_array() {
+        return Some(f(elems, false));
+    }
+    if let Some(arr) = val.as_array_mut() {
+        let borrowed = arr.borrow();
+        return Some(f(&borrowed, true));
+    }
+    None
+}
+
+/// Run `f` over a string's text, whether immutable or @mutable.
+/// Returns None for non-string types and for @strings with invalid UTF-8.
+fn with_text<F, R>(val: &Value, f: F) -> Option<R>
+where
+    F: FnOnce(&str, bool) -> R,
+{
+    // Check immutable string via HeapTag to avoid consuming f in with_string
+    if val.is_string() {
+        return val.with_string(|s| f(s, false));
+    }
+    if let Some(buf_ref) = val.as_string_mut() {
+        let borrowed = buf_ref.borrow();
+        if let Ok(s) = std::str::from_utf8(&borrowed) {
+            return Some(f(s, true));
+        }
+    }
+    None
+}
+
+/// Run `f` over byte content, whether immutable or @mutable.
+fn with_raw_bytes<F, R>(val: &Value, f: F) -> Option<R>
+where
+    F: FnOnce(&[u8], bool) -> R,
+{
+    if let Some(b) = val.as_bytes() {
+        return Some(f(b, false));
+    }
+    if let Some(blob_ref) = val.as_bytes_mut() {
+        let borrowed = blob_ref.borrow();
+        return Some(f(&borrowed, true));
+    }
+    None
+}
+
+/// Build an array Value, preserving mutability.
+fn make_array(elems: Vec<Value>, mutable: bool) -> Value {
+    if mutable {
+        Value::array_mut(elems)
+    } else {
+        Value::array(elems)
+    }
+}
+
+/// Build a string Value, preserving mutability.
+fn make_string(s: String, mutable: bool) -> Value {
+    if mutable {
+        Value::string_mut(s.into_bytes())
+    } else {
+        Value::string(s)
+    }
+}
+
+/// Build a bytes Value, preserving mutability.
+fn make_bytes(b: Vec<u8>, mutable: bool) -> Value {
+    if mutable {
+        Value::bytes_mut(b)
+    } else {
+        Value::bytes(b)
+    }
+}
+
+// ── Seq operations ──────────────────────────────────────────────────
+
 /// Get the first element of a sequence.
 pub fn seq_first(val: &Value) -> Result<Value, Value> {
     if let Some(pair) = val.as_pair() {
@@ -26,49 +110,30 @@ pub fn seq_first(val: &Value) -> Result<Value, Value> {
     if val.is_empty_list() {
         return Err(error_val("argument-error", "first: empty sequence"));
     }
-    if let Some(elems) = val.as_array() {
-        return elems
+    if let Some(r) = with_array(val, |elems, _| {
+        elems
             .first()
             .copied()
-            .ok_or_else(|| error_val("argument-error", "first: empty sequence"));
-    }
-    if let Some(arr) = val.as_array_mut() {
-        let borrowed = arr.borrow();
-        return borrowed
-            .first()
-            .copied()
-            .ok_or_else(|| error_val("argument-error", "first: empty sequence"));
-    }
-    if let Some(result) = val.with_string(|s| match s.graphemes(true).next() {
-        Some(g) => Ok(Value::string(g)),
-        None => Err(error_val("argument-error", "first: empty sequence")),
+            .ok_or_else(|| error_val("argument-error", "first: empty sequence"))
     }) {
-        return result;
+        return r;
     }
-    if let Some(buf_ref) = val.as_string_mut() {
-        let borrowed = buf_ref.borrow();
-        if let Ok(s) = std::str::from_utf8(&borrowed) {
-            return match s.graphemes(true).next() {
-                Some(g) => Ok(Value::string(g)),
-                None => Err(error_val("argument-error", "first: empty sequence")),
-            };
-        }
-        return Err(error_val("argument-error", "first: empty sequence"));
+    if let Some(r) = with_text(val, |s, _| {
+        s.graphemes(true)
+            .next()
+            .map(Value::string)
+            .ok_or_else(|| error_val("argument-error", "first: empty sequence"))
+    }) {
+        return r;
     }
-    if let Some(b) = val.as_bytes() {
-        return if b.is_empty() {
+    if let Some(r) = with_raw_bytes(val, |b, _| {
+        if b.is_empty() {
             Err(error_val("argument-error", "first: empty sequence"))
         } else {
             Ok(Value::int(b[0] as i64))
-        };
-    }
-    if let Some(blob_ref) = val.as_bytes_mut() {
-        let borrowed = blob_ref.borrow();
-        return if borrowed.is_empty() {
-            Err(error_val("argument-error", "first: empty sequence"))
-        } else {
-            Ok(Value::int(borrowed[0] as i64))
-        };
+        }
+    }) {
+        return r;
     }
     Err(seq_type_error("first", val))
 }
@@ -81,49 +146,29 @@ pub fn seq_rest(val: &Value) -> Result<Value, Value> {
     if val.is_empty_list() {
         return Ok(Value::EMPTY_LIST);
     }
-    if let Some(elems) = val.as_array() {
-        return Ok(if elems.len() <= 1 {
-            Value::array(vec![])
+    if let Some(r) = with_array(val, |elems, m| {
+        if elems.len() <= 1 {
+            make_array(vec![], m)
         } else {
-            Value::array(elems[1..].to_vec())
-        });
-    }
-    if let Some(arr) = val.as_array_mut() {
-        let borrowed = arr.borrow();
-        return Ok(if borrowed.len() <= 1 {
-            Value::array_mut(vec![])
-        } else {
-            Value::array_mut(borrowed[1..].to_vec())
-        });
-    }
-    if let Some(result) = val.with_string(|s| {
-        let rest: String = s.graphemes(true).skip(1).collect();
-        Value::string(rest)
-    }) {
-        return Ok(result);
-    }
-    if let Some(buf_ref) = val.as_string_mut() {
-        let borrowed = buf_ref.borrow();
-        if let Ok(s) = std::str::from_utf8(&borrowed) {
-            let rest: String = s.graphemes(true).skip(1).collect();
-            return Ok(Value::string_mut(rest.into_bytes()));
+            make_array(elems[1..].to_vec(), m)
         }
-        return Ok(Value::string_mut(vec![]));
+    }) {
+        return Ok(r);
     }
-    if let Some(b) = val.as_bytes() {
-        return Ok(if b.len() <= 1 {
-            Value::bytes(vec![])
-        } else {
-            Value::bytes(b[1..].to_vec())
-        });
+    if let Some(r) = with_text(val, |s, m| {
+        let rest: String = s.graphemes(true).skip(1).collect();
+        make_string(rest, m)
+    }) {
+        return Ok(r);
     }
-    if let Some(blob_ref) = val.as_bytes_mut() {
-        let borrowed = blob_ref.borrow();
-        return Ok(if borrowed.len() <= 1 {
-            Value::bytes_mut(vec![])
+    if let Some(r) = with_raw_bytes(val, |b, m| {
+        if b.len() <= 1 {
+            make_bytes(vec![], m)
         } else {
-            Value::bytes_mut(borrowed[1..].to_vec())
-        });
+            make_bytes(b[1..].to_vec(), m)
+        }
+    }) {
+        return Ok(r);
     }
     Err(seq_type_error("rest", val))
 }
@@ -142,47 +187,28 @@ pub fn seq_last(val: &Value) -> Result<Value, Value> {
         }
         return Ok(last);
     }
-    if let Some(elems) = val.as_array() {
-        return elems
+    if let Some(r) = with_array(val, |elems, _| {
+        elems
             .last()
             .copied()
-            .ok_or_else(|| error_val("argument-error", "last: empty sequence"));
-    }
-    if let Some(arr) = val.as_array_mut() {
-        let borrowed = arr.borrow();
-        return borrowed
-            .last()
-            .copied()
-            .ok_or_else(|| error_val("argument-error", "last: empty sequence"));
-    }
-    if let Some(result) = val.with_string(|s| match s.graphemes(true).next_back() {
-        Some(g) => Ok(Value::string(g)),
-        None => Err(error_val("argument-error", "last: empty sequence")),
+            .ok_or_else(|| error_val("argument-error", "last: empty sequence"))
     }) {
-        return result;
+        return r;
     }
-    if let Some(buf_ref) = val.as_string_mut() {
-        let borrowed = buf_ref.borrow();
-        if let Ok(s) = std::str::from_utf8(&borrowed) {
-            return match s.graphemes(true).next_back() {
-                Some(g) => Ok(Value::string(g)),
-                None => Err(error_val("argument-error", "last: empty sequence")),
-            };
-        }
-        return Err(error_val("argument-error", "last: empty sequence"));
+    if let Some(r) = with_text(val, |s, _| {
+        s.graphemes(true)
+            .next_back()
+            .map(Value::string)
+            .ok_or_else(|| error_val("argument-error", "last: empty sequence"))
+    }) {
+        return r;
     }
-    if let Some(b) = val.as_bytes() {
-        return b
-            .last()
+    if let Some(r) = with_raw_bytes(val, |b, _| {
+        b.last()
             .map(|&byte| Value::int(byte as i64))
-            .ok_or_else(|| error_val("argument-error", "last: empty sequence"));
-    }
-    if let Some(blob_ref) = val.as_bytes_mut() {
-        let borrowed = blob_ref.borrow();
-        return borrowed
-            .last()
-            .map(|&byte| Value::int(byte as i64))
-            .ok_or_else(|| error_val("argument-error", "last: empty sequence"));
+            .ok_or_else(|| error_val("argument-error", "last: empty sequence"))
+    }) {
+        return r;
     }
     Err(seq_type_error("last", val))
 }
@@ -190,7 +216,6 @@ pub fn seq_last(val: &Value) -> Result<Value, Value> {
 /// Get element at index n.
 pub fn seq_nth(val: &Value, n: i64) -> Result<Value, Value> {
     if val.is_pair() {
-        // Positive index: walk forward
         if n >= 0 {
             let mut current = *val;
             let mut i = 0usize;
@@ -215,7 +240,6 @@ pub fn seq_nth(val: &Value, n: i64) -> Result<Value, Value> {
                 }
             }
         } else {
-            // Negative: need length
             let mut len = 0usize;
             let mut cur = *val;
             while let Some(c) = cur.as_pair() {
@@ -238,28 +262,19 @@ pub fn seq_nth(val: &Value, n: i64) -> Result<Value, Value> {
             format!("nth: index {} out of bounds (empty list)", n),
         ));
     }
-    if let Some(elems) = val.as_array() {
-        return resolve_index(n, elems.len())
+    if let Some(r) = with_array(val, |elems, _| {
+        resolve_index(n, elems.len())
             .map(|i| elems[i])
             .ok_or_else(|| {
                 error_val(
                     "argument-error",
                     format!("nth: index {} out of bounds (length {})", n, elems.len()),
                 )
-            });
+            })
+    }) {
+        return r;
     }
-    if let Some(arr) = val.as_array_mut() {
-        let borrowed = arr.borrow();
-        return resolve_index(n, borrowed.len())
-            .map(|i| borrowed[i])
-            .ok_or_else(|| {
-                error_val(
-                    "argument-error",
-                    format!("nth: index {} out of bounds (length {})", n, borrowed.len()),
-                )
-            });
-    }
-    if let Some(result) = val.with_string(|s| {
+    if let Some(r) = with_text(val, |s, _| {
         let graphemes: Vec<&str> = s.graphemes(true).collect();
         resolve_index(n, graphemes.len())
             .map(|i| Value::string(graphemes[i]))
@@ -274,50 +289,19 @@ pub fn seq_nth(val: &Value, n: i64) -> Result<Value, Value> {
                 )
             })
     }) {
-        return result;
+        return r;
     }
-    if let Some(buf_ref) = val.as_string_mut() {
-        let borrowed = buf_ref.borrow();
-        if let Ok(s) = std::str::from_utf8(&borrowed) {
-            let graphemes: Vec<&str> = s.graphemes(true).collect();
-            return resolve_index(n, graphemes.len())
-                .map(|i| Value::string(graphemes[i]))
-                .ok_or_else(|| {
-                    error_val(
-                        "argument-error",
-                        format!(
-                            "nth: index {} out of bounds (length {})",
-                            n,
-                            graphemes.len()
-                        ),
-                    )
-                });
-        }
-        return Err(error_val(
-            "argument-error",
-            format!("nth: index {} out of bounds (empty @string)", n),
-        ));
-    }
-    if let Some(b) = val.as_bytes() {
-        return resolve_index(n, b.len())
+    if let Some(r) = with_raw_bytes(val, |b, _| {
+        resolve_index(n, b.len())
             .map(|i| Value::int(b[i] as i64))
             .ok_or_else(|| {
                 error_val(
                     "argument-error",
                     format!("nth: index {} out of bounds (length {})", n, b.len()),
                 )
-            });
-    }
-    if let Some(blob_ref) = val.as_bytes_mut() {
-        let borrowed = blob_ref.borrow();
-        return resolve_index(n, borrowed.len())
-            .map(|i| Value::int(borrowed[i] as i64))
-            .ok_or_else(|| {
-                error_val(
-                    "argument-error",
-                    format!("nth: index {} out of bounds (length {})", n, borrowed.len()),
-                )
-            });
+            })
+    }) {
+        return r;
     }
     Err(seq_type_error("nth", val))
 }
@@ -336,57 +320,33 @@ pub fn seq_butlast(val: &Value) -> Result<Value, Value> {
         }
         return Ok(list(vec[..vec.len() - 1].to_vec()));
     }
-    if let Some(elems) = val.as_array() {
-        return Ok(if elems.is_empty() {
-            Value::array(vec![])
+    if let Some(r) = with_array(val, |elems, m| {
+        if elems.is_empty() {
+            make_array(vec![], m)
         } else {
-            Value::array(elems[..elems.len() - 1].to_vec())
-        });
-    }
-    if let Some(arr) = val.as_array_mut() {
-        let borrowed = arr.borrow();
-        return Ok(if borrowed.is_empty() {
-            Value::array_mut(vec![])
-        } else {
-            Value::array_mut(borrowed[..borrowed.len() - 1].to_vec())
-        });
-    }
-    if let Some(result) = val.with_string(|s| {
-        let graphemes: Vec<&str> = s.graphemes(true).collect();
-        if graphemes.is_empty() {
-            Value::string("")
-        } else {
-            Value::string(graphemes[..graphemes.len() - 1].concat())
+            make_array(elems[..elems.len() - 1].to_vec(), m)
         }
     }) {
-        return Ok(result);
+        return Ok(r);
     }
-    if let Some(buf_ref) = val.as_string_mut() {
-        let borrowed = buf_ref.borrow();
-        if let Ok(s) = std::str::from_utf8(&borrowed) {
-            let graphemes: Vec<&str> = s.graphemes(true).collect();
-            return Ok(if graphemes.is_empty() {
-                Value::string_mut(vec![])
-            } else {
-                Value::string_mut(graphemes[..graphemes.len() - 1].concat().into_bytes())
-            });
+    if let Some(r) = with_text(val, |s, m| {
+        let graphemes: Vec<&str> = s.graphemes(true).collect();
+        if graphemes.is_empty() {
+            make_string(String::new(), m)
+        } else {
+            make_string(graphemes[..graphemes.len() - 1].concat(), m)
         }
-        return Ok(Value::string_mut(vec![]));
+    }) {
+        return Ok(r);
     }
-    if let Some(b) = val.as_bytes() {
-        return Ok(if b.is_empty() {
-            Value::bytes(vec![])
+    if let Some(r) = with_raw_bytes(val, |b, m| {
+        if b.is_empty() {
+            make_bytes(vec![], m)
         } else {
-            Value::bytes(b[..b.len() - 1].to_vec())
-        });
-    }
-    if let Some(blob_ref) = val.as_bytes_mut() {
-        let borrowed = blob_ref.borrow();
-        return Ok(if borrowed.is_empty() {
-            Value::bytes_mut(vec![])
-        } else {
-            Value::bytes_mut(borrowed[..borrowed.len() - 1].to_vec())
-        });
+            make_bytes(b[..b.len() - 1].to_vec(), m)
+        }
+    }) {
+        return Ok(r);
     }
     Err(seq_type_error("butlast", val))
 }
@@ -403,103 +363,64 @@ pub fn seq_reverse(val: &Value) -> Result<Value, Value> {
         vec.reverse();
         return Ok(list(vec));
     }
-    if let Some(elems) = val.as_array() {
+    if let Some(r) = with_array(val, |elems, m| {
         let mut vec = elems.to_vec();
         vec.reverse();
-        return Ok(Value::array(vec));
-    }
-    if let Some(arr) = val.as_array_mut() {
-        let mut vec = arr.borrow().to_vec();
-        vec.reverse();
-        return Ok(Value::array_mut(vec));
-    }
-    if let Some(result) = val.with_string(|s| {
-        let reversed: String = s.graphemes(true).rev().collect();
-        Value::string(reversed)
+        make_array(vec, m)
     }) {
-        return Ok(result);
+        return Ok(r);
     }
-    if let Some(buf_ref) = val.as_string_mut() {
-        let borrowed = buf_ref.borrow();
-        if let Ok(s) = std::str::from_utf8(&borrowed) {
-            let reversed: String = s.graphemes(true).rev().collect();
-            return Ok(Value::string_mut(reversed.into_bytes()));
-        }
-        return Ok(Value::string_mut(vec![]));
+    if let Some(r) = with_text(val, |s, m| {
+        let reversed: String = s.graphemes(true).rev().collect();
+        make_string(reversed, m)
+    }) {
+        return Ok(r);
     }
-    if let Some(b) = val.as_bytes() {
+    if let Some(r) = with_raw_bytes(val, |b, m| {
         let mut vec = b.to_vec();
         vec.reverse();
-        return Ok(Value::bytes(vec));
-    }
-    if let Some(blob_ref) = val.as_bytes_mut() {
-        let mut vec = blob_ref.borrow().to_vec();
-        vec.reverse();
-        return Ok(Value::bytes_mut(vec));
+        make_bytes(vec, m)
+    }) {
+        return Ok(r);
     }
     Err(seq_type_error("reverse", val))
 }
 
 /// Slice a sequence from start to end (type-preserving).
 pub fn seq_slice(val: &Value, start: i64, end: i64) -> Result<Value, Value> {
-    // Bytes
-    if let Some(b) = val.as_bytes() {
+    if let Some(r) = with_raw_bytes(val, |b, m| {
         let s = resolve_slice_index(start, b.len());
         let e = resolve_slice_index(end, b.len());
-        return Ok(if s >= e {
-            Value::bytes(vec![])
+        if s >= e {
+            make_bytes(vec![], m)
         } else {
-            Value::bytes(b[s..e].to_vec())
-        });
+            make_bytes(b[s..e].to_vec(), m)
+        }
+    }) {
+        return Ok(r);
     }
-    if let Some(blob_ref) = val.as_bytes_mut() {
-        let borrowed = blob_ref.borrow();
-        let s = resolve_slice_index(start, borrowed.len());
-        let e = resolve_slice_index(end, borrowed.len());
-        return Ok(if s >= e {
-            Value::bytes_mut(vec![])
-        } else {
-            Value::bytes_mut(borrowed[s..e].to_vec())
-        });
-    }
-    // Arrays
-    if let Some(elems) = val.as_array() {
+    if let Some(r) = with_array(val, |elems, m| {
         let s = resolve_slice_index(start, elems.len());
         let e = resolve_slice_index(end, elems.len());
-        return Ok(if s >= e {
-            Value::array(vec![])
+        if s >= e {
+            make_array(vec![], m)
         } else {
-            Value::array(elems[s..e].to_vec())
-        });
+            make_array(elems[s..e].to_vec(), m)
+        }
+    }) {
+        return Ok(r);
     }
-    if let Some(arr_ref) = val.as_array_mut() {
-        let borrowed = arr_ref.borrow();
-        let s = resolve_slice_index(start, borrowed.len());
-        let e = resolve_slice_index(end, borrowed.len());
-        return Ok(if s >= e {
-            Value::array_mut(vec![])
+    if let Some(r) = with_text(val, |str_val, m| {
+        let graphemes: Vec<&str> = str_val.graphemes(true).collect();
+        let s = resolve_slice_index(start, graphemes.len()).min(graphemes.len());
+        let e = resolve_slice_index(end, graphemes.len()).min(graphemes.len());
+        if s >= e {
+            make_string(String::new(), m)
         } else {
-            Value::array_mut(borrowed[s..e].to_vec())
-        });
-    }
-    // Strings (grapheme-aware)
-    if val.is_string() {
-        return val
-            .with_string(|str_val| {
-                let count = str_val.graphemes(true).count();
-                let s = resolve_slice_index(start, count);
-                let e = resolve_slice_index(end, count);
-                Ok(slice_graphemes_immut(str_val, s, e))
-            })
-            .unwrap();
-    }
-    if let Some(buf_ref) = val.as_string_mut() {
-        let borrowed = buf_ref.borrow();
-        let str_val = unsafe { std::str::from_utf8_unchecked(&borrowed) };
-        let count = str_val.graphemes(true).count();
-        let s = resolve_slice_index(start, count);
-        let e = resolve_slice_index(end, count);
-        return Ok(slice_graphemes_mut(str_val, s, e));
+            make_string(graphemes[s..e].concat(), m)
+        }
+    }) {
+        return Ok(r);
     }
     // Lists
     if val.is_empty_list() || val.is_pair() {
@@ -518,28 +439,6 @@ pub fn seq_slice(val: &Value, start: i64, end: i64) -> Result<Value, Value> {
         return Ok(result);
     }
     Err(seq_type_error("slice", val))
-}
-
-fn slice_graphemes_immut(s: &str, start: usize, end: usize) -> Value {
-    let graphemes: Vec<&str> = s.graphemes(true).collect();
-    let cs = start.min(graphemes.len());
-    let ce = end.min(graphemes.len());
-    if cs >= ce {
-        Value::string("")
-    } else {
-        Value::string(graphemes[cs..ce].concat())
-    }
-}
-
-fn slice_graphemes_mut(s: &str, start: usize, end: usize) -> Value {
-    let graphemes: Vec<&str> = s.graphemes(true).collect();
-    let cs = start.min(graphemes.len());
-    let ce = end.min(graphemes.len());
-    if cs >= ce {
-        Value::string_mut(vec![])
-    } else {
-        Value::string_mut(graphemes[cs..ce].concat().into_bytes())
-    }
 }
 
 /// Sort a sequence (type-preserving).
@@ -596,24 +495,7 @@ pub fn seq_push(val: &Value, elem: Value) -> Result<Value, Value> {
     }
     // @bytes — append byte
     if let Some(blob_ref) = val.as_bytes_mut() {
-        let byte = match elem.as_int() {
-            Some(n) if (0..=255).contains(&n) => n as u8,
-            Some(n) => {
-                return Err(error_val(
-                    "argument-error",
-                    format!("push: byte value out of range 0-255: {}", n),
-                ))
-            }
-            None => {
-                return Err(error_val(
-                    "type-error",
-                    format!(
-                        "push: @bytes value must be integer, got {}",
-                        elem.type_name()
-                    ),
-                ))
-            }
-        };
+        let byte = require_byte("push", &elem)?;
         blob_ref.borrow_mut().push(byte);
         return Ok(*val);
     }
@@ -644,24 +526,7 @@ pub fn seq_push(val: &Value, elem: Value) -> Result<Value, Value> {
     }
     // Immutable bytes
     if let Some(b) = val.as_bytes() {
-        let byte = match elem.as_int() {
-            Some(n) if (0..=255).contains(&n) => n as u8,
-            Some(n) => {
-                return Err(error_val(
-                    "argument-error",
-                    format!("push: byte value out of range 0-255: {}", n),
-                ))
-            }
-            None => {
-                return Err(error_val(
-                    "type-error",
-                    format!(
-                        "push: bytes value must be integer, got {}",
-                        elem.type_name()
-                    ),
-                ))
-            }
-        };
+        let byte = require_byte("push", &elem)?;
         let mut new = b.to_vec();
         new.push(byte);
         return Ok(Value::bytes(new));
@@ -718,4 +583,23 @@ pub fn seq_pop(val: &Value) -> Result<Value, Value> {
             val.type_name()
         ),
     ))
+}
+
+/// Validate and extract a byte value from an integer.
+fn require_byte(op: &str, val: &Value) -> Result<u8, Value> {
+    match val.as_int() {
+        Some(n) if (0..=255).contains(&n) => Ok(n as u8),
+        Some(n) => Err(error_val(
+            "argument-error",
+            format!("{}: byte value out of range 0-255: {}", op, n),
+        )),
+        None => Err(error_val(
+            "type-error",
+            format!(
+                "{}: bytes value must be integer, got {}",
+                op,
+                val.type_name()
+            ),
+        )),
+    }
 }

--- a/src/primitives/sort.rs
+++ b/src/primitives/sort.rs
@@ -23,93 +23,35 @@ pub(crate) fn prim_sort(args: &[Value]) -> (SignalBits, Value) {
 /// `(range start end)` — start to end-1
 /// `(range start end step)` — start, start+step, ... while < end (or > end for negative step)
 pub(crate) fn prim_range(args: &[Value]) -> (SignalBits, Value) {
+    macro_rules! require_num {
+        ($v:expr) => {
+            match $v.as_number() {
+                Some(n) => n,
+                None => {
+                    return (
+                        SIG_ERROR,
+                        error_val(
+                            "type-error",
+                            format!("range: expected number, got {}", $v.type_name()),
+                        ),
+                    )
+                }
+            }
+        };
+    }
+
     let (start, end, step) = match args.len() {
-        1 => {
-            let end = match args[0].as_number() {
-                Some(n) => n,
-                None => {
-                    return (
-                        SIG_ERROR,
-                        error_val(
-                            "type-error",
-                            format!("range: expected number, got {}", args[0].type_name()),
-                        ),
-                    )
-                }
-            };
-            (0.0, end, 1.0)
-        }
-        2 => {
-            let start = match args[0].as_number() {
-                Some(n) => n,
-                None => {
-                    return (
-                        SIG_ERROR,
-                        error_val(
-                            "type-error",
-                            format!("range: expected number, got {}", args[0].type_name()),
-                        ),
-                    )
-                }
-            };
-            let end = match args[1].as_number() {
-                Some(n) => n,
-                None => {
-                    return (
-                        SIG_ERROR,
-                        error_val(
-                            "type-error",
-                            format!("range: expected number, got {}", args[1].type_name()),
-                        ),
-                    )
-                }
-            };
-            (start, end, 1.0)
-        }
+        1 => (0.0, require_num!(args[0]), 1.0),
+        2 => (require_num!(args[0]), require_num!(args[1]), 1.0),
         3 => {
-            let start = match args[0].as_number() {
-                Some(n) => n,
-                None => {
-                    return (
-                        SIG_ERROR,
-                        error_val(
-                            "type-error",
-                            format!("range: expected number, got {}", args[0].type_name()),
-                        ),
-                    )
-                }
-            };
-            let end = match args[1].as_number() {
-                Some(n) => n,
-                None => {
-                    return (
-                        SIG_ERROR,
-                        error_val(
-                            "type-error",
-                            format!("range: expected number, got {}", args[1].type_name()),
-                        ),
-                    )
-                }
-            };
-            let step = match args[2].as_number() {
-                Some(n) => n,
-                None => {
-                    return (
-                        SIG_ERROR,
-                        error_val(
-                            "type-error",
-                            format!("range: expected number, got {}", args[2].type_name()),
-                        ),
-                    )
-                }
-            };
+            let step = require_num!(args[2]);
             if step == 0.0 {
                 return (
                     SIG_ERROR,
                     error_val("argument-error", "range: step cannot be zero"),
                 );
             }
-            (start, end, step)
+            (require_num!(args[0]), require_num!(args[1]), step)
         }
         _ => unreachable!(),
     };

--- a/src/value/arena.rs
+++ b/src/value/arena.rs
@@ -86,7 +86,6 @@ impl ArenaMark {
         self.root_allocs_len
     }
 
-    #[allow(dead_code)]
     pub(crate) fn bump_mark(&self) -> Option<BumpMark> {
         self.bump_mark
     }
@@ -144,31 +143,6 @@ pub fn heap_arena_len() -> usize {
     crate::value::fiberheap::with_current_heap_mut(|h| h.len()).unwrap_or(0)
 }
 
-/// Current capacity (slab chunk bytes) of the root heap.
-pub fn heap_arena_capacity() -> usize {
-    crate::value::fiberheap::with_current_heap_mut(|h| h.capacity()).unwrap_or(0)
-}
-
-/// Get the current object limit for the root heap.
-pub fn heap_arena_object_limit() -> Option<usize> {
-    crate::value::fiberheap::with_current_heap_mut(|h| h.object_limit()).flatten()
-}
-
-/// Set the object limit for the root heap. Returns the previous limit.
-pub fn heap_arena_set_object_limit(limit: Option<usize>) -> Option<usize> {
-    crate::value::fiberheap::with_current_heap_mut(|h| h.set_object_limit(limit)).flatten()
-}
-
-/// Get the peak object count for the root heap.
-pub fn heap_arena_peak() -> usize {
-    crate::value::fiberheap::with_current_heap_mut(|h| h.peak_alloc_count()).unwrap_or(0)
-}
-
-/// Reset peak to current count. Returns previous peak.
-pub fn heap_arena_reset_peak() -> usize {
-    crate::value::fiberheap::with_current_heap_mut(|h| h.reset_peak()).unwrap_or(0)
-}
-
 /// Allocate a heap object and return a Value pointing to it.
 ///
 /// Dispatches through the current FiberHeap. If no heap is installed
@@ -219,18 +193,6 @@ pub fn alloc_permanent(obj: HeapObject) -> Value {
 pub unsafe fn deref(value: Value) -> &'static HeapObject {
     let ptr = value.as_heap_ptr().unwrap() as *const HeapObject;
     &*ptr
-}
-
-/// Clone (increment refcount) a heap value.
-///
-/// # Safety
-/// The Value must be a heap pointer allocated via `alloc_permanent` (Rc-based).
-#[inline]
-pub unsafe fn clone_heap(value: Value) {
-    let ptr = value.as_heap_ptr().unwrap() as *const HeapObject;
-    let rc = Rc::from_raw(ptr);
-    let _ = Rc::clone(&rc);
-    std::mem::forget(rc); // Don't decrement refcount
 }
 
 /// Drop (decrement refcount) a heap value.

--- a/src/value/display.rs
+++ b/src/value/display.rs
@@ -8,6 +8,49 @@ use crate::value::cycle::{fmt_enter, HareState};
 use crate::value::Value;
 use std::fmt;
 
+/// Format a `@string` (mutable string buffer) value.
+fn fmt_string_mut(buf: &std::cell::RefCell<Vec<u8>>, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    let borrowed = buf.borrow();
+    write!(f, "@\"")?;
+    for &byte in borrowed.iter() {
+        if byte == b'"' {
+            write!(f, "\\\"")?;
+        } else if byte == b'\\' {
+            write!(f, "\\\\")?;
+        } else if (0x20..0x7f).contains(&byte) {
+            write!(f, "{}", byte as char)?;
+        } else {
+            write!(f, "\\x{:02x}", byte)?;
+        }
+    }
+    write!(f, "\"")
+}
+
+/// Format immutable `bytes` value.
+fn fmt_bytes(b: &[u8], f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    write!(f, "b[")?;
+    for (i, byte) in b.iter().enumerate() {
+        if i > 0 {
+            write!(f, " ")?;
+        }
+        write!(f, "{}", byte)?;
+    }
+    write!(f, "]")
+}
+
+/// Format mutable `@bytes` value.
+fn fmt_bytes_mut(blob: &std::cell::RefCell<Vec<u8>>, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    let borrowed = blob.borrow();
+    write!(f, "@b[")?;
+    for (i, byte) in borrowed.iter().enumerate() {
+        if i > 0 {
+            write!(f, " ")?;
+        }
+        write!(f, "{}", byte)?;
+    }
+    write!(f, "]")
+}
+
 /// Resolve a symbol ID to its name via the thread-local symbol table.
 fn resolve_symbol(id: u32) -> Option<String> {
     crate::context::resolve_symbol_name(id)
@@ -186,48 +229,14 @@ impl fmt::Display for Value {
             return write!(f, "<parameter:{}>", id);
         }
 
-        // @string
         if let Some(buf_ref) = self.as_string_mut() {
-            let borrowed = buf_ref.borrow();
-            write!(f, "@\"")?;
-            // Display as UTF-8 where valid, escape otherwise
-            for &byte in borrowed.iter() {
-                if byte == b'"' {
-                    write!(f, "\\\"")?;
-                } else if byte == b'\\' {
-                    write!(f, "\\\\")?;
-                } else if (0x20..0x7f).contains(&byte) {
-                    write!(f, "{}", byte as char)?;
-                } else {
-                    write!(f, "\\x{:02x}", byte)?;
-                }
-            }
-            return write!(f, "\"");
+            return fmt_string_mut(buf_ref, f);
         }
-
-        // Bytes (immutable binary data)
         if let Some(b) = self.as_bytes() {
-            write!(f, "b[")?;
-            for (i, byte) in b.iter().enumerate() {
-                if i > 0 {
-                    write!(f, " ")?;
-                }
-                write!(f, "{}", byte)?;
-            }
-            return write!(f, "]");
+            return fmt_bytes(b, f);
         }
-
-        // @bytes (mutable binary data)
         if let Some(blob_ref) = self.as_bytes_mut() {
-            let borrowed = blob_ref.borrow();
-            write!(f, "@b[")?;
-            for (i, byte) in borrowed.iter().enumerate() {
-                if i > 0 {
-                    write!(f, " ")?;
-                }
-                write!(f, "{}", byte)?;
-            }
-            return write!(f, "]");
+            return fmt_bytes_mut(blob_ref, f);
         }
 
         // Array (immutable)
@@ -382,45 +391,14 @@ impl fmt::Debug for Value {
             }
             return write!(f, "]");
         }
-        // @string
         if let Some(buf_ref) = self.as_string_mut() {
-            let borrowed = buf_ref.borrow();
-            write!(f, "@\"")?;
-            for &byte in borrowed.iter() {
-                if byte == b'"' {
-                    write!(f, "\\\"")?;
-                } else if byte == b'\\' {
-                    write!(f, "\\\\")?;
-                } else if (0x20..0x7f).contains(&byte) {
-                    write!(f, "{}", byte as char)?;
-                } else {
-                    write!(f, "\\x{:02x}", byte)?;
-                }
-            }
-            return write!(f, "\"");
+            return fmt_string_mut(buf_ref, f);
         }
-        // Bytes (immutable binary data)
         if let Some(b) = self.as_bytes() {
-            write!(f, "b[")?;
-            for (i, byte) in b.iter().enumerate() {
-                if i > 0 {
-                    write!(f, " ")?;
-                }
-                write!(f, "{}", byte)?;
-            }
-            return write!(f, "]");
+            return fmt_bytes(b, f);
         }
-        // @bytes (mutable binary data)
         if let Some(blob_ref) = self.as_bytes_mut() {
-            let borrowed = blob_ref.borrow();
-            write!(f, "@b[")?;
-            for (i, byte) in borrowed.iter().enumerate() {
-                if i > 0 {
-                    write!(f, " ")?;
-                }
-                write!(f, "{}", byte)?;
-            }
-            return write!(f, "]");
+            return fmt_bytes_mut(blob_ref, f);
         }
         // Array (immutable)
         if let Some(elems) = self.as_array() {
@@ -497,9 +475,9 @@ impl fmt::Debug for Value {
 }
 
 impl Value {
-    /// Format a cons cell (list) with Debug (quoted strings).
-    /// Uses Floyd's tortoise-and-hare to detect cycles in the cdr chain.
-    fn fmt_cons_debug(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    /// Format a cons cell (list) with cycle detection.
+    /// `debug` controls whether elements use `{:?}` (true) or `{}` (false).
+    fn fmt_cons_inner(&self, f: &mut fmt::Formatter<'_>, debug: bool) -> fmt::Result {
         write!(f, "(")?;
         let mut current = *self;
         let mut hare = HareState::new(*self);
@@ -513,54 +491,34 @@ impl Value {
             }
             first = false;
             if let Some(c) = current.as_pair() {
-                write!(f, "{:?}", c.first)?;
+                if debug {
+                    write!(f, "{:?}", c.first)?;
+                } else {
+                    write!(f, "{}", c.first)?;
+                }
                 current = c.rest;
                 if current.is_heap() && hare.advance(current) {
                     write!(f, " . <cycle>")?;
                     break;
                 }
             } else {
-                write!(f, ". {:?}", current)?;
+                if debug {
+                    write!(f, ". {:?}", current)?;
+                } else {
+                    write!(f, ". {}", current)?;
+                }
                 break;
             }
         }
         write!(f, ")")
     }
 
-    /// Format a cons cell (list) with proper list notation.
-    /// Uses Floyd's tortoise-and-hare to detect cycles in the cdr chain.
+    fn fmt_cons_debug(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.fmt_cons_inner(f, true)
+    }
+
     fn fmt_cons(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "(")?;
-
-        let mut current = *self;
-        let mut hare = HareState::new(*self);
-        let mut first = true;
-
-        loop {
-            if current.is_nil() || current.is_empty_list() {
-                break;
-            }
-
-            if !first {
-                write!(f, " ")?;
-            }
-            first = false;
-
-            if let Some(c) = current.as_pair() {
-                write!(f, "{}", c.first)?;
-                current = c.rest;
-                if current.is_heap() && hare.advance(current) {
-                    write!(f, " . <cycle>")?;
-                    break;
-                }
-            } else {
-                // Improper list: (a . b)
-                write!(f, ". {}", current)?;
-                break;
-            }
-        }
-
-        write!(f, ")")
+        self.fmt_cons_inner(f, false)
     }
 }
 

--- a/src/value/fiber.rs
+++ b/src/value/fiber.rs
@@ -539,6 +539,12 @@ impl Fiber {
             withheld: SignalBits::EMPTY,
         }
     }
+
+    /// Set an error signal on this fiber.
+    #[inline]
+    pub fn set_error(&mut self, kind: &str, msg: impl Into<String>) {
+        self.signal = Some((SIG_ERROR, crate::value::error_val(kind, msg)));
+    }
 }
 
 impl std::fmt::Debug for Fiber {

--- a/src/value/fiberheap/mod.rs
+++ b/src/value/fiberheap/mod.rs
@@ -981,25 +981,8 @@ impl FiberHeap {
         ptr
     }
 
-    /// Return an existing shared allocator from `owned_shared`, or create one.
-    ///
-    /// Prevents the per-resume leak: without this, each `with_child_fiber`
-    /// call pushes a new `SharedAllocator` that accumulates until the
-    /// owner's `FiberHeap::clear()` runs. Reusing the last allocator keeps
-    /// `owned_shared` at most length 1 for non-propagation cases.
-    #[allow(dead_code)]
-    pub(crate) fn get_or_create_shared_allocator(
-        &mut self,
-    ) -> *mut crate::value::shared_alloc::SharedAllocator {
-        if let Some(sa) = self.owned_shared.last_mut() {
-            &mut **sa as *mut crate::value::shared_alloc::SharedAllocator
-        } else {
-            self.create_shared_allocator()
-        }
-    }
-
     /// Current shared allocator pointer. Returns null if none is set.
-    #[allow(dead_code)]
+    #[cfg(test)]
     pub(crate) fn shared_alloc(&self) -> *mut crate::value::shared_alloc::SharedAllocator {
         self.shared_alloc
     }
@@ -1011,7 +994,7 @@ impl FiberHeap {
 
     /// Set the shared allocator pointer for this fiber.
     /// When non-null, `alloc()` routes all allocations to the shared allocator.
-    #[allow(dead_code)]
+    #[cfg(test)]
     pub(crate) fn set_shared_alloc(
         &mut self,
         ptr: *mut crate::value::shared_alloc::SharedAllocator,
@@ -1038,14 +1021,6 @@ impl FiberHeap {
         self.shared_alloc_count = 0;
         self.outbox = Some(Box::new(pool));
         self.outbox_active = false;
-    }
-
-    /// Detach and return the outbox pool. Called at yield time.
-    /// The parent stores the outbox and reads yielded values from it.
-    #[allow(dead_code)]
-    pub(crate) fn take_outbox(&mut self) -> Option<Box<SlabPool>> {
-        self.outbox_active = false;
-        self.outbox.take()
     }
 
     /// Check whether an outbox is installed.

--- a/src/value/fiberheap/pool.rs
+++ b/src/value/fiberheap/pool.rs
@@ -114,13 +114,6 @@ impl SlabPool {
         self.alloc_count = mark.alloc_count;
     }
 
-    /// Reset the bump arena pointer to a saved mark. Called by
-    /// `FiberHeap::release()` after dtors and tracking vecs are handled.
-    #[allow(dead_code)]
-    pub fn release_bump(&mut self, mark: BumpMark) {
-        self.arena.release_to(mark);
-    }
-
     /// Run all destructors and reset both allocators.
     pub fn teardown(&mut self) {
         self.run_dtors(0);
@@ -210,13 +203,6 @@ impl SlabPool {
     #[inline]
     pub fn refcount(&self, ptr: *const HeapObject) -> u32 {
         self.slab.refcount(ptr)
-    }
-
-    /// Get the reference count for a slot by flat index.
-    #[inline]
-    #[allow(dead_code)]
-    pub fn refcount_by_flat(&self, flat: usize) -> u32 {
-        self.slab.refcount_by_flat(flat)
     }
 
     /// Check if a pointer is in the slab (not arena).

--- a/src/value/fiberheap/slab.rs
+++ b/src/value/fiberheap/slab.rs
@@ -238,17 +238,6 @@ impl Slab {
         }
     }
 
-    /// Get the reference count for a slot by flat index.
-    #[inline]
-    #[allow(dead_code)]
-    pub fn refcount_by_flat(&self, flat: usize) -> u32 {
-        if flat < self.refcounts.len() {
-            self.refcounts[flat]
-        } else {
-            0
-        }
-    }
-
     // ── Private helpers ──────────────────────────────────────────────
 
     fn add_chunk(&mut self) {

--- a/src/value/heap.rs
+++ b/src/value/heap.rs
@@ -301,17 +301,9 @@ pub struct ThreadHandle {
 }
 
 impl ThreadHandle {
-    /// Create a new thread handle with no result yet
-    pub fn new() -> Self {
-        ThreadHandle {
-            result: Arc::new(Mutex::new(None)),
-        }
-    }
-}
-
-impl Default for ThreadHandle {
-    fn default() -> Self {
-        Self::new()
+    /// Create a new thread handle with a shared result slot.
+    pub fn new(result: Arc<Mutex<Option<Result<crate::value::send::SendBundle, String>>>>) -> Self {
+        ThreadHandle { result }
     }
 }
 
@@ -537,9 +529,8 @@ impl std::fmt::Debug for HeapObject {
 // Re-export arena types and functions so existing `use crate::value::heap::{...}`
 // import sites continue working after the arena code moved to `arena.rs`.
 pub use super::arena::{
-    alloc, alloc_permanent, clone_heap, deref, drop_heap, heap_arena_capacity, heap_arena_len,
-    heap_arena_mark, heap_arena_object_limit, heap_arena_peak, heap_arena_release,
-    heap_arena_reset_peak, heap_arena_set_object_limit, ArenaGuard, ArenaMark,
+    alloc, alloc_permanent, deref, drop_heap, heap_arena_len, heap_arena_mark, heap_arena_release,
+    ArenaGuard, ArenaMark,
 };
 
 #[cfg(test)]

--- a/src/value/intern.rs
+++ b/src/value/intern.rs
@@ -1,89 +1,63 @@
-//! String interning for the tagged-union value system.
+//! Dead-code string interner, preserved for test coverage.
 //!
-//! All strings are interned to enable O(1) equality comparison via pointer
-//! equality. This is essential because Values compare by tag+payload equality,
-//! so strings must share the same heap allocation to be equal.
-
-use std::cell::RefCell;
-use std::collections::HashMap;
-use std::rc::Rc;
-
-use crate::value::Value;
-
-use crate::value::heap::HeapObject;
-use crate::value::inline_slice::InlineSlice;
-
-thread_local! {
-    static STRING_INTERNER: RefCell<StringInterner> = RefCell::new(StringInterner::new());
-}
-
-/// An interned entry keeps its bytes pinned on the Rust heap in `bytes`, so
-/// the `InlineSlice<u8>` inside `heap.s` stays valid for the lifetime of
-/// this entry. The outer `Rc` is held by the `strings` map; cloning the Rc
-/// does not move either the HeapObject or the byte buffer.
-struct InternEntry {
-    /// Owning storage for the string bytes. Never moved or dropped while
-    /// the entry lives in the interner map.
-    _bytes: Box<[u8]>,
-    /// HeapObject whose InlineSlice points into `_bytes`.
-    heap: HeapObject,
-}
-
-struct StringInterner {
-    // Map from string content to Rc<InternEntry>
-    // We use Rc to keep the strings alive and prevent them from being dropped
-    strings: HashMap<Box<str>, Rc<InternEntry>>,
-}
-
-impl StringInterner {
-    fn new() -> Self {
-        StringInterner {
-            strings: HashMap::new(),
-        }
-    }
-
-    fn intern(&mut self, s: &str) -> *const HeapObject {
-        // Check if already interned
-        if let Some(rc) = self.strings.get(s) {
-            return &rc.heap as *const HeapObject;
-        }
-
-        // Pin the bytes on the Rust heap so the InlineSlice pointer is stable.
-        let bytes: Box<[u8]> = s.as_bytes().to_vec().into_boxed_slice();
-        let slice = unsafe { InlineSlice::from_raw(bytes.as_ptr(), bytes.len() as u32) };
-        let entry = Rc::new(InternEntry {
-            _bytes: bytes,
-            heap: HeapObject::LString {
-                s: slice,
-                traits: Value::NIL,
-            },
-        });
-        let ptr = &entry.heap as *const HeapObject;
-
-        // Store in table
-        self.strings.insert(s.into(), entry);
-
-        ptr
-    }
-}
-
-/// Intern a string, returning a pointer to the HeapObject.
-///
-/// The returned pointer is valid for the lifetime of the thread.
-/// Interned strings are never dropped during program execution.
-pub fn intern_string(s: &str) -> *const HeapObject {
-    STRING_INTERNER.with(|interner| interner.borrow_mut().intern(s))
-}
-
-/// Return the number of interned strings in the thread-local table.
-pub fn intern_string_count() -> usize {
-    STRING_INTERNER.with(|interner| interner.borrow().strings.len())
-}
+//! This module was originally used for O(1) string equality via pointer
+//! comparison. It was superseded when `Value::string()` moved to bump-arena
+//! allocation (`alloc_inline_slice`); string equality is now content-based
+//! via `InlineSlice::PartialEq`. The interner has zero production callers.
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use std::cell::RefCell;
+    use std::collections::HashMap;
+    use std::rc::Rc;
+
+    use crate::value::heap::HeapObject;
+    use crate::value::inline_slice::InlineSlice;
     use crate::value::Value;
+
+    thread_local! {
+        static STRING_INTERNER: RefCell<StringInterner> = RefCell::new(StringInterner::new());
+    }
+
+    struct InternEntry {
+        _bytes: Box<[u8]>,
+        heap: HeapObject,
+    }
+
+    struct StringInterner {
+        strings: HashMap<Box<str>, Rc<InternEntry>>,
+    }
+
+    impl StringInterner {
+        fn new() -> Self {
+            StringInterner {
+                strings: HashMap::new(),
+            }
+        }
+
+        fn intern(&mut self, s: &str) -> *const HeapObject {
+            if let Some(rc) = self.strings.get(s) {
+                return &rc.heap as *const HeapObject;
+            }
+
+            let bytes: Box<[u8]> = s.as_bytes().to_vec().into_boxed_slice();
+            let slice = unsafe { InlineSlice::from_raw(bytes.as_ptr(), bytes.len() as u32) };
+            let entry = Rc::new(InternEntry {
+                _bytes: bytes,
+                heap: HeapObject::LString {
+                    s: slice,
+                    traits: Value::NIL,
+                },
+            });
+            let ptr = &entry.heap as *const HeapObject;
+            self.strings.insert(s.into(), entry);
+            ptr
+        }
+    }
+
+    fn intern_string(s: &str) -> *const HeapObject {
+        STRING_INTERNER.with(|interner| interner.borrow_mut().intern(s))
+    }
 
     // === Basic Interning Tests ===
 

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -14,6 +14,7 @@ pub mod fiber;
 pub mod fiberheap;
 pub mod heap;
 pub mod inline_slice;
+#[cfg(test)]
 pub mod intern;
 pub mod keyword;
 pub mod repr;

--- a/src/value/repr/constructors.rs
+++ b/src/value/repr/constructors.rs
@@ -97,15 +97,6 @@ impl Value {
         })
     }
 
-    /// Create a heap string without interning. Used by `SendValue::into_value()`
-    /// to avoid thread-local interner issues when reconstructing values on
-    /// a different thread.
-    #[inline]
-    pub fn string_no_intern(s: impl AsRef<str>) -> Self {
-        // Same path as `string()` now that bytes are arena-allocated.
-        Self::string(s)
-    }
-
     /// Create a cons cell.
     #[inline]
     pub fn pair(head: Value, tail: Value) -> Self {

--- a/src/value/send.rs
+++ b/src/value/send.rs
@@ -502,7 +502,7 @@ impl SendValue {
         match self {
             SendValue::Immediate(v) => v,
             SendValue::Keyword(name) => Value::keyword(&name),
-            SendValue::String(s) => Value::string_no_intern(s),
+            SendValue::String(s) => Value::string(s),
             SendValue::Pair(first, rest, traits) => {
                 let first_val = first.into_value();
                 let rest_val = rest.into_value();
@@ -647,7 +647,7 @@ fn into_value_inner(sv: SendValue, ctx: &mut DeserContext) -> Value {
     match sv {
         SendValue::Immediate(v) => v,
         SendValue::Keyword(name) => Value::keyword(&name),
-        SendValue::String(s) => Value::string_no_intern(s),
+        SendValue::String(s) => Value::string(s),
         SendValue::Pair(first, rest, traits) => {
             let f = into_value_inner(*first, ctx);
             let r = into_value_inner(*rest, ctx);

--- a/src/value/shared_alloc.rs
+++ b/src/value/shared_alloc.rs
@@ -24,11 +24,6 @@ struct SharedMark {
 /// Previous tail-call iteration's shared allocations, preserved for one
 /// rotation cycle so argument values from iteration N remain valid until
 /// iteration N+1 copies them.
-///
-/// Not yet activated — shared rotation requires reachability analysis
-/// to avoid freeing objects referenced by live chains (e.g., cons lists
-/// accumulated via tail-call arguments).
-#[allow(dead_code)]
 struct SharedSwapPool {
     allocs: Vec<*mut HeapObject>,
     dtors: Vec<*mut HeapObject>,
@@ -94,36 +89,8 @@ impl SharedAllocator {
         });
     }
 
-    /// Capture the current pool position for rotation.
-    #[allow(dead_code)]
-    pub(crate) fn rotation_mark(&self) -> SlabMark {
-        self.pool.mark()
-    }
-
-    /// Clear the swap pool without freeing any slots. Used when a new
-    /// trampoline captures a rotation mark: discard stale swap state
-    /// from a previous child fiber so the new child's rotation doesn't
-    /// tear down objects that the previous child still references.
-    #[allow(dead_code)]
-    pub(crate) fn clear_swap(&mut self) {
-        if let Some(old) = self.swap.take() {
-            // Return objects from the swap pool to the main pool tracking.
-            // These objects are still live (they may be referenced by the
-            // previous child fiber). Move them back so teardown handles them.
-            self.pool.allocs.extend(old.allocs);
-            self.pool.dtors.extend(old.dtors);
-        }
-    }
-
     /// Rotate the shared pool at a tail-call boundary.
-    ///
-    /// Same protocol as FiberHeap::rotate_pools:
-    /// 1. Teardown swap (iteration N-2 is dead)
-    /// 2. Move current iteration's objects to swap
-    /// 3. Reset alloc_count to base level
-    #[allow(dead_code)]
     pub(crate) fn rotate(&mut self, base: &SlabMark) {
-        // 1. Teardown previous swap pool.
         if let Some(old) = self.swap.take() {
             for i in (0..old.dtors.len()).rev() {
                 unsafe { std::ptr::drop_in_place(old.dtors[i]) };
@@ -133,7 +100,6 @@ impl SharedAllocator {
             }
         }
 
-        // 2. Move current iteration's objects to swap.
         let iter_allocs = self.pool.allocs.split_off(base.allocs_len);
         let iter_dtors = self.pool.dtors.split_off(base.dtor_len);
 
@@ -146,18 +112,15 @@ impl SharedAllocator {
             })
         };
 
-        // 3. Reset alloc_count to base level.
         self.pool.alloc_count = base.alloc_count;
     }
 
     /// Run destructors, return all slots to the slab free list, and reset.
     pub fn teardown(&mut self) {
-        // Drain swap pool first.
         if let Some(old) = self.swap.take() {
             for i in (0..old.dtors.len()).rev() {
                 unsafe { std::ptr::drop_in_place(old.dtors[i]) };
             }
-            // Slab slots freed by pool.teardown() below.
         }
         self.pool.teardown();
         self.marks.clear();

--- a/src/vm/call.rs
+++ b/src/vm/call.rs
@@ -14,7 +14,7 @@ use crate::value::error_val;
 use crate::value::fiber::{CallFrame, MAX_CALL_DEPTH};
 use crate::value::{
     sorted_struct_get, BytecodeFrame, SignalBits, SuspendedFrame, TableKey, Value, SIG_ERROR,
-    SIG_HALT, SIG_OK, SIG_SWITCH,
+    SIG_HALT, SIG_OK,
 };
 // SmallVec was tried here but benchmarks showed no improvement over Vec
 // for the common 0-8 arg case. The inline storage (64 bytes) touches a
@@ -23,11 +23,6 @@ use crate::value::{
 use std::rc::Rc;
 
 use super::core::VM;
-
-/// Helper: set an error signal on the fiber.
-fn set_error(fiber: &mut crate::value::Fiber, kind: &str, msg: impl Into<String>) {
-    fiber.signal = Some((SIG_ERROR, error_val(kind, msg)));
-}
 
 impl VM {
     /// Handle the Call instruction.
@@ -117,8 +112,7 @@ impl VM {
         } else if let Some(tup) = args_val.as_array() {
             tup.to_vec()
         } else {
-            set_error(
-                &mut self.fiber,
+            self.fiber.set_error(
                 "type-error",
                 format!(
                     "splice: expected array or tuple for args, got {}",
@@ -189,8 +183,7 @@ impl VM {
                 );
             }
             if !checked && !def.arity.matches(args.len()) {
-                set_error(
-                    &mut self.fiber,
+                self.fiber.set_error(
                     "arity-error",
                     format!(
                         "{}: expected {} argument(s), got {}",
@@ -221,8 +214,7 @@ impl VM {
 
         if let Some((id, default)) = func.as_parameter() {
             if !args.is_empty() {
-                set_error(
-                    &mut self.fiber,
+                self.fiber.set_error(
                     "arity-error",
                     format!("parameter call: expected 0 arguments, got {}", args.len()),
                 );
@@ -441,28 +433,9 @@ impl VM {
             // to the initial fiber execution.
             //
             // Discard suspended frames: we're converting to error, not suspending.
-            if !closure_squelch_mask.is_empty()
-                && !bits.is_ok()
-                && !bits.contains(SIG_ERROR)
-                && !bits.contains(SIG_HALT)
-                && bits != SIG_SWITCH
-            {
-                let squelched = bits.intersection(closure_squelch_mask);
-                if !squelched.is_empty() {
-                    let squelched_str = {
-                        let registry = crate::signals::registry::global_registry().lock().unwrap();
-                        registry.format_signal_bits(squelched)
-                    };
-                    let err = crate::value::error_val(
-                        "signal-violation",
-                        format!("squelch: signal {} caught at boundary", squelched_str),
-                    );
-                    // Discard suspended frames — we're converting to error, not suspending.
-                    self.fiber.suspended = None;
-                    self.fiber.signal = Some((SIG_ERROR, err));
-                    self.fiber.call_stack.pop();
-                    return Some(SIG_ERROR);
-                }
+            if self.enforce_squelch(bits, closure_squelch_mask) {
+                self.fiber.call_stack.pop();
+                return Some(SIG_ERROR);
             }
             if bits.is_ok() {
                 let (_, value) = self.fiber.signal.take().unwrap();
@@ -538,7 +511,7 @@ impl VM {
                     return None;
                 }
                 Err((kind, msg)) => {
-                    set_error(&mut self.fiber, kind, msg);
+                    self.fiber.set_error(kind, msg);
                     self.fiber.stack.push(Value::NIL);
                     return None;
                 }
@@ -546,11 +519,8 @@ impl VM {
         }
 
         // Cannot call this value
-        set_error(
-            &mut self.fiber,
-            "type-error",
-            format!("Cannot call {:?}", func),
-        );
+        self.fiber
+            .set_error("type-error", format!("Cannot call {:?}", func));
         self.fiber.stack.push(Value::NIL);
         None
     }
@@ -619,8 +589,7 @@ impl VM {
         } else if let Some(tup) = args_val.as_array() {
             tup.to_vec()
         } else {
-            set_error(
-                &mut self.fiber,
+            self.fiber.set_error(
                 "type-error",
                 format!(
                     "splice: expected array or tuple for args, got {}",
@@ -656,8 +625,7 @@ impl VM {
                 return Some(self.handle_capability_denial_tail(def, blocked, &args));
             }
             if !checked && !def.arity.matches(args.len()) {
-                set_error(
-                    &mut self.fiber,
+                self.fiber.set_error(
                     "arity-error",
                     format!(
                         "{}: expected {} argument(s), got {}",
@@ -679,8 +647,7 @@ impl VM {
 
         if let Some((id, default)) = func.as_parameter() {
             if !args.is_empty() {
-                set_error(
-                    &mut self.fiber,
+                self.fiber.set_error(
                     "arity-error",
                     format!("parameter call: expected 0 arguments, got {}", args.len()),
                 );
@@ -731,18 +698,15 @@ impl VM {
                     return Some(SIG_OK);
                 }
                 Err((kind, msg)) => {
-                    set_error(&mut self.fiber, kind, msg);
+                    self.fiber.set_error(kind, msg);
                     return Some(SIG_ERROR);
                 }
             }
         }
 
         // Cannot call this value
-        set_error(
-            &mut self.fiber,
-            "type-error",
-            format!("Cannot call {:?}", func),
-        );
+        self.fiber
+            .set_error("type-error", format!("Cannot call {:?}", func));
         Some(SIG_ERROR)
     }
 

--- a/src/vm/comparison.rs
+++ b/src/vm/comparison.rs
@@ -1,30 +1,15 @@
 use super::core::VM;
+use crate::arithmetic::values_eq;
 use crate::value::Value;
 
 pub(crate) fn handle_eq(vm: &mut VM) {
     let b = vm.fiber.stack.pop().expect("VM bug: Stack underflow on Eq");
     let a = vm.fiber.stack.pop().expect("VM bug: Stack underflow on Eq");
-    // Fast path: bitwise identical
-    if a == b {
-        vm.fiber.stack.push(Value::TRUE);
-        return;
-    }
-    // Numeric coercion: int-int stays exact, mixed promotes to f64
-    if a.is_number() && b.is_number() {
-        if let (Some(x), Some(y)) = (a.as_int(), b.as_int()) {
-            vm.fiber
-                .stack
-                .push(if x == y { Value::TRUE } else { Value::FALSE });
-            return;
-        }
-        if let (Some(x), Some(y)) = (a.as_number(), b.as_number()) {
-            vm.fiber
-                .stack
-                .push(if x == y { Value::TRUE } else { Value::FALSE });
-            return;
-        }
-    }
-    vm.fiber.stack.push(Value::FALSE);
+    vm.fiber.stack.push(if values_eq(&a, &b) {
+        Value::TRUE
+    } else {
+        Value::FALSE
+    });
 }
 
 /// Comparison helper macro. Unchecked — incomparable types produce false

--- a/src/vm/core.rs
+++ b/src/vm/core.rs
@@ -2,7 +2,6 @@ use crate::error::{LocationMap, StackFrame};
 use crate::ffi::FFISubsystem;
 use crate::primitives::def::Doc;
 use crate::reader::SourceLoc;
-use crate::value::fiber::CallFrame;
 use crate::value::{
     BytecodeFrame, Closure, Fiber, FiberHandle, SignalBits, SuspendedFrame, Value, SIG_ERROR,
     SIG_FUEL, SIG_HALT, SIG_OK, SIG_SWITCH,
@@ -97,14 +96,6 @@ pub struct VM {
     /// in REPL mode. Set by `main.rs` at the same point as `user_args`.
     /// Read by `sys/argv`. Empty string means REPL mode.
     pub source_arg: String,
-    /// Whether JIT compilation is enabled.
-    /// Controlled by `--jit=N` CLI flag: `0` disables, `N>0` enables.
-    /// Defaults to `true`.
-    pub jit_enabled: bool,
-    /// JIT hotness threshold: a closure must be called this many times
-    /// before it becomes a JIT compilation candidate.
-    /// Set by `--jit=N` (threshold = N-1), defaulting to 10.
-    pub jit_hotness_threshold: usize,
     /// Lazy WASM compilation tier. When `--wasm=N`, hot closures are
     /// compiled to per-closure WASM modules and dispatched through Wasmtime.
     #[cfg(feature = "wasm")]
@@ -180,8 +171,6 @@ impl VM {
             rc.set_trace(kws);
         }
 
-        let jit_enabled = rc.jit.enabled();
-        let jit_threshold = rc.jit.threshold();
         #[cfg(feature = "mlir")]
         let mlir_enabled = rc.mlir.enabled();
 
@@ -211,10 +200,8 @@ impl VM {
             eval_expander: None,
             user_args: Vec::new(),
             source_arg: String::new(),
-            jit_enabled,
-            jit_hotness_threshold: jit_threshold,
             #[cfg(feature = "wasm")]
-            wasm_tier: if crate::config::get().wasm > 0 && !crate::config::get().wasm_full {
+            wasm_tier: if crate::config::get().wasm_tier_enabled() {
                 crate::wasm::lazy::WasmTier::new().ok()
             } else {
                 None
@@ -306,12 +293,40 @@ impl VM {
         result
     }
 
+    /// Check a signal against a squelch mask. If the signal is squelched,
+    /// sets the fiber to a signal-violation error and returns `true`.
+    /// Callers handle any additional side effects (stack push, call_stack pop, etc.).
+    pub(crate) fn enforce_squelch(&mut self, bits: SignalBits, mask: SignalBits) -> bool {
+        if mask.is_empty()
+            || bits.contains(crate::value::SIG_ERROR)
+            || bits.contains(crate::value::SIG_HALT)
+            || bits == crate::value::SIG_SWITCH
+        {
+            return false;
+        }
+        let squelched = bits.intersection(mask);
+        if squelched.is_empty() {
+            return false;
+        }
+        let squelched_str = {
+            let registry = crate::signals::registry::global_registry().lock().unwrap();
+            registry.format_signal_bits(squelched)
+        };
+        let err = crate::value::error_val(
+            "signal-violation",
+            format!("squelch: signal {} caught at boundary", squelched_str),
+        );
+        self.fiber.suspended = None;
+        self.fiber.signal = Some((crate::value::SIG_ERROR, err));
+        true
+    }
+
     /// Record a closure call and return whether it's "hot" (called N+ times,
     /// where N is `jit_hotness_threshold`, default 10, set via `--jit=N`).
     pub fn record_closure_call(&mut self, bytecode_ptr: *const u8) -> bool {
         let count = self.closure_call_counts.entry(bytecode_ptr).or_insert(0);
         *count += 1;
-        *count >= self.jit_hotness_threshold
+        *count >= self.runtime_config.jit.threshold()
     }
 
     /// Get call count for a closure
@@ -347,7 +362,8 @@ impl VM {
             .unwrap_or(0)
     }
 
-    pub fn push_call_frame(
+    #[cfg(test)]
+    fn push_call_frame(
         &mut self,
         name: String,
         ip: usize,
@@ -355,47 +371,12 @@ impl VM {
     ) {
         let frame_base = self.fiber.stack.len();
         self.fiber.call_depth += 1;
-        self.fiber.call_stack.push(CallFrame {
+        self.fiber.call_stack.push(crate::value::fiber::CallFrame {
             name: Rc::from(name.as_str()),
             ip,
             frame_base,
             location_map,
         });
-    }
-
-    pub fn push_call_frame_with_base(
-        &mut self,
-        name: String,
-        ip: usize,
-        frame_base: usize,
-        location_map: Rc<crate::error::LocationMap>,
-    ) {
-        self.fiber.call_depth += 1;
-        self.fiber.call_stack.push(CallFrame {
-            name: Rc::from(name.as_str()),
-            ip,
-            frame_base,
-            location_map,
-        });
-    }
-
-    pub fn pop_call_frame(&mut self) {
-        if self.fiber.call_depth > 0 {
-            self.fiber.call_depth -= 1;
-            self.fiber.call_stack.pop();
-        }
-    }
-
-    pub fn format_stack_trace(&self) -> String {
-        if self.fiber.call_stack.is_empty() {
-            "No call frames".to_string()
-        } else {
-            let mut trace = String::new();
-            for (i, frame) in self.fiber.call_stack.iter().rev().enumerate() {
-                trace.push_str(&format!("  #{}: {} (ip={})\n", i, frame.name, frame.ip));
-            }
-            trace
-        }
     }
 
     /// Capture current call stack as trace frames

--- a/src/vm/env.rs
+++ b/src/vm/env.rs
@@ -10,16 +10,10 @@
 //! - `populate_env`: fills a caller-supplied buffer; shared by `build_closure_env`
 //!   and `tail_call_inner` (which uses `tail_call_env_cache`)
 
-use crate::value::error_val;
-use crate::value::{Value, SIG_ERROR};
+use crate::value::Value;
 use std::rc::Rc;
 
 use super::core::VM;
-
-/// Helper: set an error signal on the fiber.
-fn set_error(fiber: &mut crate::value::Fiber, kind: &str, msg: impl Into<String>) {
-    fiber.signal = Some((SIG_ERROR, error_val(kind, msg)));
-}
 
 impl VM {
     /// Build a closure environment from captured variables and arguments.
@@ -193,8 +187,7 @@ impl VM {
         }
 
         if !args.len().is_multiple_of(2) {
-            set_error(
-                fiber,
+            fiber.set_error(
                 "argument-error",
                 format!("odd number of keyword arguments ({} args)", args.len()),
             );
@@ -206,8 +199,7 @@ impl VM {
             let key = match TableKey::from_value(&args[i]) {
                 Some(TableKey::Keyword(k)) => k,
                 _ => {
-                    set_error(
-                        fiber,
+                    fiber.set_error(
                         "argument-error",
                         format!(
                             "keyword argument key must be a keyword, got {}",
@@ -221,8 +213,7 @@ impl VM {
             // Strict validation for &named
             if let Some(valid) = valid_keys {
                 if !valid.iter().any(|v| v == &key) {
-                    set_error(
-                        fiber,
+                    fiber.set_error(
                         "argument-error",
                         format!(
                             "unknown named parameter :{}, valid parameters are: {}",
@@ -240,8 +231,7 @@ impl VM {
 
             let table_key = TableKey::Keyword(key.clone());
             if map.contains_key(&table_key) {
-                set_error(
-                    fiber,
+                fiber.set_error(
                     "argument-error",
                     format!("duplicate keyword argument :{}", key),
                 );

--- a/src/vm/execute.rs
+++ b/src/vm/execute.rs
@@ -58,10 +58,34 @@
 //!    parameter frames. It is not isolated.
 
 use crate::error::LocationMap;
-use crate::value::{SignalBits, Value, SIG_ERROR, SIG_HALT, SIG_SWITCH};
+use crate::value::{SignalBits, Value, SIG_ERROR};
 use std::rc::Rc;
 
 use super::core::VM;
+
+/// Advance pool rotation state at a tail-call boundary.
+///
+/// If the previous iteration was rotation-safe, either rotate pools
+/// (if a base mark exists) or capture a new base mark. If the previous
+/// iteration was NOT rotation-safe, clear the base mark to prevent
+/// rotating across an unsafe boundary.
+#[inline]
+pub(super) fn advance_rotation(
+    rotation_base: &mut Option<crate::value::fiberheap::RotationBase>,
+    prev_rotation_safe: &mut bool,
+    tail_rotation_safe: bool,
+) {
+    if *prev_rotation_safe {
+        if let Some(ref base) = rotation_base {
+            crate::value::fiberheap::with_current_heap_mut(|h| h.rotate_pools(base));
+        } else {
+            *rotation_base = crate::value::fiberheap::with_current_heap_mut(|h| h.rotation_mark());
+        }
+    } else {
+        *rotation_base = None;
+    }
+    *prev_rotation_safe = tail_rotation_safe;
+}
 
 /// Result of `execute_bytecode_saving_stack`.
 ///
@@ -99,7 +123,9 @@ impl VM {
     /// Returns `ExecResult` containing the signal, IP, and the active
     /// bytecode/constants/env at exit. The active context may differ from
     /// the input if a tail call occurred before the signal.
-    pub(crate) fn execute_bytecode_from_ip(
+    /// Core tail-call trampoline loop shared by `execute_bytecode_from_ip`
+    /// and `execute_bytecode_saving_stack`.
+    fn trampoline_loop(
         &mut self,
         bytecode: &Rc<Vec<u8>>,
         constants: &Rc<Vec<Value>>,
@@ -126,25 +152,7 @@ impl VM {
             );
 
             if !bits.is_ok() {
-                // Enforce accumulated squelch mask before exiting.
-                // Skip enforcement for error and halt signals (already terminal).
-                let squelched = bits.intersection(accumulated_squelch_mask);
-                if !accumulated_squelch_mask.is_empty()
-                    && !bits.contains(SIG_ERROR)
-                    && !bits.contains(SIG_HALT)
-                    && bits != SIG_SWITCH
-                    && !squelched.is_empty()
-                {
-                    let squelched_str = {
-                        let registry = crate::signals::registry::global_registry().lock().unwrap();
-                        registry.format_signal_bits(squelched)
-                    };
-                    let err = crate::value::error_val(
-                        "signal-violation",
-                        format!("squelch: signal {} caught at boundary", squelched_str),
-                    );
-                    self.fiber.suspended = None;
-                    self.fiber.signal = Some((SIG_ERROR, err));
+                if self.enforce_squelch(bits, accumulated_squelch_mask) {
                     break ExecResult {
                         bits: SIG_ERROR,
                         ip,
@@ -155,11 +163,6 @@ impl VM {
                         stack: vec![],
                     };
                 }
-                // Capture the inner stack for the caller. When a tail call
-                // changed current_bytecode before the signal, this stack
-                // belongs to the tail-called function's context — the caller
-                // (resume_suspended) may need it to build a continuation
-                // frame for the outer level.
                 let inner_stack = std::mem::take(&mut self.fiber.stack).into_vec();
                 break ExecResult {
                     bits,
@@ -173,17 +176,11 @@ impl VM {
             }
 
             if let Some(tail) = self.pending_tail_call.take() {
-                if prev_rotation_safe {
-                    if let Some(ref base) = rotation_base {
-                        crate::value::fiberheap::with_current_heap_mut(|h| h.rotate_pools(base));
-                    } else {
-                        rotation_base =
-                            crate::value::fiberheap::with_current_heap_mut(|h| h.rotation_mark());
-                    }
-                } else {
-                    rotation_base = None;
-                }
-                prev_rotation_safe = tail.rotation_safe;
+                advance_rotation(
+                    &mut rotation_base,
+                    &mut prev_rotation_safe,
+                    tail.rotation_safe,
+                );
                 accumulated_squelch_mask |= tail.squelch_mask;
                 current_bytecode = tail.bytecode;
                 current_constants = tail.constants;
@@ -204,17 +201,24 @@ impl VM {
         }
     }
 
+    /// Execute bytecode starting from a specific instruction pointer.
+    /// Used for resuming fibers from where they suspended.
+    pub(crate) fn execute_bytecode_from_ip(
+        &mut self,
+        bytecode: &Rc<Vec<u8>>,
+        constants: &Rc<Vec<Value>>,
+        closure_env: &Rc<Vec<Value>>,
+        start_ip: usize,
+        location_map: &Rc<LocationMap>,
+    ) -> ExecResult {
+        self.trampoline_loop(bytecode, constants, closure_env, start_ip, location_map)
+    }
+
     /// Execute bytecode returning SignalBits (for fiber/closure execution).
     /// The result value is stored in `self.fiber.signal`.
     ///
-    /// Saves/restores the caller's stack and the active allocator pointer
-    /// around execution. Handles pending tail calls in a loop.
-    ///
-    /// Returns `ExecResult` containing the signal, IP, and the active
-    /// bytecode/constants/env at exit. The active context may differ from
-    /// the input if a tail call occurred before the signal — callers that
-    /// create `SuspendedFrame`s must use the returned context, not the
-    /// original closure fields.
+    /// Saves/restores the caller's stack around execution.
+    /// Handles pending tail calls in a loop.
     pub(crate) fn execute_bytecode_saving_stack(
         &mut self,
         bytecode: &Rc<Vec<u8>>,
@@ -222,172 +226,9 @@ impl VM {
         closure_env: &Rc<Vec<Value>>,
         location_map: &Rc<LocationMap>,
     ) -> ExecResult {
-        // Save the caller's stack. Restored on return.
         let saved_stack = std::mem::take(&mut self.fiber.stack);
-
-        let mut current_bytecode = bytecode.clone();
-        let mut current_constants = constants.clone();
-        let mut current_env = closure_env.clone();
-        let mut current_location_map = location_map.clone();
-        let mut accumulated_squelch_mask = SignalBits::EMPTY;
-        // Base mark for tail-call pool rotation: lazy-initialized on first tail call.
-        let mut rotation_base: Option<crate::value::fiberheap::RotationBase> = None;
-        let mut prev_rotation_safe = true;
-
-        let result = loop {
-            let (bits, ip) = self.execute_bytecode_inner_impl(
-                &current_bytecode,
-                &current_constants,
-                &current_env,
-                0,
-                &current_location_map,
-            );
-
-            if !bits.is_ok() {
-                // Enforce accumulated squelch mask before exiting.
-                // Skip enforcement for error and halt signals (already terminal).
-                let squelched = bits.intersection(accumulated_squelch_mask);
-                if !accumulated_squelch_mask.is_empty()
-                    && !bits.contains(SIG_ERROR)
-                    && !bits.contains(SIG_HALT)
-                    && bits != SIG_SWITCH
-                    && !squelched.is_empty()
-                {
-                    let squelched_str = {
-                        let registry = crate::signals::registry::global_registry().lock().unwrap();
-                        registry.format_signal_bits(squelched)
-                    };
-                    let err = crate::value::error_val(
-                        "signal-violation",
-                        format!("squelch: signal {} caught at boundary", squelched_str),
-                    );
-                    self.fiber.suspended = None;
-                    self.fiber.signal = Some((SIG_ERROR, err));
-                    break ExecResult {
-                        bits: SIG_ERROR,
-                        ip,
-                        bytecode: current_bytecode,
-                        constants: current_constants,
-                        env: current_env,
-                        location_map: current_location_map,
-                        stack: vec![],
-                    };
-                }
-                // Capture the inner stack before restoring the outer stack.
-                // This is critical for fuel-pause resumption: when SIG_FUEL
-                // fires at a Call/TailCall instruction, the args are still on
-                // the operand stack. On resume the instruction re-executes from
-                // the saved IP, so the stack must be in the same state.
-                // SIG_YIELD is exempt — handle_yield already saved the stack
-                // into fiber.suspended, so callers skip creating a new frame.
-                let inner_stack = std::mem::take(&mut self.fiber.stack).into_vec();
-                break ExecResult {
-                    bits,
-                    ip,
-                    bytecode: current_bytecode,
-                    constants: current_constants,
-                    env: current_env,
-                    location_map: current_location_map,
-                    stack: inner_stack,
-                };
-            }
-
-            if let Some(tail) = self.pending_tail_call.take() {
-                if prev_rotation_safe {
-                    if let Some(ref base) = rotation_base {
-                        crate::value::fiberheap::with_current_heap_mut(|h| h.rotate_pools(base));
-                    } else {
-                        rotation_base =
-                            crate::value::fiberheap::with_current_heap_mut(|h| h.rotation_mark());
-                    }
-                } else {
-                    rotation_base = None;
-                }
-                prev_rotation_safe = tail.rotation_safe;
-                accumulated_squelch_mask |= tail.squelch_mask;
-                current_bytecode = tail.bytecode;
-                current_constants = tail.constants;
-                current_env = tail.env;
-                current_location_map = tail.location_map;
-            } else {
-                break ExecResult {
-                    bits,
-                    ip,
-                    bytecode: current_bytecode,
-                    constants: current_constants,
-                    env: current_env,
-                    location_map: current_location_map,
-                    stack: vec![],
-                };
-            }
-        };
-
-        // Restore the caller's stack.
-        // Note: in the non-OK path, self.fiber.stack was already taken into
-        // result.stack above, so this restores to the correct caller state.
+        let result = self.trampoline_loop(bytecode, constants, closure_env, 0, location_map);
         self.fiber.stack = saved_stack;
-
         result
-    }
-
-    /// Execute closure bytecode without copying.
-    ///
-    /// Like `execute_bytecode` but takes `&Rc` references directly,
-    /// avoiding the `.to_vec()` copies that `execute_bytecode` performs.
-    /// Used by JIT trampolines where the closure already owns Rc'd data.
-    ///
-    /// Returns `(SignalBits, Value)` — the signal and the result value.
-    /// The caller is responsible for handling the signal and formatting errors.
-    pub fn execute_closure_bytecode(
-        &mut self,
-        bytecode: &Rc<Vec<u8>>,
-        constants: &Rc<Vec<Value>>,
-        closure_env: &Rc<Vec<Value>>,
-        location_map: &Rc<LocationMap>,
-    ) -> (SignalBits, Value) {
-        self.error_loc = None;
-
-        let mut current_bytecode = bytecode.clone();
-        let mut current_constants = constants.clone();
-        let mut current_env = closure_env.clone();
-        let mut current_location_map = location_map.clone();
-        let mut rotation_base: Option<crate::value::fiberheap::RotationBase> = None;
-        let mut prev_rotation_safe = true;
-
-        loop {
-            let (bits, _ip) = self.execute_bytecode_inner_impl(
-                &current_bytecode,
-                &current_constants,
-                &current_env,
-                0,
-                &current_location_map,
-            );
-
-            if let Some(tail) = self.pending_tail_call.take() {
-                if prev_rotation_safe {
-                    if let Some(ref base) = rotation_base {
-                        crate::value::fiberheap::with_current_heap_mut(|h| h.rotate_pools(base));
-                    } else {
-                        rotation_base =
-                            crate::value::fiberheap::with_current_heap_mut(|h| h.rotation_mark());
-                    }
-                } else {
-                    rotation_base = None;
-                }
-                prev_rotation_safe = tail.rotation_safe;
-                current_bytecode = tail.bytecode;
-                current_constants = tail.constants;
-                current_env = tail.env;
-                current_location_map = tail.location_map;
-            } else {
-                let value = self
-                    .fiber
-                    .signal
-                    .take()
-                    .map(|(_, v)| v)
-                    .unwrap_or(Value::NIL);
-                return (bits, value);
-            }
-        }
     }
 }

--- a/src/vm/fiber.rs
+++ b/src/vm/fiber.rs
@@ -30,11 +30,6 @@ use std::rc::Rc;
 
 use super::core::VM;
 
-/// Helper: set an error signal on a fiber.
-fn set_error(fiber: &mut crate::value::Fiber, kind: &str, msg: impl Into<String>) {
-    fiber.signal = Some((SIG_ERROR, error_val(kind, msg)));
-}
-
 impl VM {
     // ── Shared swap protocol ────────────────────────────────────────
 
@@ -181,11 +176,8 @@ impl VM {
         let handle = match fiber_value.as_fiber() {
             Some(h) => h.clone(),
             None => {
-                set_error(
-                    &mut self.fiber,
-                    "internal-error",
-                    "SIG_RESUME with non-fiber value",
-                );
+                self.fiber
+                    .set_error("internal-error", "SIG_RESUME with non-fiber value");
                 self.fiber.stack.push(Value::NIL);
                 return None;
             }
@@ -214,8 +206,7 @@ impl VM {
                 && !result_bits.contains(SIG_ERROR)
                 && !result_bits.contains(SIG_HALT)
             {
-                set_error(
-                    &mut self.fiber,
+                self.fiber.set_error(
                     "state-error",
                     "fiber/resume: cannot propagate signal (no parent fiber to catch it)",
                 );
@@ -253,11 +244,8 @@ impl VM {
         let handle = match fiber_value.as_fiber() {
             Some(h) => h.clone(),
             None => {
-                set_error(
-                    &mut self.fiber,
-                    "internal-error",
-                    "SIG_RESUME with non-fiber value",
-                );
+                self.fiber
+                    .set_error("internal-error", "SIG_RESUME with non-fiber value");
                 return SIG_ERROR;
             }
         };
@@ -285,8 +273,7 @@ impl VM {
                 && !result_bits.contains(SIG_ERROR)
                 && !result_bits.contains(SIG_HALT)
             {
-                set_error(
-                    &mut self.fiber,
+                self.fiber.set_error(
                     "state-error",
                     "fiber/resume: cannot propagate signal (no parent fiber to catch it)",
                 );
@@ -604,8 +591,7 @@ impl VM {
         let frames = match self.fiber.suspended.take() {
             Some(frames) => frames,
             None => {
-                set_error(
-                    &mut self.fiber,
+                self.fiber.set_error(
                     "internal-error",
                     "fiber/resume: suspended fiber has no saved context",
                 );
@@ -626,11 +612,8 @@ impl VM {
         let handle = match fiber_value.as_fiber() {
             Some(h) => h.clone(),
             None => {
-                set_error(
-                    &mut self.fiber,
-                    "internal-error",
-                    "SIG_PROPAGATE with non-fiber value",
-                );
+                self.fiber
+                    .set_error("internal-error", "SIG_PROPAGATE with non-fiber value");
                 self.fiber.stack.push(Value::NIL);
                 return None;
             }
@@ -650,8 +633,7 @@ impl VM {
             None
         } else if self.current_fiber_handle.is_none() {
             // At root fiber: no parent to catch the propagated signal
-            set_error(
-                &mut self.fiber,
+            self.fiber.set_error(
                 "state-error",
                 "fiber/propagate: cannot propagate signal (no parent fiber to catch it)",
             );
@@ -667,11 +649,8 @@ impl VM {
         let handle = match fiber_value.as_fiber() {
             Some(h) => h.clone(),
             None => {
-                set_error(
-                    &mut self.fiber,
-                    "internal-error",
-                    "SIG_PROPAGATE with non-fiber value",
-                );
+                self.fiber
+                    .set_error("internal-error", "SIG_PROPAGATE with non-fiber value");
                 return SIG_ERROR;
             }
         };
@@ -689,8 +668,7 @@ impl VM {
             child_bits
         } else if self.current_fiber_handle.is_none() {
             // At root fiber: no parent to catch the propagated signal
-            set_error(
-                &mut self.fiber,
+            self.fiber.set_error(
                 "state-error",
                 "fiber/propagate: cannot propagate signal (no parent fiber to catch it)",
             );
@@ -718,11 +696,8 @@ impl VM {
         let handle = match fiber_value.as_fiber() {
             Some(h) => h.clone(),
             None => {
-                set_error(
-                    &mut self.fiber,
-                    "internal-error",
-                    "SIG_ABORT with non-fiber value",
-                );
+                self.fiber
+                    .set_error("internal-error", "SIG_ABORT with non-fiber value");
                 self.fiber.stack.push(Value::NIL);
                 return None;
             }
@@ -752,8 +727,7 @@ impl VM {
                 && !result_bits.contains(SIG_ERROR)
                 && !result_bits.contains(SIG_HALT)
             {
-                set_error(
-                    &mut self.fiber,
+                self.fiber.set_error(
                     "state-error",
                     "fiber/abort: cannot propagate signal (no parent fiber to catch it)",
                 );
@@ -776,11 +750,8 @@ impl VM {
         let handle = match fiber_value.as_fiber() {
             Some(h) => h.clone(),
             None => {
-                set_error(
-                    &mut self.fiber,
-                    "internal-error",
-                    "SIG_ABORT with non-fiber value",
-                );
+                self.fiber
+                    .set_error("internal-error", "SIG_ABORT with non-fiber value");
                 return SIG_ERROR;
             }
         };
@@ -808,8 +779,7 @@ impl VM {
                 && !result_bits.contains(SIG_ERROR)
                 && !result_bits.contains(SIG_HALT)
             {
-                set_error(
-                    &mut self.fiber,
+                self.fiber.set_error(
                     "state-error",
                     "fiber/abort: cannot propagate signal (no parent fiber to catch it)",
                 );
@@ -839,11 +809,8 @@ impl VM {
         let handle = match fiber_value.as_fiber() {
             Some(h) => h.clone(),
             None => {
-                set_error(
-                    &mut self.fiber,
-                    "internal-error",
-                    "SIG_RESUME with non-fiber value",
-                );
+                self.fiber
+                    .set_error("internal-error", "SIG_RESUME with non-fiber value");
                 return JitValue::nil();
             }
         };
@@ -871,8 +838,7 @@ impl VM {
                 && !result_bits.contains(SIG_ERROR)
                 && !result_bits.contains(SIG_HALT)
             {
-                set_error(
-                    &mut self.fiber,
+                self.fiber.set_error(
                     "state-error",
                     "fiber/resume: cannot propagate signal (no parent fiber to catch it)",
                 );
@@ -908,11 +874,8 @@ impl VM {
         let handle = match fiber_value.as_fiber() {
             Some(h) => h.clone(),
             None => {
-                set_error(
-                    &mut self.fiber,
-                    "internal-error",
-                    "SIG_PROPAGATE with non-fiber value",
-                );
+                self.fiber
+                    .set_error("internal-error", "SIG_PROPAGATE with non-fiber value");
                 return JitValue::nil();
             }
         };
@@ -929,8 +892,7 @@ impl VM {
         if child_bits.contains(SIG_ERROR) || child_bits.contains(SIG_HALT) {
             JitValue::nil()
         } else if self.current_fiber_handle.is_none() {
-            set_error(
-                &mut self.fiber,
+            self.fiber.set_error(
                 "state-error",
                 "fiber/propagate: cannot propagate signal (no parent fiber to catch it)",
             );
@@ -948,11 +910,8 @@ impl VM {
         let handle = match fiber_value.as_fiber() {
             Some(h) => h.clone(),
             None => {
-                set_error(
-                    &mut self.fiber,
-                    "internal-error",
-                    "SIG_ABORT with non-fiber value",
-                );
+                self.fiber
+                    .set_error("internal-error", "SIG_ABORT with non-fiber value");
                 return JitValue::nil();
             }
         };
@@ -979,8 +938,7 @@ impl VM {
                 && !result_bits.contains(SIG_ERROR)
                 && !result_bits.contains(SIG_HALT)
             {
-                set_error(
-                    &mut self.fiber,
+                self.fiber.set_error(
                     "state-error",
                     "fiber/abort: cannot propagate signal (no parent fiber to catch it)",
                 );

--- a/src/vm/jit_entry.rs
+++ b/src/vm/jit_entry.rs
@@ -7,7 +7,7 @@
 //! - Fallback to interpreter on compilation failure
 
 use crate::jit::{JitCode, JitRejectionInfo, JitValue, TAIL_CALL_SENTINEL, YIELD_SENTINEL};
-use crate::value::{SignalBits, SymbolId, Value, SIG_ERROR, SIG_HALT, SIG_YIELD};
+use crate::value::{SignalBits, Value, SIG_ERROR, SIG_HALT, SIG_YIELD};
 use std::sync::Arc;
 
 use super::core::VM;
@@ -30,7 +30,7 @@ impl VM {
         args: &[Value],
         func: Value,
     ) -> Option<Option<SignalBits>> {
-        if !self.jit_enabled {
+        if !self.runtime_config.jit.enabled() {
             return None;
         }
         let bytecode_ptr = closure.template.bytecode.as_ptr();
@@ -106,10 +106,9 @@ impl VM {
         closure: &crate::value::Closure,
         bytecode_ptr: *const u8,
     ) {
-        let self_sym = self.find_global_sym_for_bytecode(bytecode_ptr);
         let task = crate::jit::worker::prepare_task(
             lir_func,
-            self_sym,
+            None,
             (*closure.template.symbol_names).clone(),
             bytecode_ptr as usize,
         );
@@ -200,25 +199,9 @@ impl VM {
                 .map(|(b, _)| *b)
                 .unwrap_or(SIG_YIELD);
 
-            // Squelch enforcement: if the closure has a squelch mask and the
-            // signal matches, convert to signal-violation error.
-            let squelch_mask = closure.squelch_mask;
-            if !squelch_mask.is_empty() && !sig.contains(SIG_ERROR) && !sig.contains(SIG_HALT) {
-                let squelched = sig.intersection(squelch_mask);
-                if !squelched.is_empty() {
-                    let squelched_str = {
-                        let registry = crate::signals::registry::global_registry().lock().unwrap();
-                        registry.format_signal_bits(squelched)
-                    };
-                    let err = crate::value::error_val(
-                        "signal-violation",
-                        format!("squelch: signal {} caught at boundary", squelched_str),
-                    );
-                    self.fiber.suspended = None;
-                    self.fiber.signal = Some((SIG_ERROR, err));
-                    self.fiber.stack.push(Value::NIL);
-                    return None;
-                }
+            if self.enforce_squelch(sig, closure.squelch_mask) {
+                self.fiber.stack.push(Value::NIL);
+                return None;
             }
 
             return Some(sig);
@@ -260,25 +243,9 @@ impl VM {
                     return None;
                 } else {
                     // Suspending signal (SIG_YIELD, SIG_SWITCH, user-defined).
-                    // Squelch enforcement on the tail-call path
-                    let tail_squelch = tail.squelch_mask | closure.squelch_mask;
-                    if !tail_squelch.is_empty() {
-                        let squelched = eb.intersection(tail_squelch);
-                        if !squelched.is_empty() {
-                            let squelched_str = {
-                                let registry =
-                                    crate::signals::registry::global_registry().lock().unwrap();
-                                registry.format_signal_bits(squelched)
-                            };
-                            let err = crate::value::error_val(
-                                "signal-violation",
-                                format!("squelch: signal {} caught at boundary", squelched_str),
-                            );
-                            self.fiber.suspended = None;
-                            self.fiber.signal = Some((SIG_ERROR, err));
-                            self.fiber.stack.push(Value::NIL);
-                            return None;
-                        }
+                    if self.enforce_squelch(eb, tail.squelch_mask | closure.squelch_mask) {
+                        self.fiber.stack.push(Value::NIL);
+                        return None;
                     }
                     // Propagate so call_inner can build the caller frame.
                     return Some(eb);
@@ -334,16 +301,5 @@ impl VM {
         });
 
         result
-    }
-
-    /// Try batch JIT compilation for a hot function and its call peers.
-    ///
-    /// Find the SymbolId for a closure matching the given bytecode pointer.
-    ///
-    /// With globals removed, there is no global symbol table to scan.
-    /// Always returns `None`. Solo JIT compilation still works — it just
-    /// won't emit direct self-calls (falls back to `elle_jit_call`).
-    fn find_global_sym_for_bytecode(&self, _bytecode_ptr: *const u8) -> Option<SymbolId> {
-        None
     }
 }

--- a/src/vm/mlir_entry.rs
+++ b/src/vm/mlir_entry.rs
@@ -76,7 +76,7 @@ impl VM {
         let cache = self.mlir_cache.as_mut().unwrap();
         match cache.compile(bytecode_ptr, lir, num_captures, capture_types, param_types) {
             Ok(_name) => {
-                if crate::config::get().debug_jit {
+                if crate::config::get().has_trace("jit") {
                     eprintln!(
                         "[mlir] compiled: {}",
                         closure.template.name.as_deref().unwrap_or("<anon>")
@@ -90,7 +90,7 @@ impl VM {
                     .as_mut()
                     .unwrap()
                     .reject(bytecode_ptr, capture_types, param_types);
-                if crate::config::get().debug_jit {
+                if crate::config::get().has_trace("jit") {
                     eprintln!(
                         "[mlir] failed {}: {}",
                         closure.template.name.as_deref().unwrap_or("<anon>"),

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -94,6 +94,7 @@ impl VM {
         let mut bits;
         let mut rotation_base: Option<crate::value::fiberheap::RotationBase> = None;
         let mut prev_rotation_safe = true;
+        let mut accumulated_squelch_mask = SignalBits::EMPTY;
         loop {
             let (b, _ip) = self.execute_bytecode_inner_impl(
                 &current_bytecode,
@@ -104,23 +105,21 @@ impl VM {
             );
             bits = b;
             if let Some(tail) = self.pending_tail_call.take() {
-                if prev_rotation_safe {
-                    if let Some(ref base) = rotation_base {
-                        crate::value::fiberheap::with_current_heap_mut(|h| h.rotate_pools(base));
-                    } else {
-                        rotation_base =
-                            crate::value::fiberheap::with_current_heap_mut(|h| h.rotation_mark());
-                    }
-                } else {
-                    rotation_base = None;
-                }
-                prev_rotation_safe = tail.rotation_safe;
+                execute::advance_rotation(
+                    &mut rotation_base,
+                    &mut prev_rotation_safe,
+                    tail.rotation_safe,
+                );
+                accumulated_squelch_mask |= tail.squelch_mask;
 
                 current_bytecode = tail.bytecode;
                 current_constants = tail.constants;
                 current_env = tail.env;
                 current_location_map = tail.location_map;
             } else {
+                if self.enforce_squelch(bits, accumulated_squelch_mask) {
+                    bits = SIG_ERROR;
+                }
                 break;
             }
         }

--- a/src/vm/run_on.rs
+++ b/src/vm/run_on.rs
@@ -38,7 +38,7 @@ fn rejected(tier: &str, msg: impl Into<String>) -> Value {
 impl VM {
     /// Run a closure under pure bytecode interpretation.
     ///
-    /// Saves and restores `jit_enabled` so the VM's tier dispatch can't
+    /// Saves and restores JIT policy so the VM's tier dispatch can't
     /// route the top-level call through JIT or MLIR. Nested calls still
     /// honor the surrounding configuration — Phase 1 differential tests
     /// use leaf functions, so this is a non-issue in practice.
@@ -61,8 +61,8 @@ impl VM {
             }
         };
 
-        let saved_jit = self.jit_enabled;
-        self.jit_enabled = false;
+        let saved_jit = self.runtime_config.jit.clone();
+        self.runtime_config.jit = crate::config::JitPolicy::Off;
 
         let squelch_mask = closure.squelch_mask;
 
@@ -73,7 +73,7 @@ impl VM {
             &closure.template.location_map,
         );
 
-        self.jit_enabled = saved_jit;
+        self.runtime_config.jit = saved_jit;
 
         let bits = result.bits;
         if bits.is_ok() {
@@ -96,29 +96,8 @@ impl VM {
             return (crate::value::SIG_HALT, val);
         }
 
-        // Squelch enforcement: if the closure has a squelch mask and a
-        // non-error signal matches, convert to :signal-violation.
-        if !squelch_mask.is_empty()
-            && !bits.contains(SIG_ERROR)
-            && !bits.contains(crate::value::SIG_HALT)
-        {
-            let squelched = bits.intersection(squelch_mask);
-            if !squelched.is_empty() {
-                let squelched_str = {
-                    let registry = crate::signals::registry::global_registry().lock().unwrap();
-                    registry.format_signal_bits(squelched)
-                };
-                self.fiber.suspended = None;
-                self.fiber.signal = None;
-                return (
-                    SIG_ERROR,
-                    error_val_extra(
-                        "signal-violation",
-                        format!("squelch: signal {} caught at boundary", squelched_str),
-                        &[],
-                    ),
-                );
-            }
+        if self.enforce_squelch(bits, squelch_mask) {
+            return self.fiber.signal.take().unwrap();
         }
 
         // Other errors: extract from fiber signal.

--- a/src/vm/signal.rs
+++ b/src/vm/signal.rs
@@ -819,7 +819,7 @@ impl VM {
             );
             map.insert(
                 TableKey::from_value(&Value::keyword("flip")).unwrap(),
-                Value::bool(rc.flip),
+                Value::bool(crate::config::flip_enabled()),
             );
             map.insert(
                 TableKey::from_value(&Value::keyword("checked-intrinsics")).unwrap(),
@@ -837,7 +837,7 @@ impl VM {
                     (SIG_OK, Value::set(trace_set.into_iter().collect()))
                 }
                 "stats" => (SIG_OK, Value::bool(rc.stats)),
-                "flip" => (SIG_OK, Value::bool(rc.flip)),
+                "flip" => (SIG_OK, Value::bool(crate::config::flip_enabled())),
                 "checked-intrinsics" => {
                     (SIG_OK, Value::bool(crate::config::get().checked_intrinsics))
                 }
@@ -888,16 +888,11 @@ impl VM {
         match kw.as_str() {
             "jit" => {
                 if let Some(closure) = val.as_closure() {
-                    // Custom policy via closure — store on VM (future: store the closure)
                     let _ = closure; // TODO: store for actual dispatch
                     self.runtime_config.jit = crate::config::JitPolicy::Custom;
-                    self.jit_enabled = true;
-                    self.jit_hotness_threshold = 0;
                 } else if let Some(policy_kw) = val.as_keyword_name() {
                     match crate::config::JitPolicy::from_keyword(&policy_kw) {
                         Some(policy) => {
-                            self.jit_enabled = policy.enabled();
-                            self.jit_hotness_threshold = policy.threshold();
                             self.runtime_config.jit = policy;
                         }
                         None => {
@@ -1018,7 +1013,6 @@ impl VM {
                         ),
                     );
                 };
-                self.runtime_config.flip = on;
                 crate::config::set_flip(on);
                 Value::NIL
             }

--- a/src/vm/wasm_entry.rs
+++ b/src/vm/wasm_entry.rs
@@ -38,7 +38,7 @@ impl VM {
             .get(&bytecode_ptr)
             .copied()
             .unwrap_or(0);
-        if count < self.jit_hotness_threshold {
+        if count < self.runtime_config.jit.threshold() {
             return None;
         }
 

--- a/src/wasm/emit.rs
+++ b/src/wasm/emit.rs
@@ -596,7 +596,7 @@ impl WasmEmitter {
 
         let alloc = super::regalloc::allocate(func, 0);
         let n = alloc.max_slots;
-        if crate::config::get().debug_wasm {
+        if crate::config::get().has_trace("wasm") {
             eprintln!(
                 "[emit] closure {:?}: {} virtual regs → {} slots",
                 func.name, func.num_regs, n
@@ -651,7 +651,7 @@ impl WasmEmitter {
                 self.spill_live_map.clear();
             }
 
-            if crate::config::get().debug_wasm {
+            if crate::config::get().has_trace("wasm") {
                 eprintln!(
                     "[emit] suspending closure: name={:?} regs={} locals={} captures={} params={}",
                     func.name, func.num_regs, func.num_locals, func.num_captures, func.num_params

--- a/src/wasm/host.rs
+++ b/src/wasm/host.rs
@@ -124,7 +124,7 @@ impl ElleHost {
             resume_value: None,
             pool_to_handle: Vec::new(),
             closure_bytecodes: Vec::new(),
-            debug: crate::config::get().debug_wasm,
+            debug: crate::config::get().has_trace("wasm"),
             io_backend: None,
             precached_closures: Vec::new(),
         }

--- a/src/wasm/lazy.rs
+++ b/src/wasm/lazy.rs
@@ -105,7 +105,7 @@ impl WasmTier {
 
         match Module::new(&self.engine, &result.wasm_bytes) {
             Ok(module) => {
-                if crate::config::get().debug_wasm {
+                if crate::config::get().has_trace("wasm") {
                     eprintln!(
                         "[wasm-tier] compiled {:?} ({} bytes, {} consts)",
                         lir_func.name,
@@ -123,7 +123,7 @@ impl WasmTier {
                 true
             }
             Err(e) => {
-                if crate::config::get().debug_wasm {
+                if crate::config::get().has_trace("wasm") {
                     eprintln!("[wasm-tier] compile failed for {:?}: {}", lir_func.name, e);
                 }
                 false

--- a/src/wasm/regalloc.rs
+++ b/src/wasm/regalloc.rs
@@ -186,7 +186,7 @@ pub fn allocate(func: &LirFunction, pinned_regs: u32) -> RegAlloc {
     let max_slots = cross_block_count + pool_high_water;
 
     // Debug: check for any registers in 0..num_regs not in the map
-    if crate::config::get().debug_wasm {
+    if crate::config::get().has_trace("wasm") {
         for reg_id in 0..func.num_regs {
             if !reg_to_slot.contains_key(&Reg(reg_id)) {
                 eprintln!(

--- a/src/wasm/store.rs
+++ b/src/wasm/store.rs
@@ -67,7 +67,7 @@ pub fn create_engine() -> Result<Engine> {
     config.wasm_tail_call(true);
     config.wasm_multi_value(true);
 
-    if crate::config::get().jit == 0 {
+    if !crate::config::get().jit_enabled() {
         config.cranelift_opt_level(OptLevel::None);
     } else {
         config.cranelift_opt_level(OptLevel::Speed);

--- a/tests/integration/dispatch.rs
+++ b/tests/integration/dispatch.rs
@@ -37,7 +37,9 @@ fn test_lint_good_file_exits_zero() {
 }
 
 #[test]
-fn test_lint_bad_file_exits_two() {
+fn test_lint_naming_file_exits_zero() {
+    // Kebab-case naming lint was removed — naming-bad.lisp now produces
+    // zero diagnostics and exits 0.
     let output = Command::new(get_elle_binary())
         .args(["lint", "tests/fixtures/naming-bad.lisp"])
         .output()
@@ -45,8 +47,8 @@ fn test_lint_bad_file_exits_two() {
 
     assert_eq!(
         output.status.code().unwrap_or(-1),
-        2,
-        "elle lint on bad-naming file should exit 2 (warnings), stderr: {}",
+        0,
+        "elle lint on naming-bad.lisp should exit 0 (no warnings), stderr: {}",
         String::from_utf8_lossy(&output.stderr)
     );
 }

--- a/tests/integration/jit.rs
+++ b/tests/integration/jit.rs
@@ -2210,7 +2210,7 @@ fn test_nqueens_letrec_no_jit() {
 
     let mut symbols = SymbolTable::new();
     let mut vm = VM::new();
-    vm.jit_enabled = false;
+    vm.runtime_config.jit = elle::config::JitPolicy::Off;
     let _signals = register_primitives(&mut vm, &mut symbols);
 
     let result = eval(
@@ -2346,7 +2346,7 @@ fn test_nqueens_4queens_no_jit() {
 
     let mut symbols = SymbolTable::new();
     let mut vm = VM::new();
-    vm.jit_enabled = false;
+    vm.runtime_config.jit = elle::config::JitPolicy::Off;
     let _signals = register_primitives(&mut vm, &mut symbols);
 
     let result = eval(

--- a/tests/integration/lint.rs
+++ b/tests/integration/lint.rs
@@ -16,7 +16,9 @@ fn test_lint_naming_good() {
 }
 
 #[test]
-fn test_lint_naming_bad() {
+fn test_lint_naming_bad_no_longer_warns() {
+    // The kebab-case naming lint was removed — naming-bad.lisp should
+    // now produce zero diagnostics.
     let config = LintConfig {
         min_severity: Severity::Warning,
         format: OutputFormat::Human,
@@ -25,13 +27,10 @@ fn test_lint_naming_bad() {
 
     let result = linter.lint_file("tests/fixtures/naming-bad.lisp");
     assert!(result.is_ok());
-    assert!(!linter.diagnostics().is_empty());
-
-    // All diagnostics should be warnings about naming
-    for diag in linter.diagnostics() {
-        assert_eq!(diag.rule, "naming-kebab-case");
-        assert_eq!(diag.severity, Severity::Warning);
-    }
+    assert!(
+        linter.diagnostics().is_empty(),
+        "naming-bad.lisp should produce no diagnostics after kebab lint removal"
+    );
 }
 
 #[test]
@@ -42,12 +41,11 @@ fn test_json_output() {
     };
     let mut linter = Linter::new(config);
 
-    let result = linter.lint_file("tests/fixtures/naming-bad.lisp");
+    let result = linter.lint_str("(+ 1 2)", "test.lisp");
     assert!(result.is_ok());
 
     let output = linter.format_output();
     assert!(output.contains("\"diagnostics\""));
-    assert!(output.contains("naming-kebab-case"));
 }
 
 #[test]


### PR DESCRIPTION
Dead code removed:
- String interner gated behind #[cfg(test)]; debug/intern-count primitive removed
- VM: execute_closure_bytecode, format_stack_trace, push_call_frame_with_base, find_global_sym_for_bytecode (all zero callers)
- pipeline::compile_to_lir (exported, zero callers)
- value/arena: heap_arena_capacity/peak/reset_peak/object_limit/set_object_limit, clone_heap (zero callers)
- FiberHeap: get_or_create_shared_allocator, take_outbox (zero callers)
- SharedAllocator: rotation_mark, clear_swap (zero callers)
- SlabPool::release_bump, refcount_by_flat (zero callers)
- ThreadHandle::Default impl removed; constructor takes explicit Arc arg
- Value::string_no_intern removed (was pure alias for string())
- lint: DiagnosticContext, Diagnostic::with_suggestions, HirLinter::diagnostics_mut
- hir/lint: W003 non-exhaustive-match check (analyzer hard-errors before HIR)
- primitives/display: dead arity guards in prim_pp/prim_describe
- primitives/access: unreachable None arms after is_struct/is_struct_mut guards
- lib/resource.lisp: removed debug/intern-count references

Bug fixes:
- prim_min/prim_max: add type check on args[0] (previously accepted non-numbers)
- prim_assert: use error_val instead of manual struct; convert non-string messages
- execute_bytecode: accumulate and enforce squelch_mask in top-level trampoline

Vestigial complexity removed:
- config: JitPolicy::Conservative, WasmPolicy::Modular (unreachable variants)
- config: RuntimeConfig.flip removed; reads go through flip_enabled() atomic
- config: RuntimeConfig.dump/dump_bits/has_dump_bit removed (only static Config read)
- VM: jit_enabled/jit_hotness_threshold fields removed; reads go through runtime_config.jit.enabled()/threshold() directly

Deduplication:
- VM::enforce_squelch() replaces 8 inline squelch enforcement blocks across execute.rs, mod.rs, run_on.rs, call.rs, jit_entry.rs
- execute::advance_rotation() replaces 4 inline rotation-advance blocks
- execute.rs: trampoline_loop() unifies execute_bytecode_from_ip and execute_bytecode_saving_stack into one core loop
- Fiber::set_error() method replaces 3 identical free functions in vm/
- fold_bitwise() deduplicates bit/and, bit/or, bit/xor
- prim_range: macro deduplicates 3-way arg extraction
- resolve_and_splice_include() deduplicates 3 include-resolution loops in compile_file_to_lir, compile_file_frontend, splice_includes
- error::parse_located_error() shared by main.rs and lint/cli.rs
- display.rs: fmt_string_mut/fmt_bytes/fmt_bytes_mut shared between Display and Debug; fmt_cons_inner unifies fmt_cons and fmt_cons_debug