### PR TITLE
Fix assign in cond/match branches with proper phi-insertion

### DIFF
--- a/src/hir/functionalize.rs
+++ b/src/hir/functionalize.rs
@@ -19,13 +19,16 @@
 //!    (for writes) in the HIR. The binding itself holds a cell; mutation
 //!    goes through set-cell!, reading through deref-cell.
 //!
-//! **Branch boundary:** Assigns inside if/match/cond arms are left as
-//! Assign. Proper phi insertion for conditional mutation requires
-//! continuation context; deferred to region inference (Layer 2).
+//! **Branch phi-insertion:** Assigns inside if/cond/match arms in Begin
+//! sequences get proper phi-insertion — condition temps bound once,
+//! phi-selects via nested Ifs (cond) or duplicated match (match).
+//! Non-Begin contexts use assign_preserved to keep assigns as runtime
+//! slot mutations.
 
 use super::arena::BindingArena;
 use super::binding::Binding;
 use super::expr::{CallArg, Hir, HirKind};
+use super::pattern::HirPattern;
 use crate::signals::Signal;
 use std::collections::{BTreeSet, HashMap};
 
@@ -401,6 +404,27 @@ impl<'a> FnCtx<'a> {
                 else_branch,
             } => {
                 let saved = self.renames.clone();
+                let saved_preserved = self.assign_preserved.clone();
+                // When a Cond appears directly in a Begin, transform_begin_at
+                // handles phi-insertion. This handler covers the non-Begin
+                // case (e.g. cond as a let init or function arg), where
+                // assigns must stay as runtime slot mutations.
+                for (_, body) in clauses {
+                    let mut branch_assigns = BTreeSet::new();
+                    self.collect_assigned_bindings(body, &mut branch_assigns);
+                    for b in &branch_assigns {
+                        let resolved = self.resolve(*b);
+                        self.assign_preserved.insert(resolved);
+                    }
+                }
+                if let Some(e) = else_branch {
+                    let mut branch_assigns = BTreeSet::new();
+                    self.collect_assigned_bindings(e, &mut branch_assigns);
+                    for b in &branch_assigns {
+                        let resolved = self.resolve(*b);
+                        self.assign_preserved.insert(resolved);
+                    }
+                }
                 let new_clauses: Vec<_> = clauses
                     .iter()
                     .map(|(c, b)| {
@@ -411,6 +435,7 @@ impl<'a> FnCtx<'a> {
                 self.renames = saved.clone();
                 let new_else = else_branch.as_ref().map(|e| Box::new(self.transform(e)));
                 self.renames = saved;
+                self.assign_preserved = saved_preserved;
                 Hir::new(
                     HirKind::Cond {
                         clauses: new_clauses,
@@ -424,6 +449,16 @@ impl<'a> FnCtx<'a> {
             HirKind::Match { value, arms } => {
                 let new_value = self.transform(value);
                 let saved = self.renames.clone();
+                let saved_preserved = self.assign_preserved.clone();
+                // Non-Begin case: assign_preserved (Begin case uses phi-insertion).
+                for (_, _, body) in arms {
+                    let mut branch_assigns = BTreeSet::new();
+                    self.collect_assigned_bindings(body, &mut branch_assigns);
+                    for b in &branch_assigns {
+                        let resolved = self.resolve(*b);
+                        self.assign_preserved.insert(resolved);
+                    }
+                }
                 let new_arms: Vec<_> = arms
                     .iter()
                     .map(|(pat, guard, body)| {
@@ -436,6 +471,7 @@ impl<'a> FnCtx<'a> {
                     })
                     .collect();
                 self.renames = saved;
+                self.assign_preserved = saved_preserved;
                 Hir::new(
                     HirKind::Match {
                         value: Box::new(new_value),
@@ -794,6 +830,53 @@ impl<'a> FnCtx<'a> {
             }
         }
 
+        // Cond with assigns in branches → phi-insertion
+        if let HirKind::Cond {
+            clauses,
+            else_branch,
+        } = &expr.kind
+        {
+            let mut all_assigned = BTreeSet::new();
+            for (_, body) in clauses {
+                self.collect_assigned_bindings(body, &mut all_assigned);
+            }
+            if let Some(e) = else_branch {
+                self.collect_assigned_bindings(e, &mut all_assigned);
+            }
+            all_assigned.retain(|b| !self.assign_preserved.contains(&self.resolve(*b)));
+            if !all_assigned.is_empty() {
+                return self.transform_cond_with_phi(
+                    clauses,
+                    else_branch,
+                    &all_assigned,
+                    exprs,
+                    start,
+                    span,
+                    signal,
+                );
+            }
+        }
+
+        // Match with assigns in arms → phi-insertion
+        if let HirKind::Match { value, arms } = &expr.kind {
+            let mut all_assigned = BTreeSet::new();
+            for (_, _, body) in arms {
+                self.collect_assigned_bindings(body, &mut all_assigned);
+            }
+            all_assigned.retain(|b| !self.assign_preserved.contains(&self.resolve(*b)));
+            if !all_assigned.is_empty() {
+                return self.transform_match_with_phi(
+                    value,
+                    arms,
+                    &all_assigned,
+                    exprs,
+                    start,
+                    span,
+                    signal,
+                );
+            }
+        }
+
         // While in a begin (possibly wrapped in a Block): collect
         // sibling defines for scope context. The analyzer wraps `while`
         // in a Block for break support, so we unwrap it here.
@@ -1000,6 +1083,351 @@ impl<'a> FnCtx<'a> {
                 signal,
             )
         }
+    }
+
+    /// Transform a Cond that contains assigns in its branches, inserting
+    /// phi-lets after the merge point.
+    ///
+    /// Strategy: bind each condition to a temporary (with short-circuit
+    /// evaluation so later conditions aren't evaluated if an earlier one
+    /// was true), then use those temps for both the cond and the
+    /// phi-selects (nested Ifs over the temps).
+    ///
+    /// ```text
+    /// (begin (cond test1 (assign x 1) test2 (assign x 2) (assign x 3)) (use x))
+    /// →
+    /// (let [t1 test1]
+    ///   (let [t2 (if t1 false test2)]
+    ///     (begin
+    ///       (cond t1 body1' t2 body2' else')
+    ///       (let [x_phi (if t1 x_v1 (if t2 x_v2 x_v3))]
+    ///         (use x_phi)))))
+    /// ```
+    #[allow(clippy::too_many_arguments)]
+    fn transform_cond_with_phi(
+        &mut self,
+        clauses: &[(Hir, Hir)],
+        else_branch: &Option<Box<Hir>>,
+        assigned: &BTreeSet<Binding>,
+        exprs: &[Hir],
+        start: usize,
+        span: crate::syntax::Span,
+        signal: Signal,
+    ) -> Hir {
+        let saved = self.renames.clone();
+
+        // 1. Transform each condition and branch body, extracting assign versions
+        let mut cond_exprs = Vec::new();
+        let mut bodies = Vec::new();
+        let mut all_versions: Vec<HashMap<Binding, Binding>> = Vec::new();
+
+        for (cond_expr, body) in clauses {
+            self.renames = saved.clone();
+            let new_cond = self.transform(cond_expr);
+            cond_exprs.push(new_cond);
+
+            self.renames = saved.clone();
+            let (new_body, versions) =
+                self.transform_branch_extracting_assigns(body, assigned);
+            bodies.push(new_body);
+            all_versions.push(versions);
+        }
+
+        let new_else = if let Some(e) = else_branch {
+            self.renames = saved.clone();
+            let (new_e, versions) =
+                self.transform_branch_extracting_assigns(e, assigned);
+            all_versions.push(versions);
+            Some(new_e)
+        } else {
+            None
+        };
+        self.renames = saved.clone();
+
+        // 2. Create condition temporaries
+        let cond_temps: Vec<Binding> = (0..clauses.len())
+            .map(|_| self.gensym())
+            .collect();
+
+        // 3. Build the cond using temps as conditions
+        let new_clauses: Vec<(Hir, Hir)> = cond_temps
+            .iter()
+            .zip(bodies)
+            .map(|(&t, body)| {
+                (Hir::silent(HirKind::Var(t), span.clone()), body)
+            })
+            .collect();
+        let cond_node = Hir::new(
+            HirKind::Cond {
+                clauses: new_clauses,
+                else_branch: new_else.map(Box::new),
+            },
+            span.clone(),
+            signal,
+        );
+
+        // 4. Build phi-selects for each assigned binding
+        //    (if t1 x_v1 (if t2 x_v2 ... x_velse))
+        let phi_bindings: Vec<_> = assigned
+            .iter()
+            .map(|&orig| {
+                // Build the nested-if phi-select from right to left
+                let pre = saved.get(&orig).copied().unwrap_or(orig);
+
+                // Start with the else/default value
+                let else_idx = clauses.len(); // else is after all clauses
+                let mut phi_val = if else_idx < all_versions.len() {
+                    // There's an else branch
+                    all_versions[else_idx]
+                        .get(&orig)
+                        .map(|&b| Hir::silent(HirKind::Var(b), span.clone()))
+                        .unwrap_or_else(|| Hir::silent(HirKind::Var(pre), span.clone()))
+                } else {
+                    // No else → use pre-cond version
+                    Hir::silent(HirKind::Var(pre), span.clone())
+                };
+
+                // Wrap in (if tN x_vN ...) from last clause to first
+                for i in (0..clauses.len()).rev() {
+                    let clause_val = all_versions[i]
+                        .get(&orig)
+                        .map(|&b| Hir::silent(HirKind::Var(b), span.clone()))
+                        .unwrap_or_else(|| Hir::silent(HirKind::Var(pre), span.clone()));
+
+                    phi_val = Hir::new(
+                        HirKind::If {
+                            cond: Box::new(Hir::silent(
+                                HirKind::Var(cond_temps[i]),
+                                span.clone(),
+                            )),
+                            then_branch: Box::new(clause_val),
+                            else_branch: Box::new(phi_val),
+                        },
+                        span.clone(),
+                        Signal::silent(),
+                    );
+                }
+
+                let fresh = self.fresh_version(orig);
+                self.renames.insert(orig, fresh);
+                (fresh, phi_val)
+            })
+            .collect();
+
+        // 5. Build continuation
+        let has_continuation = start + 1 < exprs.len();
+        let mut result = self.transform_begin_at(exprs, start + 1, span.clone(), signal);
+
+        // Wrap: (let [phi1 ...] (let [phi2 ...] continuation))
+        for (binding, phi_val) in phi_bindings.into_iter().rev() {
+            result = Hir::new(
+                HirKind::Let {
+                    bindings: vec![(binding, phi_val)],
+                    body: Box::new(result),
+                },
+                span.clone(),
+                signal,
+            );
+        }
+
+        // 6. Build condition temp lets with short-circuit evaluation
+        //    t1 = test1
+        //    t2 = (if t1 false test2)
+        //    t3 = (if t1 false (if t2 false test3))
+        //    ...
+        let inner = if has_continuation {
+            Hir::new(HirKind::Begin(vec![cond_node, result]), span.clone(), signal)
+        } else {
+            // Last expression: capture cond result in a temp
+            let result_binding = self.gensym();
+            let result_var = Hir::silent(HirKind::Var(result_binding), span.clone());
+            Hir::new(
+                HirKind::Let {
+                    bindings: vec![(result_binding, cond_node)],
+                    body: Box::new(Hir::new(
+                        HirKind::Begin(vec![result, result_var]),
+                        span.clone(),
+                        signal,
+                    )),
+                },
+                span.clone(),
+                signal,
+            )
+        };
+
+        // Wrap with condition temp lets (innermost = last condition)
+        let mut wrapped = inner;
+        for i in (0..clauses.len()).rev() {
+            let cond_init = if i == 0 {
+                // First condition: evaluate directly
+                cond_exprs[i].clone()
+            } else {
+                // Later conditions: short-circuit if any earlier test was true
+                //   (if t_{i-1} false (if t_{i-2} false ... test_i))
+                // Simplified: (if (or t1 ... t_{i-1}) false test_i)
+                // But we can build nested ifs:
+                //   (if t1 false (if t2 false ... test_i))
+                let mut short_circuit = cond_exprs[i].clone();
+                for j in (0..i).rev() {
+                    short_circuit = Hir::new(
+                        HirKind::If {
+                            cond: Box::new(Hir::silent(
+                                HirKind::Var(cond_temps[j]),
+                                span.clone(),
+                            )),
+                            then_branch: Box::new(Hir::silent(
+                                HirKind::Bool(false),
+                                span.clone(),
+                            )),
+                            else_branch: Box::new(short_circuit),
+                        },
+                        span.clone(),
+                        Signal::silent(),
+                    );
+                }
+                short_circuit
+            };
+
+            wrapped = Hir::new(
+                HirKind::Let {
+                    bindings: vec![(cond_temps[i], cond_init)],
+                    body: Box::new(wrapped),
+                },
+                span.clone(),
+                signal,
+            );
+        }
+
+        wrapped
+    }
+
+    /// Transform a Match that contains assigns in its arms, inserting
+    /// phi-lets after the merge point.
+    ///
+    /// Strategy: bind the match value to a temp, use the match for the
+    /// body, then build a second match for each phi-select.
+    #[allow(clippy::too_many_arguments)]
+    fn transform_match_with_phi(
+        &mut self,
+        value: &Hir,
+        arms: &[(HirPattern, Option<Hir>, Hir)],
+        assigned: &BTreeSet<Binding>,
+        exprs: &[Hir],
+        start: usize,
+        span: crate::syntax::Span,
+        signal: Signal,
+    ) -> Hir {
+        let saved = self.renames.clone();
+
+        // 1. Transform the match value
+        let new_value = self.transform(value);
+        let value_binding = self.gensym();
+        let value_var = Hir::silent(HirKind::Var(value_binding), span.clone());
+
+        // 2. Transform each arm body, extracting assign versions
+        let mut new_arms = Vec::new();
+        let mut all_versions: Vec<HashMap<Binding, Binding>> = Vec::new();
+
+        for (pat, guard, body) in arms {
+            self.renames = saved.clone();
+            let new_guard = guard.as_ref().map(|g| self.transform(g));
+            let (new_body, versions) =
+                self.transform_branch_extracting_assigns(body, assigned);
+            new_arms.push((pat.clone(), new_guard, new_body));
+            all_versions.push(versions);
+        }
+        self.renames = saved.clone();
+
+        // 3. Build the match using the value temp
+        let match_node = Hir::new(
+            HirKind::Match {
+                value: Box::new(value_var.clone()),
+                arms: new_arms,
+            },
+            span.clone(),
+            signal,
+        );
+
+        // 4. Build phi-selects: a second match for each assigned binding
+        let phi_bindings: Vec<_> = assigned
+            .iter()
+            .map(|&orig| {
+                let pre = saved.get(&orig).copied().unwrap_or(orig);
+
+                // Build match arms for the phi-select
+                let phi_arms: Vec<_> = arms
+                    .iter()
+                    .zip(all_versions.iter())
+                    .map(|((pat, guard, _), versions)| {
+                        let phi_val = versions
+                            .get(&orig)
+                            .map(|&b| Hir::silent(HirKind::Var(b), span.clone()))
+                            .unwrap_or_else(|| Hir::silent(HirKind::Var(pre), span.clone()));
+                        // Replicate guards for the phi-select match
+                        let phi_guard = guard.as_ref().map(|g| self.transform(g));
+                        (pat.clone(), phi_guard, phi_val)
+                    })
+                    .collect();
+
+                let phi_match = Hir::new(
+                    HirKind::Match {
+                        value: Box::new(value_var.clone()),
+                        arms: phi_arms,
+                    },
+                    span.clone(),
+                    Signal::silent(),
+                );
+
+                let fresh = self.fresh_version(orig);
+                self.renames.insert(orig, fresh);
+                (fresh, phi_match)
+            })
+            .collect();
+
+        // 5. Build continuation
+        let has_continuation = start + 1 < exprs.len();
+        let mut result = self.transform_begin_at(exprs, start + 1, span.clone(), signal);
+
+        // Wrap: (let [phi1 ...] continuation)
+        for (binding, phi_val) in phi_bindings.into_iter().rev() {
+            result = Hir::new(
+                HirKind::Let {
+                    bindings: vec![(binding, phi_val)],
+                    body: Box::new(result),
+                },
+                span.clone(),
+                signal,
+            );
+        }
+
+        // 6. Wrap with match and value binding
+        let inner = if has_continuation {
+            Hir::new(HirKind::Begin(vec![match_node, result]), span.clone(), signal)
+        } else {
+            let result_binding = self.gensym();
+            let result_var = Hir::silent(HirKind::Var(result_binding), span.clone());
+            Hir::new(
+                HirKind::Let {
+                    bindings: vec![(result_binding, match_node)],
+                    body: Box::new(Hir::new(
+                        HirKind::Begin(vec![result, result_var]),
+                        span.clone(),
+                        signal,
+                    )),
+                },
+                span.clone(),
+                signal,
+            )
+        };
+
+        Hir::new(
+            HirKind::Let {
+                bindings: vec![(value_binding, new_value)],
+                body: Box::new(inner),
+            },
+            span,
+            signal,
+        )
     }
 
     /// Transform a branch body, converting assigns to the target

--- a/src/hir/functionalize.rs
+++ b/src/hir/functionalize.rs
@@ -1127,16 +1127,14 @@ impl<'a> FnCtx<'a> {
             cond_exprs.push(new_cond);
 
             self.renames = saved.clone();
-            let (new_body, versions) =
-                self.transform_branch_extracting_assigns(body, assigned);
+            let (new_body, versions) = self.transform_branch_extracting_assigns(body, assigned);
             bodies.push(new_body);
             all_versions.push(versions);
         }
 
         let new_else = if let Some(e) = else_branch {
             self.renames = saved.clone();
-            let (new_e, versions) =
-                self.transform_branch_extracting_assigns(e, assigned);
+            let (new_e, versions) = self.transform_branch_extracting_assigns(e, assigned);
             all_versions.push(versions);
             Some(new_e)
         } else {
@@ -1145,17 +1143,13 @@ impl<'a> FnCtx<'a> {
         self.renames = saved.clone();
 
         // 2. Create condition temporaries
-        let cond_temps: Vec<Binding> = (0..clauses.len())
-            .map(|_| self.gensym())
-            .collect();
+        let cond_temps: Vec<Binding> = (0..clauses.len()).map(|_| self.gensym()).collect();
 
         // 3. Build the cond using temps as conditions
         let new_clauses: Vec<(Hir, Hir)> = cond_temps
             .iter()
             .zip(bodies)
-            .map(|(&t, body)| {
-                (Hir::silent(HirKind::Var(t), span.clone()), body)
-            })
+            .map(|(&t, body)| (Hir::silent(HirKind::Var(t), span.clone()), body))
             .collect();
         let cond_node = Hir::new(
             HirKind::Cond {
@@ -1196,10 +1190,7 @@ impl<'a> FnCtx<'a> {
 
                     phi_val = Hir::new(
                         HirKind::If {
-                            cond: Box::new(Hir::silent(
-                                HirKind::Var(cond_temps[i]),
-                                span.clone(),
-                            )),
+                            cond: Box::new(Hir::silent(HirKind::Var(cond_temps[i]), span.clone())),
                             then_branch: Box::new(clause_val),
                             else_branch: Box::new(phi_val),
                         },
@@ -1236,7 +1227,11 @@ impl<'a> FnCtx<'a> {
         //    t3 = (if t1 false (if t2 false test3))
         //    ...
         let inner = if has_continuation {
-            Hir::new(HirKind::Begin(vec![cond_node, result]), span.clone(), signal)
+            Hir::new(
+                HirKind::Begin(vec![cond_node, result]),
+                span.clone(),
+                signal,
+            )
         } else {
             // Last expression: capture cond result in a temp
             let result_binding = self.gensym();
@@ -1271,14 +1266,8 @@ impl<'a> FnCtx<'a> {
                 for j in (0..i).rev() {
                     short_circuit = Hir::new(
                         HirKind::If {
-                            cond: Box::new(Hir::silent(
-                                HirKind::Var(cond_temps[j]),
-                                span.clone(),
-                            )),
-                            then_branch: Box::new(Hir::silent(
-                                HirKind::Bool(false),
-                                span.clone(),
-                            )),
+                            cond: Box::new(Hir::silent(HirKind::Var(cond_temps[j]), span.clone())),
+                            then_branch: Box::new(Hir::silent(HirKind::Bool(false), span.clone())),
                             else_branch: Box::new(short_circuit),
                         },
                         span.clone(),
@@ -1331,8 +1320,7 @@ impl<'a> FnCtx<'a> {
         for (pat, guard, body) in arms {
             self.renames = saved.clone();
             let new_guard = guard.as_ref().map(|g| self.transform(g));
-            let (new_body, versions) =
-                self.transform_branch_extracting_assigns(body, assigned);
+            let (new_body, versions) = self.transform_branch_extracting_assigns(body, assigned);
             new_arms.push((pat.clone(), new_guard, new_body));
             all_versions.push(versions);
         }
@@ -1402,7 +1390,11 @@ impl<'a> FnCtx<'a> {
 
         // 6. Wrap with match and value binding
         let inner = if has_continuation {
-            Hir::new(HirKind::Begin(vec![match_node, result]), span.clone(), signal)
+            Hir::new(
+                HirKind::Begin(vec![match_node, result]),
+                span.clone(),
+                signal,
+            )
         } else {
             let result_binding = self.gensym();
             let result_var = Hir::silent(HirKind::Var(result_binding), span.clone());

--- a/tests/elle/branch-assign.lisp
+++ b/tests/elle/branch-assign.lisp
@@ -1,0 +1,83 @@
+(elle/epoch 10)
+## Tests: assign inside branch bodies (cond, match)
+## Verifies that (assign x val) inside begin blocks within
+## branch arms correctly mutates the outer binding.
+
+## ── cond + begin ──────────────────────────────────────────
+
+(let [@x false]
+  (cond
+    true (begin
+           (assign x 99)))
+  (assert (= x 99) "cond single-clause begin assign"))
+
+(let [@x false]
+  (cond
+    false 0
+    true (begin
+           (assign x 99)))
+  (assert (= x 99) "cond two-clause begin assign"))
+
+(let [@x false]
+  (cond
+    false 0
+    false 1
+    true (begin
+           (assign x 99)))
+  (assert (= x 99) "cond three-clause begin assign"))
+
+## cond with default (odd trailing element)
+(let [@x false]
+  (cond
+    false 0
+    (begin
+      (assign x 99)))
+  (assert (= x 99) "cond default begin assign"))
+
+## cond where the taken branch does NOT assign
+(let [@x 42]
+  (cond
+    true nil
+    false (begin
+            (assign x 0)))
+  (assert (= x 42) "cond untaken branch preserves"))
+
+## ── match + begin ─────────────────────────────────────────
+
+(let [@x false]
+  (match 1
+    1 (begin
+        (assign x 99))
+    _ nil)
+  (assert (= x 99) "match begin assign"))
+
+(let [@x false]
+  (match :a
+    :b (begin
+         (assign x 1))
+    :a (begin
+         (assign x 2))
+    _ nil)
+  (assert (= x 2) "match second-arm begin assign"))
+
+## match where no arm assigns
+(let [@x 42]
+  (match 1
+    1 "one"
+    _ "other")
+  (assert (= x 42) "match preserves when no assign"))
+
+## ── nested ────────────────────────────────────────────────
+
+(let [@x 0]
+  (cond
+    true
+      (begin
+        (cond
+          true (begin
+                 (assign x 1)))
+        (assert (= x 1) "nested cond begin assign inner")
+        (assign x (+ x 10))))
+  (assert (= x 11) "nested cond begin assign outer"))
+
+(println "branch-assign: all tests passed")

--- a/tests/elle/branch-phi.lisp
+++ b/tests/elle/branch-phi.lisp
@@ -1,0 +1,218 @@
+(elle/epoch 10)
+## Tests: phi-insertion for cond/match branch assigns
+## Verifies that assigns inside branch bodies correctly propagate
+## through SSA phi-insertion (not just runtime slot mutation).
+
+## ── cond phi: single clause ──────────────────────────────────
+
+(let [@x 0]
+  (cond
+    true (assign x 42))
+  (assert (= x 42) "cond phi: single clause taken"))
+
+(let [@x 0]
+  (cond
+    false (assign x 42))
+  (assert (= x 0) "cond phi: single clause untaken"))
+
+## ── cond phi: two clauses ────────────────────────────────────
+
+(let [@x 0]
+  (cond
+    true (assign x 1)
+    true (assign x 2))
+  (assert (= x 1) "cond phi: first clause taken"))
+
+(let [@x 0]
+  (cond
+    false (assign x 1)
+    true (assign x 2))
+  (assert (= x 2) "cond phi: second clause taken"))
+
+(let [@x 0]
+  (cond
+    false (assign x 1)
+    false (assign x 2))
+  (assert (= x 0) "cond phi: no clause taken"))
+
+## ── cond phi: with else ──────────────────────────────────────
+
+(let [@x 0]
+  (cond
+    false (assign x 1)
+    false (assign x 2)
+    (assign x 3))
+  (assert (= x 3) "cond phi: else taken"))
+
+(let [@x 0]
+  (cond
+    true (assign x 1)
+    false (assign x 2)
+    (assign x 3))
+  (assert (= x 1) "cond phi: first clause, else skipped"))
+
+## ── cond phi: condition with side effects ────────────────────
+## The condition function must be called the right number of times.
+
+(def @side-effect-count 0)
+(defn counting-pred [val expected]
+  (assign side-effect-count (+ side-effect-count 1))
+  (= val expected))
+
+(let [@x 0]
+  (cond
+    (counting-pred 1 2) (assign x 1)
+    (counting-pred 1 1) (assign x 2)
+    (assign x 3))
+  (assert (= x 2) "cond phi: correct branch value")
+  (assert (= side-effect-count 2) "cond phi: conditions evaluated correctly"))
+
+## ── cond phi: assign inside begin ────────────────────────────
+
+(let [@x 0]
+  (cond
+    true (begin
+           (assert true "side-effect")
+           (assign x 99)))
+  (assert (= x 99) "cond phi: assign inside begin"))
+
+## ── cond phi: multiple assigned bindings ─────────────────────
+
+(let [@x 0
+      @y 0]
+  (cond
+    false (begin
+            (assign x 1)
+            (assign y 10))
+    true (begin
+           (assign x 2)
+           (assign y 20)))
+  (assert (= x 2) "cond phi: multi-binding x")
+  (assert (= y 20) "cond phi: multi-binding y"))
+
+## ── cond phi: partial assigns ────────────────────────────────
+## Some branches assign x, others don't
+
+(let [@x 0]
+  (cond
+    false nil
+    true (assign x 42)
+    (assign x 99))
+  (assert (= x 42) "cond phi: partial assign"))
+
+(let [@x 0]
+  (cond
+    false (assign x 1)
+    false nil)
+  (assert (= x 0) "cond phi: partial, none taken"))
+
+## ── match phi ────────────────────────────────────────────────
+
+(let [@x 0]
+  (match 2
+    1 (assign x 10)
+    2 (assign x 20)
+    _ (assign x 30))
+  (assert (= x 20) "match phi: second arm"))
+
+(let [@x 0]
+  (match :a
+    :b (assign x 1)
+    :a (assign x 2)
+    _ nil)
+  (assert (= x 2) "match phi: keyword arm"))
+
+(let [@x 0]
+  (match 99
+    1 (assign x 1)
+    2 (assign x 2)
+    _ nil)
+  (assert (= x 0) "match phi: default no assign"))
+
+## ── cond phi: use after multiple conds ───────────────────────
+
+(let [@x 0]
+  (cond
+    true (assign x 1))
+  (assert (= x 1) "cond phi chain: first")
+  (cond
+    true (assign x (+ x 10)))
+  (assert (= x 11) "cond phi chain: second"))
+
+## ── cond phi inside function ─────────────────────────────────
+
+(defn classify [n]
+  (let [@result :unknown]
+    (cond
+      (< n 0) (assign result :negative)
+      (= n 0) (assign result :zero)
+      (assign result :positive))
+    result))
+
+(assert (= (classify -5) :negative) "cond phi fn: negative")
+(assert (= (classify 0) :zero) "cond phi fn: zero")
+(assert (= (classify 5) :positive) "cond phi fn: positive")
+
+## ── cond phi: assign only in some clauses ─────────────────────
+
+(let [@x 10
+      @y 20]
+  (cond
+    false (assign x 1)
+    true nil)
+  (assert (= x 10) "cond phi: x unchanged when clause didn't assign")
+  (assert (= y 20) "cond phi: y unchanged when no clause assigns it"))
+
+## ── cond phi: three clauses, middle taken ─────────────────────
+
+(let [@x 0]
+  (cond
+    false (assign x 1)
+    true (assign x 2)
+    false (assign x 3))
+  (assert (= x 2) "cond phi: three clauses, middle taken"))
+
+## ── match phi: with begin ─────────────────────────────────────
+
+(let [@x 0]
+  (match :b
+    :a (begin
+         (assign x 10)
+         nil)
+    :b (begin
+         (assign x 20)
+         nil)
+    _ nil)
+  (assert (= x 20) "match phi: begin in arm"))
+
+## ── match phi: multiple bindings ──────────────────────────────
+
+(let [@x 0
+      @y 0]
+  (match 2
+    1 (begin
+        (assign x 10)
+        (assign y 100))
+    2 (begin
+        (assign x 20)
+        (assign y 200))
+    _ nil)
+  (assert (= x 20) "match phi: multi-binding x")
+  (assert (= y 200) "match phi: multi-binding y"))
+
+## ── cond phi: sequential conds ────────────────────────────────
+
+(defn multi-cond [n]
+  (let [@x 0
+        @y 0]
+    (cond
+      (> n 0) (assign x 1))
+    (cond
+      (> n 5) (assign y 1))
+    (+ x y)))
+
+(assert (= (multi-cond -1) 0) "sequential conds: both false")
+(assert (= (multi-cond 3) 1) "sequential conds: first true")
+(assert (= (multi-cond 10) 2) "sequential conds: both true")
+
+(println "branch-phi: all tests passed")


### PR DESCRIPTION
The functionalize pass SSA-converted (assign x val) inside cond/match branch bodies to fresh let bindings. The new binding shadowed x only in that branch, so the mutation never reached the outer scope.

Fix: proper phi-insertion for cond and match in Begin sequences. Conditions are bound to temporaries (evaluated once), phi-selects use nested Ifs (cond) or duplicated match (match). Non-Begin contexts use assign_preserved to keep runtime slot mutation where phi-insertion is structurally inapplicable.