### PR TITLE
CLI module: --help, --, rest args, choices, negatable flags

### DIFF
--- a/lib/cli.lisp
+++ b/lib/cli.lisp
@@ -2,8 +2,9 @@
 ## lib/cli.lisp — CLI argument parsing (pure Elle)
 ##
 ## Declarative argument parsing from a spec struct + argv list.
-## Supports flags, string options, count, append, positionals,
-## defaults, subcommands, short/long forms, and = syntax.
+## Supports flags, string options, count, append, rest, positionals,
+## defaults, subcommands, short/long forms, = syntax, -- separator,
+## choices validation, negatable flags, and auto-help.
 ##
 ## Usage:
 ##   (def cli ((import "std/cli")))
@@ -53,26 +54,42 @@
                                      :param :action
                                      :message (string ":action must be a keyword, got "
                                      (type-of v))}))))
-             default-val (require-string spec:default "default" "cli/parse")
-             required? spec:required]
+             default-val spec:default
+             required? spec:required
+             help-text (require-string spec:help "help" "cli/parse")
+             meta-var (require-string spec:meta "meta" "cli/parse")
+             choices spec:choices
+             negatable? spec:negatable]
         (when (and short-name (not (= (length short-name) 1)))
           (error {:error :cli-error
                   :reason :invalid-short
                   :option short-name
                   :message (string ":short must be a single character, got \""
                                    short-name "\"")}))
-        (unless (contains? |:set :flag :count :append| action-kw)
+        (unless (contains? |:set :flag :count :append :rest| action-kw)
           (error {:error :cli-error
                   :reason :unknown-action
                   :action action-kw
                   :message (string "unknown action " action-kw
-                                   ", expected :set, :flag, :count, or :append")}))
+                                   ", expected :set, :flag, :count, :append, or :rest")}))
+        (when (and choices (not (array? choices)))
+          (error {:error :cli-error
+                  :reason :invalid-choices
+                  :message ":choices must be an array of strings"}))
+        (when (and negatable? (not (= action-kw :flag)))
+          (error {:error :cli-error
+                  :reason :invalid-negatable
+                  :message ":negatable is only valid on :flag actions"}))
         {:name name
          :long long-name
          :short short-name
          :action action-kw
          :default default-val
-         :required required?})))
+         :required required?
+         :help help-text
+         :meta meta-var
+         :choices choices
+         :negatable negatable?})))
 
   ## ── Argv parsing engine ──────────────────────────────────────────
 
@@ -96,18 +113,55 @@
           (begin
             (push (result k) value)
             result)
+        :rest
+          (begin
+            (push (result k) value)
+            result)
         _ result)))
+
+  (defn validate-choices [spec value option-str]
+    (when (and spec:choices (not (find (fn [c] (= c value)) spec:choices)))
+      (error {:error :cli-error
+              :reason :invalid-choice
+              :option option-str
+              :value value
+              :choices spec:choices
+              :message (string option-str ": expected one of "
+                               (string/join spec:choices ", ") "; got \"" value
+                               "\"")})))
 
   (defn init-result [specs]
     (let [r @{}]
       (each s in specs
         (let [k (keyword s:name)]
           (match s:action
-            :flag (put r k false)
+            :flag
+              (put r k (if (nil? s:default) false s:default))
             :count (put r k 0)
             :append (put r k @[])
+            :rest (put r k @[])
             _ (put r k s:default))))
       r))
+
+  (defn handle-positional [result pos-specs pi arg]
+    (if (< pi (length pos-specs))
+      (let [ps (pos-specs pi)]
+        (if (= ps:action :rest)
+          (begin
+            (push (result (keyword ps:name)) arg)
+            pi)
+          (begin
+            (put result (keyword ps:name) arg)
+            (inc pi))))
+      (if (and (> (length pos-specs) 0)
+               (= ((pos-specs (dec (length pos-specs))) :action) :rest))
+        (let [ps (pos-specs (dec (length pos-specs)))]
+          (push (result (keyword ps:name)) arg)
+          pi)
+        (error {:error :cli-error
+                :reason :unexpected-argument
+                :argument arg
+                :message (string "unexpected argument \"" arg "\"")}))))
 
   (defn parse-argv [specs argv]
     "Parse argv list against normalized specs. Returns mutable struct."
@@ -117,79 +171,87 @@
            argc (length args)]
       (def @pi 0)
       (def @i 0)
