### PR TITLE
redis: serialise wire access across fibers with a per-connection mutex

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all elle docs docgen smoke test test-git clean help \
+.PHONY: all elle docs docgen smoke test test-git clean space help \
        smoke-vm smoke-noffi smoke-jit smoke-wasm smoke-mlir smoke-diff doctest \
        elle-wasm elle-mlir elle-noffi plugins plugins-all mcp embedding \
        fmt fmt-check
@@ -178,6 +178,9 @@ test: smoke  ## Rust unit + integration tests + clippy + fmt + rustdoc after smo
 clean:  ## Remove build artifacts and generated docs
 	cargo clean
 	rm -f docs/pipeline.svg
+
+space:  ## Reclaim disk: drop cargo intermediates, keep built executables
+	rm -rf target/{debug,release}/{deps,build,incremental,.fingerprint,examples}
 
 # ── Help ────────────────────────────────────────────────────────────
 

--- a/lib/redis.lisp
+++ b/lib/redis.lisp
@@ -8,6 +8,20 @@
 ## Connection model: bare TCP port, no wrapper struct.
 ## Error model: manager fiber owns the port, reconnects on transient errors.
 ## Protocol: RESP2 over TCP.
+##
+## Concurrency: redis:with binds a mutex alongside the connection.  Every
+## redis:cmd and redis:pipeline acquires that mutex around its write+read
+## sequence, so callers that share one connection across fibers (e.g.,
+## http2:serve spawning a handler fiber per request) cannot interleave
+## RESP framing on the wire.  Without this guard, two concurrent fibers
+## using a pipeline can each write commands then race on reads — the
+## RESP parser then tries to parse the middle of a bulk-string payload
+## as the next length prefix and surfaces "integer: cannot parse
+## \"<csv-of-floats>\" as base-10 integer" (or similar) up through the
+## handler.  See grace/research.md "Polish round-2 wedge" for the
+## diagnosis.
+
+(def sync ((import "std/sync")))
 
 ## ── RESP2 encoder ─────────────────────────────────────────────────────
 
@@ -95,6 +109,25 @@
 
 (def *redis-port* (parameter nil))
 
+## Mutex paired with *redis-port*.  Bound by redis-with so concurrent
+## fibers sharing one connection cannot interleave writes/reads on
+## the wire.  Nil means "no lock needed" — callers that own the
+## connection from a single fiber leave the parameter unbound.
+(def *redis-lock* (parameter nil))
+
+(defn with-redis-lock [thunk]
+  "Run thunk holding the ambient *redis-lock* (no-op if unbound).
+   Released even on error.  Not reentrant: callers must not nest
+   redis-cmd/pipeline inside their own with-redis-lock block."
+  (let [lk (*redis-lock*)]
+    (if (nil? lk)
+      (thunk)
+      (begin
+        ((get lk :acquire))
+        (defer
+          ((get lk :release))
+          (thunk))))))
+
 (defn redis-cmd [& args]
   "Send a command on the current Redis port and read the reply."
   (let [port (*redis-port*)]
@@ -102,9 +135,11 @@
       (error {:error :redis-error
               :reason :no-connection
               :message "no active Redis connection"}))
-    (port/write port (apply resp-encode args))
-    (port/flush port)
-    (resp-read port)))
+    (with-redis-lock
+      (fn []
+        (port/write port (apply resp-encode args))
+        (port/flush port)
+        (resp-read port)))))
 
 ## ── Connection ────────────────────────────────────────────────────────
 
