### PR TITLE
Fix fuel preemption losing callee state in nested closure calls

### DIFF
--- a/src/vm/call.rs
+++ b/src/vm/call.rs
@@ -14,7 +14,7 @@ use crate::value::error_val;
 use crate::value::fiber::{CallFrame, MAX_CALL_DEPTH};
 use crate::value::{
     sorted_struct_get, BytecodeFrame, SignalBits, SuspendedFrame, TableKey, Value, SIG_ERROR,
-    SIG_HALT, SIG_OK,
+    SIG_FUEL, SIG_HALT, SIG_OK,
 };
 // SmallVec was tried here but benchmarks showed no improvement over Vec
 // for the common 0-8 arg case. The inline storage (64 bytes) touches a
@@ -480,6 +480,25 @@ impl VM {
                     });
 
                     let mut frames = self.fiber.suspended.take().unwrap_or_default();
+
+                    // When the callee was interrupted mid-execution by a
+                    // non-yield signal (e.g. SIG_FUEL), the callee's inner
+                    // frame lives in result.stack — not in fiber.suspended
+                    // (only SIG_YIELD's handle_yield populates that).
+                    // Without this, the callee's state is lost and resume
+                    // injects nil as the Call's return value.
+                    if frames.is_empty() && !result.stack.is_empty() {
+                        frames.push(SuspendedFrame::Bytecode(BytecodeFrame {
+                            bytecode: result.bytecode,
+                            constants: result.constants,
+                            env: result.env,
+                            ip: result.ip,
+                            stack: result.stack,
+                            location_map: result.location_map,
+                            push_resume_value: !bits.contains(SIG_FUEL),
+                        }));
+                    }
+
                     if self
                         .runtime_config
                         .has_trace_bit(crate::config::trace_bits::FIBER)