+      (def @past-sep false)
       (while (< i argc)
         (let [arg (args i)]
-          (cond  ## --long=value
-            (and (string/starts-with? arg "--") (string/contains? arg "="))
-              (let* [eq (string/find arg "=")
-                     name (slice arg 2 eq)
-                     value (slice arg (inc eq) (length arg))
-                     spec (find-by-long specs name)]
-                (unless spec
-                  (error {:error :cli-error
-                          :reason :unknown-option
-                          :option (string "--" name)
-                          :message (string "unknown option --" name)}))
-                (apply-action result spec:name spec:action value))  ## --long
-            (string/starts-with? arg "--")
-              (let* [name (slice arg 2 (length arg))
-                     spec (find-by-long specs name)]
-                (unless spec
-                  (error {:error :cli-error
-                          :reason :unknown-option
-                          :option (string "--" name)
-                          :message (string "unknown option --" name)}))
-                (match spec:action
-                  :flag (apply-action result spec:name :flag nil)
-                  :count (apply-action result spec:name :count nil)
-                  _
-                    (begin
-                      (assign i (inc i))
-                      (when (>= i argc)
+          (if past-sep
+            (assign pi (handle-positional result pos-specs pi arg))
+            (cond
+              (= arg "--") (assign past-sep true)  ## --long=value
+              (and (string/starts-with? arg "--") (string/contains? arg "="))
+                (let* [eq (string/find arg "=")
+                       name (slice arg 2 eq)
+                       value (slice arg (inc eq) (length arg))
+                       spec (find-by-long specs name)]
+                  (unless spec
+                    (error {:error :cli-error
+                            :reason :unknown-option
+                            :option (string "--" name)
+                            :message (string "unknown option --" name)}))
+                  (apply-action result spec:name spec:action value)
+                  (validate-choices spec value (string "--" name)))  ## --long
+              (string/starts-with? arg "--")
+                (let [name (slice arg 2 (length arg))]
+                  (if (and (string/starts-with? name "no-")
+                           (let [base (slice name 3 (length name))
+                                 s (find-by-long specs base)]
+                             (and s s:negatable)))
+                    (let* [base (slice name 3 (length name))
+                           spec (find-by-long specs base)]
+                      (put result (keyword spec:name) false))
+                    (let [spec (find-by-long specs name)]
+                      (unless spec
                         (error {:error :cli-error
-                                :reason :missing-value
+                                :reason :unknown-option
                                 :option (string "--" name)
-                                :message (string "--" name " requires a value")}))  ## -x short — handles stacked flags like -vvv
-                      (apply-action result spec:name spec:action (args i)))))
-            (and (string/starts-with? arg "-") (> (length arg) 1))
-              (let [chars (slice arg 1 (length arg))]
-                (def @ci 0)
-                (while (< ci (length chars))
-                  (let* [ch (chars ci)
-                         spec (find-by-short specs ch)]
-                    (unless spec
-                      (error {:error :cli-error
-                              :reason :unknown-option
-                              :option (string "-" ch)
-                              :message (string "unknown option -" ch)}))
-                    (match spec:action
-                      :flag (apply-action result spec:name :flag nil)
-                      :count (apply-action result spec:name :count nil)
-                      _
-                        (if (< (inc ci) (length chars))
-                          (begin
-                            (apply-action result spec:name spec:action
-                            (slice chars (inc ci) (length chars)))
-                            (assign ci (length chars)))
+                                :message (string "unknown option --" name)}))
+                      (match spec:action
+                        :flag (apply-action result spec:name :flag nil)
+                        :count (apply-action result spec:name :count nil)
+                        _
                           (begin
                             (assign i (inc i))
                             (when (>= i argc)
                               (error {:error :cli-error
                                       :reason :missing-value
-                                      :option (string "-" ch)
-                                      :message (string "-" ch
+                                      :option (string "--" name)
+                                      :message (string "--" name
                                       " requires a value")}))
-                            (apply-action result spec:name spec:action (args i))))))
-                  (assign ci (inc ci))))  ## Positional
-            true
-              (if (< pi (length pos-specs))
-                (begin
-                  (put result (keyword ((pos-specs pi) :name)) arg)
-                  (assign pi (inc pi)))
-                (error {:error :cli-error
-                        :reason :unexpected-argument
-                        :argument arg
-                        :message (string "unexpected argument \"" arg "\"")}))))
+                            (apply-action result spec:name spec:action (args i))
+                            (validate-choices spec (args i) (string "--" name)))))))
+              (and (string/starts-with? arg "-") (> (length arg) 1))
+                (let [chars (slice arg 1 (length arg))]
+                  (def @ci 0)
+                  (while (< ci (length chars))
+                    (let* [ch (chars ci)
+                           spec (find-by-short specs ch)]
+                      (unless spec
+                        (error {:error :cli-error
+                                :reason :unknown-option
+                                :option (string "-" ch)
+                                :message (string "unknown option -" ch)}))
+                      (match spec:action
+                        :flag (apply-action result spec:name :flag nil)
+                        :count (apply-action result spec:name :count nil)
+                        _
+                          (if (< (inc ci) (length chars))
+                            (let [val (slice chars (inc ci) (length chars))]
+                              (apply-action result spec:name spec:action val)
+                              (validate-choices spec val (string "-" ch))
+                              (assign ci (length chars)))
+                            (begin
+                              (assign i (inc i))
+                              (when (>= i argc)
+                                (error {:error :cli-error
+                                        :reason :missing-value
+                                        :option (string "-" ch)
+                                        :message (string "-" ch
+                                        " requires a value")}))
+                              (apply-action result spec:name spec:action
+                              (args i))
+                              (validate-choices spec (args i) (string "-" ch))))))
+                    (assign ci (inc ci))))
+              true (assign pi (handle-positional result pos-specs pi arg)))))
         (assign i (inc i)))  ## Check required args
       (each s in specs
         (when s:required
@@ -200,6 +262,110 @@
                     :message (string "missing required argument: " s:name)}))))
       result))
 