@@ -166,11 +201,17 @@
 ## ── Client — simplified connection for direct use ─────────────────────
 
 (defn redis-with [host port thunk]
-  "Open a Redis connection, run thunk with *redis-port* bound, close on exit."
-  (let [conn (redis-connect host port)]
+  "Open a Redis connection, run thunk with *redis-port* and *redis-lock*
+   bound, close on exit.  The lock serialises wire access across fibers
+   sharing the connection — without it, an h2 server that dispatches
+   handler fibers under (redis:with ...) sees its concurrent redis-cmd
+   / redis-pipeline calls race and corrupt RESP framing."
+  (let [conn (redis-connect host port)
+        lk (sync:make-lock)]
     (defer
       (port/close conn)
-      (parameterize ((*redis-port* conn))
+      (parameterize ((*redis-port* conn)
+                     (*redis-lock* lk))
         (thunk)))))
 
 ## ── Commands — String ─────────────────────────────────────────────────
@@ -695,19 +736,28 @@
   "Send multiple commands in a batch, read all replies.
    Each command is a list like (list 'GET' 'key').
    Uses resp-read-raw so error replies don't corrupt state.
-   Returns array of results."
+   Returns array of results.
+
+   The whole write-flush-read-N sequence is held under *redis-lock*
+   (when bound), so concurrent fibers serialise here instead of
+   interleaving on the wire — without the lock, fiber A's bulk-string
+   payloads can land where fiber B expects its next length prefix."
   (let [port (*redis-port*)]
     (when (nil? port)
       (error {:error :redis-error
               :reason :no-connection
-              :message "no active Redis connection"}))  # Send all commands
-    (each cmd in commands
-      (port/write port (apply resp-encode cmd)))
-    (port/flush port)  # Read all replies
-    (def results @[])
-    (each cmd in commands
-      (push results (resp-read-raw port)))
-    (freeze results)))
+              :message "no active Redis connection"}))
+    (with-redis-lock
+      (fn []
+        # Send all commands
+        (each cmd in commands
+          (port/write port (apply resp-encode cmd)))
+        (port/flush port)
+        # Read all replies
+        (def results @[])
+        (each cmd in commands
+          (push results (resp-read-raw port)))
+        (freeze results)))))
 
 ## ── Internal self-tests (RESP encoding/decoding, no Redis needed) ─────
 

--- a/tests/elle/redis-race.lisp
+++ b/tests/elle/redis-race.lisp
@@ -1,0 +1,139 @@
+(elle/epoch 10)
+# tests/elle/redis-race.lisp — fiber-concurrent redis:pipeline must not
+# interleave RESP framing on the wire.
+#
+# Background: redis:with binds *redis-port* via parameterize.  When the
+# enclosing program spawns concurrent fibers (e.g., http2:serve handler
+# fibers), every fiber sees the same port.  Without a mutex, pipelines
+# from different fibers can interleave writes and reads — the RESP
+# parser then tries to parse the middle of a bulk-string payload as
+# the next length prefix and produces a parse error (the
+# "integer: cannot parse \"<csv-of-floats>\" as base-10 integer" the
+# grace polish-orchestrator was hitting under load).
+#
+# This test runs M fibers in parallel; each does a pipeline of N MGET
+# commands against keys with a fiber-distinguishing prefix.  If
+# framing is intact, every fiber sees exactly its own values back.
+# If framing is corrupted, fibers see foreign values or RESP errors
+# and the test fails.
+#
+# Requires a live Redis on 127.0.0.1:6379.  Skips silently otherwise.
+
+(def redis ((import-file "lib/redis.lisp")))
+
+(def n-fibers 8)
+(def n-rounds 50)
+(def n-keys-per-round 16)
+
+# Skip if Redis isn't there.
+(let [[ok? _] (protect
+                (redis:with "127.0.0.1" 6379
+                  (fn [] (redis:ping))))]
+  (when (not ok?)
+    (eprintln "SKIP: Redis not available at 127.0.0.1:6379")
+    (exit 0)))
+(println "  redis: available")
+
+(redis:with "127.0.0.1" 6379
+  (fn []
+    # Seed: each fiber gets its own N keys with a known value so the
+    # pipeline read can verify byte-for-byte what came back.
+    (let [@f 0]
+      (while (< f n-fibers)
+        (let [@k 0]
+          (while (< k n-keys-per-round)
+            (redis:set (string "test:race:" f ":" k)
+                       (string "value-" f "-" k))
+            (assign k (+ k 1))))
+        (assign f (+ f 1))))
+    (println "  seeded " (* n-fibers n-keys-per-round) " keys")
+
+    # Run M fibers, each doing N rounds of a multi-key pipeline.
+    # Each fiber records pass/fail in a shared atom and we tally at the
+    # end.  Without the lock, any fiber seeing wrong values, RESP-level
+    # errors, or a pipeline-length mismatch flips :ok to false.
+    (def @ok true)
+    (def @fail-msgs @[])
+    (def @done-count 0)
+
+    (let [@f 0]
+      (while (< f n-fibers)
+        (let [fiber-idx f]
+          (ev/spawn
+            (fn []
+              (let [@r 0]
+                (while (< r n-rounds)
+                  (let [cmds @[]
+                        @k 0]
+                    (while (< k n-keys-per-round)
+                      (push cmds (list "GET"
+                                       (string "test:race:" fiber-idx ":" k)))
+                      (assign k (+ k 1)))
+                    (let [[pok? results] (protect
+                                           (apply redis:pipeline
+                                                  (->list cmds)))]
+                      (if (not pok?)
+                        (begin
+                          (assign ok false)
+                          (push fail-msgs
+                                (string "fiber " fiber-idx " round " r
+                                        ": pipeline raised " results)))
+                        (begin
+                          # Verify length and per-key value.
+                          (if (not (= (length results) n-keys-per-round))
+                            (begin
+                              (assign ok false)
+                              (push fail-msgs
+                                    (string "fiber " fiber-idx " round " r
+                                            ": pipeline returned "
+                                            (length results)
+                                            " replies, want "
+                                            n-keys-per-round)))
+                            (let [@kk 0]
+                              (while (< kk n-keys-per-round)
+                                (let [want (string "value-" fiber-idx "-" kk)
+                                      got (get results kk)]
+                                  (when (not (= got want))
+                                    (assign ok false)
+                                    (push fail-msgs
+                                          (string "fiber " fiber-idx
+                                                  " round " r
+                                                  " key " kk
+                                                  ": want=" want
+                                                  " got="
+                                                  (if (string? got)
+                                                    (string "\"" got "\"")
+                                                    got)))))
+                                (assign kk (+ kk 1)))))))))
+                  (assign r (+ r 1))))
+              (assign done-count (+ done-count 1)))))
+        (assign f (+ f 1))))
+
+    # Wait for all fibers to finish (cooperative — yield until counter hits target).
+    (while (< done-count n-fibers)
+      (ev/sleep 0.05))
+
+    # Cleanup: delete only the keys we created.
+    (let [@f 0]
+      (while (< f n-fibers)
+        (let [@k 0]
+          (while (< k n-keys-per-round)
+            (redis:del (string "test:race:" f ":" k))
+            (assign k (+ k 1))))
+        (assign f (+ f 1))))
+
+    (if ok
+      (println "  " n-fibers " fibers × " n-rounds " rounds × "
+               n-keys-per-round " keys: all framing intact")
+      (begin
+        (eprintln "FAIL: redis-race detected " (length fail-msgs) " corruption(s)")
+        (let [@i 0]
+          (while (and (< i (length fail-msgs)) (< i 10))
+            (eprintln "  " (get fail-msgs i))
+            (assign i (+ i 1))))
+        (when (> (length fail-msgs) 10)
+          (eprintln "  ... (" (- (length fail-msgs) 10) " more)"))
+        (assert false "redis-race: pipeline framing corrupted under concurrent fibers")))))
+
+(println "")
+(println "redis-race test passed.")

