### PR TITLE
Trait-based dispatch for :Sequence and :Collection protocols

### DIFF
--- a/docs/traits.md
+++ b/docs/traits.md
@@ -1,44 +1,209 @@
 # Traits
 
-Traits attach metadata to values. Any heap-allocated value can carry a
-trait table (an immutable struct).
+Every heap-allocated value carries a `traits` field — a pointer to a
+trait table (struct or @struct). Collection and sequence types get a
+shared default traitset stamped at allocation time. Other heap types
+start with `nil` traits.
 
-## Attaching traits
+## Reading traits
 
-```lisp
-(def v (with-traits [1 2 3] {:type :point :dim 2}))
-(traits v)                 # => {:type :point :dim 2}
-(traits [1 2 3])           # => nil (no traits attached)
 ```
+(traits [1 2 3])           # => @{:Sequence {...} :Collection {...}}
+(traits {:a 1})            # => @{:Collection {...}}
+(traits 42)                # => nil (immediate, no traits)
+```
+
+All arrays share the same traitset pointer. All lists share the same
+traitset pointer. This is identity-equal:
+
+```
+(identical? (traits [1 2]) (traits [3 4]))  # => true
+```
+
+## Attaching per-instance traits
+
+`with-traits` creates a new value with a custom trait table:
+
+```
+(def v (with-traits [1 2 3] {:type :point}))
+(traits v)                 # => {:type :point}
+```
+
+The trait table can be an immutable struct or a mutable @struct.
+Data operations (get, length, first, etc.) see through traits — they
+operate on the underlying data, not the trait table.
 
 ## Traits are invisible to equality
 
 Traits do not affect structural equality, ordering, or hashing:
 
-```lisp
-(def plain [1 2 3])
-(def annotated (with-traits [1 2 3] {:type :point}))
-(= plain annotated)        # => true
+```
+(= [1 2 3] (with-traits [1 2 3] {:type :point}))  # => true
 ```
 
-## Dispatch on traits
+## Protocol dispatch
 
-```lisp
-(defn describe [val]
-  (match (traits val)
-    {:type :point}  "a point"
-    {:type :color}  "a color"
-    _               "unknown"))
+Primitives like `first`, `rest`, `length`, `empty?`, `has?`, `last`,
+`second` dispatch through trait table lookup instead of hardcoded type
+cascades. Each collection/sequence type gets a shared default traitset
+stamped at allocation time.
 
-(describe (with-traits [255 0 0] {:type :color}))  # => "a color"
-(describe (with-traits [1 2] {:type :point}))      # => "a point"
-(describe [1 2 3])                                  # => "unknown"
+### Trait table schema
+
+A trait table is a **mutable @struct shell** mapping protocol keywords
+to **immutable method structs**:
+
 ```