+  ## ── Help formatting ────────────────────────────────────────────
+
+  (defn format-opt-left [spec]
+    "Build the left column string for one option in help output."
+    (if (and (nil? spec:long) (nil? spec:short))
+      nil
+      (let [short-part (if spec:short (string "-" spec:short) nil)
+            long-part (cond
+                        (and spec:long spec:negatable) (string "--[no-]"
+                        spec:long)
+                        spec:long (string "--" spec:long)
+                        true nil)
+            combined (cond
+                       (and short-part long-part) (string short-part ", "
+                       long-part)
+                       short-part short-part
+                       long-part (string "    " long-part)
+                       true "")
+            suffix (if (contains? |:set :append| spec:action)
+                     (let [mv (cond
+                                spec:meta spec:meta
+                                spec:choices (string/join spec:choices "|")
+                                true "VALUE")]
+                       (string "=" mv))
+                     "")]
+        (string "  " combined suffix))))
+
+  (defn format-help [spec]
+    "Assemble full help text from a command spec."
+    (let* [norm-args (map parse-arg-spec (or spec:args []))
+           name (or spec:name "program")
+           lines @[]
+           header (string name (if spec:version (string " v" spec:version) "")
+                          (if spec:description
+                            (string " — " spec:description)
+                            ""))
+           named-args (filter (fn [s] (or s:long s:short)) norm-args)
+           pos-args (positionals norm-args)
+           cmds (or spec:commands [])]
+      (push lines header)
+      (push lines "")
+      (let [usage-parts @[name]
+            _ (when (> (length named-args) 0) (push usage-parts "[OPTIONS]"))
+            _ (each p in pos-args
+                (if (= p:action :rest)
+                  (push usage-parts (string "<" p:name "...>"))
+                  (push usage-parts (string "<" p:name ">"))))]
+        (push lines (string "Usage: " (string/join (->list usage-parts) " "))))
+      (when (> (length named-args) 0)
+        (let [left-cols (map format-opt-left named-args)
+              max-w (min 28
+                         (+ 2 (fold (fn [mx s] (max mx (length s))) 0 left-cols)))]
+          (push lines "")
+          (push lines "Options:")
+          (each idx in (range (length named-args))
+            (let* [s (named-args idx)
+                   left (left-cols idx)
+                   right-parts @[]
+                   _ (when s:help (push right-parts s:help))
+                   _ (when (and s:default (= s:action :flag))
+                       (push right-parts
+                             (if s:default "(default: on)" "(default: off)")))
+                   _ (when (and s:default (not (= s:action :flag)))
+                       (push right-parts (string "(default: \"" s:default "\")")))
+                   right (string/join (->list right-parts) " ")
+                   pad-len (max 1 (- max-w (length left)))
+                   pad (string/repeat " " pad-len)]
+              (push lines (string left pad right))))))
+      (when (> (length cmds) 0)
+        (let* [cmd-lefts (map (fn [c] (string "  " c:name)) cmds)
+               max-w (min 28
+                          (+ 2
+                             (fold (fn [mx s] (max mx (length s))) 0 cmd-lefts)))]
+          (push lines "")
+          (push lines "Commands:")
+          (each idx in (range (length cmds))
+            (let* [c (cmds idx)
+                   left (cmd-lefts idx)
+                   desc (or c:description "")
+                   pad-len (max 1 (- max-w (length left)))
+                   pad (string/repeat " " pad-len)]
+              (push lines (string left pad desc))))))
+      (string/join (->list lines) "\n")))
+
+  (defn help [spec]
+    "Return formatted help string for a command spec."
+    (format-help spec))
+
+  ## ── Auto-help detection ────────────────────────────────────────
+
+  (defn check-auto-help [spec norm-args argv]
+    "If argv contains --help/-h and no spec claims those, signal help."
+    (let [has-help-long (find (fn [s] (= s:long "help")) norm-args)
+          has-help-short (find (fn [s] (= s:short "h")) norm-args)
+          argv-arr (->array argv)]
+      (when (not (and has-help-long has-help-short))
+        (each idx in (range (length argv-arr))
+          (let [arg (argv-arr idx)]
+            (when (or (and (not has-help-long) (= arg "--help"))
+                      (and (not has-help-short) (= arg "-h")))
+              (error {:error :cli-error
+                      :reason :help-requested
+                      :message (format-help spec)})))))))
+
   ## ── Subcommand support ───────────────────────────────────────────
 
   (defn parse-with-commands [spec argv]
@@ -208,6 +374,7 @@
            cmds-spec (or spec:commands [])
            norm-args (map parse-arg-spec args-spec)
            has-cmds (> (length cmds-spec) 0)]