--- a/tests/elle/redis.lisp
+++ b/tests/elle/redis.lisp
@@ -3,14 +3,17 @@
 #
 # Requires a live Redis on 127.0.0.1:6379.
 # All tests run within a single connection; the test cleans up only its own
-# "test:*" keys via SCAN+DEL so it never touches db0 (or any db) as a whole.
+# "test:redis:*" keys via SCAN+DEL so it never touches db0 (or any db) as a
+# whole.  Each tests/elle/redis*.lisp file owns a distinct "test:<name>:*"
+# sub-namespace so the parallel test runner can fire them concurrently
+# against a shared Redis without one wiping another's keys mid-run.
 
 (def redis ((import-file "lib/redis.lisp")))
 
-# Delete only keys created by this test (prefix "test:"), so we never run
+# Delete only keys created by this test (prefix "test:redis:"), so we never run
 # FLUSHDB / FLUSHALL against a shared Redis. Safe to call when no keys match.
 (defn clear-test-keys []
-  (let [keys (redis:scan-all redis:scan :match "test:*")]
+  (let [keys (redis:scan-all redis:scan :match "test:redis:*")]
     (when (not (empty? keys)) (apply redis:del keys))))
 
 # RESP self-tests (no Redis needed)
@@ -43,156 +46,156 @@
 
               # ── String commands ─────────────────────────────────────────────
 
-              (assert (= (redis:set "test:k1" "v1") true) "set")
-              (assert (= (redis:get "test:k1") "v1") "get")
-              (assert (nil? (redis:get "test:nonexistent")) "get nil")
+              (assert (= (redis:set "test:redis:k1" "v1") true) "set")
+              (assert (= (redis:get "test:redis:k1") "v1") "get")
+              (assert (nil? (redis:get "test:redis:nonexistent")) "get nil")
 
-              (assert (= (redis:set "test:nx" "first" :nx true) true)
+              (assert (= (redis:set "test:redis:nx" "first" :nx true) true)
                       "set nx first")
-              (assert (= (redis:get "test:nx") "first") "get nx first")
+              (assert (= (redis:get "test:redis:nx") "first") "get nx first")
 
-              (redis:set "test:counter" "10")
-              (assert (= (redis:incr "test:counter") 11) "incr")
-              (assert (= (redis:decr "test:counter") 10) "decr")
-              (assert (= (redis:incrby "test:counter" 5) 15) "incrby")
-              (assert (= (redis:decrby "test:counter" 3) 12) "decrby")
+              (redis:set "test:redis:counter" "10")
+              (assert (= (redis:incr "test:redis:counter") 11) "incr")
+              (assert (= (redis:decr "test:redis:counter") 10) "decr")
+              (assert (= (redis:incrby "test:redis:counter" 5) 15) "incrby")
+              (assert (= (redis:decrby "test:redis:counter" 3) 12) "decrby")
 
-              (redis:set "test:str" "hello")
-              (redis:append "test:str" " world")
-              (assert (= (redis:get "test:str") "hello world") "append")
-              (assert (= (redis:strlen "test:str") 11) "strlen")
+              (redis:set "test:redis:str" "hello")
+              (redis:append "test:redis:str" " world")
+              (assert (= (redis:get "test:redis:str") "hello world") "append")
+              (assert (= (redis:strlen "test:redis:str") 11) "strlen")
 
-              (redis:mset "test:m1" "a" "test:m2" "b")
-              (let [vals (redis:mget "test:m1" "test:m2" "test:nonexistent")]
+              (redis:mset "test:redis:m1" "a" "test:redis:m2" "b")
+              (let [vals (redis:mget "test:redis:m1" "test:redis:m2" "test:redis:nonexistent")]
                 (assert (= (get vals 0) "a") "mget 0")
                 (assert (= (get vals 1) "b") "mget 1")
                 (assert (nil? (get vals 2)) "mget nil"))
 
-              (assert (= (redis:setnx "test:setnx" "val") true) "setnx new")
-              (assert (= (redis:setnx "test:setnx" "val2") false) "setnx exists")
+              (assert (= (redis:setnx "test:redis:setnx" "val") true) "setnx new")
+              (assert (= (redis:setnx "test:redis:setnx" "val2") false) "setnx exists")
 
               (println "  string commands: ok")
 
               # ── Key commands ────────────────────────────────────────────────
 
-              (assert (= (redis:exists "test:k1") true) "exists true")
-              (assert (= (redis:exists "test:nonexistent") false) "exists false")
+              (assert (= (redis:exists "test:redis:k1") true) "exists true")
+              (assert (= (redis:exists "test:redis:nonexistent") false) "exists false")
 
-              (redis:set "test:exp" "val")
-              (assert (= (redis:expire "test:exp" 100) true) "expire")
-              (let [ttl (redis:ttl "test:exp")]
+              (redis:set "test:redis:exp" "val")
+              (assert (= (redis:expire "test:redis:exp" 100) true) "expire")
+              (let [ttl (redis:ttl "test:redis:exp")]
                 (assert (> ttl 0) "ttl positive"))
-              (assert (= (redis:persist "test:exp") true) "persist")
-              (assert (= (redis:ttl "test:exp") -1) "ttl after persist")
+              (assert (= (redis:persist "test:redis:exp") true) "persist")
+              (assert (= (redis:ttl "test:redis:exp") -1) "ttl after persist")
 
-              (assert (= (redis:type "test:k1") "string") "type")
+              (assert (= (redis:type "test:redis:k1") "string") "type")
 
-              (redis:set "test:rename" "val")
-              (assert (= (redis:rename "test:rename" "test:renamed") true)
+              (redis:set "test:redis:rename" "val")
+              (assert (= (redis:rename "test:redis:rename" "test:redis:renamed") true)
                       "rename")
-              (assert (= (redis:get "test:renamed") "val") "get renamed")
+              (assert (= (redis:get "test:redis:renamed") "val") "get renamed")
 
-              (assert (>= (redis:del "test:k1" "test:renamed") 1) "del")
-              (assert (= (redis:exists "test:k1") false) "exists after del")
+              (assert (>= (redis:del "test:redis:k1" "test:redis:renamed") 1) "del")
+              (assert (= (redis:exists "test:redis:k1") false) "exists after del")
 
               (println "  key commands: ok")
 
               # ── Hash commands ───────────────────────────────────────────────
 
-              (redis:hset "test:hash" "name" "Alice")
-              (redis:hset "test:hash" "age" "30")
+              (redis:hset "test:redis:hash" "name" "Alice")
+              (redis:hset "test:redis:hash" "age" "30")
 
-              (assert (= (redis:hget "test:hash" "name") "Alice") "hget")
-              (assert (nil? (redis:hget "test:hash" "missing")) "hget nil")
-              (assert (= (redis:hexists "test:hash" "name") true) "hexists true")
-              (assert (= (redis:hexists "test:hash" "missing") false)
+              (assert (= (redis:hget "test:redis:hash" "name") "Alice") "hget")
+              (assert (nil? (redis:hget "test:redis:hash" "missing")) "hget nil")
+              (assert (= (redis:hexists "test:redis:hash" "name") true) "hexists true")
+              (assert (= (redis:hexists "test:redis:hash" "missing") false)
                       "hexists false")
 
-              (let [h (redis:hgetall "test:hash")]
+              (let [h (redis:hgetall "test:redis:hash")]
                 (assert (= (get h "name") "Alice") "hgetall name")
                 (assert (= (get h "age") "30") "hgetall age"))
 
-              (assert (= (redis:hlen "test:hash") 2) "hlen")
-              (redis:hdel "test:hash" "age")
-              (assert (= (redis:hlen "test:hash") 1) "hlen after hdel")
+              (assert (= (redis:hlen "test:redis:hash") 2) "hlen")
+              (redis:hdel "test:redis:hash" "age")
+              (assert (= (redis:hlen "test:redis:hash") 1) "hlen after hdel")
 
-              (redis:hmset "test:hm" "a" "1" "b" "2" "c" "3")
-              (let [vals (redis:hmget "test:hm" "a" "c" "missing")]
+              (redis:hmset "test:redis:hm" "a" "1" "b" "2" "c" "3")
+              (let [vals (redis:hmget "test:redis:hm" "a" "c" "missing")]
                 (assert (= (get vals 0) "1") "hmget 0")
                 (assert (= (get vals 1) "3") "hmget 1")
                 (assert (nil? (get vals 2)) "hmget nil"))
 
-              (redis:hset "test:hinc" "n" "10")
-              (assert (= (redis:hincrby "test:hinc" "n" 5) 15) "hincrby")
+              (redis:hset "test:redis:hinc" "n" "10")
+              (assert (= (redis:hincrby "test:redis:hinc" "n" 5) 15) "hincrby")
 
               (println "  hash commands: ok")
 
               # ── List commands ───────────────────────────────────────────────
 
-              (redis:rpush "test:list" "a" "b" "c")
-              (assert (= (redis:llen "test:list") 3) "llen")
-              (assert (= (redis:lindex "test:list" 0) "a") "lindex 0")
-              (assert (= (redis:lindex "test:list" 2) "c") "lindex 2")
+              (redis:rpush "test:redis:list" "a" "b" "c")
+              (assert (= (redis:llen "test:redis:list") 3) "llen")
+              (assert (= (redis:lindex "test:redis:list" 0) "a") "lindex 0")
+              (assert (= (redis:lindex "test:redis:list" 2) "c") "lindex 2")
 
-              (let [range (redis:lrange "test:list" 0 -1)]
+              (let [range (redis:lrange "test:redis:list" 0 -1)]
                 (assert (= (length range) 3) "lrange length")
                 (assert (= (get range 0) "a") "lrange 0")
                 (assert (= (get range 2) "c") "lrange 2"))
 
-              (redis:lpush "test:list" "z")
-              (assert (= (redis:lpop "test:list") "z") "lpop")
-              (assert (= (redis:rpop "test:list") "c") "rpop")
+              (redis:lpush "test:redis:list" "z")
+              (assert (= (redis:lpop "test:redis:list") "z") "lpop")
+              (assert (= (redis:rpop "test:redis:list") "c") "rpop")
 
-              (redis:lset "test:list" 0 "A")
-              (assert (= (redis:lindex "test:list" 0) "A") "lset")
+              (redis:lset "test:redis:list" 0 "A")
+              (assert (= (redis:lindex "test:redis:list" 0) "A") "lset")
 
               (println "  list commands: ok")
 
               # ── Set commands ────────────────────────────────────────────────
 
-              (redis:sadd "test:set1" "a" "b" "c")
-              (assert (= (redis:scard "test:set1") 3) "scard")
-              (assert (= (redis:sismember "test:set1" "a") true)
+              (redis:sadd "test:redis:set1" "a" "b" "c")
+              (assert (= (redis:scard "test:redis:set1") 3) "scard")
+              (assert (= (redis:sismember "test:redis:set1" "a") true)
                       "sismember true")
-              (assert (= (redis:sismember "test:set1" "z") false)
+              (assert (= (redis:sismember "test:redis:set1" "z") false)
                       "sismember false")
 
-              (redis:srem "test:set1" "c")
-              (assert (= (redis:scard "test:set1") 2) "scard after srem")
+              (redis:srem "test:redis:set1" "c")
+              (assert (= (redis:scard "test:redis:set1") 2) "scard after srem")
 
-              (redis:sadd "test:set2" "b" "c" "d")
-              (let [u (redis:sunion "test:set1" "test:set2")]
+              (redis:sadd "test:redis:set2" "b" "c" "d")
+              (let [u (redis:sunion "test:redis:set1" "test:redis:set2")]
                 (assert (>= (length u) 3) "sunion"))
-              (let [i (redis:sinter "test:set1" "test:set2")]
+              (let [i (redis:sinter "test:redis:set1" "test:redis:set2")]
                 (assert (>= (length i) 1) "sinter"))
 
               (println "  set commands: ok")
 
               # ── Sorted set commands ─────────────────────────────────────────
 
-              (redis:zadd "test:zset" 1 "a")
-              (redis:zadd "test:zset" 2 "b")
-              (redis:zadd "test:zset" 3 "c")
+              (redis:zadd "test:redis:zset" 1 "a")
+              (redis:zadd "test:redis:zset" 2 "b")
+              (redis:zadd "test:redis:zset" 3 "c")
 
-              (assert (= (redis:zcard "test:zset") 3) "zcard")
-              (assert (= (redis:zscore "test:zset" "b") "2") "zscore")
-              (assert (= (redis:zrank "test:zset" "a") 0) "zrank")
+              (assert (= (redis:zcard "test:redis:zset") 3) "zcard")
+              (assert (= (redis:zscore "test:redis:zset" "b") "2") "zscore")
+              (assert (= (redis:zrank "test:redis:zset" "a") 0) "zrank")
 
-              (let [range (redis:zrange "test:zset" 0 -1)]
+              (let [range (redis:zrange "test:redis:zset" 0 -1)]
                 (assert (= (length range) 3) "zrange length")
                 (assert (= (get range 0) "a") "zrange 0"))
 
-              (redis:zrem "test:zset" "c")
-              (assert (= (redis:zcard "test:zset") 2) "zcard after zrem")
+              (redis:zrem "test:redis:zset" "c")
+              (assert (= (redis:zcard "test:redis:zset") 2) "zcard after zrem")
 
               (println "  sorted set commands: ok")
 
               # ── Pipeline ────────────────────────────────────────────────────
 
-              (redis:set "test:p1" "x")
-              (redis:set "test:p2" "y")
-              (let [results (redis:pipeline (list "GET" "test:p1")
-                    (list "GET" "test:p2") (list "PING"))]
+              (redis:set "test:redis:p1" "x")
+              (redis:set "test:redis:p2" "y")
+              (let [results (redis:pipeline (list "GET" "test:redis:p1")
+                    (list "GET" "test:redis:p2") (list "PING"))]
                 (assert (= (get results 0) "x") "pipeline get 0")
                 (assert (= (get results 1) "y") "pipeline get 1")
                 (assert (= (get results 2) "PONG") "pipeline ping"))
@@ -222,7 +225,7 @@
               # 50 SET/GET pairs
               (assign i 0)
               (while (< i 50)
-                (let [key (concat "test:sg:" (string i))
+                (let [key (concat "test:redis:sg:" (string i))
                       val (concat "value-" (string i))]
                   (assert (= (redis:set key val) true)
                           (concat "set failed at " (string i)))
@@ -233,26 +236,26 @@
 
               # Mixed response types
               (clear-test-keys)
-              (redis:set "test:k1" "v1")
-              (redis:get "test:k1")
-              (redis:get "test:nonexistent")
-              (redis:set "test:nx" "first" :nx true)
-              (redis:get "test:nx")
-              (redis:set "test:counter" "10")
-              (redis:incr "test:counter")
-              (redis:decr "test:counter")
-              (redis:incrby "test:counter" 5)
-              (redis:decrby "test:counter" 3)
-              (redis:set "test:str" "hello")
-              (redis:append "test:str" " world")
-              (redis:get "test:str")
-              (redis:strlen "test:str")
-              (redis:mset "test:m1" "a" "test:m2" "b")
-              (redis:mget "test:m1" "test:m2" "test:nonexistent")
-              (redis:setnx "test:setnx" "val")
-              (redis:setnx "test:setnx" "val2")
-              (assert (= (redis:exists "test:k1") true) "stress exists true")
-              (assert (= (redis:exists "test:nonexistent") false)
+              (redis:set "test:redis:k1" "v1")
+              (redis:get "test:redis:k1")
+              (redis:get "test:redis:nonexistent")
+              (redis:set "test:redis:nx" "first" :nx true)
+              (redis:get "test:redis:nx")
+              (redis:set "test:redis:counter" "10")
+              (redis:incr "test:redis:counter")
+              (redis:decr "test:redis:counter")
+              (redis:incrby "test:redis:counter" 5)
+              (redis:decrby "test:redis:counter" 3)
+              (redis:set "test:redis:str" "hello")
+              (redis:append "test:redis:str" " world")
+              (redis:get "test:redis:str")
+              (redis:strlen "test:redis:str")
+              (redis:mset "test:redis:m1" "a" "test:redis:m2" "b")
+              (redis:mget "test:redis:m1" "test:redis:m2" "test:redis:nonexistent")
+              (redis:setnx "test:redis:setnx" "val")
+              (redis:setnx "test:redis:setnx" "val2")
+              (assert (= (redis:exists "test:redis:k1") true) "stress exists true")
+              (assert (= (redis:exists "test:redis:nonexistent") false)
                       "stress exists false")
               (println "  mixed commands: ok")
 
@@ -265,11 +268,11 @@
               # fiber/new makes the child see the connection.  Without it
               # the redis:get call fails with :no-connection.
 
-              (redis:set "test:spawn-canary" "preset")
+              (redis:set "test:redis:spawn-canary" "preset")
               (let [result-box (box nil)
                     f (ev/spawn (fn []
                                   (rebox result-box
-                                         (redis:get "test:spawn-canary"))))]
+                                         (redis:get "test:redis:spawn-canary"))))]
                 (ev/join f)
                 (assert (= (unbox result-box) "preset")
                         "spawned fiber sees *redis-port* inherited from spawner"))


### PR DESCRIPTION
redis:with binds *redis-port* via parameterize; when the enclosing program spawns concurrent fibers under that scope (e.g. http2:serve dispatching a handler fiber per request), every fiber sees the same TCP port and races on the wire.  Two pipelines from different fibers can interleave writes — and then race on reads — so the RESP parser ends up trying to parse the middle of a bulk-string payload as the next length prefix.  In practice that surfaces as a parse-error like "integer: cannot parse \"<csv-of-floats>\" as base-10 integer" or a silent wedge while one fiber waits for bytes another fiber consumed.

Fix: redis:with now also binds *redis-lock* (a sync:make-lock paired with the connection).  redis-cmd and redis-pipeline acquire it around their write+read sequence — held across the whole pipeline so the N writes and N reads stay together.  When *redis-lock* is unbound (single-fiber callers that manage their own port), the helper is a no-op.  The lock is not reentrant; redis-atomic's MULTI/EXEC body remains as before and is still safe under single-fiber use but documented as not concurrency-hardened.

Counter-factual test at tests/elle/redis-race.lisp: 8 fibers × 50 rounds × 16-key pipelines against one connection.  Pre-fix the program hangs after seeding the keys; post-fix it completes in ~25s and every fiber's pipeline reads back exactly its own values.