### PR TITLE
Cross-module escape projection for struct-field callees

### DIFF
--- a/src/compiler/bytecode.rs
+++ b/src/compiler/bytecode.rs
@@ -351,6 +351,12 @@ pub struct Bytecode {
     /// compilation. When an importing file sees `module:field`, the analyzer
     /// uses this projection instead of the conservative `Polymorphic` fallback.
     pub signal_projection: Option<std::collections::HashMap<String, crate::signals::Signal>>,
+    /// Escape projection: maps keyword field names to escape analysis
+    /// properties (rotation-safe, param-safe). Populated during lowering
+    /// for module-pattern files that return a struct of closures.
+    /// When an importing file sees `module:field` as a callee, the lowerer
+    /// uses this projection to determine safety properties.
+    pub escape_projection: Option<std::collections::HashMap<String, bool>>,
 }
 
 impl Bytecode {
@@ -362,6 +368,7 @@ impl Bytecode {
             location_map: LocationMap::new(),
             signal: crate::signals::Signal::silent(),
             signal_projection: None,
+            escape_projection: None,
         }
     }
 

--- a/src/hir/analyze/binding.rs
+++ b/src/hir/analyze/binding.rs
@@ -589,6 +589,9 @@ impl<'a> Analyzer<'a> {
         if let Some(proj) = self.last_import_projection.take() {
             self.projection_env.insert(binding, proj);
         }
+        if let Some(proj) = self.last_import_escape_projection.take() {
+            self.escape_projection_env.insert(binding, proj);
+        }
         // Compile-time squelch: the value was `(squelch f mask)`
         if let Some(sig) = self.last_squelch_signal.take() {
             self.signal_env.insert(binding, sig);

--- a/src/hir/analyze/call.rs
+++ b/src/hir/analyze/call.rs
@@ -98,6 +98,7 @@ impl<'a> Analyzer<'a> {
         // the target file's signal projection and stash it for the binding
         // analysis to pick up via `last_import_projection`.
         self.last_import_projection = None;
+        self.last_import_escape_projection = None;
         if let HirKind::Call {
             func: inner_func,
             args: inner_args,
@@ -110,6 +111,8 @@ impl<'a> Analyzer<'a> {
                         if let Some(resolved) = crate::primitives::modules::resolve_import(spec) {
                             self.last_import_projection =
                                 crate::pipeline::get_or_compile_projection(&resolved);
+                            self.last_import_escape_projection =
+                                crate::pipeline::get_or_compile_escape_projection(&resolved);
                         }
                     }
                 }

--- a/src/hir/analyze/mod.rs
+++ b/src/hir/analyze/mod.rs
@@ -159,6 +159,9 @@ pub struct Analyzer<'a> {
     /// access (`module:field`) uses the projected signal instead of the
     /// conservative `Polymorphic` fallback.
     projection_env: HashMap<Binding, HashMap<String, Signal>>,
+    /// Escape projection env: maps bindings from import-and-call patterns
+    /// to their field→safe properties from the imported module's lowering.
+    pub(crate) escape_projection_env: HashMap<Binding, HashMap<String, bool>>,
     /// Compile-time squelch result signal. Set during call analysis when
     /// the analyzer detects `(squelch f mask)` and computes the resulting
     /// closure's signal statically. Consumed by binding analysis to seed
@@ -168,6 +171,8 @@ pub struct Analyzer<'a> {
     /// analyzer sees `((import "literal"))` and the target file has a
     /// projection. Consumed by binding analysis to populate projection_env.
     last_import_projection: Option<HashMap<String, Signal>>,
+    /// Escape projection from the most recently compiled import.
+    last_import_escape_projection: Option<HashMap<String, bool>>,
     /// Tracks signal sources within the current lambda body for polymorphic inference
     current_signal_sources: SignalSources,
     /// Parameters of the current lambda being analyzed (for polymorphic inference)
@@ -251,8 +256,10 @@ impl<'a> Analyzer<'a> {
             arity_env: HashMap::new(),
 
             projection_env: HashMap::new(),
+            escape_projection_env: HashMap::new(),
             last_squelch_signal: None,
             last_import_projection: None,
+            last_import_escape_projection: None,
             current_signal_sources: SignalSources::default(),
             current_lambda_params: Vec::new(),
             block_contexts: Vec::new(),

--- a/src/lir/lower/escape.rs
+++ b/src/lir/lower/escape.rs
@@ -492,7 +492,7 @@ impl<'a> Lowerer<'a> {
     /// Built-in primitives do not internally create heap objects that
     /// escape to external mutable structures — they only produce return
     /// values and/or mutate their arguments (caught separately).
-    fn callee_is_primitive(&self, func: &Hir) -> bool {
+    pub(super) fn callee_is_primitive(&self, func: &Hir) -> bool {
         let binding = match &func.kind {
             HirKind::Var(b) => b,
             HirKind::DerefCell { cell } => match &cell.kind {
@@ -2205,7 +2205,7 @@ impl<'a> Lowerer<'a> {
 
     /// Check if an expression is either a rotation-safe closure or not a
     /// closure at all. Used by struct field analysis.
-    fn value_is_rotation_safe_closure_or_non_closure(&self, hir: &Hir) -> bool {
+    pub(super) fn value_is_rotation_safe_closure_or_non_closure(&self, hir: &Hir) -> bool {
         match &hir.kind {
             // Lambda: check its body
             HirKind::Lambda { body, .. } => !self.body_escapes_heap_values(body),
@@ -2290,7 +2290,7 @@ impl<'a> Lowerer<'a> {
         }
     }
 
-    fn value_is_param_safe_closure_or_non_closure(&self, hir: &Hir) -> bool {
+    pub(super) fn value_is_param_safe_closure_or_non_closure(&self, hir: &Hir) -> bool {
         match &hir.kind {
             HirKind::Lambda { body, params, .. } => {
                 !self.body_stores_params_externally(body, params)

--- a/src/lir/lower/mod.rs
+++ b/src/lir/lower/mod.rs
@@ -369,6 +369,10 @@ pub struct Lowerer<'a> {
     /// closures by `ClosureId` (index into this list). Built depth-first
     /// during lowering.
     closures: Vec<LirFunction>,
+    /// Escape projection: maps struct field names to rotation-safe/param-safe.
+    /// Computed during lowering for module-pattern files. Consumed by the
+    /// compile pipeline and stored on Bytecode for cross-module propagation.
+    escape_projection: Option<HashMap<String, bool>>,
     /// Binding of the current function being analyzed (for self-tail-call
     /// detection in escape analysis and drop insertion).
     current_function_binding: Option<Binding>,
@@ -421,6 +425,7 @@ impl<'a> Lowerer<'a> {
             discard_slot: None,
             symbol_names: HashMap::new(),
             closures: Vec::new(),
+            escape_projection: None,
             current_function_binding: None,
             current_function_params: None,
             region_info: RegionInfo::empty(),
@@ -518,6 +523,21 @@ impl<'a> Lowerer<'a> {
         &self.scope_stats
     }
 
+    /// Take the computed escape projection (if any).
+    /// Called by the compile pipeline after lowering.
+    pub fn take_escape_projection(&mut self) -> Option<HashMap<String, bool>> {
+        self.escape_projection.take()
+    }
+
+    /// Seed `callee_struct_fields_rotation_safe` and `callee_struct_fields_param_safe`
+    /// for a binding from an imported module's escape projection.
+    pub fn seed_import_escape_projection(&mut self, binding: Binding, all_safe: bool) {
+        self.callee_struct_fields_rotation_safe
+            .insert(binding, all_safe);
+        self.callee_struct_fields_param_safe
+            .insert(binding, all_safe);
+    }
+
     /// Lower a HIR expression to an LIR module.
     ///
     /// Returns an `LirModule` with the entry function and a flat list of
@@ -565,6 +585,9 @@ impl<'a> Lowerer<'a> {
         self.current_func.result_is_immediate = self.result_is_safe(hir, &[]);
         self.current_func.has_outward_heap_set = self.body_contains_dangerous_outward_set(hir, &[]);
         self.current_func.rotation_safe = !self.body_escapes_heap_values(hir);
+
+        // Compute escape projection for module-pattern files.
+        self.escape_projection = self.compute_escape_projection(hir);
 
         let mut entry =
             std::mem::replace(&mut self.current_func, LirFunction::new(Arity::Exact(0)));
@@ -1956,6 +1979,80 @@ impl<'a> Lowerer<'a> {
             if !changed {
                 break;
             }
+        }
+    }
+
+    /// Compute escape projection for module-pattern files.
+    ///
+    /// Walks the HIR's return position (through Letrec/Begin/Lambda) to find
+    /// a struct literal. For each field, checks whether the value binding is
+    /// rotation-safe and param-safe. Returns a map from field name to
+    /// all-safe boolean (rotation AND param safe).
+    fn compute_escape_projection(&self, hir: &Hir) -> Option<HashMap<String, bool>> {
+        self.extract_escape_struct(hir)
+    }
+
+    fn extract_escape_struct(&self, hir: &Hir) -> Option<HashMap<String, bool>> {
+        match &hir.kind {
+            HirKind::Call { func, args, .. } => {
+                // Check if this is a struct construction call
+                if !self.callee_is_primitive(func) {
+                    return None;
+                }
+                let binding = match &func.kind {
+                    HirKind::Var(b) => b,
+                    _ => return None,
+                };
+                let bi = self.arena.get(*binding);
+                let name = self.symbol_names.get(&bi.name.0)?;
+                if name != "struct" {
+                    return None;
+                }
+                let mut projection = HashMap::new();
+                let mut i = 0;
+                while i + 1 < args.len() {
+                    if let HirKind::Keyword(key) = &args[i].expr.kind {
+                        let val = &args[i + 1].expr;
+                        let safe = self.value_is_rotation_safe_closure_or_non_closure(val)
+                            && self.value_is_param_safe_closure_or_non_closure(val);
+                        projection.insert(key.clone(), safe);
+                    }
+                    i += 2;
+                }
+                if projection.is_empty() {
+                    None
+                } else {
+                    Some(projection)
+                }
+            }
+            HirKind::Lambda { body, .. } => self.extract_escape_struct(body),
+            HirKind::Begin(exprs) => exprs.last().and_then(|e| self.extract_escape_struct(e)),
+            HirKind::Let { bindings, body } | HirKind::Letrec { bindings, body } => {
+                // If body is a Var referencing a binding, recurse into its init
+                if let HirKind::Var(b) = &body.kind {
+                    if let Some((_, init)) = bindings.iter().find(|(bind, _)| bind == b) {
+                        return self.extract_escape_struct(init);
+                    }
+                }
+                self.extract_escape_struct(body)
+            }
+            HirKind::Define { value, .. } => self.extract_escape_struct(value),
+            HirKind::If {
+                then_branch,
+                else_branch,
+                ..
+            } => {
+                // Both branches must return structs; AND the safety values
+                let a = self.extract_escape_struct(then_branch)?;
+                let b = self.extract_escape_struct(else_branch)?;
+                let mut merged = a;
+                for (k, v) in b {
+                    let entry = merged.entry(k).or_insert(true);
+                    *entry = *entry && v;
+                }
+                Some(merged)
+            }
+            _ => None,
         }
     }
 

--- a/src/pipeline/cache.rs
+++ b/src/pipeline/cache.rs
@@ -38,6 +38,11 @@ thread_local! {
     /// encounters `(import "...")` with a literal string argument.
     static PROJECTION_CACHE: std::cell::RefCell<HashMap<String, Option<HashMap<String, Signal>>>> =
         std::cell::RefCell::new(HashMap::new());
+
+    /// Escape projection cache: maps resolved file paths to their
+    /// keyword→safe projections. Populated alongside signal projections.
+    static ESCAPE_PROJECTION_CACHE: std::cell::RefCell<HashMap<String, Option<HashMap<String, bool>>>> =
+        std::cell::RefCell::new(HashMap::new());
 }
 
 /// Run a closure with access to the cached macro-expansion VM.
@@ -201,4 +206,37 @@ pub fn get_or_compile_projection(resolved_path: &str) -> Option<HashMap<String, 
     });
 
     projection
+}
+
+/// Look up or compute the escape projection for a file.
+///
+/// Returns a map from field name to `true` (all closure fields are
+/// rotation-safe and param-safe) for module-pattern files that return
+/// a struct of closures.
+pub fn get_or_compile_escape_projection(resolved_path: &str) -> Option<HashMap<String, bool>> {
+    let cached = ESCAPE_PROJECTION_CACHE.with(|pc| pc.borrow().get(resolved_path).cloned());
+    if let Some(proj) = cached {
+        return proj;
+    }
+
+    // Read the file and compile it
+    let source = std::fs::read_to_string(resolved_path).ok()?;
+    let mut symbols = SymbolTable::new();
+    let result = super::compile::compile_file(&source, &mut symbols, resolved_path).ok()?;
+    let escape_proj = result.bytecode.escape_projection;
+
+    // Cache signal projection too if not already cached
+    let signal_proj = result.bytecode.signal_projection;
+    PROJECTION_CACHE.with(|pc| {
+        pc.borrow_mut()
+            .entry(resolved_path.to_string())
+            .or_insert(signal_proj);
+    });
+
+    ESCAPE_PROJECTION_CACHE.with(|pc| {
+        pc.borrow_mut()
+            .insert(resolved_path.to_string(), escape_proj.clone());
+    });
+
+    escape_proj
 }

--- a/src/pipeline/compile.rs
+++ b/src/pipeline/compile.rs
@@ -272,7 +272,7 @@ pub fn compile_file_to_lir(
 /// expansion (with file-scope stamping and include resolution), analysis,
 /// error surfacing, tail-call marking, and functionalization.
 ///
-/// Returns `(hir, arena, expander, prim_values, signal_projection)`.
+/// Returns `(hir, arena, expander, prim_values, signal_projection, escape_projection_env)`.
 /// Callers that don't need all fields can ignore the extras.
 #[allow(clippy::type_complexity)]
 fn compile_file_frontend(
@@ -286,6 +286,7 @@ fn compile_file_frontend(
         crate::syntax::Expander,
         std::collections::HashMap<crate::hir::Binding, crate::value::Value>,
         Option<std::collections::HashMap<String, crate::signals::Signal>>,
+        std::collections::HashMap<crate::hir::Binding, std::collections::HashMap<String, bool>>,
     ),
     String,
 > {
@@ -362,6 +363,7 @@ fn compile_file_frontend(
     let mut hir = analyzer.analyze_file_letrec(forms, span)?;
     let prim_values = analyzer.primitive_values().clone();
     let signal_projection = analyzer.take_signal_projection();
+    let escape_projection_env = std::mem::take(&mut analyzer.escape_projection_env);
     let errors = analyzer.take_errors();
     drop(analyzer);
 
@@ -384,7 +386,14 @@ fn compile_file_frontend(
     functionalize(&mut hir, &mut arena);
     crate::hir::typeinfer::infer_and_rewrite(&mut hir, &arena, symbols);
 
-    Ok((hir, arena, expander, prim_values, signal_projection))
+    Ok((
+        hir,
+        arena,
+        expander,
+        prim_values,
+        signal_projection,
+        escape_projection_env,
+    ))
 }
 
 /// Compile a file as a single synthetic letrec.
@@ -403,7 +412,7 @@ pub fn compile_file_to_fhir(
     ),
     String,
 > {
-    let (hir, arena, _expander, _prim_values, _signal_projection) =
+    let (hir, arena, _expander, _prim_values, _signal_projection, _escape_proj_env) =
         compile_file_frontend(source, symbols, source_name)?;
     let names = symbols.all_names();
     Ok((hir, arena, names))
@@ -435,7 +444,7 @@ fn compile_file_inner(
     symbols: &mut SymbolTable,
     source_name: &str,
 ) -> Result<(CompileResult, crate::syntax::Expander), String> {
-    let (hir, arena, expander, prim_values, signal_projection) =
+    let (hir, arena, expander, prim_values, signal_projection, escape_projection_env) =
         compile_file_frontend(source, symbols, source_name)?;
 
     // Lower to LIR
@@ -448,7 +457,15 @@ fn compile_file_inner(
         .with_primitive_values(prim_values)
         .with_symbol_names(symbol_names.clone())
         .with_region_info(region_info);
+
+    // Seed escape projections from imported modules
+    for (binding, proj) in &escape_projection_env {
+        let all_safe = proj.values().all(|&v| v);
+        lowerer.seed_import_escape_projection(*binding, all_safe);
+    }
+
     let lir_module = lowerer.lower(&hir)?;
+    let escape_projection = lowerer.take_escape_projection();
 
     // Emit bytecode
     let signal = lir_module.entry.signal;
@@ -456,6 +473,7 @@ fn compile_file_inner(
     let (mut bytecode, _, _) = emitter.emit_module(&lir_module);
     bytecode.signal = signal;
     bytecode.signal_projection = signal_projection;
+    bytecode.escape_projection = escape_projection;
 
     Ok((CompileResult { bytecode }, expander))
 }

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -10,8 +10,8 @@ mod eval;
 // Re-export public API
 pub use analyze::{analyze, analyze_file};
 pub use cache::{
-    get_or_compile_projection, lookup_stdlib_value, register_repl_binding, register_repl_macros,
-    update_cache_with_stdlib,
+    get_or_compile_escape_projection, get_or_compile_projection, lookup_stdlib_value,
+    register_repl_binding, register_repl_macros, update_cache_with_stdlib,
 };
 pub use compile::{
     compile, compile_file, compile_file_repl, compile_file_to_fhir, compile_file_to_lir,


### PR DESCRIPTION
Module-pattern files (fn returning struct of closures) now export escape analysis properties alongside signal projections. When a caller imports a module and accesses its fields as callees (e.g. `module:func`), the lowerer uses the escape projection to determine rotation-safety and param-safety, enabling flip rotation in while loops that call imported module functions.

Plumbed through: Analyzer → compile_file_frontend → Lowerer → Bytecode → projection cache. The escape projection maps struct field names to safe/unsafe booleans computed during the module's lowering pass.