+      (check-auto-help spec norm-args argv)
       (when has-cmds
         (each s in norm-args
           (when (contains? |"command" "command-args"| s:name)
@@ -273,4 +440,4 @@
     (let [user-argv (if (> (length argv) 0) (rest argv) ())]
       (parse-with-commands spec (->list user-argv))))
 
-  {:parse parse})
+  {:parse parse :help help})

--- a/tests/elle/lib/cli.lisp
+++ b/tests/elle/lib/cli.lisp
@@ -90,4 +90,196 @@
 (let [r (cli:parse {:name "app" :args []} ["app"])]
   (assert (struct? r) "empty argv returns struct"))
 
+# ── -- separator stops option parsing ──────────────────────────
+
+(let [r (cli:parse {:name "app"
+                    :args [{:name "verbose" :short "v" :action :flag}
+                           {:name "file"}]} ["app" "--" "-v"])]
+  (assert (= r:verbose false) "-- separator: flag not parsed")
+  (assert (= r:file "-v") "-- separator: -v treated as positional"))
+
+(let [r (cli:parse {:name "app"
+                    :args [{:name "verbose" :short "v" :action :flag}
+                           {:name "a"} {:name "b"}]} ["app" "-v" "--" "x" "y"])]
+  (assert (= r:verbose true) "-- separator: flag before -- still works")
+  (assert (= r:a "x") "-- separator: first positional after --")
+  (assert (= r:b "y") "-- separator: second positional after --"))
+
+# ── :rest action collects remaining positionals ────────────────
+
+(let [r (cli:parse {:name "app"
+                    :args [{:name "cmd"} {:name "files" :action :rest}]}
+                   ["app" "build" "a.txt" "b.txt" "c.txt"])]
+  (assert (= r:cmd "build") "rest: first positional")
+  (assert (= (length r:files) 3) "rest: collects remaining count")
+  (assert (= (r:files 0) "a.txt") "rest: first")
+  (assert (= (r:files 1) "b.txt") "rest: second")
+  (assert (= (r:files 2) "c.txt") "rest: third"))
+
+(let [r (cli:parse {:name "app" :args [{:name "files" :action :rest}]} ["app"])]
+  (assert (= (length r:files) 0) "rest: empty when no args"))
+
+(let [r (cli:parse {:name "app"
+                    :args [{:name "verbose" :short "v" :action :flag}
+                           {:name "files" :action :rest}]}
+                   ["app" "-v" "--" "--weird" "-x"])]
+  (assert (= r:verbose true) "rest+--: flag before --")
+  (assert (= (length r:files) 2) "rest+--: collects after --")
+  (assert (= (r:files 0) "--weird") "rest+--: first")
+  (assert (= (r:files 1) "-x") "rest+--: second"))
+
+# ── :choices validation ────────────────────────────────────────
+
+(let [r (cli:parse {:name "app"
+                    :args [{:name "format"
+                            :long "format"
+                            :choices ["json" "text"]}]}
+                   ["app" "--format" "json"])]
+  (assert (= r:format "json") "choices: valid value accepted"))
+
+(let [[ok err] (protect (cli:parse {:name "app"
+                                    :args [{:name "format"
+                                    :long "format"
+                                    :choices ["json" "text"]}]}
+                                   ["app" "--format" "xml"]))]
+  (assert (not ok) "choices: invalid value rejected")
+  (assert (= err:reason :invalid-choice) "choices: error reason"))
+
+(let [r (cli:parse {:name "app"
+                    :args [{:name "tags"
+                            :long "tag"
+                            :action :append
+                            :choices ["a" "b" "c"]}]}
+                   ["app" "--tag" "a" "--tag" "b"])]
+  (assert (= (length r:tags) 2) "choices+append: valid values accepted"))
+
+(let [[ok _] (protect (cli:parse {:name "app"
+                                  :args [{:name "tags"
+                                  :long "tag"
+                                  :action :append
+                                  :choices ["a" "b"]}]}
+                                 ["app" "--tag" "a" "--tag" "x"]))]
+  (assert (not ok) "choices+append: invalid value rejected"))
+
+# ── negatable flags ────────────────────────────────────────────
+
+(let [r (cli:parse {:name "app"
+                    :args [{:name "color"
+                            :long "color"
+                            :action :flag
+                            :default true
+                            :negatable true}]} ["app" "--no-color"])]
+  (assert (= r:color false) "negatable: --no-color sets false"))
+
+(let [r (cli:parse {:name "app"
+                    :args [{:name "color"
+                            :long "color"
+                            :action :flag
+                            :default true
+                            :negatable true}]} ["app" "--color"])]
+  (assert (= r:color true) "negatable: --color sets true"))
+
+(let [r (cli:parse {:name "app"
+                    :args [{:name "color"
+                            :long "color"
+                            :action :flag
+                            :default true
+                            :negatable true}]} ["app"])]
+  (assert (= r:color true) "negatable: default true preserved"))
+
+(let [[ok _] (protect (cli:parse {:name "app"
+                                  :args [{:name "color"
+                                  :long "color"
+                                  :action :flag}]} ["app" "--no-color"]))]
+  (assert (not ok) "negatable: --no-X fails when not negatable"))
+
+# ── cli:help returns formatted string ─────────────────────────
+
+(let [h (cli:help {:name "myapp"
+                   :description "A tool"
+                   :version "1.0.0"
+                   :args [{:name "verbose"
+                           :short "v"
+                           :long "verbose"
+                           :action :flag
+                           :help "Be verbose"}
+                          {:name "output"
+                           :short "o"
+                           :long "output"
+                           :help "Output file"
+                           :meta "FILE"}
+                          {:name "format"
+                           :long "format"
+                           :choices ["json" "text"]
+                           :help "Output format"}
+                          {:name "color"
+                           :long "color"
+                           :action :flag
+                           :default true
+                           :negatable true
+                           :help "Colorize output"}
+                          {:name "file" :help "Input file"}]})]
+  (assert (string/contains? h "myapp") "help: contains app name")
+  (assert (string/contains? h "v1.0.0") "help: contains version")
+  (assert (string/contains? h "A tool") "help: contains description")
+  (assert (string/contains? h "Usage:") "help: contains usage line")
+  (assert (string/contains? h "Options:") "help: contains options header")
+  (assert (string/contains? h "-v, --verbose") "help: short+long flag")
+  (assert (string/contains? h "--format=json|text") "help: choices as metavar")
+  (assert (string/contains? h "--[no-]color") "help: negatable flag syntax")
+  (assert (string/contains? h "<file>") "help: positional in usage")
+  (assert (string/contains? h "FILE") "help: metavar shown"))
+
+(let [h (cli:help {:name "app"
+                   :args [{:name "files" :action :rest :help "Input files"}]})]
+  (assert (string/contains? h "<files...>") "help: rest shown as <name...>"))
+
+(let [h (cli:help {:name "app"
+                   :commands [{:name "build" :description "Build the project"}
+                              {:name "test" :description "Run tests"}]})]
+  (assert (string/contains? h "Commands:") "help: commands section")
+  (assert (string/contains? h "build") "help: command name")
+  (assert (string/contains? h "Build the project") "help: command description"))
+
+# ── auto-help signals :help-requested ──────────────────────────
+
+(let [[ok err] (protect (cli:parse {:name "app"
+                                    :args [{:name "verbose"
+                                    :short "v"
+                                    :action :flag}]} ["app" "--help"]))]
+  (assert (not ok) "auto-help: --help signals error")
+  (assert (= err:reason :help-requested) "auto-help: reason is :help-requested")
+  (assert (string/contains? err:message "Usage:")
+          "auto-help: message has help text"))
+
+(let [[ok err] (protect (cli:parse {:name "app"
+                                    :args [{:name "verbose"
+                                    :short "v"
+                                    :action :flag}]} ["app" "-h"]))]
+  (assert (not ok) "auto-help: -h signals error")
+  (assert (= err:reason :help-requested) "auto-help: -h reason"))
+
+# ── auto-help suppressed when spec claims -h/--help ────────────
+
+(let [r (cli:parse {:name "app"
+                    :args [{:name "help" :long "help" :action :flag}]}
+                   ["app" "--help"])]
+  (assert (= r:help true) "auto-help suppressed: --help is user flag"))
+
+(let [r (cli:parse {:name "app" :args [{:name "host" :short "h"}]}
+                   ["app" "-h" "localhost"])]
+  (assert (= r:host "localhost") "auto-help suppressed: -h is user option"))
+
+# ── subcommand --help shows subcommand help ────────────────────
+
+(let [[ok err] (protect (cli:parse {:name "app"
+                                    :commands [{:name "build"
+                                    :description "Build things"
+                                    :args [{:name "target" :long "target"}]}]}
+                                   ["app" "build" "--help"]))]
+  (assert (not ok) "subcmd help: signals error")
+  (assert (= err:reason :help-requested) "subcmd help: reason")
+  (assert (string/contains? err:message "build")
+          "subcmd help: contains subcmd name"))
+
 (println "cli: all tests passed")


### PR DESCRIPTION
Add missing CLI features to lib/cli.lisp:
- `--` separator stops option parsing
- `:rest` action collects remaining positionals into a list
- `:choices` validation restricts values to a known set
- `:negatable true` enables `--no-X` to unset flags
- `cli:help` pure function returns formatted help string
- Auto-help: `--help`/`-h` signals `:help-requested` unless spec claims them
- New spec fields: `:help`, `:meta`, `:choices`, `:negatable`, `:description`, `:version`