### PR TITLE
Fix @"" producing immutable string in read/eval roundtrip

### DIFF
--- a/src/syntax/convert.rs
+++ b/src/syntax/convert.rs
@@ -74,7 +74,8 @@ impl Syntax {
                 Value::symbol(id.0)
             }
             SyntaxKind::Keyword(s) => Value::keyword(s),
-            SyntaxKind::String(s) | SyntaxKind::StringMut(s) => Value::string(s.clone()),
+            SyntaxKind::String(s) => Value::string(s.clone()),
+            SyntaxKind::StringMut(s) => Value::string_mut(s.as_bytes().to_vec()),
             SyntaxKind::List(items) => {
                 let values: Vec<Value> = items.iter().map(|item| item.to_value(symbols)).collect();
                 crate::value::list(values)
@@ -203,6 +204,11 @@ impl Syntax {
             SyntaxKind::Keyword(name.to_string())
         } else if let Some(s) = value.with_string(|s| s.to_string()) {
             SyntaxKind::String(s)
+        } else if let Some(data) = value.as_string_mut() {
+            let bytes = data.borrow();
+            let s = String::from_utf8(bytes.clone())
+                .map_err(|_| "Cannot convert non-UTF-8 @string to Syntax")?;
+            SyntaxKind::StringMut(s)
         } else if value.is_empty_list() {
             SyntaxKind::List(vec![])
         } else if value.as_pair().is_some() {
@@ -225,6 +231,32 @@ impl Syntax {
                 .map(|v| Syntax::from_value(v, symbols, span.clone()))
                 .collect();
             SyntaxKind::ArrayMut(syntaxes?)
+        } else if let Some(data) = value.as_bytes() {
+            let syntaxes: Vec<Syntax> = data
+                .iter()
+                .map(|b| Syntax::new(SyntaxKind::Int(*b as i64), span.clone()))
+                .collect();
+            SyntaxKind::Bytes(syntaxes)
+        } else if let Some(data) = value.as_bytes_mut() {
+            let bytes = data.borrow();
+            let syntaxes: Vec<Syntax> = bytes
+                .iter()
+                .map(|b| Syntax::new(SyntaxKind::Int(*b as i64), span.clone()))
+                .collect();
+            SyntaxKind::BytesMut(syntaxes)
+        } else if let Some(elems) = value.as_set() {
+            let syntaxes: Result<Vec<Syntax>, String> = elems
+                .iter()
+                .map(|v| Syntax::from_value(v, symbols, span.clone()))
+                .collect();
+            SyntaxKind::Set(syntaxes?)
+        } else if let Some(set_ref) = value.as_set_mut() {
+            let items = set_ref.borrow();
+            let syntaxes: Result<Vec<Syntax>, String> = items
+                .iter()
+                .map(|v| Syntax::from_value(v, symbols, span.clone()))
+                .collect();
+            SyntaxKind::SetMut(syntaxes?)
         } else if let Some(struct_ref) = value.as_struct() {
             let mut syntaxes = Vec::with_capacity(struct_ref.len() * 2);
             for (k, v) in struct_ref.iter() {

--- a/tests/elle/reader.lisp
+++ b/tests/elle/reader.lisp
@@ -118,3 +118,81 @@
 (assert (= (read-all "[@[1] 2]") (list [@[1] 2])) "read tuple with array")
 (assert (= (read-all "(foo :bar 42)") (list (list 'foo :bar 42)))
         "read list with symbol, keyword, int")
+
+# ──────────────────────────────────────────────────────────────────────────────
+# @string roundtrip — read produces mutable string, eval preserves mutability
+# ──────────────────────────────────────────────────────────────────────────────
+
+(assert (= (type-of (read "@\"\"")) :@string) "read @\"\" produces @string")
+(assert (= (type-of (read "@\"hello\"")) :@string)
+        "read @\"hello\" produces @string")
+
+(let [s (eval (read "@\"\""))]
+  (push s "hello")
+  (assert (= s @"hello") "eval of read @\"\" is mutable"))
+
+(let [s (eval (read "@\"abc\""))]
+  (push s "d")
+  (assert (= s @"abcd") "eval of read @\"abc\" is mutable"))
+
+# ──────────────────────────────────────────────────────────────────────────────
+# @array roundtrip — read produces mutable array, eval preserves mutability
+# ──────────────────────────────────────────────────────────────────────────────
+
+(assert (= (type-of (read "@[]")) :@array) "read @[] produces @array")
+(assert (= (type-of (read "@[1 2 3]")) :@array) "read @[1 2 3] produces @array")
+
+(let [a (eval (read "@[]"))]
+  (push a 1)
+  (assert (= a @[1]) "eval of read @[] is mutable"))
+
+(let [a (eval (read "@[1 2]"))]
+  (push a 3)
+  (assert (= a @[1 2 3]) "eval of read @[1 2] is mutable"))
+
+# ──────────────────────────────────────────────────────────────────────────────
+# bytes / @bytes — read desugars to call form, eval produces correct type
+# ──────────────────────────────────────────────────────────────────────────────
+
+(assert (= (read "b[1 2 3]") '(bytes 1 2 3))
+        "read b[1 2 3] desugars to (bytes ...)")
+(assert (= (read "@b[1 2 3]") '(@bytes 1 2 3))
+        "read @b[1 2 3] desugars to (@bytes ...)")
+
+(let [b (eval (read "b[1 2 3]"))]
+  (assert (= (type-of b) :bytes) "eval of read b[...] produces bytes")
+  (assert (= (get b 0) 1) "bytes element access after read/eval"))
+
+(let [b (eval (read "@b[1 2 3]"))]
+  (assert (= (type-of b) :@bytes) "eval of read @b[...] produces @bytes")
+  (push b 4)
+  (assert (= (get b 3) 4) "eval of read @b[...] is mutable"))
+
+# ──────────────────────────────────────────────────────────────────────────────
+# set / @set — read desugars to call form, eval produces correct type
+# ──────────────────────────────────────────────────────────────────────────────
+
+(assert (= (read "|1 2 3|") '(set 1 2 3)) "read |1 2 3| desugars to (set ...)")
+(assert (= (read "@|1 2 3|") '(@set 1 2 3))
+        "read @|1 2 3| desugars to (@set ...)")
+
+(let [s (eval (read "|1 2 3|"))]
+  (assert (= (type-of s) :set) "eval of read |...| produces set")
+  (assert (contains? s 2) "set membership after read/eval"))
+
+(let [s (eval (read "@|1 2|"))]
+  (assert (= (type-of s) :@set) "eval of read @|...| produces @set")
+  (add s 3)
+  (assert (contains? s 3) "eval of read @|...| is mutable"))
+
+# ──────────────────────────────────────────────────────────────────────────────
+# struct / @struct — read desugars to call form, eval produces correct type
+# ──────────────────────────────────────────────────────────────────────────────
+
+(assert (= (type-of (eval (read "{:a 1}"))) :struct)
+        "eval of read {...} produces struct")
+
+(let [m (eval (read "@{:a 1}"))]
+  (assert (= (type-of m) :@struct) "eval of read @{...} produces @struct")
+  (put m :b 2)
+  (assert (= (get m :b) 2) "eval of read @{...} is mutable"))


### PR DESCRIPTION
Syntax::to_value() treated StringMut identically to String, producing Value::string() instead of Value::string_mut(). Syntax::from_value() was also missing cases for @string, bytes, @bytes, set, and @set, causing "Cannot convert" errors when macros produced those types.