### PR TITLE
Split rotation-safety from outward-set safety in escape analysis

### DIFF
--- a/src/compiler/bytecode.rs
+++ b/src/compiler/bytecode.rs
@@ -2,6 +2,16 @@ use crate::error::LocationMap;
 use crate::reader::SourceLoc;
 use crate::value::Value;
 
+/// Per-field escape analysis info for cross-module projection.
+#[derive(Debug, Clone, Copy)]
+pub struct FieldEscapeInfo {
+    /// True when the field's closure is rotation-safe AND param-safe.
+    pub rotation_safe: bool,
+    /// True when the field's closure is outward-safe (no external
+    /// heap stores, even if it returns heap values).
+    pub outward_safe: bool,
+}
+
 /// Bytecode instruction set
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
@@ -352,11 +362,11 @@ pub struct Bytecode {
     /// uses this projection instead of the conservative `Polymorphic` fallback.
     pub signal_projection: Option<std::collections::HashMap<String, crate::signals::Signal>>,
     /// Escape projection: maps keyword field names to escape analysis
-    /// properties (rotation-safe, param-safe). Populated during lowering
-    /// for module-pattern files that return a struct of closures.
-    /// When an importing file sees `module:field` as a callee, the lowerer
-    /// uses this projection to determine safety properties.
-    pub escape_projection: Option<std::collections::HashMap<String, bool>>,
+    /// properties. Populated during lowering for module-pattern files
+    /// that return a struct of closures. When an importing file sees
+    /// `module:field` as a callee, the lowerer uses this projection to
+    /// determine safety properties.
+    pub escape_projection: Option<std::collections::HashMap<String, FieldEscapeInfo>>,
 }
 
 impl Bytecode {

--- a/src/config.rs
+++ b/src/config.rs
@@ -210,7 +210,7 @@ pub const TRACE_KEYWORDS: &[&str] = &[
 /// (which enables runtime logging), `--dump=` runs the compiler up to each
 /// requested stage, prints the artifact, and exits without executing.
 pub const DUMP_KEYWORDS: &[&str] = &[
-    "ast", "hir", "fhir", "lir", "jit", "cfg", "dfa", "defuse", "regions", "git",
+    "ast", "hir", "fhir", "lir", "jit", "cfg", "dfa", "defuse", "regions", "escape", "git",
 ];
 
 pub mod dump_bits {
@@ -224,7 +224,8 @@ pub mod dump_bits {
     pub const FHIR: u32 = 1 << 7;
     pub const DEFUSE: u32 = 1 << 8;
     pub const REGIONS: u32 = 1 << 9;
-    pub const ALL: u32 = (1 << 10) - 1;
+    pub const ESCAPE: u32 = 1 << 10;
+    pub const ALL: u32 = (1 << 11) - 1;
 
     /// Convert a keyword name to its bit. Returns 0 for unknown keywords.
     pub fn from_name(name: &str) -> u32 {
@@ -239,6 +240,7 @@ pub mod dump_bits {
             "git" => GIT,
             "defuse" => DEFUSE,
             "regions" => REGIONS,
+            "escape" => ESCAPE,
             _ => 0,
         }
     }

--- a/src/hir/analyze/mod.rs
+++ b/src/hir/analyze/mod.rs
@@ -161,7 +161,8 @@ pub struct Analyzer<'a> {
     projection_env: HashMap<Binding, HashMap<String, Signal>>,
     /// Escape projection env: maps bindings from import-and-call patterns
     /// to their field→safe properties from the imported module's lowering.
-    pub(crate) escape_projection_env: HashMap<Binding, HashMap<String, bool>>,
+    pub(crate) escape_projection_env:
+        HashMap<Binding, HashMap<String, crate::compiler::bytecode::FieldEscapeInfo>>,
     /// Compile-time squelch result signal. Set during call analysis when
     /// the analyzer detects `(squelch f mask)` and computes the resulting
     /// closure's signal statically. Consumed by binding analysis to seed
@@ -172,7 +173,8 @@ pub struct Analyzer<'a> {
     /// projection. Consumed by binding analysis to populate projection_env.
     last_import_projection: Option<HashMap<String, Signal>>,
     /// Escape projection from the most recently compiled import.
-    last_import_escape_projection: Option<HashMap<String, bool>>,
+    last_import_escape_projection:
+        Option<HashMap<String, crate::compiler::bytecode::FieldEscapeInfo>>,
     /// Tracks signal sources within the current lambda body for polymorphic inference
     current_signal_sources: SignalSources,
     /// Parameters of the current lambda being analyzed (for polymorphic inference)

--- a/src/jit/translate.rs
+++ b/src/jit/translate.rs
@@ -664,6 +664,7 @@ impl<'a> FunctionTranslator<'a> {
                 let lir_module = crate::lir::LirModule {
                     entry: func.clone(),
                     closures: self.module_closures.clone(),
+                    escape_dump: None,
                 };
                 let (nested_bytecode, nested_yield_points, nested_call_sites) =
                     emitter.emit_module(&lir_module);

--- a/src/lir/lower/escape.rs
+++ b/src/lir/lower/escape.rs
@@ -630,6 +630,7 @@ impl<'a> Lowerer<'a> {
                             }
                         } else if !self.callee_is_primitive(func)
                             && !self.callee_is_rotation_safe(func)
+                            && !self.callee_is_outward_safe(func)
                             && !self.callee_is_non_escaping_stdlib(func)
                             && !self.callee_is_param_safe(func)
                             && !self.computed_callee_is_safe(func, scope_bindings)
@@ -1593,6 +1594,181 @@ impl<'a> Lowerer<'a> {
         }
     }
 
+    /// Check whether a function body has outward side effects: stores heap
+    /// values into external mutable state. Unlike `body_escapes_heap_values`,
+    /// this does NOT care about heap content in tail-call return values.
+    /// A function is outward-safe if its body never stores heap values
+    /// externally, even if it returns structs containing heap values.
+    pub(super) fn body_has_outward_side_effects(&self, hir: &Hir) -> bool {
+        match &hir.kind {
+            HirKind::Assign { value, .. } => {
+                !self.result_is_safe(value, &[]) || self.body_has_outward_side_effects(value)
+            }
+            HirKind::Call {
+                func,
+                args,
+                is_tail,
+            } => {
+                // Mutating primitives escape even in tail position
+                if self.callee_is_mutating_primitive(func)
+                    && args
+                        .iter()
+                        .any(|a| !Self::arg_is_compile_time_immediate(&a.expr))
+                {
+                    return true;
+                }
+                if *is_tail {
+                    // For outward-safety, tail-call args become return values,
+                    // not external stores. We only need the callee itself to
+                    // be outward-safe (no arg check needed).
+                    if !self.callee_is_primitive(func)
+                        && !self.callee_is_outward_safe(func)
+                        && !self.callee_is_non_escaping_stdlib(func)
+                    {
+                        return true;
+                    }
+                    return false;
+                }
+                if !self.callee_is_primitive(func)
+                    && !self.callee_is_outward_safe(func)
+                    && !self.callee_is_non_escaping_stdlib(func)
+                    && !self.callee_is_param_safe(func)
+                {
+                    return true;
+                }
+                self.body_has_outward_side_effects(func)
+                    || args
+                        .iter()
+                        .any(|a| self.body_has_outward_side_effects(&a.expr))
+            }
+            HirKind::Lambda { .. } => false,
+            HirKind::Emit { value, .. } => {
+                !self.result_is_safe(value, &[]) || self.body_has_outward_side_effects(value)
+            }
+            HirKind::Int(_)
+            | HirKind::Float(_)
+            | HirKind::Bool(_)
+            | HirKind::Nil
+            | HirKind::Keyword(_)
+            | HirKind::EmptyList
+            | HirKind::String(_)
+            | HirKind::Var(_) => false,
+            HirKind::If {
+                cond,
+                then_branch,
+                else_branch,
+            } => {
+                self.body_has_outward_side_effects(cond)
+                    || self.body_has_outward_side_effects(then_branch)
+                    || self.body_has_outward_side_effects(else_branch)
+            }
+            HirKind::Begin(exprs) => exprs.iter().any(|e| self.body_has_outward_side_effects(e)),
+            HirKind::Cond {
+                clauses,
+                else_branch,
+            } => {
+                clauses.iter().any(|(c, b)| {
+                    self.body_has_outward_side_effects(c) || self.body_has_outward_side_effects(b)
+                }) || else_branch
+                    .as_ref()
+                    .is_some_and(|b| self.body_has_outward_side_effects(b))
+            }
+            HirKind::And(exprs) | HirKind::Or(exprs) => {
+                exprs.iter().any(|e| self.body_has_outward_side_effects(e))
+            }
+            HirKind::Let { bindings, body } | HirKind::Letrec { bindings, body } => {
+                bindings
+                    .iter()
+                    .any(|(_, init)| self.body_has_outward_side_effects(init))
+                    || self.body_has_outward_side_effects(body)
+            }
+            HirKind::Define { value, .. } => self.body_has_outward_side_effects(value),
+            HirKind::While { cond, body } => {
+                self.body_has_outward_side_effects(cond) || self.body_has_outward_side_effects(body)
+            }
+            HirKind::Block { body, .. } => {
+                body.iter().any(|e| self.body_has_outward_side_effects(e))
+            }
+            HirKind::Break { value, .. } => self.body_has_outward_side_effects(value),
+            HirKind::Match { value, arms } => {
+                self.body_has_outward_side_effects(value)
+                    || arms
+                        .iter()
+                        .any(|(_, _, body)| self.body_has_outward_side_effects(body))
+            }
+            HirKind::Parameterize { bindings, body } => {
+                bindings
+                    .iter()
+                    .any(|(_, v)| self.body_has_outward_side_effects(v))
+                    || self.body_has_outward_side_effects(body)
+            }
+            HirKind::Loop { bindings, body } => {
+                bindings
+                    .iter()
+                    .any(|(_, init)| self.body_has_outward_side_effects(init))
+                    || self.body_has_outward_side_effects(body)
+            }
+            HirKind::Recur { args } => args.iter().any(|a| !self.result_is_safe(a, &[])),
+            HirKind::MakeCell { value } => self.body_has_outward_side_effects(value),
+            HirKind::DerefCell { cell } => self.body_has_outward_side_effects(cell),
+            HirKind::SetCell { cell, value } => {
+                self.body_has_outward_side_effects(cell)
+                    || self.body_has_outward_side_effects(value)
+            }
+            HirKind::Intrinsic { args, .. } => {
+                args.iter().any(|a| self.body_has_outward_side_effects(a))
+            }
+            _ => true,
+        }
+    }
+
+    /// Check if a callee is a known outward-safe user function.
+    /// An outward-safe function never stores heap values into external
+    /// mutable state, but may return structs containing heap values.
+    fn callee_is_outward_safe(&self, func: &Hir) -> bool {
+        let binding = match &func.kind {
+            HirKind::Var(b) => b,
+            HirKind::DerefCell { cell } => match &cell.kind {
+                HirKind::Var(b) => b,
+                _ => return self.callee_from_struct_get_is_outward_safe(func),
+            },
+            _ => return self.callee_from_struct_get_is_outward_safe(func),
+        };
+        self.callee_outward_safe
+            .get(binding)
+            .copied()
+            .unwrap_or(false)
+    }
+
+    /// Like `callee_from_struct_get_is_rotation_safe` but for outward-safety.
+    fn callee_from_struct_get_is_outward_safe(&self, func: &Hir) -> bool {
+        let HirKind::Call { args, .. } = &func.kind else {
+            return false;
+        };
+        if !self.value_is_non_allocating_accessor(func) {
+            return false;
+        }
+        let Some(first_arg) = args.first() else {
+            return false;
+        };
+        let struct_binding = match &first_arg.expr.kind {
+            HirKind::Var(b) => b,
+            HirKind::DerefCell { cell } => match &cell.kind {
+                HirKind::Var(b) => b,
+                _ => return false,
+            },
+            _ => return false,
+        };
+        let bi = self.arena.get(*struct_binding);
+        if !bi.is_immutable || bi.is_mutated {
+            return false;
+        }
+        self.callee_struct_fields_outward_safe
+            .get(struct_binding)
+            .copied()
+            .unwrap_or(false)
+    }
+
     /// Check if a callee is a known param-safe user function.
     /// A param-safe function never stores its parameters into external
     /// mutable state, so calling it with heap args won't escape them.
@@ -2303,6 +2479,91 @@ impl<'a> Lowerer<'a> {
                     && !self.callee_param_safe.contains_key(b)
             }
             HirKind::DerefCell { cell } => self.value_is_param_safe_closure_or_non_closure(cell),
+            HirKind::Int(_)
+            | HirKind::Float(_)
+            | HirKind::Bool(_)
+            | HirKind::Nil
+            | HirKind::Keyword(_)
+            | HirKind::EmptyList
+            | HirKind::String(_)
+            | HirKind::Quote(_) => true,
+            _ => false,
+        }
+    }
+
+    /// Walk a function body's return positions to check whether all
+    /// closures in any returned struct are outward-safe.
+    pub(super) fn body_returns_struct_fields_outward_safe(&self, hir: &Hir) -> bool {
+        match &hir.kind {
+            HirKind::Call { func, args, .. } if self.callee_is_primitive(func) => {
+                args.iter().enumerate().all(|(i, a)| {
+                    if i % 2 == 0 {
+                        return true; // key position
+                    }
+                    self.value_is_outward_safe_closure_or_non_closure(&a.expr)
+                })
+            }
+            HirKind::Call { func, .. } => {
+                let binding = self.extract_callee_binding(func);
+                match binding {
+                    Some(b) => self
+                        .callee_struct_fields_outward_safe
+                        .get(b)
+                        .copied()
+                        .unwrap_or(false),
+                    None => false,
+                }
+            }
+            HirKind::If {
+                then_branch,
+                else_branch,
+                ..
+            } => {
+                self.body_returns_struct_fields_outward_safe(then_branch)
+                    && self.body_returns_struct_fields_outward_safe(else_branch)
+            }
+            HirKind::Begin(exprs) => exprs
+                .last()
+                .is_none_or(|e| self.body_returns_struct_fields_outward_safe(e)),
+            HirKind::Let { body, .. } | HirKind::Letrec { body, .. } => {
+                self.body_returns_struct_fields_outward_safe(body)
+            }
+            HirKind::Cond {
+                clauses,
+                else_branch,
+            } => {
+                clauses
+                    .iter()
+                    .all(|(_, b)| self.body_returns_struct_fields_outward_safe(b))
+                    && else_branch
+                        .as_ref()
+                        .is_none_or(|b| self.body_returns_struct_fields_outward_safe(b))
+            }
+            HirKind::Match { arms, .. } => arms
+                .iter()
+                .all(|(_, _, body)| self.body_returns_struct_fields_outward_safe(body)),
+            HirKind::Block { body, .. } => body
+                .last()
+                .is_none_or(|e| self.body_returns_struct_fields_outward_safe(e)),
+            _ => false,
+        }
+    }
+
+    /// Check if an expression is either an outward-safe closure or not a
+    /// closure at all. Used by struct field analysis.
+    pub(super) fn value_is_outward_safe_closure_or_non_closure(&self, hir: &Hir) -> bool {
+        match &hir.kind {
+            HirKind::Lambda { body, .. } => !self.body_has_outward_side_effects(body),
+            HirKind::Var(b) => {
+                if self.callee_outward_safe.get(b).copied().unwrap_or(false) {
+                    return true;
+                }
+                // If not in any function map, it's not a closure — safe
+                !self.callee_rotation_safe.contains_key(b)
+                    && !self.callee_param_safe.contains_key(b)
+                    && !self.callee_outward_safe.contains_key(b)
+            }
+            HirKind::DerefCell { cell } => self.value_is_outward_safe_closure_or_non_closure(cell),
             HirKind::Int(_)
             | HirKind::Float(_)
             | HirKind::Bool(_)

--- a/src/lir/lower/mod.rs
+++ b/src/lir/lower/mod.rs
@@ -286,12 +286,19 @@ pub struct Lowerer<'a> {
     /// A function returns-param-safe if all closures it returns are
     /// param-safe (their bodies don't store params externally).
     callee_returns_param_safe: HashMap<Binding, bool>,
+    /// Binding → outward_safe for function definitions. A function is
+    /// outward-safe if its body never stores heap values into external
+    /// mutable state. Unlike rotation-safe, it does NOT care about
+    /// return value heap content. Used by `walk_for_outward_set`.
+    callee_outward_safe: HashMap<Binding, bool>,
     /// Binding → struct-fields-rotation-safe. True when a binding holds
     /// a struct where all closure-typed values are rotation-safe.
     /// Used by `callee_is_rotation_safe` to handle `(get struct :field)` callees.
     callee_struct_fields_rotation_safe: HashMap<Binding, bool>,
     /// Binding → struct-fields-param-safe. Same for param-safety.
     callee_struct_fields_param_safe: HashMap<Binding, bool>,
+    /// Binding → struct-fields-outward-safe. Same for outward-safety.
+    callee_struct_fields_outward_safe: HashMap<Binding, bool>,
     /// Binding → result_is_immediate for function definitions.
     /// Precomputed via fixpoint iteration so that `call_result_is_safe`
     /// can identify user functions that always return immediates.
@@ -340,10 +347,10 @@ pub struct Lowerer<'a> {
     /// closures by `ClosureId` (index into this list). Built depth-first
     /// during lowering.
     closures: Vec<LirFunction>,
-    /// Escape projection: maps struct field names to rotation-safe/param-safe.
+    /// Escape projection: maps struct field names to escape analysis info.
     /// Computed during lowering for module-pattern files. Consumed by the
     /// compile pipeline and stored on Bytecode for cross-module propagation.
-    escape_projection: Option<HashMap<String, bool>>,
+    escape_projection: Option<HashMap<String, crate::compiler::bytecode::FieldEscapeInfo>>,
     /// Binding of the current function being analyzed (for self-tail-call
     /// detection in escape analysis and drop insertion).
     current_function_binding: Option<Binding>,
@@ -377,11 +384,13 @@ impl<'a> Lowerer<'a> {
             non_escaping_stdlib: FxHashSet::default(),
             callee_rotation_safe: HashMap::new(),
             callee_param_safe: HashMap::new(),
+            callee_outward_safe: HashMap::new(),
             callee_return_safe: HashMap::new(),
             callee_returns_rotation_safe: HashMap::new(),
             callee_returns_param_safe: HashMap::new(),
             callee_struct_fields_rotation_safe: HashMap::new(),
             callee_struct_fields_param_safe: HashMap::new(),
+            callee_struct_fields_outward_safe: HashMap::new(),
             callee_result_immediate: HashMap::new(),
             callee_return_params: HashMap::new(),
             callee_rest_index: HashMap::new(),
@@ -494,19 +503,124 @@ impl<'a> Lowerer<'a> {
         &self.scope_stats
     }
 
+    /// Format escape analysis maps for `--dump=escape`.
+    pub fn format_escape_analysis(&self) -> String {
+        use std::fmt::Write;
+        let mut out = String::new();
+        let name = |b: &Binding| -> String {
+            let bi = self.arena.get(*b);
+            self.symbol_names
+                .get(&bi.name.0)
+                .cloned()
+                .unwrap_or_else(|| format!("?#{}", b.0))
+        };
+        writeln!(
+            out,
+            ";; rotation_safe ({} entries):",
+            self.callee_rotation_safe.len()
+        )
+        .unwrap();
+        let mut entries: Vec<_> = self.callee_rotation_safe.iter().collect();
+        entries.sort_by_key(|(b, _)| b.0);
+        for (b, safe) in &entries {
+            writeln!(out, "  {:30} rotation_safe={}", name(b), safe).unwrap();
+        }
+        writeln!(
+            out,
+            ";; param_safe ({} entries):",
+            self.callee_param_safe.len()
+        )
+        .unwrap();
+        let mut entries: Vec<_> = self.callee_param_safe.iter().collect();
+        entries.sort_by_key(|(b, _)| b.0);
+        for (b, safe) in &entries {
+            writeln!(out, "  {:30} param_safe={}", name(b), safe).unwrap();
+        }
+        writeln!(
+            out,
+            ";; struct_fields_rotation_safe ({} entries):",
+            self.callee_struct_fields_rotation_safe.len()
+        )
+        .unwrap();
+        let mut entries: Vec<_> = self.callee_struct_fields_rotation_safe.iter().collect();
+        entries.sort_by_key(|(b, _)| b.0);
+        for (b, safe) in &entries {
+            writeln!(out, "  {:30} struct_fields_rotation_safe={}", name(b), safe).unwrap();
+        }
+        writeln!(
+            out,
+            ";; struct_fields_param_safe ({} entries):",
+            self.callee_struct_fields_param_safe.len()
+        )
+        .unwrap();
+        let mut entries: Vec<_> = self.callee_struct_fields_param_safe.iter().collect();
+        entries.sort_by_key(|(b, _)| b.0);
+        for (b, safe) in &entries {
+            writeln!(out, "  {:30} struct_fields_param_safe={}", name(b), safe).unwrap();
+        }
+        writeln!(
+            out,
+            ";; outward_safe ({} entries):",
+            self.callee_outward_safe.len()
+        )
+        .unwrap();
+        let mut entries: Vec<_> = self.callee_outward_safe.iter().collect();
+        entries.sort_by_key(|(b, _)| b.0);
+        for (b, safe) in &entries {
+            writeln!(out, "  {:30} outward_safe={}", name(b), safe).unwrap();
+        }
+        writeln!(
+            out,
+            ";; struct_fields_outward_safe ({} entries):",
+            self.callee_struct_fields_outward_safe.len()
+        )
+        .unwrap();
+        let mut entries: Vec<_> = self.callee_struct_fields_outward_safe.iter().collect();
+        entries.sort_by_key(|(b, _)| b.0);
+        for (b, safe) in &entries {
+            writeln!(out, "  {:30} struct_fields_outward_safe={}", name(b), safe).unwrap();
+        }
+        if let Some(ref proj) = self.escape_projection {
+            writeln!(out, ";; escape_projection ({} fields):", proj.len()).unwrap();
+            let mut entries: Vec<_> = proj.iter().collect();
+            entries.sort_by_key(|(k, _)| (*k).clone());
+            for (k, info) in &entries {
+                writeln!(
+                    out,
+                    "  :{:29} rotation_safe={} outward_safe={}",
+                    k, info.rotation_safe, info.outward_safe
+                )
+                .unwrap();
+            }
+        } else {
+            writeln!(out, ";; escape_projection: none").unwrap();
+        }
+        out
+    }
+
     /// Take the computed escape projection (if any).
     /// Called by the compile pipeline after lowering.
-    pub fn take_escape_projection(&mut self) -> Option<HashMap<String, bool>> {
+    pub fn take_escape_projection(
+        &mut self,
+    ) -> Option<HashMap<String, crate::compiler::bytecode::FieldEscapeInfo>> {
         self.escape_projection.take()
     }
 
-    /// Seed `callee_struct_fields_rotation_safe` and `callee_struct_fields_param_safe`
-    /// for a binding from an imported module's escape projection.
-    pub fn seed_import_escape_projection(&mut self, binding: Binding, all_safe: bool) {
+    /// Seed `callee_struct_fields_*` for a binding from an imported module's
+    /// escape projection. `rotation_safe` controls rotation and param maps;
+    /// `outward_safe` controls the outward-safe map.
+    pub fn seed_import_escape_projection(
+        &mut self,
+        binding: Binding,
+        rotation_safe: bool,
+        outward_safe: bool,
+    ) {
         self.callee_struct_fields_rotation_safe
-            .insert(binding, all_safe);
+            .insert(binding, rotation_safe);
         self.callee_struct_fields_param_safe
-            .insert(binding, all_safe);
+            .insert(binding, rotation_safe);
+        self.callee_struct_fields_outward_safe
+            .insert(binding, outward_safe);
     }
 
     /// Lower a HIR expression to an LIR module.
@@ -534,6 +648,7 @@ impl<'a> Lowerer<'a> {
         self.precompute_return_safe(hir);
         self.precompute_param_safety(hir);
         self.precompute_rotation_safety(hir);
+        self.precompute_outward_safety(hir);
         self.precompute_returns_rotation_safe(hir);
         self.precompute_returns_param_safe(hir);
         self.widen_rotation_safety(hir);
@@ -575,7 +690,12 @@ impl<'a> Lowerer<'a> {
             }
         }
 
-        Ok(LirModule { entry, closures })
+        let escape_dump = Some(self.format_escape_analysis());
+        Ok(LirModule {
+            entry,
+            closures,
+            escape_dump,
+        })
     }
 
     // === Helper Methods ===
@@ -1712,6 +1832,42 @@ impl<'a> Lowerer<'a> {
         self.scope_stats.rotation_safe = self.callee_rotation_safe.values().filter(|&&v| v).count();
     }
 
+    /// Precompute `callee_outward_safe` for all function definitions.
+    ///
+    /// A function is outward-safe if its body never stores heap values into
+    /// external mutable state. Unlike rotation-safe, it does NOT care about
+    /// heap content in tail-call return values. Fixpoint: seed all safe,
+    /// iterate `body_has_outward_side_effects` until stable.
+    fn precompute_outward_safety(&mut self, hir: &Hir) {
+        let mut defs: Vec<(Binding, Vec<Binding>, &Hir)> = Vec::new();
+        Self::collect_lambda_defs_with_params(hir, &mut defs);
+        if defs.is_empty() {
+            return;
+        }
+
+        // Seed: all functions optimistically outward-safe.
+        for &(binding, _, _) in &defs {
+            self.callee_outward_safe.insert(binding, true);
+        }
+
+        // Iterate until stable.
+        loop {
+            let mut changed = false;
+            for &(binding, _, body) in &defs {
+                if !self.callee_outward_safe[&binding] {
+                    continue; // already unsafe, skip
+                }
+                if self.body_has_outward_side_effects(body) {
+                    self.callee_outward_safe.insert(binding, false);
+                    changed = true;
+                }
+            }
+            if !changed {
+                break;
+            }
+        }
+    }
+
     /// Precompute `callee_returns_rotation_safe` for all function definitions.
     ///
     /// A function returns-rotation-safe if every closure it returns (in all
@@ -1828,8 +1984,9 @@ impl<'a> Lowerer<'a> {
         }
     }
 
-    /// Precompute `callee_struct_fields_rotation_safe` and
-    /// `callee_struct_fields_param_safe` for all Lambda-bound functions.
+    /// Precompute `callee_struct_fields_rotation_safe`,
+    /// `callee_struct_fields_param_safe`, and `callee_struct_fields_outward_safe`
+    /// for all Lambda-bound functions.
     ///
     /// A function has struct-fields-rotation-safe if its body returns
     /// a struct where all closure-valued fields are rotation-safe.
@@ -1845,6 +2002,7 @@ impl<'a> Lowerer<'a> {
             self.callee_struct_fields_rotation_safe
                 .insert(binding, true);
             self.callee_struct_fields_param_safe.insert(binding, true);
+            self.callee_struct_fields_outward_safe.insert(binding, true);
         }
 
         // Iterate rotation-safe until stable.
@@ -1874,6 +2032,24 @@ impl<'a> Lowerer<'a> {
                 }
                 if !self.body_returns_struct_fields_param_safe(body) {
                     self.callee_struct_fields_param_safe.insert(binding, false);
+                    changed = true;
+                }
+            }
+            if !changed {
+                break;
+            }
+        }
+
+        // Iterate outward-safe until stable.
+        loop {
+            let mut changed = false;
+            for &(binding, body) in &defs {
+                if !self.callee_struct_fields_outward_safe[&binding] {
+                    continue;
+                }
+                if !self.body_returns_struct_fields_outward_safe(body) {
+                    self.callee_struct_fields_outward_safe
+                        .insert(binding, false);
                     changed = true;
                 }
             }
@@ -1951,19 +2127,55 @@ impl<'a> Lowerer<'a> {
                 break;
             }
         }
+
+        // Same for outward-safe
+        loop {
+            let mut changed = false;
+            for &(binding, init) in &all_bindings {
+                if self
+                    .callee_struct_fields_outward_safe
+                    .contains_key(&binding)
+                {
+                    continue;
+                }
+                if let HirKind::Call { func, .. } = &init.kind {
+                    let callee = self.extract_callee_binding(func);
+                    if let Some(b) = callee {
+                        if let Some(&safe) = self.callee_struct_fields_outward_safe.get(b) {
+                            self.callee_struct_fields_outward_safe.insert(binding, safe);
+                            changed = true;
+                        }
+                    }
+                }
+                if let HirKind::Var(b) = &init.kind {
+                    if let Some(&safe) = self.callee_struct_fields_outward_safe.get(b) {
+                        self.callee_struct_fields_outward_safe.insert(binding, safe);
+                        changed = true;
+                    }
+                }
+            }
+            if !changed {
+                break;
+            }
+        }
     }
 
     /// Compute escape projection for module-pattern files.
     ///
     /// Walks the HIR's return position (through Letrec/Begin/Lambda) to find
-    /// a struct literal. For each field, checks whether the value binding is
-    /// rotation-safe and param-safe. Returns a map from field name to
-    /// all-safe boolean (rotation AND param safe).
-    fn compute_escape_projection(&self, hir: &Hir) -> Option<HashMap<String, bool>> {
+    /// a struct literal. For each field, checks rotation-safe, param-safe,
+    /// and outward-safe properties.
+    fn compute_escape_projection(
+        &self,
+        hir: &Hir,
+    ) -> Option<HashMap<String, crate::compiler::bytecode::FieldEscapeInfo>> {
         self.extract_escape_struct(hir)
     }
 
-    fn extract_escape_struct(&self, hir: &Hir) -> Option<HashMap<String, bool>> {
+    fn extract_escape_struct(
+        &self,
+        hir: &Hir,
+    ) -> Option<HashMap<String, crate::compiler::bytecode::FieldEscapeInfo>> {
         match &hir.kind {
             HirKind::Call { func, args, .. } => {
                 // Check if this is a struct construction call
@@ -1984,9 +2196,16 @@ impl<'a> Lowerer<'a> {
                 while i + 1 < args.len() {
                     if let HirKind::Keyword(key) = &args[i].expr.kind {
                         let val = &args[i + 1].expr;
-                        let safe = self.value_is_rotation_safe_closure_or_non_closure(val)
+                        let rotation_safe = self.value_is_rotation_safe_closure_or_non_closure(val)
                             && self.value_is_param_safe_closure_or_non_closure(val);
-                        projection.insert(key.clone(), safe);
+                        let outward_safe = self.value_is_outward_safe_closure_or_non_closure(val);
+                        projection.insert(
+                            key.clone(),
+                            crate::compiler::bytecode::FieldEscapeInfo {
+                                rotation_safe,
+                                outward_safe,
+                            },
+                        );
                     }
                     i += 2;
                 }
@@ -2018,8 +2237,15 @@ impl<'a> Lowerer<'a> {
                 let b = self.extract_escape_struct(else_branch)?;
                 let mut merged = a;
                 for (k, v) in b {
-                    let entry = merged.entry(k).or_insert(true);
-                    *entry = *entry && v;
+                    let entry =
+                        merged
+                            .entry(k)
+                            .or_insert(crate::compiler::bytecode::FieldEscapeInfo {
+                                rotation_safe: true,
+                                outward_safe: true,
+                            });
+                    entry.rotation_safe = entry.rotation_safe && v.rotation_safe;
+                    entry.outward_safe = entry.outward_safe && v.outward_safe;
                 }
                 Some(merged)
             }

--- a/src/lir/types.rs
+++ b/src/lir/types.rs
@@ -43,6 +43,8 @@ pub struct ClosureId(pub u32);
 pub struct LirModule {
     pub entry: LirFunction,
     pub closures: Vec<LirFunction>,
+    /// Escape analysis dump for `--dump=escape`. Populated by the lowerer.
+    pub escape_dump: Option<String>,
 }
 
 impl Reg {

--- a/src/main.rs
+++ b/src/main.rs
@@ -217,10 +217,12 @@ fn run_dump(contents: &str, source_name: &str, symbols: &mut SymbolTable) -> Res
         print!("{}", elle::hir::format_regions(&info, &arena, &names));
     }
 
-    let needs_pipeline = cfg
-        .dump
-        .iter()
-        .any(|k| matches!(k.as_str(), "hir" | "lir" | "cfg" | "dfa" | "jit" | "git"));
+    let needs_pipeline = cfg.dump.iter().any(|k| {
+        matches!(
+            k.as_str(),
+            "hir" | "lir" | "cfg" | "dfa" | "jit" | "git" | "escape"
+        )
+    });
     if !needs_pipeline {
         return Ok(());
     }
@@ -230,6 +232,13 @@ fn run_dump(contents: &str, source_name: &str, symbols: &mut SymbolTable) -> Res
             eprintln!("{}", e);
             e
         })?;
+
+    if cfg.dump.contains("escape") {
+        println!(";; ── escape analysis ────────────────────────────────────────");
+        if let Some(ref dump) = module.escape_dump {
+            print!("{}", dump);
+        }
+    }
 
     if cfg.dump.contains("hir") {
         println!(";; ── hir ────────────────────────────────────────────────────");

--- a/src/pipeline/cache.rs
+++ b/src/pipeline/cache.rs
@@ -63,7 +63,7 @@ thread_local! {
 
     /// Escape projection cache: maps resolved file paths to their
     /// keyword→safe projections. Populated alongside signal projections.
-    static ESCAPE_PROJECTION_CACHE: std::cell::RefCell<HashMap<String, Option<HashMap<String, bool>>>> =
+    static ESCAPE_PROJECTION_CACHE: std::cell::RefCell<HashMap<String, Option<HashMap<String, crate::compiler::bytecode::FieldEscapeInfo>>>> =
         std::cell::RefCell::new(HashMap::new());
 }
 
@@ -213,7 +213,9 @@ pub fn get_or_compile_projection(resolved_path: &str) -> Option<HashMap<String, 
 /// Returns a map from field name to `true` (all closure fields are
 /// rotation-safe and param-safe) for module-pattern files that return
 /// a struct of closures.
-pub fn get_or_compile_escape_projection(resolved_path: &str) -> Option<HashMap<String, bool>> {
+pub fn get_or_compile_escape_projection(
+    resolved_path: &str,
+) -> Option<HashMap<String, crate::compiler::bytecode::FieldEscapeInfo>> {
     let cached = ESCAPE_PROJECTION_CACHE.with(|pc| pc.borrow().get(resolved_path).cloned());
     if let Some(proj) = cached {
         return proj;

--- a/src/pipeline/compile.rs
+++ b/src/pipeline/compile.rs
@@ -219,7 +219,10 @@ fn compile_file_frontend(
         crate::syntax::Expander,
         std::collections::HashMap<crate::hir::Binding, crate::value::Value>,
         Option<std::collections::HashMap<String, crate::signals::Signal>>,
-        std::collections::HashMap<crate::hir::Binding, std::collections::HashMap<String, bool>>,
+        std::collections::HashMap<
+            crate::hir::Binding,
+            std::collections::HashMap<String, crate::compiler::bytecode::FieldEscapeInfo>,
+        >,
     ),
     String,
 > {
@@ -372,8 +375,9 @@ fn compile_file_inner(
 
     // Seed escape projections from imported modules
     for (binding, proj) in &escape_projection_env {
-        let all_safe = proj.values().all(|&v| v);
-        lowerer.seed_import_escape_projection(*binding, all_safe);
+        let rotation_safe = proj.values().all(|v| v.rotation_safe);
+        let outward_safe = proj.values().all(|v| v.outward_safe);
+        lowerer.seed_import_escape_projection(*binding, rotation_safe, outward_safe);
     }
 
     let lir_module = lowerer.lower(&hir)?;

--- a/tests/elle/leak.lisp
+++ b/tests/elle/leak.lisp
@@ -1406,3 +1406,26 @@
       d10k (t13-struct-field 10000)]
   (assert (or checked? (bounded? d100 d10k 30))
           (string "t13 struct-field: d100=" d100 " d10k=" d10k)))
+
+# 13g: struct-returning function with heap values (outward-safe)
+# do-process returns {:x i :label (string ...)} — rotation_safe=false
+# but outward_safe=true because no external heap stores.
+(defn make-heap-module []
+  (defn do-process [i]
+    {:x i :label (string "item-" i)})
+  {:process do-process})
+
+(def heap-mod (make-heap-module))
+
+(defn t13-heap-struct-field [n]
+  (def before (arena/count))
+  (def @i 0)
+  (while (%lt i n)
+    (heap-mod:process i)
+    (assign i (%add i 1)))
+  (%sub (arena/count) before))
+
+(let [d100 (t13-heap-struct-field 100)
+      d10k (t13-heap-struct-field 10000)]
+  (assert (or checked? (bounded? d100 d10k 30))
+          (string "t13 heap-struct-field: d100=" d100 " d10k=" d10k)))

--- a/tests/integration/dump_cli.rs
+++ b/tests/integration/dump_cli.rs
@@ -157,7 +157,7 @@ fn unknown_stage_is_rejected() {
     assert!(!status.success(), "expected non-zero exit for bogus stage");
     assert!(
         err.contains("--dump: unknown stage 'bogus'")
-            && err.contains("Valid: ast, hir, fhir, lir, jit, cfg, dfa, defuse, regions, git"),
+            && err.contains("Valid: ast, hir, fhir, lir, jit, cfg, dfa, defuse, regions, escape, git"),
         "expected helpful error listing valid stages, got:\n{}",
         err
     );


### PR DESCRIPTION
Functions like `(defn do-process [i] {:x i :label (string "item-" i)})` are correctly marked rotation_safe=false (heap values in return struct would dangle under frame rotation). However, walk_for_outward_set was using rotation_safe as a proxy for "no outward stores", blocking while- loop flip for callers of these functions — causing linear leaks.

Introduce a new `outward_safe` property: true when a function never stores heap values into external mutable state, regardless of what it returns. This is strictly weaker than rotation_safe — every rotation- safe function is outward-safe, but not vice versa.

Implementation:
- New `--dump=escape` flag for escape analysis debugging
- New analysis function `body_has_outward_side_effects` (like body_escapes_heap_values but skips tail-call arg checks)
- New maps: callee_outward_safe, callee_struct_fields_outward_safe
- Fixpoint iteration in `precompute_outward_safety`
- Cross-module propagation via FieldEscapeInfo struct in escape projection
- walk_for_outward_set now checks callee_is_outward_safe

The naive fix (skip tail-call arg check for all primitives) caused use-after-free in fiber/new. This approach is sound because it only relaxes the outward-set check, not the rotation-safety check itself.