### PR TITLE
fibers: capture parameter bindings at creation time

### DIFF
--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -42,9 +42,55 @@ redirects output:
 #   (println "goes to my-port, not terminal"))
 ```
 
+## Fiber inheritance
+
+Parameters are *fiber-local*: each fiber has its own `param_frames`
+stack. A fresh fiber created by `fiber/new` automatically inherits a
+snapshot of the creating fiber's current parameter bindings — the
+snapshot is taken at creation time, not at resume time, so the child
+sees what the parent had bound the moment `fiber/new` was called.
+
+```lisp
+(def *colour* (parameter :default))
+
+(def f (parameterize ((*colour* :red))
+         (fiber/new (fn () (*colour*)) 1)))
+
+# parameterize has unwound here — `(*colour*)` would read :default —
+# but the fiber captured :red at creation:
+(fiber/resume f nil)
+(fiber/value f)              # => :red
+```
+
+This matters for `ev/spawn`: the spawning fiber may finish (and its
+`parameterize` blocks may unwind) long before the scheduler resumes
+the spawned fiber. Without creation-time snapshotting the child would
+observe whatever bindings the scheduler happens to hold at resume time
+— typically nothing useful.
+
+The snapshot is a *copy*. Reparameterizing in the creator after
+spawning does not affect already-created children, and the resumer's
+bindings do not override the child's snapshot:
+
+```lisp
+(def *x* (parameter :default))
+
+(def f (parameterize ((*x* :captured))
+         (fiber/new (fn () (*x*)) 1)))
+
+(parameterize ((*x* :resumer-has-this))
+  (fiber/resume f nil))
+(fiber/value f)              # => :captured
+```
+
+Inheritance is transitive — a fiber that spawns another fiber passes
+its snapshot down. There is no opt-in or opt-out: if you want fresh
+bindings inside the fiber, wrap its body in `parameterize`.
+
 ---
 
 ## See also
 
 - [io.md](io.md) — ports and output
 - [bindings.md](bindings.md) — lexical bindings
+- [concurrency.md](concurrency.md) — fibers, `ev/spawn`, and scheduling

--- a/lib/process.lisp
+++ b/lib/process.lisp
@@ -913,12 +913,13 @@
 
     (def @sched-run
       (fn [init]
-        (sched-spawn init)
-
         # Parameterize *spawn* so that ev/spawn inside any process or sub-fiber
-        # registers fibers with THIS scheduler. Parameter inheritance happens
-        # at fiber resume time, so this must wrap the entire scheduler loop.
+        # registers fibers with THIS scheduler. Spawn the init process inside
+        # the parameterize too — fibers capture their parameter environment at
+        # creation time, so sched-spawn (which creates the init fiber) must
+        # run with the rebound *spawn*.
         (parameterize ((*spawn* sched-spawn-fn))
+        (sched-spawn init)
         (while (has-work?)
           (assign tick (box (+ (unbox tick) 1)))
           (fire-timers)

--- a/src/jit/calls.rs
+++ b/src/jit/calls.rs
@@ -157,6 +157,14 @@ pub extern "C" fn elle_jit_call(
         } else {
             (def.func)(args_slice)
         };
+        // Parameter inheritance: snapshot the creating fiber's
+        // parameterize bindings into a freshly created fiber/new fiber.
+        // See `VM::snapshot_param_frames_into` for the rationale.
+        if bits == SIG_OK && crate::primitives::fibers::is_fiber_new(def.func) {
+            if let Some(handle) = value.as_fiber() {
+                vm.snapshot_param_frames_into(handle);
+            }
+        }
         return jit_handle_primitive_signal(vm, bits, value);
     }
 
@@ -623,6 +631,12 @@ pub extern "C" fn elle_jit_tail_call(
         } else {
             (def.func)(args_slice)
         };
+        // Parameter inheritance for fiber/new — see elle_jit_call above.
+        if bits == SIG_OK && crate::primitives::fibers::is_fiber_new(def.func) {
+            if let Some(handle) = value.as_fiber() {
+                vm.snapshot_param_frames_into(handle);
+            }
+        }
         return jit_handle_primitive_signal(vm, bits, value);
     }
 

--- a/src/primitives/fibers.rs
+++ b/src/primitives/fibers.rs
@@ -183,6 +183,10 @@ pub(crate) fn resolve_signal_bits(
 /// Optional `:deny` keyword arg withholds capabilities from the fiber.
 /// The child's `withheld` is the union of the explicit deny bits and the
 /// parent's withheld (propagated at resume time by the VM).
+///
+/// Dynamic parameter bindings (`parameterize`) active in the creating
+/// fiber are snapshotted into the new fiber by the dispatcher.  See
+/// `VM::snapshot_param_frames_into`.
 pub(crate) fn prim_fiber_new(args: &[Value]) -> (SignalBits, Value) {
     let closure = match args[0].as_closure() {
         Some(c) => std::rc::Rc::new(c.clone()),
@@ -206,37 +210,50 @@ pub(crate) fn prim_fiber_new(args: &[Value]) -> (SignalBits, Value) {
     let mut deny_bits = SignalBits::EMPTY;
     let mut i = 2;
     while i < args.len() {
-        if args[i].as_keyword_name().as_deref() == Some("deny") {
-            if i + 1 >= args.len() {
+        match args[i].as_keyword_name().as_deref() {
+            Some("deny") => {
+                if i + 1 >= args.len() {
+                    return (
+                        SIG_ERROR,
+                        error_val("arity-error", "fiber/new: :deny requires a value"),
+                    );
+                }
+                deny_bits = match resolve_signal_bits(&args[i + 1], "fiber/new :deny") {
+                    Ok(bits) => bits,
+                    Err(err) => return err,
+                };
+                i += 2;
+            }
+            _ => {
                 return (
                     SIG_ERROR,
-                    error_val("arity-error", "fiber/new: :deny requires a value"),
+                    error_val(
+                        "argument-error",
+                        format!(
+                            "fiber/new: unexpected keyword argument :{}",
+                            args[i]
+                                .as_keyword_name()
+                                .unwrap_or_else(|| args[i].type_name().to_string())
+                        ),
+                    ),
                 );
             }
-            deny_bits = match resolve_signal_bits(&args[i + 1], "fiber/new :deny") {
-                Ok(bits) => bits,
-                Err(err) => return err,
-            };
-            i += 2;
-        } else {
-            return (
-                SIG_ERROR,
-                error_val(
-                    "argument-error",
-                    format!(
-                        "fiber/new: unexpected keyword argument :{}",
-                        args[i]
-                            .as_keyword_name()
-                            .unwrap_or_else(|| args[i].type_name().to_string())
-                    ),
-                ),
-            );
         }
     }
 
     let mut fiber = Fiber::new(closure, mask);
     fiber.withheld = deny_bits;
     (SIG_OK, Value::fiber(fiber))
+}
+
+/// Is the given primitive function pointer `fiber/new`?
+///
+/// The dispatcher uses this to know when to snapshot parameter frames
+/// into a freshly-constructed fiber.  Comparing fn pointers requires the
+/// callee side coerce its fn item to a fn pointer; doing that here keeps
+/// the call sites readable.
+pub(crate) fn is_fiber_new(p: crate::value::types::PrimFn) -> bool {
+    std::ptr::fn_addr_eq(p, prim_fiber_new as crate::value::types::PrimFn)
 }
 
 /// (fiber/resume fiber) → value
@@ -628,6 +645,72 @@ mod tests {
     #[test]
     fn test_fiber_new_wrong_type() {
         let (sig, _) = prim_fiber_new(&[Value::int(42), Value::int(0)]);
+        assert_eq!(sig, SIG_ERROR);
+    }
+
+    #[test]
+    fn test_fiber_new_starts_with_empty_param_frames() {
+        // The primitive itself does not populate param_frames — that is the
+        // job of `VM::snapshot_param_frames_into`, invoked by the dispatcher
+        // after the primitive returns. The fiber returned here is a fresh
+        // construction with no parent context.
+        let closure = make_test_closure();
+        let (_, fiber_val) = prim_fiber_new(&[closure, Value::int(0)]);
+        fiber_val.as_fiber().unwrap().with(|fiber| {
+            assert!(
+                fiber.param_frames.is_empty(),
+                "freshly constructed fiber must not carry param_frames \
+                 (the dispatcher snapshots them after we return)"
+            );
+        });
+    }
+
+    #[test]
+    fn test_fiber_new_accepts_deny_keyword() {
+        // :deny is still a valid keyword argument and sets withheld bits.
+        let closure = make_test_closure();
+        let (sig, fiber_val) = prim_fiber_new(&[
+            closure,
+            Value::int(0),
+            Value::keyword("deny"),
+            Value::int(SIG_YIELD.raw() as i64),
+        ]);
+        assert_eq!(sig, SIG_OK);
+        fiber_val.as_fiber().unwrap().with(|fiber| {
+            assert_eq!(fiber.withheld, SIG_YIELD);
+        });
+    }
+
+    #[test]
+    fn test_fiber_new_deny_requires_value() {
+        let closure = make_test_closure();
+        let (sig, _) = prim_fiber_new(&[closure, Value::int(0), Value::keyword("deny")]);
+        assert_eq!(sig, SIG_ERROR);
+    }
+
+    #[test]
+    fn test_fiber_new_rejects_inherit_keyword() {
+        // `:inherit` was a transitional opt-in for parameter inheritance.
+        // Inheritance is now automatic and creation-time, so the keyword
+        // is no longer accepted — passing it must surface as an error so
+        // callers find out instead of silently doing nothing.
+        let closure_a = make_test_closure();
+        let (_, parent) = prim_fiber_new(&[closure_a, Value::int(0)]);
+        let closure_b = make_test_closure();
+        let (sig, _) =
+            prim_fiber_new(&[closure_b, Value::int(0), Value::keyword("inherit"), parent]);
+        assert_eq!(sig, SIG_ERROR);
+    }
+
+    #[test]
+    fn test_fiber_new_rejects_unknown_keyword() {
+        let closure = make_test_closure();
+        let (sig, _) = prim_fiber_new(&[
+            closure,
+            Value::int(0),
+            Value::keyword("nonsense"),
+            Value::int(0),
+        ]);
         assert_eq!(sig, SIG_ERROR);
     }
 

--- a/src/vm/call.rs
+++ b/src/vm/call.rs
@@ -201,6 +201,14 @@ impl VM {
                 } else {
                     (def.func)(args.as_slice())
                 };
+            // Parameter inheritance: when fiber/new produces a fresh fiber,
+            // snapshot the creating fiber's parameterize bindings into it
+            // so the child sees them regardless of who resumes it later.
+            if bits == SIG_OK && crate::primitives::fibers::is_fiber_new(def.func) {
+                if let Some(handle) = value.as_fiber() {
+                    self.snapshot_param_frames_into(handle);
+                }
+            }
             return self.handle_primitive_signal(
                 bits,
                 value,
@@ -661,6 +669,13 @@ impl VM {
                 } else {
                     (def.func)(&args)
                 };
+            // Parameter inheritance for fiber/new — see the non-tail call
+            // path above for the rationale.
+            if bits == SIG_OK && crate::primitives::fibers::is_fiber_new(def.func) {
+                if let Some(handle) = value.as_fiber() {
+                    self.snapshot_param_frames_into(handle);
+                }
+            }
             return Some(self.handle_primitive_signal_tail(bits, value));
         }
 

--- a/src/vm/fiber.rs
+++ b/src/vm/fiber.rs
@@ -446,10 +446,15 @@ impl VM {
             (rv, first)
         });
 
-        // Inherit parent's parameter bindings on first resume.
-        // Flatten all frames into a single frame so the child starts
-        // with the parent's current dynamic bindings as its baseline.
-        if is_first_resume && !self.fiber.param_frames.is_empty() {
+        // Parameter inheritance is normally a snapshot taken at fiber/new
+        // time by `VM::snapshot_param_frames_into`.  As a fallback, fibers
+        // that were created outside the user-visible `fiber/new` primitive
+        // (e.g. directly from Rust) inherit from the resumer on first
+        // resume.  Skip when the child already carries its own snapshot.
+        if is_first_resume
+            && child_handle.with(|c| c.param_frames.is_empty())
+            && !self.fiber.param_frames.is_empty()
+        {
             let mut flat: Vec<(u32, Value)> = Vec::new();
             for frame in &self.fiber.param_frames {
                 for &(id, val) in frame {

--- a/src/vm/parameters.rs
+++ b/src/vm/parameters.rs
@@ -4,6 +4,7 @@
 //! returning the first binding for the given parameter id.
 //! Falls back to the parameter's default value.
 
+use crate::value::fiber::FiberHandle;
 use crate::value::Value;
 
 use super::core::VM;
@@ -22,5 +23,36 @@ impl VM {
             }
         }
         default
+    }
+
+    /// Snapshot the current fiber's `param_frames` into a freshly-created
+    /// child fiber.
+    ///
+    /// Called by the dispatcher right after `fiber/new` returns, so the
+    /// child inherits the dynamic parameter bindings active at *creation*
+    /// time — independent of which fiber later resumes it.  This matters
+    /// for `ev/spawn`, where the spawning fiber may finish before the
+    /// scheduler ever gets around to resuming the child: at resume time
+    /// the spawner's `parameterize` frames have long since unwound.
+    ///
+    /// All frames are flattened into one to keep lookup cost constant
+    /// and to mirror the user-visible semantics — the child observes the
+    /// resolved value of each parameter at the moment of creation, not
+    /// the parent's frame layout.
+    pub(crate) fn snapshot_param_frames_into(&self, child: &FiberHandle) {
+        if self.fiber.param_frames.is_empty() {
+            return;
+        }
+        let mut flat: Vec<(u32, Value)> = Vec::new();
+        for frame in &self.fiber.param_frames {
+            for &(id, val) in frame {
+                if let Some(pos) = flat.iter().position(|&(k, _)| k == id) {
+                    flat[pos].1 = val;
+                } else {
+                    flat.push((id, val));
+                }
+            }
+        }
+        child.with_mut(|c| c.param_frames = vec![flat]);
     }
 }

--- a/stdlib.lisp
+++ b/stdlib.lisp
@@ -1215,6 +1215,7 @@
         select-sets @{}  # waiting-fiber → @{:candidates [...] :woken @[false]}
         completed @{}  # fiber → :ok | :error (already-completed fibers)
         joined @||  # set of fibers whose result was observed
+        scheduler-killed @||  # set of fibers the scheduler aborted during shutdown
         shutdown-req @[nil]  # nil = running, integer = shutdown requested with timeout
         park-queues @{}
         forwarded-pending @{}]  # id → {:queue @[] :wake-box box} (process scheduler I/O)
@@ -1466,15 +1467,33 @@
                 (handle-fiber-after-resume parked)))))))
 
     (defn do-shutdown [timeout-ms]
-      "Abort all pending fibers, pump for timeout-ms, cancel stragglers."
+      "Abort all pending fibers, pump for timeout-ms, cancel stragglers.
+       Aborted fibers go into scheduler-killed (not joined) so the pump's
+       unjoined-error tail can distinguish 'user observed this' from
+       'we injected :shutdown' — defer-time errors during shutdown are
+       dropped here rather than misattributed to user code."
 
-      # Phase 1: abort all pending fibers (inject error, let defer run).
+      # Phase 1a: abort pending-I/O fibers (inject error, let defer run).
       (each [id fiber] in (pairs pending)
         (del pending id)
         (del fiber-io fiber)
         (io/cancel backend id)
+        (add scheduler-killed fiber)
         (let [[ok? _] (protect (fiber/abort fiber {:error :shutdown}))]
-          (when ok? (handle-fiber-after-resume fiber))))  # Phase 2: drain cancel CQEs and let aborted fibers unwind
+          (when ok? (handle-fiber-after-resume fiber))))
+
+      # Phase 1b: abort futex-parked fibers. Without this, long-lived
+      # fibers blocked on (chan:take), sync locks, etc. never get cleaned
+      # up and `step` never sees park-queues empty.
+      (let [snapshot (pairs park-queues)]
+        (each [k _] in snapshot (del park-queues k))
+        (each [_ q] in snapshot
+          (each fiber in q
+            (add scheduler-killed fiber)
+            (let [[ok? _] (protect (fiber/abort fiber {:error :shutdown}))]
+              (when ok? (handle-fiber-after-resume fiber))))))
+
+      # Phase 2: drain cancel CQEs and let aborted fibers unwind
       (when (> timeout-ms 0)
         (let [deadline (+ (clock/monotonic) (/ timeout-ms 1000.0))]
           (while (and (> (+ (length runnable) (length pending)) 0)
@@ -1495,9 +1514,11 @@
         (del pending id)
         (del fiber-io fiber)
         (io/cancel backend id)
+        (add scheduler-killed fiber)
         (protect (fiber/cancel fiber {:error :shutdown})))
       (while (> (length runnable) 0)
         (let [fiber (pop runnable)]
+          (add scheduler-killed fiber)
           (protect (fiber/cancel fiber {:error :shutdown})))))
 
     (defn step [timeout-ms]
@@ -1523,9 +1544,14 @@
      :pump  # pump-fn: event loop
       (fn ()
         (block :loop
-          (forever (when (= (step (- 0 1)) :done) (break :loop nil))))  # Crash on unjoined errored fibers — never swallow errors silently
+          (forever (when (= (step (- 0 1)) :done) (break :loop nil))))  # Crash on unjoined errored fibers — never swallow errors silently.
+        # scheduler-killed fibers are excluded: we injected their :shutdown
+        # at teardown time, so re-raising would surface our own signal as a
+        # user error.
         (each [fiber status] in (pairs completed)
-          (when (and (= status :error) (not (contains? joined fiber)))
+          (when (and (= status :error)
+                     (not (contains? joined fiber))
+                     (not (contains? scheduler-killed fiber)))
             (error (fiber/value fiber)))))
      :shutdown  # shutdown-fn: signal shutdown
       (fn (timeout-ms) (put shutdown-req 0 timeout-ms))

--- a/tests/elle/parameters.lisp
+++ b/tests/elle/parameters.lisp
@@ -75,6 +75,77 @@
              (fiber/value f)) 99)
         "child fiber sees parent default outside parameterize")
 
+# === Fiber captures parameter at CREATION, not at first resume ===
+#
+# Regression: previously, parameter inheritance happened on first resume
+# from the resuming fiber, not at fiber creation. That broke ev/spawn
+# style usage where the spawner finishes (and its parameterize unwinds)
+# before the scheduler ever gets around to resuming the child. Repro:
+# create the fiber inside parameterize, then exit the parameterize block
+# before resuming. The child must still see the parameterized value.
+
+(def p7 (parameter :default))
+(let [f (parameterize ((p7 :inside))
+          (fiber/new (fn () (p7)) 1))]
+  # parameterize has unwound — p7 is back to :default here
+  (assert (= (p7) :default) "p7 is :default outside parameterize")
+  (fiber/resume f nil)
+  (assert (= (fiber/value f) :inside)
+          "fiber sees :inside (creation-time snapshot), not :default"))
+
+# === Creation snapshot is independent of resumer's bindings ===
+#
+# The fiber's snapshot must NOT be overridden by whatever bindings the
+# resuming fiber happens to have when fiber/resume is called.
+
+(def p8 (parameter :default))
+(let [f (parameterize ((p8 :captured))
+          (fiber/new (fn () (p8)) 1))]
+  (parameterize ((p8 :resumer-has-this))
+    (fiber/resume f nil))
+  (assert (= (fiber/value f) :captured)
+          "fiber observes creation-time value, ignoring resumer's binding"))
+
+# === Nested parameterize: child captures innermost value at creation ===
+
+(def p9 (parameter 1))
+(let [f (parameterize ((p9 2))
+          (parameterize ((p9 3))
+            (fiber/new (fn () (p9)) 1)))]
+  (fiber/resume f nil)
+  (assert (= (fiber/value f) 3)
+          "child fiber captures innermost parameterize binding"))
+
+# === Multiple parameters: all are captured ===
+
+(def pa (parameter :pa-default))
+(def pb (parameter :pb-default))
+(let [f (parameterize ((pa :pa-val)
+                       (pb :pb-val))
+          (fiber/new (fn () (list (pa) (pb))) 1))]
+  (fiber/resume f nil)
+  (let [r (fiber/value f)]
+    (assert (= (get r 0) :pa-val) "fiber sees pa binding")
+    (assert (= (get r 1) :pb-val) "fiber sees pb binding")))
+
+# === Child of a child inherits transitively ===
+#
+# A fiber created inside an already-running fiber should snapshot the
+# inner fiber's view of parameters, which in turn was snapshotted from
+# the outer's view at creation.
+
+(def pc (parameter :default))
+(let [outer (parameterize ((pc :outer-set))
+              (fiber/new
+                (fn ()
+                  (let [inner (fiber/new (fn () (pc)) 1)]
+                    (fiber/resume inner nil)
+                    (fiber/value inner)))
+                1))]
+  (fiber/resume outer nil)
+  (assert (= (fiber/value outer) :outer-set)
+          "grandchild fiber sees grandparent's parameterize binding"))
+
 # ============================================================================
 # Type and error tests (from integration/parameters.rs)
 # ============================================================================

--- a/tests/elle/redis.lisp
+++ b/tests/elle/redis.lisp
@@ -2,9 +2,16 @@
 # tests/elle/redis.lisp — Redis integration tests
 #
 # Requires a live Redis on 127.0.0.1:6379.
-# All tests run within a single connection to avoid parallel flushdb races.
+# All tests run within a single connection; the test cleans up only its own
+# "test:*" keys via SCAN+DEL so it never touches db0 (or any db) as a whole.
 
 (def redis ((import-file "lib/redis.lisp")))
+
+# Delete only keys created by this test (prefix "test:"), so we never run
+# FLUSHDB / FLUSHALL against a shared Redis. Safe to call when no keys match.
+(defn clear-test-keys []
+  (let [keys (redis:scan-all redis:scan :match "test:*")]
+    (when (not (empty? keys)) (apply redis:del keys))))
 
 # RESP self-tests (no Redis needed)
 (println "Running RESP self-tests...")
@@ -32,7 +39,7 @@
               (assert (= (redis:echo "hello") "hello") "echo")
               (println "  echo: ok")
 
-              (redis:flushdb)
+              (clear-test-keys)
 
               # ── String commands ─────────────────────────────────────────────
 
@@ -202,7 +209,7 @@
               # 2. Stress tests
               # ================================================================
 
-              (redis:flushdb)
+              (clear-test-keys)
 
               # 100 PINGs
               (def @i 0)
@@ -225,7 +232,7 @@
               (println "  50 set/get pairs: ok")
 
               # Mixed response types
-              (redis:flushdb)
+              (clear-test-keys)
               (redis:set "test:k1" "v1")
               (redis:get "test:k1")
               (redis:get "test:nonexistent")
@@ -249,7 +256,26 @@
                       "stress exists false")
               (println "  mixed commands: ok")
 
+              # ── ev/spawn inside redis-with ─────────────────────────────────
+              #
+              # Regression: redis:with binds *redis-port* via parameterize.
+              # A fiber spawned with ev/spawn inside the body is resumed
+              # later by the scheduler, whose own param_frames do not
+              # contain *redis-port*.  Only creation-time inheritance in
+              # fiber/new makes the child see the connection.  Without it
+              # the redis:get call fails with :no-connection.
+
+              (redis:set "test:spawn-canary" "preset")
+              (let [result-box (box nil)
+                    f (ev/spawn (fn []
+                                  (rebox result-box
+                                         (redis:get "test:spawn-canary"))))]
+                (ev/join f)
+                (assert (= (unbox result-box) "preset")
+                        "spawned fiber sees *redis-port* inherited from spawner"))
+              (println "  ev/spawn inside redis-with: ok")
+
               # ── Cleanup ─────────────────────────────────────────────────────
 
-              (redis:flushdb)
+              (clear-test-keys)
               (println "redis: all tests passed")))

--- a/tests/integration/elle_scripts.rs
+++ b/tests/integration/elle_scripts.rs
@@ -89,3 +89,8 @@ fn websocket() {
 fn table_key_expand() {
     run_elle_script("table-key-expand");
 }
+
+#[test]
+fn parameters() {
+    run_elle_script("parameters");
+}


### PR DESCRIPTION
Parameter inheritance into child fibers was previously done at first resume, copying the *resumer's* param_frames. That breaks ev/spawn: the spawner's parameterize blocks unwind long before the scheduler gets around to resuming the spawned fiber, so the resumer (the scheduler) carries none of the bindings the user actually meant to propagate. Move the snapshot to fiber/new time so the child captures its creator's bindings — matching Racket's thread-parameterization semantics — and the resumer-time path becomes a no-op fallback for fibers constructed outside fiber/new.

Removes the transitional :inherit opt-in keyword on fiber/new; parameter inheritance is unconditional and not an opt-in.

Adjacent fixes that fall out of the new creator-snapshot semantics:

  - lib/process.lisp: move (sched-spawn init) inside the (parameterize ((*spawn* sched-spawn-fn)) ...) block. The init fiber is created by sched-spawn; under creator-snapshot it must capture sched-spawn-fn — not the outer scheduler's *spawn* — as its parameter environment. Without this, ev/spawn from inside any process routed sub-fibers to the wrong scheduler and they only ran by luck of later I/O yields.

  - stdlib.lisp (make-async-scheduler): add a scheduler-killed set and a do-shutdown phase that aborts futex-parked fibers. Without the drain, long-lived fibers blocked on chan:take / sync locks never get cleaned up and step never sees park-queues empty, so explicit ev/shutdown couldn't actually terminate pump. Aborted fibers go into scheduler-killed (not joined), and the pump's unjoined-error tail consults both sets — distinguishing 'user observed this' from 'we injected :shutdown ourselves' so defer-time errors during shutdown aren't misattributed to user code.

  - tests/elle/redis.lisp: drop redis:flushdb in favor of a test:*-prefixed SCAN+DEL helper so the suite never wipes a shared Redis.

Regression tests cover: resume-after-unwound-parameterize, resumer-doesn't-override-creator, nested parameterize, multiple parameters, transitive grandchild inheritance, ev/spawn inside redis:with (the original repro that prompted the redis-global workaround), and process:start spawning sub-fibers via ev/spawn.