+@{:Sequence   {:first (fn [self] ...)
+               :rest  (fn [self] ...)
+               :last  (fn [self] ...)
+               :nth   (fn [self n] ...)
+               :iter  (fn [self] ...)}
+  :Collection {:length (fn [self] ...)
+               :empty? (fn [self] ...)
+               :has?   (fn [self needle] ...)
+               :conj   (fn [self item] ...)
+               :empty  (fn [self] ...)}}
+```
+
+The mutable shell lets users swap entire protocols on a shared traitset.
+Immutable method structs avoid RefCell borrow on per-method lookup.
+
+### Which types get which protocols
+
+| Type              | :Sequence | :Collection |
+|-------------------|-----------|-------------|
+| list (pair / ())  | yes       | yes         |
+| array / @array    | yes       | yes         |
+| string / @string  | yes       | yes         |
+| bytes / @bytes    | yes       | yes         |
+| set / @set        | no        | yes         |
+| struct / @struct  | no        | yes         |
+
+Immediates (int, float, bool, nil, keyword, symbol) have no traitset.
+
+### Dispatch algorithm
+
+When a primitive like `first` is called on value `v`:
+
+1. Read `v`'s `traits` field (always populated for collection types)
+2. Look up `:Sequence` in the @struct (linear scan, 2 keys)
+3. Look up `:first` in the method struct (linear scan, 5 keys)
+4. Call the method (NativeFn direct call or closure via VM context)
+
+If the value has user-attached traits that lack the requested protocol,
+the dispatcher falls back to the default traitset from the registry.
+This means `(with-traits [1 2 3] {:tag :my-type})` still supports
+`first`, `length`, etc. — the user traits don't mask the defaults.
+
+### Edge cases
+
+- **Empty list** `()` is an immediate — no traitset. `first` returns
+  an error, `rest` returns `()`, `length` returns 0, `empty?` returns
+  true. These are handled as pre-checks in the primitives.
+- **Syntax objects** support `first`, `rest`, `length`, `empty?` via
+  pre-checks (used during macro expansion). No traitset.
+- **Symbols and keywords** support `length` via pre-check.
+- **nil** supports `length` (returns 0) and `empty?` (returns true)
+  via pre-check.
+
+### Non-overridable operations
+
+`butlast`, `reverse` are defined in terms of the underlying
+implementations, not through trait dispatch. User-defined Sequence
+types that only implement the trait protocol won't support these.
+
+## Iterator protocol
+
+`:iter` returns a **fiber**. Each `(yield item)` produces one element.
+When the fiber completes (status `:dead`), iteration is done.
+
+```
+(def arr [10 20 30])
+(def iter-fn (((traits arr) :Sequence) :iter))
+(def fib (iter-fn arr))
+(fiber/resume fib)   # => 10
+(fiber/resume fib)   # => 20
+(fiber/resume fib)   # => 30
+(fiber/status fib)   # => :dead
+```
+
+## Sharing and mutability
+
+Default traitsets are **shared by reference**. All arrays point to the
+same @struct. Mutating the shared @struct is visible to all instances.
+
+Per-instance override via `with-traits`:
+
+```
+(def v (with-traits [1 2 3]
+         @{:Sequence {:first (fn [self] :custom)}}))
+(first v)        # => :custom
+(first [1 2 3])  # => 1 (default, unaffected)
+```
+
+## Custom sequence types
+
+Any value can implement `:Sequence` via `with-traits`:
+
+```
+(defn make-range [start end]
+  (with-traits {:start start :end end}
+    @{:Sequence
+      {:first (fn [self] (self :start))
+       :rest  (fn [self]
+                (if (>= (+ (self :start) 1) (self :end))
+                  ()
+                  (make-range (+ (self :start) 1) (self :end))))
+       :iter  (fn [self]
+                (fiber/new (fn []
+                  (def @i (self :start))
+                  (while (< i (self :end))
+                    (yield i)
+                    (assign i (+ i 1)))) |:yield|))}}))
+
+(first (make-range 0 10))        # => 0
+(first (rest (make-range 0 10))) # => 1
+```
+
+## Cross-thread behavior
+
+Default traitsets are thread-local permanent allocations. When sending
+a value to another thread:
+
+- Default traits are skipped (sent as NIL). The receiving thread's
+  constructors stamp its own registry defaults.
+- User-attached traits are deep-copied faithfully.
+
+Detection uses pointer identity against `default_traits_for(tag)`,
+not a type heuristic. User-attached @struct traits are preserved.
+
+## Allocation
+
+Default traitsets use `alloc_permanent` (Rc-backed, never reclaimed
+by arena scope operations). This ensures they don't interfere with
+scope-based arena reclamation. The traitset pointer in a heap object
+is just a pointer — no arena bookkeeping overhead.
+
+`collect_heap_children` traces the `traits` field for all heap
+variants. Permanent traitsets won't match `slab_owns()` and are
+skipped. User-attached traits (arena-allocated via `with-traits`) are
+properly traced.
+
+## Performance
+
+The hot path for builtin types:
+- Read `traits` field (pointer in the heap object)
+- Linear scan for protocol keyword (2 entries in the @struct)
+- Linear scan for method keyword (5 entries in the method struct)
+- Native function call (same Rust code as the old type cascade)
+
+`lookup_keyword` avoids allocating a `TableKey` — it compares the
+keyword discriminant and string directly.
 
 ---
 
 ## See also
 
-- [types.md](types.md) — type system
-- [structs.md](structs.md) — struct operations (trait tables are structs)
-- [match.md](match.md) — pattern matching for dispatch
+- [types.md](types.md) — type system and heap tags
+- [structs.md](structs.md) — struct operations

--- a/src/primitives/list/advanced.rs
+++ b/src/primitives/list/advanced.rs
@@ -1,6 +1,6 @@
 //! Advanced list operations: append, concat, take, drop, butlast, reverse, last
 use crate::primitives::collection::coll_combine;
-use crate::primitives::seq::{seq_butlast, seq_last, seq_reverse};
+use crate::primitives::seq::{seq_butlast, seq_reverse};
 use crate::value::fiber::{SignalBits, SIG_ERROR, SIG_OK};
 use crate::value::{error_val, list, Value};
 
@@ -36,7 +36,11 @@ pub(crate) fn prim_take(args: &[Value]) -> (SignalBits, Value) {
     (SIG_OK, list(taken))
 }
 
-/// Get all elements of a sequence except the last
+/// Get all elements of a sequence except the last.
+///
+/// butlast doesn't have a trait method — it's defined in terms of
+/// the underlying seq/collection implementations. User-defined Sequence
+/// types that only implement the trait protocol won't support butlast.
 pub(crate) fn prim_butlast(args: &[Value]) -> (SignalBits, Value) {
     match seq_butlast(&args[0]) {
         Ok(v) => (SIG_OK, v),
@@ -477,7 +481,11 @@ pub(crate) fn prim_concat(args: &[Value]) -> (SignalBits, Value) {
     )
 }
 
-/// Reverse a sequence (list, array, @array, string)
+/// Reverse a sequence (list, array, @array, string).
+///
+/// reverse doesn't have a trait method — it's defined in terms of
+/// the underlying seq/collection implementations. User-defined Sequence
+/// types that only implement the trait protocol won't support reverse.
 pub(crate) fn prim_reverse(args: &[Value]) -> (SignalBits, Value) {
     match seq_reverse(&args[0]) {
         Ok(v) => (SIG_OK, v),
@@ -487,10 +495,7 @@ pub(crate) fn prim_reverse(args: &[Value]) -> (SignalBits, Value) {
 
 /// Get the last element of a sequence
 pub(crate) fn prim_last(args: &[Value]) -> (SignalBits, Value) {
-    match seq_last(&args[0]) {
-        Ok(v) => (SIG_OK, v),
-        Err(e) => (SIG_ERROR, e),
-    }
+    crate::primitives::traitregistry::dispatch_trait_method(&args[0], "Sequence", "last", args)
 }
 
 /// Drop the first n elements of a list

--- a/src/primitives/list/mod.rs
+++ b/src/primitives/list/mod.rs
@@ -3,7 +3,6 @@ mod advanced;
 
 use crate::primitives::collection::{coll_empty, coll_len, coll_to_vec};
 use crate::primitives::def::PrimitiveDef;
-use crate::primitives::seq::{seq_first, seq_nth, seq_rest};
 use crate::signals::Signal;
 use crate::syntax::SyntaxKind;
 use crate::value::fiber::{SignalBits, SIG_ERROR, SIG_OK};
@@ -26,25 +25,24 @@ pub(crate) fn prim_first(args: &[Value]) -> (SignalBits, Value) {
             return (SIG_OK, Value::syntax(items[0].clone()));
         }
     }
-    match seq_first(&args[0]) {
-        Ok(v) => (SIG_OK, v),
-        Err(e) => (SIG_ERROR, e),
+    // Empty list is an immediate — no traitset, error explicitly
+    if args[0].is_empty_list() {
+        return (
+            SIG_ERROR,
+            error_val("argument-error", "first: empty sequence"),
+        );
     }
+    crate::primitives::traitregistry::dispatch_trait_method(&args[0], "Sequence", "first", args)
 }
 
 /// Get the second element of a sequence
 pub(crate) fn prim_second(args: &[Value]) -> (SignalBits, Value) {
-    // Syntax is not a seq type, handle it inline
-    match seq_nth(&args[0], 1) {
-        Ok(v) => (SIG_OK, v),
-        Err(_) => (
-            SIG_ERROR,
-            error_val(
-                "argument-error",
-                "second: sequence has fewer than 2 elements",
-            ),
-        ),
-    }
+    crate::primitives::traitregistry::dispatch_trait_method(
+        &args[0],
+        "Sequence",
+        "nth",
+        &[args[0], Value::int(1)],
+    )
 }
 
 /// Get the rest of a sequence (list, array, @array, string, @string, bytes, @bytes)
@@ -64,10 +62,11 @@ pub(crate) fn prim_rest(args: &[Value]) -> (SignalBits, Value) {
             return (SIG_OK, Value::syntax(rest));
         }
     }
-    match seq_rest(&args[0]) {
-        Ok(v) => (SIG_OK, v),
-        Err(e) => (SIG_ERROR, e),
+    // Empty list is an immediate — no traitset, return empty list
+    if args[0].is_empty_list() {
+        return (SIG_OK, Value::EMPTY_LIST);
     }
+    crate::primitives::traitregistry::dispatch_trait_method(&args[0], "Sequence", "rest", args)
 }
 
 /// Create a list from arguments
@@ -101,26 +100,48 @@ pub(crate) fn prim_to_list(args: &[Value]) -> (SignalBits, Value) {
 
 /// Get the length of a collection (universal for all container types)
 pub(crate) fn prim_length(args: &[Value]) -> (SignalBits, Value) {
-    match coll_len(&args[0]) {
-        Ok(n) => (SIG_OK, Value::int(n as i64)),
-        Err(e) => (SIG_ERROR, e),
+    // Types without traitsets that still support length
+    if args[0].is_nil()
+        || args[0].is_symbol()
+        || args[0].as_keyword_name().is_some()
+        || args[0].as_syntax().is_some()
+        || args[0].is_empty_list()
+    {
+        match coll_len(&args[0]) {
+            Ok(n) => return (SIG_OK, Value::int(n as i64)),
+            Err(e) => return (SIG_ERROR, e),
+        }
     }
+    crate::primitives::traitregistry::dispatch_trait_method(&args[0], "Collection", "length", args)
 }
 
 /// Check if a collection is empty (O(1) operation for most types)
 pub(crate) fn prim_empty(args: &[Value]) -> (SignalBits, Value) {
-    match coll_empty(&args[0]) {
-        Ok(empty) => (SIG_OK, if empty { Value::TRUE } else { Value::FALSE }),
-        Err(e) => (SIG_ERROR, e),
+    // Types without traitsets that still support empty?
+    if args[0].as_syntax().is_some() || args[0].is_empty_list() || args[0].is_nil() {
+        match coll_empty(&args[0]) {
+            Ok(empty) => return (SIG_OK, if empty { Value::TRUE } else { Value::FALSE }),
+            Err(e) => return (SIG_ERROR, e),
+        }
     }
+    crate::primitives::traitregistry::dispatch_trait_method(&args[0], "Collection", "empty?", args)
 }
 
 /// Check if a collection is non-empty (negation of empty?)
 pub(crate) fn prim_nonempty(args: &[Value]) -> (SignalBits, Value) {
-    match coll_empty(&args[0]) {
-        Ok(empty) => (SIG_OK, if empty { Value::FALSE } else { Value::TRUE }),
-        Err(e) => (SIG_ERROR, e),
+    let (sig, val) = prim_empty(args);
+    if sig != SIG_OK {
+        return (sig, val);
     }
+    // Negate the boolean result
+    (
+        SIG_OK,
+        if val == Value::TRUE {
+            Value::FALSE
+        } else {
+            Value::TRUE
+        },
+    )
 }
 
 /// Declarative primitive definitions for list operations

--- a/src/primitives/lstruct.rs
+++ b/src/primitives/lstruct.rs
@@ -1,7 +1,6 @@
 //! Struct operations primitives (mutable hash tables)
 //!
 //! Polymorphic collection access (get, put) is in `access.rs`.
-use crate::primitives::collection::coll_has;
 use crate::primitives::def::PrimitiveDef;
 use crate::signals::Signal;
 use crate::value::fiber::{SignalBits, SIG_ERROR, SIG_OK};
@@ -298,8 +297,5 @@ pub(crate) fn prim_values(args: &[Value]) -> (SignalBits, Value) {
 /// Polymorphic has? - works on structs, sets, and strings
 /// `(has? collection key-or-value)`
 pub(crate) fn prim_has_key(args: &[Value]) -> (SignalBits, Value) {
-    match coll_has(&args[0], &args[1]) {
-        Ok(found) => (SIG_OK, if found { Value::TRUE } else { Value::FALSE }),
-        Err(e) => (SIG_ERROR, e),
-    }
+    crate::primitives::traitregistry::dispatch_trait_method(&args[0], "Collection", "has?", args)
 }

--- a/src/primitives/mod.rs
+++ b/src/primitives/mod.rs
@@ -54,6 +54,7 @@ pub mod string;
 pub mod structs;
 pub mod subprocess;
 pub mod time;
+pub mod traitregistry;
 pub mod traits;
 pub mod types;
 pub mod unix;

--- a/src/primitives/traitregistry.rs
+++ b/src/primitives/traitregistry.rs
@@ -1,0 +1,687 @@
+//! Thread-local trait registry: default traitsets stamped at allocation.
+//!
+//! Each collection/sequence HeapTag has a shared @struct traitset.
+//! Constructors read the registry entry and stamp it into the new
+//! object's `traits` field. All instances of a type share the same
+//! @struct pointer by default.
+
+use std::cell::Cell;
+use std::collections::BTreeMap;
+
+use crate::value::heap::HeapTag;
+use crate::value::types::TableKey;
+use crate::value::Value;
+
+/// Number of HeapTag variants (max index is CaptureCell = 28).
+const NUM_TAGS: usize = 29;
+
+thread_local! {
+    static DEFAULT_TRAITS: Cell<*const [Value; NUM_TAGS]> =
+        const { Cell::new(std::ptr::null()) };
+}
+
+/// Return the default traitset for a given HeapTag.
+/// Returns `Value::NIL` if the registry is not initialized or the tag
+/// has no default traitset.
+#[inline]
+pub fn default_traits_for(tag: HeapTag) -> Value {
+    DEFAULT_TRAITS.with(|cell| {
+        let ptr = cell.get();
+        if ptr.is_null() {
+            Value::NIL
+        } else {
+            unsafe { (*ptr)[tag as usize] }
+        }
+    })
+}
+
+/// Initialize the thread-local default traits registry.
+///
+/// Leaks a `Box<[Value; NUM_TAGS]>` — same pattern as the root heap.
+/// Called from VM initialization before any allocations happen.
+pub fn init_default_traits() {
+    DEFAULT_TRAITS.with(|cell| {
+        if !cell.get().is_null() {
+            return; // already initialized
+        }
+        let mut table = [Value::NIL; NUM_TAGS];
+
+        // Build method structs for :Sequence and :Collection protocols,
+        // then assemble @struct traitsets for each collection type.
+
+        // ── :Sequence methods (immutable struct) ────────────────────
+        let seq_methods = build_sequence_methods();
+
+        // ── :Collection methods (immutable struct) ──────────────────
+        let coll_methods = build_collection_methods();
+
+        // ── Build traitsets ─────────────────────────────────────────
+
+        // Sequence + Collection types: array, @array, list, string,
+        // @string, bytes, @bytes
+        let seq_coll = make_traitset(Some(seq_methods), Some(coll_methods));
+
+        // Collection-only types: set, @set, struct, @struct
+        let coll_only = make_traitset(None, Some(coll_methods));
+
+        // Stamp entries
+        table[HeapTag::LArray as usize] = seq_coll;
+        table[HeapTag::LArrayMut as usize] = seq_coll;
+        table[HeapTag::Pair as usize] = seq_coll;
+        table[HeapTag::LString as usize] = seq_coll;
+        table[HeapTag::LStringMut as usize] = seq_coll;
+        table[HeapTag::LBytes as usize] = seq_coll;
+        table[HeapTag::LBytesMut as usize] = seq_coll;
+        table[HeapTag::LSet as usize] = coll_only;
+        table[HeapTag::LSetMut as usize] = coll_only;
+        table[HeapTag::LStruct as usize] = coll_only;
+        table[HeapTag::LStructMut as usize] = coll_only;
+
+        let leaked = Box::leak(Box::new(table));
+        cell.set(leaked as *const [Value; NUM_TAGS]);
+    });
+}
+
+/// Build the :Sequence method struct (immutable).
+fn build_sequence_methods() -> Value {
+    use crate::primitives::def::PrimitiveDef;
+    use crate::signals::Signal;
+    use crate::value::types::Arity;
+
+    // Native function definitions for sequence methods.
+    // These are leaked static refs, same pattern as permanent NativeFns.
+    static SEQ_FIRST: PrimitiveDef = PrimitiveDef {
+        name: "trait:Sequence:first",
+        func: trait_seq_first,
+        signal: Signal::errors(),
+        arity: Arity::Exact(1),
+        doc: "Sequence trait: first element",
+        params: &["self"],
+        category: "trait",
+        example: "",
+        aliases: &[],
+    };
+    static SEQ_REST: PrimitiveDef = PrimitiveDef {
+        name: "trait:Sequence:rest",
+        func: trait_seq_rest,
+        signal: Signal::errors(),
+        arity: Arity::Exact(1),
+        doc: "Sequence trait: rest of sequence",
+        params: &["self"],
+        category: "trait",
+        example: "",
+        aliases: &[],
+    };
+    static SEQ_LAST: PrimitiveDef = PrimitiveDef {
+        name: "trait:Sequence:last",
+        func: trait_seq_last,
+        signal: Signal::errors(),
+        arity: Arity::Exact(1),
+        doc: "Sequence trait: last element",
+        params: &["self"],
+        category: "trait",
+        example: "",
+        aliases: &[],
+    };
+    static SEQ_NTH: PrimitiveDef = PrimitiveDef {
+        name: "trait:Sequence:nth",
+        func: trait_seq_nth,
+        signal: Signal::errors(),
+        arity: Arity::Exact(2),
+        doc: "Sequence trait: nth element",
+        params: &["self", "n"],
+        category: "trait",
+        example: "",
+        aliases: &[],
+    };
+    static SEQ_ITER: PrimitiveDef = PrimitiveDef {
+        name: "trait:Sequence:iter",
+        func: trait_seq_iter,
+        signal: Signal::errors(),
+        arity: Arity::Exact(1),
+        doc: "Sequence trait: fiber iterator",
+        params: &["self"],
+        category: "trait",
+        example: "",
+        aliases: &[],
+    };
+
+    let mut entries = BTreeMap::new();
+    entries.insert(
+        TableKey::Keyword("first".into()),
+        Value::native_fn(&SEQ_FIRST),
+    );
+    entries.insert(
+        TableKey::Keyword("rest".into()),
+        Value::native_fn(&SEQ_REST),
+    );
+    entries.insert(
+        TableKey::Keyword("last".into()),
+        Value::native_fn(&SEQ_LAST),
+    );
+    entries.insert(TableKey::Keyword("nth".into()), Value::native_fn(&SEQ_NTH));
+    entries.insert(
+        TableKey::Keyword("iter".into()),
+        Value::native_fn(&SEQ_ITER),
+    );
+    alloc_permanent_struct(entries)
+}
+
+/// Build the :Collection method struct (immutable).
+///
+/// All collection types currently share the same native implementations
+/// (coll_len, coll_empty, coll_has dispatch internally on type). If
+/// collection types ever need divergent method sets, split this back
+/// into per-category builders.
+fn build_collection_methods() -> Value {
+    use crate::primitives::def::PrimitiveDef;
+    use crate::signals::Signal;
+    use crate::value::types::Arity;
+
+    static COLL_LENGTH: PrimitiveDef = PrimitiveDef {
+        name: "trait:Collection:length",
+        func: trait_coll_length,
+        signal: Signal::errors(),
+        arity: Arity::Exact(1),
+        doc: "Collection trait: element count",
+        params: &["self"],
+        category: "trait",
+        example: "",
+        aliases: &[],
+    };
+    static COLL_EMPTY: PrimitiveDef = PrimitiveDef {
+        name: "trait:Collection:empty?",
+        func: trait_coll_empty,
+        signal: Signal::errors(),
+        arity: Arity::Exact(1),
+        doc: "Collection trait: is empty?",
+        params: &["self"],
+        category: "trait",
+        example: "",
+        aliases: &[],
+    };
+    static COLL_HAS: PrimitiveDef = PrimitiveDef {
+        name: "trait:Collection:has?",
+        func: trait_coll_has,
+        signal: Signal::errors(),
+        arity: Arity::Exact(2),
+        doc: "Collection trait: membership test",
+        params: &["self", "needle"],
+        category: "trait",
+        example: "",
+        aliases: &[],
+    };
+    static COLL_CONJ: PrimitiveDef = PrimitiveDef {
+        name: "trait:Collection:conj",
+        func: trait_coll_conj,
+        signal: Signal::errors(),
+        arity: Arity::Exact(2),
+        doc: "Collection trait: add element",
+        params: &["self", "item"],
+        category: "trait",
+        example: "",
+        aliases: &[],
+    };
+    static COLL_EMPTY_NEW: PrimitiveDef = PrimitiveDef {
+        name: "trait:Collection:empty",
+        func: trait_coll_empty_new,
+        signal: Signal::errors(),
+        arity: Arity::Exact(1),
+        doc: "Collection trait: empty container of same type",
+        params: &["self"],
+        category: "trait",
+        example: "",
+        aliases: &[],
+    };
+
+    let mut entries = BTreeMap::new();
+    entries.insert(
+        TableKey::Keyword("length".into()),
+        Value::native_fn(&COLL_LENGTH),
+    );
+    entries.insert(
+        TableKey::Keyword("empty?".into()),
+        Value::native_fn(&COLL_EMPTY),
+    );
+    entries.insert(
+        TableKey::Keyword("has?".into()),
+        Value::native_fn(&COLL_HAS),
+    );
+    entries.insert(
+        TableKey::Keyword("conj".into()),
+        Value::native_fn(&COLL_CONJ),
+    );
+    entries.insert(
+        TableKey::Keyword("empty".into()),
+        Value::native_fn(&COLL_EMPTY_NEW),
+    );
+    alloc_permanent_struct(entries)
+}
+
+/// Allocate an immutable struct as a permanent (Rc-backed) allocation.
+/// Permanent allocations are never reclaimed by arena scope operations,
+/// so they are safe to reference from any scope.
+fn alloc_permanent_struct(entries: BTreeMap<TableKey, Value>) -> Value {
+    use crate::value::heap::{alloc_permanent, HeapObject};
+    let sorted: Vec<(TableKey, Value)> = entries.into_iter().collect();
+    alloc_permanent(HeapObject::LStruct {
+        data: sorted,
+        traits: Value::NIL,
+    })
+}
+
+/// Allocate a mutable struct as a permanent (Rc-backed) allocation.
+fn alloc_permanent_struct_mut(entries: BTreeMap<TableKey, Value>) -> Value {
+    use crate::value::heap::{alloc_permanent, HeapObject};
+    use std::cell::RefCell;
+    use std::rc::Rc;
+    alloc_permanent(HeapObject::LStructMut {
+        data: Rc::new(RefCell::new(entries)),
+        traits: Value::NIL,
+    })
+}
+
+/// Build a traitset @struct from optional protocol method structs.
+fn make_traitset(sequence: Option<Value>, collection: Option<Value>) -> Value {
+    let mut entries = BTreeMap::new();
+    if let Some(seq) = sequence {
+        entries.insert(TableKey::Keyword("Sequence".into()), seq);
+    }
+    if let Some(coll) = collection {
+        entries.insert(TableKey::Keyword("Collection".into()), coll);
+    }
+    alloc_permanent_struct_mut(entries)
+}
+
+// ── Trait method implementations ────────────────────────────────────
+
+use crate::value::fiber::{SignalBits, SIG_ERROR, SIG_OK};
+
+fn trait_seq_first(args: &[Value]) -> (SignalBits, Value) {
+    match super::seq::seq_first(&args[0]) {
+        Ok(v) => (SIG_OK, v),
+        Err(e) => (SIG_ERROR, e),
+    }
+}
+
+fn trait_seq_rest(args: &[Value]) -> (SignalBits, Value) {
+    match super::seq::seq_rest(&args[0]) {
+        Ok(v) => (SIG_OK, v),
+        Err(e) => (SIG_ERROR, e),
+    }
+}
+
+fn trait_seq_last(args: &[Value]) -> (SignalBits, Value) {
+    match super::seq::seq_last(&args[0]) {
+        Ok(v) => (SIG_OK, v),
+        Err(e) => (SIG_ERROR, e),
+    }
+}
+
+fn trait_seq_nth(args: &[Value]) -> (SignalBits, Value) {
+    let n = match args[1].as_int() {
+        Some(n) => n,
+        None => {
+            return (
+                SIG_ERROR,
+                crate::value::error_val(
+                    "type-error",
+                    format!("nth: expected integer index, got {}", args[1].type_name()),
+                ),
+            )
+        }
+    };
+    match super::seq::seq_nth(&args[0], n) {
+        Ok(v) => (SIG_OK, v),
+        Err(e) => (SIG_ERROR, e),
+    }
+}
+
+fn trait_seq_iter(args: &[Value]) -> (SignalBits, Value) {
+    use crate::value::fiber::Fiber;
+
+    let val = args[0];
+
+    // Collect all elements, then create a native iterator fiber
+    // that yields them one by one on each resume.
+    let elements = match super::collection::coll_to_vec(&val) {
+        Ok(v) => v,
+        Err(e) => return (SIG_ERROR, e),
+    };
+
+    let mask = crate::signals::SIG_YIELD;
+    let fiber = Fiber::native_iter(elements, mask);
+    (SIG_OK, Value::fiber(fiber))
+}
+
+fn trait_coll_length(args: &[Value]) -> (SignalBits, Value) {
+    match super::collection::coll_len(&args[0]) {
+        Ok(n) => (SIG_OK, Value::int(n as i64)),
+        Err(e) => (SIG_ERROR, e),
+    }
+}
+
+fn trait_coll_empty(args: &[Value]) -> (SignalBits, Value) {
+    match super::collection::coll_empty(&args[0]) {
+        Ok(empty) => (SIG_OK, Value::bool(empty)),
+        Err(e) => (SIG_ERROR, e),
+    }
+}
+
+fn trait_coll_has(args: &[Value]) -> (SignalBits, Value) {
+    match super::collection::coll_has(&args[0], &args[1]) {
+        Ok(found) => (SIG_OK, Value::bool(found)),
+        Err(e) => (SIG_ERROR, e),
+    }
+}
+
+fn trait_coll_conj(args: &[Value]) -> (SignalBits, Value) {
+    let coll = &args[0];
+    let item = args[1];
+
+    // Array: append
+    if let Some(elems) = coll.as_array() {
+        let mut new = elems.to_vec();
+        new.push(item);
+        return (SIG_OK, Value::array(new));
+    }
+    if let Some(arr) = coll.as_array_mut() {
+        arr.borrow_mut().push(item);
+        return (SIG_OK, *coll);
+    }
+
+    // List: prepend (cons)
+    if coll.is_pair() || coll.is_empty_list() {
+        return (SIG_OK, Value::pair(item, *coll));
+    }
+
+    // Set: add
+    if let Some(s) = coll.as_set() {
+        let frozen = super::sets::freeze_value(item);
+        let mut new: std::collections::BTreeSet<Value> = s.iter().copied().collect();
+        new.insert(frozen);
+        return (SIG_OK, Value::set(new));
+    }
+    if let Some(s) = coll.as_set_mut() {
+        let frozen = super::sets::freeze_value(item);
+        s.borrow_mut().insert(frozen);
+        return (SIG_OK, *coll);
+    }
+
+    // String: append string
+    if coll.is_string() {
+        let s = item.with_string(|s| s.to_string()).unwrap_or_default();
+        return coll
+            .with_string(|base| {
+                let mut new = base.to_string();
+                new.push_str(&s);
+                (SIG_OK, Value::string(new))
+            })
+            .unwrap_or_else(|| {
+                (
+                    SIG_ERROR,
+                    crate::value::error_val("type-error", "conj: unreachable string case"),
+                )
+            });
+    }
+
+    // Bytes: append byte
+    if let Some(b) = coll.as_bytes() {
+        if let Some(n) = item.as_int() {
+            if (0..=255).contains(&n) {
+                let mut new = b.to_vec();
+                new.push(n as u8);
+                return (SIG_OK, Value::bytes(new));
+            }
+        }
+    }
+
+    (
+        SIG_ERROR,
+        crate::value::error_val(
+            "type-error",
+            format!("conj: unsupported collection type {}", coll.type_name()),
+        ),
+    )
+}
+
+fn trait_coll_empty_new(args: &[Value]) -> (SignalBits, Value) {
+    let coll = &args[0];
+
+    if coll.as_array().is_some() {
+        return (SIG_OK, Value::array(vec![]));
+    }
+    if coll.as_array_mut().is_some() {
+        return (SIG_OK, Value::array_mut(vec![]));
+    }
+    if coll.is_pair() || coll.is_empty_list() {
+        return (SIG_OK, Value::EMPTY_LIST);
+    }
+    if coll.as_set().is_some() {
+        return (SIG_OK, Value::set(std::collections::BTreeSet::new()));
+    }
+    if coll.as_set_mut().is_some() {
+        return (SIG_OK, Value::set_mut(std::collections::BTreeSet::new()));
+    }
+    if coll.as_struct().is_some() {
+        return (
+            SIG_OK,
+            Value::struct_from(std::collections::BTreeMap::new()),
+        );
+    }
+    if coll.as_struct_mut().is_some() {
+        return (SIG_OK, Value::struct_mut());
+    }
+    if coll.is_string() {
+        return (SIG_OK, Value::string(""));
+    }
+    if coll.as_string_mut().is_some() {
+        return (SIG_OK, Value::string_mut(vec![]));
+    }
+    if coll.as_bytes().is_some() {
+        return (SIG_OK, Value::bytes(vec![]));
+    }
+    if coll.as_bytes_mut().is_some() {
+        return (SIG_OK, Value::bytes_mut(vec![]));
+    }
+
+    (
+        SIG_ERROR,
+        crate::value::error_val(
+            "type-error",
+            format!("empty: unsupported collection type {}", coll.type_name()),
+        ),
+    )
+}
+
+// ── Dispatch helper ─────────────────────────────────────────────────
+
+/// Read the traits field from a value.
+///
+/// Returns the traits @struct for heap objects, or `Value::NIL` for
+/// immediates and infrastructure types. No fallback, no registry lookup.
+pub fn get_traitset(val: &Value) -> Value {
+    if !val.is_heap() {
+        return Value::NIL;
+    }
+    unsafe {
+        match crate::value::heap::deref(*val) {
+            crate::value::heap::HeapObject::LString { traits, .. }
+            | crate::value::heap::HeapObject::LArray { traits, .. }
+            | crate::value::heap::HeapObject::LArrayMut { traits, .. }
+            | crate::value::heap::HeapObject::LStruct { traits, .. }
+            | crate::value::heap::HeapObject::LStructMut { traits, .. }
+            | crate::value::heap::HeapObject::LStringMut { traits, .. }
+            | crate::value::heap::HeapObject::LBytes { traits, .. }
+            | crate::value::heap::HeapObject::LBytesMut { traits, .. }
+            | crate::value::heap::HeapObject::LSet { traits, .. }
+            | crate::value::heap::HeapObject::LSetMut { traits, .. }
+            | crate::value::heap::HeapObject::Closure { traits, .. }
+            | crate::value::heap::HeapObject::LBox { traits, .. }
+            | crate::value::heap::HeapObject::CaptureCell { traits, .. }
+            | crate::value::heap::HeapObject::Fiber { traits, .. }
+            | crate::value::heap::HeapObject::Syntax { traits, .. }
+            | crate::value::heap::HeapObject::ManagedPointer { traits, .. }
+            | crate::value::heap::HeapObject::External { traits, .. }
+            | crate::value::heap::HeapObject::Parameter { traits, .. }
+            | crate::value::heap::HeapObject::ThreadHandle { traits, .. } => *traits,
+            crate::value::heap::HeapObject::Pair(pair) => pair.traits,
+            _ => Value::NIL,
+        }
+    }
+}
+
+/// Look up a trait method on a value and call it.
+///
+/// Reads the traits field (always populated for collection types),
+/// looks up the protocol and method, and calls the method.
+/// If the value's trait table doesn't contain the requested protocol,
+/// falls back to the default traitset from the registry.
+/// Returns `(SignalBits, Value)` directly.
+pub fn dispatch_trait_method(
+    val: &Value,
+    protocol: &str,
+    method: &str,
+    args: &[Value],
+) -> (SignalBits, Value) {
+    use crate::value::error_val;
+
+    let traits_val = get_traitset(val);
+    if traits_val.is_nil() {
+        return (
+            SIG_ERROR,
+            error_val(
+                "type-error",
+                format!("{}: no trait table on {} value", method, val.type_name()),
+            ),
+        );
+    }
+
+    // Look up protocol in the value's trait table
+    let mut protocol_val = lookup_keyword(&traits_val, protocol);
+
+    // If protocol not found in the value's traits, try the default
+    // traitset from the registry (user traits may override only some protocols)
+    if protocol_val.is_nil() && val.is_heap() {
+        let tag = unsafe { crate::value::heap::deref(*val) }.tag();
+        let default = default_traits_for(tag);
+        if !default.is_nil() {
+            protocol_val = lookup_keyword(&default, protocol);
+        }
+    }
+
+    if protocol_val.is_nil() {
+        return (
+            SIG_ERROR,
+            error_val(
+                "type-error",
+                format!(
+                    "{}: no :{} protocol on {} value",
+                    method,
+                    protocol,
+                    val.type_name()
+                ),
+            ),
+        );
+    }
+
+    let method_fn = lookup_keyword(&protocol_val, method);
+    if method_fn.is_nil() {
+        return (
+            SIG_ERROR,
+            error_val(
+                "type-error",
+                format!(
+                    "{}: no :{} method in :{} protocol",
+                    method, method, protocol
+                ),
+            ),
+        );
+    }
+
+    call_method_fn(&method_fn, protocol, method, args)
+}
+
+/// Call a resolved trait method (NativeFn or Closure).
+fn call_method_fn(
+    method_fn: &Value,
+    protocol: &str,
+    method: &str,
+    args: &[Value],
+) -> (SignalBits, Value) {
+    // NativeFn — call directly
+    if let Some(prim_fn) = method_fn.as_native_fn() {
+        return prim_fn(args);
+    }
+
+    // Closure — call via VM context
+    if let Some(closure) = method_fn.as_closure() {
+        let vm_ptr = match crate::context::get_vm_context() {
+            Some(ptr) => ptr,
+            None => {
+                return (
+                    SIG_ERROR,
+                    crate::value::error_val(
+                        "internal-error",
+                        "trait dispatch: no VM context for closure call",
+                    ),
+                );
+            }
+        };
+        let vm = unsafe { &mut *vm_ptr };
+        match vm.call_closure(closure, args) {
+            Ok(v) => return (SIG_OK, v),
+            Err(msg) => {
+                return (SIG_ERROR, crate::value::error_val("trait-error", msg));
+            }
+        }
+    }
+
+    // Not callable
+    (
+        SIG_ERROR,
+        crate::value::error_val(
+            "type-error",
+            format!(
+                "{}:{}: trait method is not callable ({})",
+                protocol,
+                method,
+                method_fn.type_name()
+            ),
+        ),
+    )
+}
+
+/// Look up a keyword key in a struct without allocating a TableKey.
+///
+/// Trait tables are small (2–5 entries), so linear scan on the keyword
+/// discriminant + string comparison avoids the String allocation that
+/// `TableKey::Keyword(key.into())` would require on every dispatch.
+fn lookup_keyword(val: &Value, key: &str) -> Value {
+    // Immutable struct — linear scan (small tables)
+    if let Some(entries) = val.as_struct() {
+        for (k, v) in entries.iter() {
+            if let TableKey::Keyword(ref s) = k {
+                if s == key {
+                    return *v;
+                }
+            }
+        }
+        return Value::NIL;
+    }
+
+    // Mutable struct — linear scan on values
+    if let Some(map_ref) = val.as_struct_mut() {
+        let borrowed = map_ref.borrow();
+        for (k, v) in borrowed.iter() {
+            if let TableKey::Keyword(ref s) = k {
+                if s == key {
+                    return *v;
+                }
+            }
+        }
+        return Value::NIL;
+    }
+
+    Value::NIL
+}

--- a/src/primitives/traits.rs
+++ b/src/primitives/traits.rs
@@ -36,14 +36,18 @@ pub(crate) fn prim_with_traits(args: &[Value]) -> (SignalBits, Value) {
         );
     }
 
-    // Validate: table must be an immutable struct (LStruct)
-    if !table.is_heap() || unsafe { deref(table) }.tag() != crate::value::heap::HeapTag::LStruct {
+    // Validate: table must be a struct (LStruct or LStructMut)
+    if !table.is_heap() || {
+        let tag = unsafe { deref(table) }.tag();
+        tag != crate::value::heap::HeapTag::LStruct
+            && tag != crate::value::heap::HeapTag::LStructMut
+    } {
         return (
             SIG_ERROR,
             error_val(
                 "type-error",
                 format!(
-                    "with-traits: trait table must be an immutable struct, got {}",
+                    "with-traits: trait table must be a struct, got {}",
                     table.type_name()
                 ),
             ),
@@ -171,41 +175,14 @@ unsafe fn clone_with_traits(value: Value, table: Value) -> Result<Value, String>
 
 /// (traits value) → trait table or nil
 ///
-/// Returns the trait table attached to value, or nil if none.
-/// For immediate values and infrastructure types, returns nil (no error).
+/// Returns the trait table attached to value. Since traits are stamped at
+/// allocation for collection types, this simply reads the traits field.
+/// Returns nil for immediates and infrastructure types.
 pub(crate) fn prim_traits(args: &[Value]) -> (SignalBits, Value) {
-    let value = args[0];
-    if !value.is_heap() {
-        return (SIG_OK, Value::NIL);
-    }
-    let table = unsafe {
-        match deref(value) {
-            HeapObject::LString { traits, .. }
-            | HeapObject::LArray { traits, .. }
-            | HeapObject::LArrayMut { traits, .. }
-            | HeapObject::LStruct { traits, .. }
-            | HeapObject::LStructMut { traits, .. }
-            | HeapObject::LStringMut { traits, .. }
-            | HeapObject::LBytes { traits, .. }
-            | HeapObject::LBytesMut { traits, .. }
-            | HeapObject::LSet { traits, .. }
-            | HeapObject::LSetMut { traits, .. }
-            | HeapObject::Closure { traits, .. }
-            | HeapObject::LBox { traits, .. }
-            | HeapObject::CaptureCell { traits, .. }
-            | HeapObject::Fiber { traits, .. }
-            | HeapObject::Syntax { traits, .. }
-            | HeapObject::ManagedPointer { traits, .. }
-            | HeapObject::External { traits, .. }
-            | HeapObject::Parameter { traits, .. }
-            | HeapObject::ThreadHandle { traits, .. } => *traits,
-            // Pair is a named struct variant — different access
-            HeapObject::Pair(pair) => pair.traits,
-            // Infrastructure types — no trait field
-            _ => Value::NIL,
-        }
-    };
-    (SIG_OK, table)
+    (
+        SIG_OK,
+        crate::primitives::traitregistry::get_traitset(&args[0]),
+    )
 }
 
 pub(crate) const PRIMITIVES: &[PrimitiveDef] = &[
@@ -214,7 +191,7 @@ pub(crate) const PRIMITIVES: &[PrimitiveDef] = &[
         func: prim_with_traits,
         signal: Signal::errors(),
         arity: Arity::Exact(2),
-        doc: "Attach a trait table to a value. Returns a new value with the same data and the given trait table. The table must be an immutable struct.",
+        doc: "Attach a trait table to a value. Returns a new value with the same data and the given trait table. The table must be a struct (immutable or mutable).",
         params: &["value", "table"],
         category: "traits",
         example: "(with-traits [1 2 3] {:Seq {:first (fn (v) (get v 0))}})",

--- a/src/value/fiber.rs
+++ b/src/value/fiber.rs
@@ -514,6 +514,58 @@ pub struct Fiber {
     /// denial signal is emitted instead. Default: empty (full access).
     /// Transitive: `child.withheld = parent.withheld | deny_bits`.
     pub withheld: SignalBits,
+    /// Native iterator state for trait-based :iter fibers.
+    /// When set, fiber/resume pulls the next value from here instead of
+    /// executing bytecode. `None` = normal bytecode fiber.
+    pub native_iter: Option<NativeIter>,
+}
+
+/// A Rust-side iterator that feeds values to a fiber.
+/// Each resume pops the next element; exhaustion kills the fiber.
+pub struct NativeIter {
+    pub elements: Vec<Value>,
+    pub cursor: usize,
+}
+
+/// Create a minimal no-op closure for native iterator fibers.
+/// The bytecode is a single Return instruction (opcode 3) which
+/// is never actually executed — native iter fibers short-circuit
+/// in the VM's resume path.
+fn noop_closure() -> Rc<Closure> {
+    use crate::error::LocationMap;
+    use crate::signals::Signal;
+    use crate::value::arena::alloc_inline_slice;
+    use crate::value::closure::ClosureTemplate;
+    use crate::value::types::Arity;
+    use std::collections::HashMap;
+
+    Rc::new(Closure {
+        template: Rc::new(ClosureTemplate {
+            bytecode: Rc::new(vec![3, 0, 0, 0]), // Return
+            arity: Arity::Exact(0),
+            num_locals: 0,
+            num_captures: 0,
+            num_params: 0,
+            constants: Rc::new(vec![]),
+            signal: Signal::silent(),
+            capture_params_mask: 0,
+            capture_locals_mask: 0,
+            symbol_names: Rc::new(HashMap::new()),
+            location_map: Rc::new(LocationMap::new()),
+            rotation_safe: false,
+            lir_function: None,
+            doc: None,
+            syntax: None,
+            vararg_kind: crate::hir::VarargKind::List,
+            name: None,
+            result_is_immediate: true,
+            has_outward_heap_set: false,
+            wasm_func_idx: None,
+            spirv: std::cell::OnceCell::new(),
+        }),
+        env: alloc_inline_slice(&[]),
+        squelch_mask: SignalBits::EMPTY,
+    })
 }
 
 impl Fiber {
@@ -537,6 +589,38 @@ impl Fiber {
             call_stack: Vec::new(),
             fuel: None,
             withheld: SignalBits::EMPTY,
+            native_iter: None,
+        }
+    }
+
+    /// Create a native iterator fiber from a Vec of elements.
+    ///
+    /// Each `fiber/resume` call returns the next element. When all
+    /// elements are exhausted, the fiber dies. No bytecode is executed.
+    pub fn native_iter(elements: Vec<Value>, mask: SignalBits) -> Self {
+        let closure = noop_closure();
+        Fiber {
+            heap: Box::new(crate::value::fiberheap::FiberHeap::new()),
+            stack: SmallVec::new(),
+            frames: Vec::new(),
+            status: FiberStatus::Paused,
+            mask,
+            parent: None,
+            parent_value: None,
+            child: None,
+            child_value: None,
+            closure,
+            param_frames: Vec::new(),
+            signal: None,
+            suspended: None,
+            call_depth: 0,
+            call_stack: Vec::new(),
+            fuel: None,
+            withheld: SignalBits::EMPTY,
+            native_iter: Some(NativeIter {
+                elements,
+                cursor: 0,
+            }),
         }
     }
 

--- a/src/value/fiberheap/mod.rs
+++ b/src/value/fiberheap/mod.rs
@@ -1109,10 +1109,15 @@ impl FiberHeap {
             HeapObject::Pair(c) => {
                 let head = c.first;
                 let tail = c.rest;
+                let traits = c.traits;
                 // Drop the borrow on self before recursing.
                 let head = self.deep_copy_to_outbox(head);
                 let tail = self.deep_copy_to_outbox(tail);
-                let new_obj = HeapObject::Pair(crate::value::heap::Pair::new(head, tail));
+                let new_obj = HeapObject::Pair(crate::value::heap::Pair {
+                    first: head,
+                    rest: tail,
+                    traits,
+                });
                 self.outbox.as_mut().unwrap().alloc(new_obj)
             }
             HeapObject::LString { s, traits } => {
@@ -1385,28 +1390,43 @@ impl FiberHeap {
 
     /// Collect all heap-typed child Values from a HeapObject into `out`.
     fn collect_heap_children(obj: &HeapObject, out: &mut Vec<Value>) {
+        // Helper: push traits if heap-allocated (permanent traitsets
+        // won't match slab_owns, but user-attached traits will).
+        let push_traits = |traits: &Value, out: &mut Vec<Value>| {
+            if traits.is_heap() {
+                out.push(*traits);
+            }
+        };
         match obj {
-            HeapObject::LArrayMut { data, .. } => {
+            HeapObject::LArrayMut { data, traits, .. } => {
                 out.extend(data.borrow().iter().filter(|v| v.is_heap()).copied());
+                push_traits(traits, out);
             }
-            HeapObject::LStructMut { data, .. } => {
+            HeapObject::LStructMut { data, traits, .. } => {
                 out.extend(data.borrow().values().filter(|v| v.is_heap()).copied());
+                push_traits(traits, out);
             }
-            HeapObject::LArray { elements, .. } => {
+            HeapObject::LArray {
+                elements, traits, ..
+            } => {
                 out.extend(elements.as_slice().iter().filter(|v| v.is_heap()).copied());
+                push_traits(traits, out);
             }
-            HeapObject::LStruct { data, .. } => {
+            HeapObject::LStruct { data, traits, .. } => {
                 out.extend(data.iter().map(|(_, v)| *v).filter(|v| v.is_heap()));
+                push_traits(traits, out);
             }
             HeapObject::Pair(pair) => {
                 out.extend(
-                    [pair.first, pair.rest]
+                    [pair.first, pair.rest, pair.traits]
                         .iter()
                         .filter(|v| v.is_heap())
                         .copied(),
                 );
             }
-            HeapObject::Closure { closure, .. } => {
+            HeapObject::Closure {
+                closure, traits, ..
+            } => {
                 out.extend(
                     closure
                         .env
@@ -1415,21 +1435,40 @@ impl FiberHeap {
                         .filter(|v| v.is_heap())
                         .copied(),
                 );
+                push_traits(traits, out);
             }
-            HeapObject::LBox { cell, .. } | HeapObject::CaptureCell { cell, .. } => {
+            HeapObject::LBox { cell, traits, .. }
+            | HeapObject::CaptureCell { cell, traits, .. } => {
                 let v = *cell.borrow();
                 if v.is_heap() {
                     out.push(v);
                 }
+                push_traits(traits, out);
             }
-            HeapObject::LSet { data, .. } => {
+            HeapObject::LSet { data, traits, .. } => {
                 out.extend(data.as_slice().iter().filter(|v| v.is_heap()).copied());
+                push_traits(traits, out);
             }
-            HeapObject::LSetMut { data, .. } => {
+            HeapObject::LSetMut { data, traits, .. } => {
                 out.extend(data.borrow().iter().filter(|v| v.is_heap()).copied());
+                push_traits(traits, out);
             }
-            HeapObject::Parameter { default, .. } => {
+            HeapObject::LString { traits, .. }
+            | HeapObject::LStringMut { traits, .. }
+            | HeapObject::LBytes { traits, .. }
+            | HeapObject::LBytesMut { traits, .. }
+            | HeapObject::Syntax { traits, .. }
+            | HeapObject::ManagedPointer { traits, .. }
+            | HeapObject::External { traits, .. }
+            | HeapObject::Fiber { traits, .. }
+            | HeapObject::ThreadHandle { traits, .. } => {
+                push_traits(traits, out);
+            }
+            HeapObject::Parameter {
+                default, traits, ..
+            } => {
                 out.extend(std::iter::once(*default).filter(|v| v.is_heap()));
+                push_traits(traits, out);
             }
             _ => {}
         }

--- a/src/value/repr/constructors.rs
+++ b/src/value/repr/constructors.rs
@@ -88,48 +88,48 @@ impl Value {
     #[inline]
     pub fn string(s: impl AsRef<str>) -> Self {
         use crate::value::arena::alloc_inline_slice;
-        use crate::value::heap::{alloc, HeapObject};
+        use crate::value::heap::{alloc, HeapObject, HeapTag};
         let bytes = s.as_ref().as_bytes();
         let slice = alloc_inline_slice::<u8>(bytes);
         alloc(HeapObject::LString {
             s: slice,
-            traits: Value::NIL,
+            traits: crate::primitives::traitregistry::default_traits_for(HeapTag::LString),
         })
     }
 
     /// Create a cons cell.
     #[inline]
     pub fn pair(head: Value, tail: Value) -> Self {
-        use crate::value::heap::{alloc, HeapObject, Pair};
+        use crate::value::heap::{alloc, HeapObject, HeapTag, Pair};
         alloc(HeapObject::Pair(Pair {
             first: head,
             rest: tail,
-            traits: Value::NIL,
+            traits: crate::primitives::traitregistry::default_traits_for(HeapTag::Pair),
         }))
     }
 
     /// Create a mutable @array.
     #[inline]
     pub fn array_mut(elements: Vec<Value>) -> Self {
-        use crate::value::heap::{alloc, HeapObject};
+        use crate::value::heap::{alloc, HeapObject, HeapTag};
         use std::cell::RefCell;
         use std::rc::Rc;
         alloc(HeapObject::LArrayMut {
             data: Rc::new(RefCell::new(elements)),
-            traits: Value::NIL,
+            traits: crate::primitives::traitregistry::default_traits_for(HeapTag::LArrayMut),
         })
     }
 
     /// Create an empty mutable @struct.
     #[inline]
     pub fn struct_mut() -> Self {
-        use crate::value::heap::{alloc, HeapObject};
+        use crate::value::heap::{alloc, HeapObject, HeapTag};
         use std::cell::RefCell;
         use std::collections::BTreeMap;
         use std::rc::Rc;
         alloc(HeapObject::LStructMut {
             data: Rc::new(RefCell::new(BTreeMap::new())),
-            traits: Value::NIL,
+            traits: crate::primitives::traitregistry::default_traits_for(HeapTag::LStructMut),
         })
     }
 
@@ -138,12 +138,12 @@ impl Value {
     pub fn struct_mut_from(
         entries: std::collections::BTreeMap<crate::value::heap::TableKey, Value>,
     ) -> Self {
-        use crate::value::heap::{alloc, HeapObject};
+        use crate::value::heap::{alloc, HeapObject, HeapTag};
         use std::cell::RefCell;
         use std::rc::Rc;
         alloc(HeapObject::LStructMut {
             data: Rc::new(RefCell::new(entries)),
-            traits: Value::NIL,
+            traits: crate::primitives::traitregistry::default_traits_for(HeapTag::LStructMut),
         })
     }
 
@@ -166,10 +166,10 @@ impl Value {
     /// Caller must ensure entries are sorted by key and contain no duplicates.
     #[inline]
     pub fn struct_from_sorted(entries: Vec<(crate::value::heap::TableKey, Value)>) -> Self {
-        use crate::value::heap::{alloc, HeapObject};
+        use crate::value::heap::{alloc, HeapObject, HeapTag};
         alloc(HeapObject::LStruct {
             data: entries,
-            traits: Value::NIL,
+            traits: crate::primitives::traitregistry::default_traits_for(HeapTag::LStruct),
         })
     }
 
@@ -222,23 +222,23 @@ impl Value {
     #[inline]
     pub fn array(elements: Vec<Value>) -> Self {
         use crate::value::arena::alloc_inline_slice;
-        use crate::value::heap::{alloc, HeapObject};
+        use crate::value::heap::{alloc, HeapObject, HeapTag};
         let slice = alloc_inline_slice::<Value>(&elements);
         alloc(HeapObject::LArray {
             elements: slice,
-            traits: Value::NIL,
+            traits: crate::primitives::traitregistry::default_traits_for(HeapTag::LArray),
         })
     }
 
     /// Create a mutable @string value.
     #[inline]
     pub fn string_mut(bytes: Vec<u8>) -> Self {
-        use crate::value::heap::{alloc, HeapObject};
+        use crate::value::heap::{alloc, HeapObject, HeapTag};
         use std::cell::RefCell;
         use std::rc::Rc;
         alloc(HeapObject::LStringMut {
             data: Rc::new(RefCell::new(bytes)),
-            traits: Value::NIL,
+            traits: crate::primitives::traitregistry::default_traits_for(HeapTag::LStringMut),
         })
     }
 
@@ -246,23 +246,23 @@ impl Value {
     #[inline]
     pub fn bytes(data: Vec<u8>) -> Self {
         use crate::value::arena::alloc_inline_slice;
-        use crate::value::heap::{alloc, HeapObject};
+        use crate::value::heap::{alloc, HeapObject, HeapTag};
         let slice = alloc_inline_slice::<u8>(&data);
         alloc(HeapObject::LBytes {
             data: slice,
-            traits: Value::NIL,
+            traits: crate::primitives::traitregistry::default_traits_for(HeapTag::LBytes),
         })
     }
 
     /// Create a mutable @bytes value.
     #[inline]
     pub fn bytes_mut(data: Vec<u8>) -> Self {
-        use crate::value::heap::{alloc, HeapObject};
+        use crate::value::heap::{alloc, HeapObject, HeapTag};
         use std::cell::RefCell;
         use std::rc::Rc;
         alloc(HeapObject::LBytesMut {
             data: Rc::new(RefCell::new(data)),
-            traits: Value::NIL,
+            traits: crate::primitives::traitregistry::default_traits_for(HeapTag::LBytesMut),
         })
     }
 
@@ -382,25 +382,25 @@ impl Value {
     #[inline]
     pub fn set(items: BTreeSet<Value>) -> Self {
         use crate::value::arena::alloc_inline_slice;
-        use crate::value::heap::{alloc, HeapObject};
+        use crate::value::heap::{alloc, HeapObject, HeapTag};
         // BTreeSet iterates in sorted order; collect into Vec and copy into arena.
         let sorted: Vec<Value> = items.into_iter().collect();
         let slice = alloc_inline_slice::<Value>(&sorted);
         alloc(HeapObject::LSet {
             data: slice,
-            traits: Value::NIL,
+            traits: crate::primitives::traitregistry::default_traits_for(HeapTag::LSet),
         })
     }
 
     /// Create a mutable set value.
     #[inline]
     pub fn set_mut(items: BTreeSet<Value>) -> Self {
-        use crate::value::heap::{alloc, HeapObject};
+        use crate::value::heap::{alloc, HeapObject, HeapTag};
         use std::cell::RefCell;
         use std::rc::Rc;
         alloc(HeapObject::LSetMut {
             data: Rc::new(RefCell::new(items)),
-            traits: Value::NIL,
+            traits: crate::primitives::traitregistry::default_traits_for(HeapTag::LSetMut),
         })
     }
 }

--- a/src/value/send.rs
+++ b/src/value/send.rs
@@ -9,7 +9,7 @@
 //!
 //! The solution: SendValue stores owned copies of heap data, not raw pointers.
 
-use super::heap::{alloc, deref, HeapObject, Pair};
+use super::heap::{alloc, deref, HeapObject, HeapTag, Pair};
 use super::repr::Value;
 use crate::error::LocationMap;
 use crate::hir::VarargKind;
@@ -17,6 +17,34 @@ use crate::signals::Signal;
 use crate::value::fiber::SignalBits;
 use crate::value::types::Arity;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
+
+/// Send a traits field. Default traitsets (from the registry) are
+/// skipped (sent as NIL) since the receiving thread has its own registry.
+/// User-attached traits are deep-copied normally.
+fn send_traits(traits: Value, tag: HeapTag, ctx: &mut SerContext) -> Result<SendValue, String> {
+    if traits.is_nil() {
+        return Ok(SendValue::Immediate(Value::NIL));
+    }
+    // Check pointer identity against the registry default for this tag.
+    // This correctly distinguishes registry defaults (skip) from user-attached
+    // @struct traits (send faithfully).
+    let default = crate::primitives::traitregistry::default_traits_for(tag);
+    if !default.is_nil() && traits.payload == default.payload {
+        return Ok(SendValue::Immediate(Value::NIL));
+    }
+    // User-attached traits — send normally
+    from_value_inner(traits, ctx)
+}
+
+/// Resolve a received traits value: if NIL, stamp the receiving thread's
+/// default traitset for the given heap tag.
+fn recv_traits(traits_val: Value, tag: HeapTag) -> Value {
+    if traits_val.is_nil() {
+        crate::primitives::traitregistry::default_traits_for(tag)
+    } else {
+        traits_val
+    }
+}
 
 /// Sendable snapshot of a closure.
 ///
@@ -78,6 +106,12 @@ pub enum SendValue {
 
     /// Deep copy of structs (immutable maps, with traits)
     Struct(
+        BTreeMap<crate::value::heap::TableKey, SendValue>,
+        Box<SendValue>,
+    ),
+
+    /// Deep copy of @structs (mutable maps, with traits)
+    StructMut(
         BTreeMap<crate::value::heap::TableKey, SendValue>,
         Box<SendValue>,
     ),
@@ -194,7 +228,7 @@ fn from_value_inner(value: Value, ctx: &mut SerContext) -> Result<SendValue, Str
         HeapObject::Pair(pair) => {
             let first = from_value_inner(pair.first, ctx)?;
             let rest = from_value_inner(pair.rest, ctx)?;
-            let traits = from_value_inner(pair.traits, ctx)?;
+            let traits = send_traits(pair.traits, HeapTag::Pair, ctx)?;
             Ok(SendValue::Pair(
                 Box::new(first),
                 Box::new(rest),
@@ -213,7 +247,7 @@ fn from_value_inner(value: Value, ctx: &mut SerContext) -> Result<SendValue, Str
                 .map_err(|_| "Cannot borrow array for sending".to_string())?;
             let copied: Result<Vec<SendValue>, String> =
                 borrowed.iter().map(|v| from_value_inner(*v, ctx)).collect();
-            let traits_sv = from_value_inner(*traits, ctx)?;
+            let traits_sv = send_traits(*traits, HeapTag::LArrayMut, ctx)?;
             Ok(SendValue::Array(copied?, Box::new(traits_sv)))
         }
 
@@ -228,7 +262,7 @@ fn from_value_inner(value: Value, ctx: &mut SerContext) -> Result<SendValue, Str
                 }
                 copied.insert(k.clone(), from_value_inner(*v, ctx)?);
             }
-            let traits_sv = from_value_inner(*traits, ctx)?;
+            let traits_sv = send_traits(*traits, HeapTag::LStruct, ctx)?;
             Ok(SendValue::Struct(copied, Box::new(traits_sv)))
         }
 
@@ -240,7 +274,7 @@ fn from_value_inner(value: Value, ctx: &mut SerContext) -> Result<SendValue, Str
         } => {
             let copied: Result<Vec<SendValue>, String> =
                 elems.iter().map(|v| from_value_inner(*v, ctx)).collect();
-            let traits_sv = from_value_inner(*traits, ctx)?;
+            let traits_sv = send_traits(*traits, HeapTag::LArray, ctx)?;
             Ok(SendValue::Tuple(copied?, Box::new(traits_sv)))
         }
 
@@ -253,7 +287,7 @@ fn from_value_inner(value: Value, ctx: &mut SerContext) -> Result<SendValue, Str
             let borrowed = buf_ref
                 .try_borrow()
                 .map_err(|_| "Cannot borrow @string for sending".to_string())?;
-            let traits_sv = from_value_inner(*traits, ctx)?;
+            let traits_sv = send_traits(*traits, HeapTag::LStringMut, ctx)?;
             Ok(SendValue::Buffer(borrowed.clone(), Box::new(traits_sv)))
         }
 
@@ -267,7 +301,7 @@ fn from_value_inner(value: Value, ctx: &mut SerContext) -> Result<SendValue, Str
                 .try_borrow()
                 .map_err(|_| "Cannot borrow box for sending".to_string())?;
             let contents = from_value_inner(*borrowed, ctx)?;
-            let traits_sv = from_value_inner(*traits, ctx)?;
+            let traits_sv = send_traits(*traits, HeapTag::LBox, ctx)?;
             Ok(SendValue::LBox(Box::new(contents), Box::new(traits_sv)))
         }
 
@@ -281,7 +315,7 @@ fn from_value_inner(value: Value, ctx: &mut SerContext) -> Result<SendValue, Str
                 .try_borrow()
                 .map_err(|_| "Cannot borrow capture cell for sending".to_string())?;
             let contents = from_value_inner(*borrowed, ctx)?;
-            let traits_sv = from_value_inner(*traits, ctx)?;
+            let traits_sv = send_traits(*traits, HeapTag::CaptureCell, ctx)?;
             Ok(SendValue::CaptureCell(
                 Box::new(contents),
                 Box::new(traits_sv),
@@ -291,8 +325,25 @@ fn from_value_inner(value: Value, ctx: &mut SerContext) -> Result<SendValue, Str
         // Float values that couldn't be stored inline
         HeapObject::Float(f) => Ok(SendValue::Float(*f)),
 
-        // Unsafe: mutable @structs
-        HeapObject::LStructMut { .. } => Err("Cannot send mutable @struct".to_string()),
+        // Mutable @structs — deep copy all values, plus traits
+        HeapObject::LStructMut {
+            data: map_ref,
+            traits,
+            ..
+        } => {
+            let borrowed = map_ref
+                .try_borrow()
+                .map_err(|_| "Cannot borrow @struct for sending".to_string())?;
+            let mut copied = BTreeMap::new();
+            for (k, v) in borrowed.iter() {
+                if !k.is_sendable() {
+                    return Err("Cannot send @struct with identity keys".to_string());
+                }
+                copied.insert(k.clone(), from_value_inner(*v, ctx)?);
+            }
+            let traits_sv = send_traits(*traits, HeapTag::LStructMut, ctx)?;
+            Ok(SendValue::StructMut(copied, Box::new(traits_sv)))
+        }
 
         // Closures: intern into the table, with cycle detection via pre-insertion
         HeapObject::Closure {
@@ -433,7 +484,7 @@ fn from_value_inner(value: Value, ctx: &mut SerContext) -> Result<SendValue, Str
         HeapObject::LBytes {
             data: b, traits, ..
         } => {
-            let traits_sv = from_value_inner(*traits, ctx)?;
+            let traits_sv = send_traits(*traits, HeapTag::LBytes, ctx)?;
             Ok(SendValue::Bytes(b.as_slice().to_vec(), Box::new(traits_sv)))
         }
 
@@ -446,7 +497,7 @@ fn from_value_inner(value: Value, ctx: &mut SerContext) -> Result<SendValue, Str
             let borrowed = blob_ref
                 .try_borrow()
                 .map_err(|_| "Cannot borrow @bytes for sending".to_string())?;
-            let traits_sv = from_value_inner(*traits, ctx)?;
+            let traits_sv = send_traits(*traits, HeapTag::LBytesMut, ctx)?;
             Ok(SendValue::Blob(borrowed.clone(), Box::new(traits_sv)))
         }
 
@@ -456,7 +507,7 @@ fn from_value_inner(value: Value, ctx: &mut SerContext) -> Result<SendValue, Str
         } => {
             let copied: Result<Vec<SendValue>, String> =
                 s.iter().map(|v| from_value_inner(*v, ctx)).collect();
-            let traits_sv = from_value_inner(*traits, ctx)?;
+            let traits_sv = send_traits(*traits, HeapTag::LSet, ctx)?;
             Ok(SendValue::LSet(copied?, Box::new(traits_sv)))
         }
 
@@ -471,7 +522,7 @@ fn from_value_inner(value: Value, ctx: &mut SerContext) -> Result<SendValue, Str
                 .map_err(|_| "Cannot borrow mutable set for sending".to_string())?;
             let copied: Result<Vec<SendValue>, String> =
                 borrowed.iter().map(|v| from_value_inner(*v, ctx)).collect();
-            let traits_sv = from_value_inner(*traits, ctx)?;
+            let traits_sv = send_traits(*traits, HeapTag::LSetMut, ctx)?;
             Ok(SendValue::LSetMut(copied?, Box::new(traits_sv)))
         }
     }
@@ -506,7 +557,7 @@ impl SendValue {
             SendValue::Pair(first, rest, traits) => {
                 let first_val = first.into_value();
                 let rest_val = rest.into_value();
-                let traits_val = traits.into_value();
+                let traits_val = recv_traits(traits.into_value(), HeapTag::Pair);
                 let pair = Pair {
                     first: first_val,
                     rest: rest_val,
@@ -516,7 +567,7 @@ impl SendValue {
             }
             SendValue::Array(items, traits) => {
                 let values: Vec<Value> = items.into_iter().map(|sv| sv.into_value()).collect();
-                let traits_val = traits.into_value();
+                let traits_val = recv_traits(traits.into_value(), HeapTag::LArrayMut);
                 alloc(HeapObject::LArrayMut {
                     data: std::rc::Rc::new(std::cell::RefCell::new(values)),
                     traits: traits_val,
@@ -528,15 +579,26 @@ impl SendValue {
                     .into_iter()
                     .map(|(k, sv)| (k, sv.into_value()))
                     .collect();
-                let traits_val = traits.into_value();
+                let traits_val = recv_traits(traits.into_value(), HeapTag::LStruct);
                 alloc(HeapObject::LStruct {
                     data: entries,
                     traits: traits_val,
                 })
             }
+            SendValue::StructMut(map, traits) => {
+                let entries: BTreeMap<_, _> = map
+                    .into_iter()
+                    .map(|(k, sv)| (k, sv.into_value()))
+                    .collect();
+                let traits_val = recv_traits(traits.into_value(), HeapTag::LStructMut);
+                alloc(HeapObject::LStructMut {
+                    data: std::rc::Rc::new(std::cell::RefCell::new(entries)),
+                    traits: traits_val,
+                })
+            }
             SendValue::Tuple(items, traits) => {
                 let values: Vec<Value> = items.into_iter().map(|sv| sv.into_value()).collect();
-                let traits_val = traits.into_value();
+                let traits_val = recv_traits(traits.into_value(), HeapTag::LArray);
                 let slice = crate::value::arena::alloc_inline_slice::<Value>(&values);
                 alloc(HeapObject::LArray {
                     elements: slice,
@@ -544,14 +606,14 @@ impl SendValue {
                 })
             }
             SendValue::Buffer(bytes, traits) => {
-                let traits_val = traits.into_value();
+                let traits_val = recv_traits(traits.into_value(), HeapTag::LStringMut);
                 alloc(HeapObject::LStringMut {
                     data: std::rc::Rc::new(std::cell::RefCell::new(bytes)),
                     traits: traits_val,
                 })
             }
             SendValue::Bytes(bytes, traits) => {
-                let traits_val = traits.into_value();
+                let traits_val = recv_traits(traits.into_value(), HeapTag::LBytes);
                 let slice = crate::value::arena::alloc_inline_slice::<u8>(&bytes);
                 alloc(HeapObject::LBytes {
                     data: slice,
@@ -559,7 +621,7 @@ impl SendValue {
                 })
             }
             SendValue::Blob(bytes, traits) => {
-                let traits_val = traits.into_value();
+                let traits_val = recv_traits(traits.into_value(), HeapTag::LBytesMut);
                 alloc(HeapObject::LBytesMut {
                     data: std::rc::Rc::new(std::cell::RefCell::new(bytes)),
                     traits: traits_val,
@@ -585,7 +647,7 @@ impl SendValue {
             SendValue::FFIType(desc) => alloc(HeapObject::FFIType(desc)),
             SendValue::LSet(items, traits) => {
                 let set: BTreeSet<Value> = items.into_iter().map(|sv| sv.into_value()).collect();
-                let traits_val = traits.into_value();
+                let traits_val = recv_traits(traits.into_value(), HeapTag::LSet);
                 // BTreeSet iterates in sorted order; collect into Vec and copy into arena.
                 let sorted: Vec<Value> = set.into_iter().collect();
                 let slice = crate::value::arena::alloc_inline_slice::<Value>(&sorted);
@@ -596,7 +658,7 @@ impl SendValue {
             }
             SendValue::LSetMut(items, traits) => {
                 let set: BTreeSet<Value> = items.into_iter().map(|sv| sv.into_value()).collect();
-                let traits_val = traits.into_value();
+                let traits_val = recv_traits(traits.into_value(), HeapTag::LSetMut);
                 alloc(HeapObject::LSetMut {
                     data: std::rc::Rc::new(std::cell::RefCell::new(set)),
                     traits: traits_val,
@@ -651,7 +713,7 @@ fn into_value_inner(sv: SendValue, ctx: &mut DeserContext) -> Value {
         SendValue::Pair(first, rest, traits) => {
             let f = into_value_inner(*first, ctx);
             let r = into_value_inner(*rest, ctx);
-            let t = into_value_inner(*traits, ctx);
+            let t = recv_traits(into_value_inner(*traits, ctx), HeapTag::Pair);
             alloc(HeapObject::Pair(Pair {
                 first: f,
                 rest: r,
@@ -663,7 +725,7 @@ fn into_value_inner(sv: SendValue, ctx: &mut DeserContext) -> Value {
                 .into_iter()
                 .map(|sv| into_value_inner(sv, ctx))
                 .collect();
-            let traits_val = into_value_inner(*traits, ctx);
+            let traits_val = recv_traits(into_value_inner(*traits, ctx), HeapTag::LArrayMut);
             alloc(HeapObject::LArrayMut {
                 data: std::rc::Rc::new(RefCell::new(values)),
                 traits: traits_val,
@@ -675,9 +737,20 @@ fn into_value_inner(sv: SendValue, ctx: &mut DeserContext) -> Value {
                 .into_iter()
                 .map(|(k, sv)| (k, into_value_inner(sv, ctx)))
                 .collect();
-            let traits_val = into_value_inner(*traits, ctx);
+            let traits_val = recv_traits(into_value_inner(*traits, ctx), HeapTag::LStruct);
             alloc(HeapObject::LStruct {
                 data: entries,
+                traits: traits_val,
+            })
+        }
+        SendValue::StructMut(map, traits) => {
+            let entries: BTreeMap<_, _> = map
+                .into_iter()
+                .map(|(k, sv)| (k, into_value_inner(sv, ctx)))
+                .collect();
+            let traits_val = recv_traits(into_value_inner(*traits, ctx), HeapTag::LStructMut);
+            alloc(HeapObject::LStructMut {
+                data: std::rc::Rc::new(RefCell::new(entries)),
                 traits: traits_val,
             })
         }
@@ -686,7 +759,7 @@ fn into_value_inner(sv: SendValue, ctx: &mut DeserContext) -> Value {
                 .into_iter()
                 .map(|sv| into_value_inner(sv, ctx))
                 .collect();
-            let traits_val = into_value_inner(*traits, ctx);
+            let traits_val = recv_traits(into_value_inner(*traits, ctx), HeapTag::LArray);
             let slice = crate::value::arena::alloc_inline_slice::<Value>(&values);
             alloc(HeapObject::LArray {
                 elements: slice,
@@ -694,14 +767,14 @@ fn into_value_inner(sv: SendValue, ctx: &mut DeserContext) -> Value {
             })
         }
         SendValue::Buffer(bytes, traits) => {
-            let traits_val = into_value_inner(*traits, ctx);
+            let traits_val = recv_traits(into_value_inner(*traits, ctx), HeapTag::LStringMut);
             alloc(HeapObject::LStringMut {
                 data: std::rc::Rc::new(RefCell::new(bytes)),
                 traits: traits_val,
             })
         }
         SendValue::Bytes(bytes, traits) => {
-            let traits_val = into_value_inner(*traits, ctx);
+            let traits_val = recv_traits(into_value_inner(*traits, ctx), HeapTag::LBytes);
             let slice = crate::value::arena::alloc_inline_slice::<u8>(&bytes);
             alloc(HeapObject::LBytes {
                 data: slice,
@@ -709,7 +782,7 @@ fn into_value_inner(sv: SendValue, ctx: &mut DeserContext) -> Value {
             })
         }
         SendValue::Blob(bytes, traits) => {
-            let traits_val = into_value_inner(*traits, ctx);
+            let traits_val = recv_traits(into_value_inner(*traits, ctx), HeapTag::LBytesMut);
             alloc(HeapObject::LBytesMut {
                 data: std::rc::Rc::new(RefCell::new(bytes)),
                 traits: traits_val,
@@ -769,7 +842,7 @@ fn into_value_inner(sv: SendValue, ctx: &mut DeserContext) -> Value {
                 .into_iter()
                 .map(|sv| into_value_inner(sv, ctx))
                 .collect();
-            let traits_val = into_value_inner(*traits, ctx);
+            let traits_val = recv_traits(into_value_inner(*traits, ctx), HeapTag::LSet);
             // BTreeSet iterates in sorted order; collect into Vec and copy into arena.
             let sorted: Vec<Value> = set.into_iter().collect();
             let slice = crate::value::arena::alloc_inline_slice::<Value>(&sorted);
@@ -783,7 +856,7 @@ fn into_value_inner(sv: SendValue, ctx: &mut DeserContext) -> Value {
                 .into_iter()
                 .map(|sv| into_value_inner(sv, ctx))
                 .collect();
-            let traits_val = into_value_inner(*traits, ctx);
+            let traits_val = recv_traits(into_value_inner(*traits, ctx), HeapTag::LSetMut);
             alloc(HeapObject::LSetMut {
                 data: std::rc::Rc::new(RefCell::new(set)),
                 traits: traits_val,

--- a/src/vm/core.rs
+++ b/src/vm/core.rs
@@ -156,6 +156,9 @@ impl VM {
         // Install the root fiber heap before any allocation can happen.
         crate::value::fiberheap::install_root_heap();
 
+        // Initialize default trait tables for collection/sequence types.
+        crate::primitives::traitregistry::init_default_traits();
+
         let mut fiber = Fiber::new(root_closure(), SIG_OK);
         // Root fiber starts alive (it's the currently executing context)
         fiber.status = crate::value::FiberStatus::Alive;

--- a/src/vm/fiber.rs
+++ b/src/vm/fiber.rs
@@ -24,7 +24,7 @@ use crate::value::error_val;
 use crate::value::fiber::FiberStatus;
 use crate::value::{
     BytecodeFrame, FiberHandle, SignalBits, SuspendedFrame, Value, SIG_ERROR, SIG_FUEL, SIG_HALT,
-    SIG_OK, SIG_SWITCH, SIG_TERMINAL,
+    SIG_OK, SIG_SWITCH, SIG_TERMINAL, SIG_YIELD,
 };
 use std::rc::Rc;
 
@@ -418,6 +418,27 @@ impl VM {
         child_handle: &FiberHandle,
         child_value: Value,
     ) -> (SignalBits, Value) {
+        // ── Native iterator fast path ────────────────────────────────
+        // Native iter fibers hold a Vec<Value> + cursor. Each resume
+        // yields the next element; exhaustion kills the fiber.
+        let is_native = child_handle.with(|f| f.native_iter.is_some());
+        if is_native {
+            return child_handle.with_mut(|f| {
+                let iter = f.native_iter.as_mut().unwrap();
+                if iter.cursor < iter.elements.len() {
+                    let val = iter.elements[iter.cursor];
+                    iter.cursor += 1;
+                    f.status = FiberStatus::Paused;
+                    f.signal = Some((SIG_YIELD, val));
+                    (SIG_YIELD, val)
+                } else {
+                    f.status = FiberStatus::Dead;
+                    f.signal = Some((SIG_OK, Value::NIL));
+                    (SIG_OK, Value::NIL)
+                }
+            });
+        }
+
         // Extract resume value and status before taking the fiber
         let (resume_value, is_first_resume) = child_handle.with_mut(|child| {
             let rv = child.signal.take().map(|(_, v)| v).unwrap_or(Value::NIL);

--- a/tests/elle/concurrency.lisp
+++ b/tests/elle/concurrency.lisp
@@ -130,11 +130,12 @@
 # Error tests (from integration/concurrency.rs)
 # ============================================================================
 
-# spawn_rejects_mutable_table_capture
-(let [[ok? _] (protect ((fn ()
-                          (let [t (@struct)]
-                            (spawn (fn () t))))))]
-  (assert (not ok?) "spawn rejects mutable @struct capture"))
+# spawn_sends_mutable_struct_capture
+(let [[ok? result] (protect ((fn ()
+                               (let [t (@struct :a 1)]
+                                 (join (spawn (fn () (t :a))))))))]
+  (assert ok? "spawn sends mutable @struct capture")
+  (assert (= result 1) "spawned @struct preserves data"))
 
 # spawn_rejects_native_function
 (let [[ok? _] (protect ((fn () (spawn abs))))]
@@ -190,11 +191,29 @@
                (join (spawn (fn () (add-offset 32)))))) 42)
         "spawn closure capturing closure and data")
 
-(let [[ok? _] (protect ((fn ()
-                          (let [t (@struct)]
-                            (let [f (fn () t)]
-                              (spawn (fn () (f))))))))]
-  (assert (not ok?) "spawn rejects closure capturing closure with @struct"))
+(let [[ok? result] (protect ((fn ()
+                               (let [t (@struct :x 42)]
+                                 (let [f (fn () (t :x))]
+                                   (join (spawn (fn () (f)))))))))]
+  (assert ok? "spawn sends closure capturing closure with @struct")
+  (assert (= result 42) "spawned @struct through closure preserves data"))
+
+# ============================================================================
+# Cross-thread trait survival
+# ============================================================================
+
+# User-attached traits survive cross-thread send
+(begin
+  (def v (with-traits [1 2 3] {:tag :my-type}))
+  (def result (join (spawn (fn [] (traits v)))))
+  (assert (not (nil? result)) "user traits survive cross-thread send")
+  (assert (= (result :tag) :my-type) "user trait data preserved across threads"))
+
+# Default traits are re-stamped on the receiving thread
+(begin
+  (def v [10 20 30])
+  (def result (join (spawn (fn [] (first v)))))
+  (assert (= result 10) "default trait dispatch works across threads"))
 
 # ============================================================================
 # Recursive closure tests (letrec)

--- a/tests/elle/trait-dispatch.lisp
+++ b/tests/elle/trait-dispatch.lisp
@@ -1,0 +1,263 @@
+(elle/epoch 10)
+## Trait-based dispatch test suite
+##
+## Tests for dispatching first/rest/length/empty? through trait tables.
+
+# ============================================================================
+# Default traitsets are stamped at allocation
+# ============================================================================
+
+# Every array has a traitset (not nil)
+(assert (not (nil? (traits [1 2 3]))) "array has default traitset")
+
+# Every list has a traitset
+(assert (not (nil? (traits (pair 1 ())))) "list has default traitset")
+
+# Every string has a traitset
+(assert (not (nil? (traits "hello world"))) "string has default traitset")
+
+# Every set has a traitset
+(assert (not (nil? (traits (set 1 2 3)))) "set has default traitset")
+
+# Every struct has a traitset
+(assert (not (nil? (traits {:a 1}))) "struct has default traitset")
+
+# Mutable variants too
+(assert (not (nil? (traits @[1 2 3]))) "@array has default traitset")
+
+(assert (not (nil? (traits @"hello"))) "@string has default traitset")
+
+(assert (not (nil? (traits (@set 1 2)))) "@set has default traitset")
+
+(assert (not (nil? (traits @{:a 1}))) "@struct has default traitset")
+
+# ============================================================================
+# Default traitsets are shared (identical?)
+# ============================================================================
+
+# Two arrays share the same traitset pointer
+(assert (identical? (traits [1 2 3]) (traits [4 5 6]))
+        "arrays share the same default traitset")
+
+# Two lists share the same traitset pointer
+(assert (identical? (traits (pair 1 ())) (traits (pair 2 ())))
+        "lists share the same default traitset")
+
+# ============================================================================
+# Default traitset contains :Sequence and :Collection protocols
+# ============================================================================
+
+(begin
+  (def t (traits [1 2 3]))
+  (assert (not (nil? (t :Sequence))) "array traitset has :Sequence protocol")
+  (assert (not (nil? (t :Collection))) "array traitset has :Collection protocol"))
+
+(begin
+  (def t (traits (set 1 2 3)))
+  (assert (nil? (t :Sequence)) "set traitset has NO :Sequence protocol")
+  (assert (not (nil? (t :Collection))) "set traitset has :Collection protocol"))
+
+(begin
+  (def t (traits {:a 1}))
+  (assert (nil? (t :Sequence)) "struct traitset has NO :Sequence protocol")
+  (assert (not (nil? (t :Collection)))
+          "struct traitset has :Collection protocol"))
+
+# ============================================================================
+# :Sequence method struct has expected keys
+# ============================================================================
+
+(begin
+  (def seq-methods ((traits [1 2 3]) :Sequence))
+  (assert (not (nil? (seq-methods :first))) ":Sequence has :first")
+  (assert (not (nil? (seq-methods :rest))) ":Sequence has :rest")
+  (assert (not (nil? (seq-methods :last))) ":Sequence has :last")
+  (assert (not (nil? (seq-methods :nth))) ":Sequence has :nth")
+  (assert (not (nil? (seq-methods :iter))) ":Sequence has :iter"))
+
+# ============================================================================
+# :Collection method struct has expected keys
+# ============================================================================
+
+(begin
+  (def coll-methods ((traits [1 2 3]) :Collection))
+  (assert (not (nil? (coll-methods :length))) ":Collection has :length")
+  (assert (not (nil? (coll-methods :empty?))) ":Collection has :empty?")
+  (assert (not (nil? (coll-methods :has?))) ":Collection has :has?")
+  (assert (not (nil? (coll-methods :conj))) ":Collection has :conj")
+  (assert (not (nil? (coll-methods :empty))) ":Collection has :empty"))
+
+# ============================================================================
+# Primitives dispatch through trait methods
+# ============================================================================
+
+# first dispatches through :Sequence :first
+(assert (= (first [10 20 30]) 10) "first dispatches on array")
+(assert (= (first (pair 10 (pair 20 ()))) 10) "first dispatches on list")
+(assert (= (first "abc") "a") "first dispatches on string")
+
+# rest dispatches through :Sequence :rest
+(assert (= (rest [10 20 30]) [20 30]) "rest dispatches on array")
+(assert (= (rest (pair 10 (pair 20 ()))) (pair 20 ())) "rest dispatches on list")
+
+# length dispatches through :Collection :length
+(assert (= (length [1 2 3]) 3) "length dispatches on array")
+(assert (= (length "hello") 5) "length dispatches on string")
+(assert (= (length (set 1 2 3)) 3) "length dispatches on set")
+(assert (= (length {:a 1 :b 2}) 2) "length dispatches on struct")
+
+# empty? dispatches through :Collection :empty?
+(assert (empty? []) "empty? on empty array")
+(assert (empty? ()) "empty? on empty list")
+(assert (not (empty? [1])) "empty? on nonempty array")
+
+# ============================================================================
+# with-traits accepts @struct (mutable shell)
+# ============================================================================
+
+(begin
+  (def tbl @{:Sequence {:first (fn [self] :custom)}})
+  (def v (with-traits [1 2 3] tbl))
+  (assert (= (traits v) tbl) "with-traits accepts @struct as trait table"))
+
+# ============================================================================
+# Per-instance override changes dispatch
+# ============================================================================
+
+(begin
+  (def custom-first (fn [self] :overridden))
+  (def custom-seq
+    {:first custom-first
+     :rest (fn [self] [])
+     :iter (fn [self] (fiber/new (fn [] (yield :overridden)) |:yield|))})
+  (def v (with-traits [1 2 3] @{:Sequence custom-seq}))
+  (assert (= (first v) :overridden)
+          "per-instance override: first dispatches to custom method"))
+
+# ============================================================================
+# Mutating a shared default propagates to all instances
+# ============================================================================
+# Traitsets are permanent @struct allocations shared by all instances of
+# a type. Mutating the shared traitset is visible through all instances.
+
+(begin
+  (def a [1 2 3])
+  (def b [4 5 6])
+  (def shared (traits a))
+  (assert (identical? shared (traits b)) "sanity: arrays share traitset")
+  (assert (not (nil? (shared :Sequence))) "shared default has :Sequence")  # Mutate the shared traitset — add a custom protocol
+  (put shared :Custom {:greet (fn [self] :hello)})  # Verify it's visible on both instances
+  (assert (not (nil? ((traits a) :Custom))) "mutation visible on a")
+  (assert (not (nil? ((traits b) :Custom))) "mutation visible on b")
+  (assert (identical? ((traits a) :Custom) ((traits b) :Custom))
+          "mutation propagates identically")  # Clean up: remove the test protocol so it doesn't affect later tests
+  (del shared :Custom))
+
+# ============================================================================
+# Fiber-based iterator protocol
+# ============================================================================
+
+(begin
+  (def arr [10 20 30])
+  (def iter-fn (((traits arr) :Sequence) :iter))
+  (def fib (iter-fn arr))
+  (assert (= (fiber/status fib) :paused) "iterator fiber starts paused")
+  (assert (= (fiber/resume fib) 10) "iterator yields first element")
+  (assert (= (fiber/resume fib) 20) "iterator yields second element")
+  (assert (= (fiber/resume fib) 30) "iterator yields third element")
+  (fiber/resume fib)  # fiber completes
+  (assert (= (fiber/status fib) :dead) "iterator fiber is dead after exhaustion"))
+
+# List iterator
+(begin
+  (def lst (pair 1 (pair 2 (pair 3 ()))))
+  (def iter-fn (((traits lst) :Sequence) :iter))
+  (def fib (iter-fn lst))
+  (assert (= (fiber/resume fib) 1) "list iter yields 1")
+  (assert (= (fiber/resume fib) 2) "list iter yields 2")
+  (assert (= (fiber/resume fib) 3) "list iter yields 3")
+  (fiber/resume fib)
+  (assert (= (fiber/status fib) :dead) "list iter exhausted"))
+
+# ============================================================================
+# Custom Sequence on a struct (user-defined type)
+# ============================================================================
+
+(begin
+  (def make-range
+    (fn [start end]
+      (with-traits {:start start :end end}
+                   @{:Sequence {:first (fn [self] (self :start))
+                                :rest (fn [self]
+                                        (if (>= (+ (self :start) 1) (self :end))
+                                          ()
+                                          (make-range (+ (self :start) 1)
+                                          (self :end))))
+                                :empty? (fn [self]
+                                          (>= (self :start) (self :end)))
+                                :iter (fn [self]
+                                        (fiber/new (fn []
+                                          (def @i (self :start))
+                                          (while (< i (self :end))
+                                            (yield i)
+                                            (assign i (+ i 1)))) |:yield|))}})))
+  (def r (make-range 0 5))
+  (assert (= (first r) 0) "custom seq: first")
+  (assert (= (first (rest r)) 1) "custom seq: first of rest")
+
+  # Iterator — user fiber starts :new, transitions to :paused on yield
+  (def iter-fn (((traits r) :Sequence) :iter))
+  (def fib (iter-fn r))
+  (def acc @[])  # Collect yielded values: resume and push while fiber stays paused
+  (def @done false)
+  (while (not done)
+    (def v (fiber/resume fib))
+    (if (= (fiber/status fib) :dead) (assign done true) (push acc v)))
+  (assert (= (freeze acc) [0 1 2 3 4])
+          "custom seq: iterator collects all elements"))
+
+# ============================================================================
+# :Collection :conj
+# ============================================================================
+
+(begin
+  (def coll-methods ((traits [1 2]) :Collection))
+  (def conj-fn (coll-methods :conj))
+  (assert (= (conj-fn [1 2] 3) [1 2 3]) "conj appends to array"))
+
+(begin
+  (def coll-methods ((traits (pair 1 ())) :Collection))
+  (def conj-fn (coll-methods :conj))
+  (assert (= (first (conj-fn (pair 2 ()) 1)) 1) "conj prepends to list"))
+
+(begin
+  (def coll-methods ((traits (set 1 2)) :Collection))
+  (def conj-fn (coll-methods :conj))
+  (assert (has? (conj-fn (set 1 2) 3) 3) "conj adds to set"))
+
+# ============================================================================
+# :Collection :empty
+# ============================================================================
+
+(begin
+  (def empty-fn (((traits [1 2 3]) :Collection) :empty))
+  (def e (empty-fn [1 2 3]))
+  (assert (array? e) "empty of array is array")
+  (assert (empty? e) "empty of array is empty"))
+
+(begin
+  (def empty-fn (((traits (set 1 2)) :Collection) :empty))
+  (def e (empty-fn (set 1 2)))
+  (assert (set? e) "empty of set is set")
+  (assert (empty? e) "empty of set is empty"))
+
+# ============================================================================
+# Immediates have no traitset (unchanged)
+# ============================================================================
+
+(assert (nil? (traits 42)) "integer has no traits")
+(assert (nil? (traits nil)) "nil has no traits")
+(assert (nil? (traits true)) "bool has no traits")
+(assert (nil? (traits :kw)) "keyword has no traits")
+
+(println "trait-dispatch: all tests passed")

--- a/tests/elle/traits.lisp
+++ b/tests/elle/traits.lisp
@@ -17,13 +17,17 @@
   (def v (with-traits [1 2 3] tbl))
   (assert (= (traits v) tbl) "traits retrieves the attached table"))
 
-# traits on an untraited value returns nil
-(assert (= (traits [1 2 3]) nil) "traits returns nil for untraited array")
+# Collection/sequence types now have default traitsets (not nil)
+(assert (not (nil? (traits [1 2 3])))
+        "traits returns traitset for array (default)")
 
-(assert (= (traits {:a 1}) nil) "traits returns nil for untraited struct")
+(assert (not (nil? (traits {:a 1})))
+        "traits returns traitset for struct (default)")
 
-(assert (= (traits "hello world") nil) "traits returns nil for untraited string")
+(assert (not (nil? (traits "hello world")))
+        "traits returns traitset for string (default)")
 
+# Immediate types still have no traits
 (assert (= (traits 42) nil) "traits returns nil for integer (immediate)")
 
 (assert (= (traits nil) nil) "traits returns nil for nil (immediate)")
@@ -36,12 +40,12 @@
 # Falsy / truthy via traits
 # ============================================================================
 
-# nil is falsy — (traits untraited) is usable as false branch
-(assert (not (traits [1 2 3])) "nil from traits is falsy")
+# Default traitsets are truthy (not nil)
+(assert (traits [1 2 3]) "default traitset on array is truthy")
 
-(assert (not (traits "hello world")) "nil from traits on string is falsy")
+(assert (traits "hello world") "default traitset on string is truthy")
 
-# the retrieved table is an immutable struct
+# the retrieved table is a struct (may be immutable or mutable)
 (assert (struct? (traits (with-traits [1 2] {:a 1})))
         "traits result is a struct")
 
@@ -297,11 +301,9 @@
 # Validation errors
 # ============================================================================
 
-# Trait table must be an immutable struct — not a mutable struct
-(let [[ok? err] (protect ((fn () (with-traits [1 2 3] @{:a 1}))))]
-  (assert (not ok?) "with-traits rejects mutable struct as table")
-  (assert (= (get err :error) :type-error)
-          "with-traits rejects mutable struct as table"))
+# Trait table now accepts both immutable and mutable structs
+(let [[ok? _] (protect ((fn () (with-traits [1 2 3] @{:a 1}))))]
+  (assert ok? "with-traits accepts mutable struct as table"))
 
 # Trait table must be a struct — not an array
 (let [[ok? err] (protect ((fn () (with-traits [1 2 3] [1 2]))))]

--- a/tests/integration/thread_transfer.rs
+++ b/tests/integration/thread_transfer.rs
@@ -480,26 +480,21 @@ fn test_closure_capturing_nested_closures() {
 // ============================================================================
 
 #[test]
-fn test_closure_capturing_non_sendable_rejected() {
-    // A closure that captures a mutable @struct (via an inner closure) is rejected.
+fn test_closure_capturing_struct_mut_sendable() {
+    // A closure that captures a mutable @struct (via an inner closure) is now sendable.
     let result = eval_source(
         r#"
-        (let [t (@struct)]
-          (let [f (fn () t)]
-            (spawn (fn () (f)))))
+        (let [t (@struct :x 42)]
+          (let [f (fn () (t :x))]
+            (join (spawn (fn () (f))))))
         "#,
     );
 
-    // spawn should error because f captures a mutable @struct.
+    // spawn should succeed — @struct is sendable.
     assert!(
-        result.is_err(),
-        "Expected spawn to fail for non-sendable transitive capture"
-    );
-    let err = result.unwrap_err();
-    assert!(
-        err.contains("@struct") || err.contains("struct") || err.contains("mutable"),
-        "Error should mention @struct: {}",
-        err
+        result.is_ok(),
+        "Expected spawn to succeed for @struct capture: {:?}",
+        result
     );
 }
 


### PR DESCRIPTION
Primitives (first, rest, length, empty?, has?, last, second) dispatch through trait table lookup instead of hardcoded type cascades. Each collection/sequence type gets a shared default traitset stamped at allocation time via permanent (Rc-backed) allocations.

Key design decisions:

- Permanent allocation for shared traitsets (alloc_permanent) — never reclaimed by arena scope ops, no interference with scope marks
- Stamp at allocation: every constructor calls default_traits_for(tag)
- Single get_traitset() reads the traits field; prim_traits is a one-liner
- dispatch_trait_method falls back to registry defaults when user traits lack a protocol
- lookup_keyword does linear scan without String allocation
- send_traits uses pointer identity (not tag heuristic) to detect registry defaults
- collect_heap_children traces traits field for all heap variants
- LStructMut is sendable (SendValue::StructMut variant)
- recv_traits stamps receiving thread's defaults on reconstruction

Tests: default traitset presence/sharing, protocol dispatch, custom Sequence on struct, iterator protocol, shared-default mutation propagation, cross-thread trait survival, @struct sendability.