--- a/tests/elle/fuel-apply-fold.lisp
+++ b/tests/elle/fuel-apply-fold.lisp
@@ -1,0 +1,117 @@
+(elle/epoch 10)
+## ── Fuel: apply and fold preemption bugs
+##
+## Reproduces two runtime bugs where fuel preemption corrupts state:
+## 1. fold accumulator reset — after fuel preemption, accumulator silently
+##    resets to its initial value instead of preserving progress.
+## 2. apply splice corruption — after fuel preemption, apply's splice
+##    sees nil instead of the argument list.
+##
+## Both work outside process:start (no fuel preemption). Root cause is in
+## the Rust runtime — apply's splice and fold's tail-call don't preserve
+## state correctly across fuel-exhaustion yields.
+##
+## Fibers use |:fuel :error| mask so that runtime errors from the bugs
+## are caught by the fiber rather than propagating to the test runner.
+
+(def @failures 0)
+
+(defn check [name ok]
+  (if ok
+    (println "  PASS:" name)
+    (do
+      (println "  FAIL:" name)
+      (assign failures (+ failures 1)))))
+
+# ── Scenario 1: fold accumulator loss ──────────────────────────────────
+#
+# fold over (range 100) summing with fuel=50 (insufficient to complete
+# without preemption). After refuel+resume, expect value 100; the bug
+# corrupts the accumulator causing a type error or wrong value.
+
+(println "Scenario 1: fold accumulator loss")
+(let [f (fiber/new (fn [] (fold (fn [acc _] (+ acc 1)) 0 (range 100)))
+                   |:fuel :error|)]
+  (fiber/set-fuel f 50)
+  (fiber/resume f)
+  (check "fiber paused on fuel exhaustion" (= (fiber/status f) :paused))
+  (fiber/set-fuel f 100000)
+  (fiber/resume f)
+  (check "fiber completes after refuel" (= (fiber/status f) :dead))
+  (check "accumulator preserved (expected 100)" (= (fiber/value f) 100)))
+
+# ── Scenario 2: fold with concat ──────────────────────────────────────
+#
+# fold building a bytes buffer by appending one byte per iteration over
+# (range 200) with fuel=100. After refuel+resume, expect 200-byte result;
+# the bug corrupts the accumulator.
+
+(println "Scenario 2: fold with concat")
+(let [f (fiber/new (fn []
+                     (fold (fn [acc _] (concat acc (bytes 65))) (bytes)
+                           (range 200))) |:fuel :error|)]
+  (fiber/set-fuel f 100)
+  (fiber/resume f)
+  (check "fiber paused on fuel exhaustion" (= (fiber/status f) :paused))
+  (fiber/set-fuel f 100000)
+  (fiber/resume f)
+  (check "fiber completes after refuel" (= (fiber/status f) :dead))
+  (check "200 bytes preserved across preemption"
+         (and (= (fiber/status f) :dead) (= (length (fiber/value f)) 200))))
+
+# ── Scenario 3: apply splice corruption ───────────────────────────────
+#
+# (apply + (range 100)) with fuel=30. After refuel+resume, expect 4950;
+# the bug throws "splice: expected array, tuple, or list, got nil".
+
+(println "Scenario 3: apply splice corruption")
+(let [f (fiber/new (fn [] (apply + (range 100))) |:fuel :error|)]
+  (fiber/set-fuel f 30)
+  (fiber/resume f)
+  (check "fiber paused on fuel exhaustion" (= (fiber/status f) :paused))
+  (fiber/set-fuel f 100000)
+  (fiber/resume f)
+  (check "fiber completes after refuel (no splice nil error)"
+         (= (fiber/status f) :dead))
+  (check "correct sum (expected 4950)" (= (fiber/value f) 4950)))
+
+# ── Scenario 4: apply concat with many chunks ────────────────────────
+#
+# (apply concat ...) over 500 two-byte arrays with fuel=100. After
+# refuel+resume, expect 1000 bytes.
+
+(println "Scenario 4: apply concat with many chunks")
+(let [f (fiber/new (fn []
+                     (apply concat (map (fn [_] (bytes 65 66)) (range 500))))
+                   |:fuel :error|)]
+  (fiber/set-fuel f 100)
+  (fiber/resume f)
+  (check "fiber paused on fuel exhaustion" (= (fiber/status f) :paused))
+  (fiber/set-fuel f 100000)
+  (fiber/resume f)
+  (check "fiber completes after refuel" (= (fiber/status f) :dead))
+  (check "1000 bytes from 500 two-byte chunks"
+         (and (= (fiber/status f) :dead) (= (length (fiber/value f)) 1000))))
+
+# ── Scenario 5: Baseline — fold without preemption ────────────────────
+#
+# Same fold as test 1 but with fuel=100000 (enough to complete without
+# preemption). Proves fold works when fuel is sufficient.
+
+(println "Scenario 5: baseline fold without preemption")
+(let [f (fiber/new (fn [] (fold (fn [acc _] (+ acc 1)) 0 (range 100)))
+                   |:fuel :error|)]
+  (fiber/set-fuel f 100000)
+  (fiber/resume f)
+  (check "fiber completes with sufficient fuel" (= (fiber/status f) :dead))
+  (check "correct value without preemption (expected 100)"
+         (= (fiber/value f) 100)))
+
+# ── Summary ───────────────────────────────────────────────────────────
+
+(println)
+(if (= failures 0)
+  (println "All checks passed.")
+  (do
+    (println failures "check(s) failed.")
+    (assert false "fuel-apply-fold: regression tests failed")))


### PR DESCRIPTION
When SIG_FUEL fires inside a closure called via call_inner (e.g. the accumulator function inside fold), the callee's execution state lives in ExecResult.stack — but call_inner's suspend branch only checked fiber.suspended (which only SIG_YIELD populates via handle_yield). The callee's inner frame was lost, and on resume the caller continued as if the callee returned nil.

Fix: when fiber.suspended is empty and result.stack is non-empty, construct the callee's SuspendedFrame from ExecResult before appending the caller frame. This ensures the resume chain re-enters the callee from where it paused.

Adds tests/elle/fuel-apply-fold.lisp with 5 scenarios covering fold accumulator preservation, fold with concat, apply splice, apply concat, and a no-preemption baseline.