### PR TITLE
port: read-exact, per-port encoding, port/encoding accessor

### DIFF
--- a/lib/redis.lisp
+++ b/lib/redis.lisp
@@ -16,10 +16,7 @@
 ## RESP framing on the wire.  Without this guard, two concurrent fibers
 ## using a pipeline can each write commands then race on reads — the
 ## RESP parser then tries to parse the middle of a bulk-string payload
-## as the next length prefix and surfaces "integer: cannot parse
-## \"<csv-of-floats>\" as base-10 integer" (or similar) up through the
-## handler.  See grace/research.md "Polish round-2 wedge" for the
-## diagnosis.
+## as the next length prefix.
 
 (def sync ((import "std/sync")))
 
@@ -65,7 +62,7 @@
           (let [len (parse-int body)]
             (if (= len -1)
               nil
-              (let [data (port/read port (+ len 2))]
+              (let [data (port/read-exact port (+ len 2))]
                 (when (nil? data)
                   (error {:error :redis-error
                           :reason :unexpected-eof
@@ -128,6 +125,22 @@
           ((get lk :release))
           (thunk))))))
 
+(defn require-binary-port [port where]
+  "RESP is a byte-framed protocol: bulk-string lengths are byte counts,
+   `\\r\\n` terminators are exact bytes.  A text-mode port would
+   grapheme-count port/read-exact and lossy-decode bulk payloads,
+   silently corrupting framing.  Fail loudly instead."
+  (when (not (= :binary (port/encoding port)))
+    (error {:error :redis-error
+            :reason :wrong-port-encoding
+            :where where
+            :encoding (port/encoding port)
+            :message (string where ": redis requires a binary port (got "
+                             (port/encoding port)
+                             "); open the connection with :encoding :binary "
+                             "(or use tcp/connect's default, or port/open-bytes "
+                             "for file-port test stand-ins)")})))
+
 (defn redis-cmd [& args]
   "Send a command on the current Redis port and read the reply."
   (let [port (*redis-port*)]
@@ -135,6 +148,7 @@
       (error {:error :redis-error
               :reason :no-connection
               :message "no active Redis connection"}))
+    (require-binary-port port "redis-cmd")
     (with-redis-lock
       (fn []
         (port/write port (apply resp-encode args))
@@ -747,6 +761,7 @@
       (error {:error :redis-error
               :reason :no-connection
               :message "no active Redis connection"}))
+    (require-binary-port port "redis-pipeline")
     (with-redis-lock
       (fn []
         # Send all commands
@@ -781,35 +796,35 @@
 
   # resp-read: simple string
   (spit "/tmp/elle-redis-test-simple" "+OK\r\n")
-  (let [p (port/open "/tmp/elle-redis-test-simple" :read)]
+  (let [p (port/open-bytes "/tmp/elle-redis-test-simple" :read)]
     (defer
       (port/close p)
       (assert (= (resp-read p) "OK") "resp-read simple string")))
 
   # resp-read: integer
   (spit "/tmp/elle-redis-test-int" ":42\r\n")
-  (let [p (port/open "/tmp/elle-redis-test-int" :read)]
+  (let [p (port/open-bytes "/tmp/elle-redis-test-int" :read)]
     (defer
       (port/close p)
       (assert (= (resp-read p) 42) "resp-read integer")))
 
   # resp-read: bulk string
   (spit "/tmp/elle-redis-test-bulk" "$5\r\nhello\r\n")
-  (let [p (port/open "/tmp/elle-redis-test-bulk" :read)]
+  (let [p (port/open-bytes "/tmp/elle-redis-test-bulk" :read)]
     (defer
       (port/close p)
       (assert (= (resp-read p) "hello") "resp-read bulk string")))
 
   # resp-read: nil bulk string
   (spit "/tmp/elle-redis-test-nil" "$-1\r\n")
-  (let [p (port/open "/tmp/elle-redis-test-nil" :read)]
+  (let [p (port/open-bytes "/tmp/elle-redis-test-nil" :read)]
     (defer
       (port/close p)
       (assert (nil? (resp-read p)) "resp-read nil bulk string")))
 
   # resp-read: array
   (spit "/tmp/elle-redis-test-arr" "*2\r\n$3\r\nfoo\r\n$3\r\nbar\r\n")
-  (let [p (port/open "/tmp/elle-redis-test-arr" :read)]
+  (let [p (port/open-bytes "/tmp/elle-redis-test-arr" :read)]
     (defer
       (port/close p)
       (let [result (resp-read p)]
@@ -819,7 +834,7 @@
 
   # resp-read: error
   (spit "/tmp/elle-redis-test-err" "-ERR unknown command\r\n")
-  (let [p (port/open "/tmp/elle-redis-test-err" :read)]
+  (let [p (port/open-bytes "/tmp/elle-redis-test-err" :read)]
     (defer
       (port/close p)
       (let [[ok? val] (protect (resp-read p))]
@@ -830,7 +845,7 @@
 
   # resp-read-raw: error returns struct instead of signaling
   (spit "/tmp/elle-redis-test-raw-err" "-ERR bad\r\n")
-  (let [p (port/open "/tmp/elle-redis-test-raw-err" :read)]
+  (let [p (port/open-bytes "/tmp/elle-redis-test-raw-err" :read)]
     (defer
       (port/close p)
       (let [result (resp-read-raw p)]
@@ -848,7 +863,7 @@
   # resp-read: nested array
   (spit "/tmp/elle-redis-test-nested"
         "*2\r\n*2\r\n:1\r\n:2\r\n*2\r\n:3\r\n:4\r\n")
-  (let [p (port/open "/tmp/elle-redis-test-nested" :read)]
+  (let [p (port/open-bytes "/tmp/elle-redis-test-nested" :read)]
     (defer
       (port/close p)
       (let [result (resp-read p)]
@@ -858,7 +873,7 @@
 
   # resp-read: empty array
   (spit "/tmp/elle-redis-test-empty-arr" "*0\r\n")
-  (let [p (port/open "/tmp/elle-redis-test-empty-arr" :read)]
+  (let [p (port/open-bytes "/tmp/elle-redis-test-empty-arr" :read)]
     (defer
       (port/close p)
       (let [result (resp-read p)]
@@ -1001,6 +1016,10 @@
    :resp-encode resp-encode
    :resp-read resp-read
    :resp-read-raw resp-read-raw
+
+   # Port-encoding guard (callable by users who want to assert their
+   # port up front, e.g. when wrapping their own redis connection).
+   :require-binary-port require-binary-port
 
    # Internal tests
    :test run-internal-tests})

--- a/src/io/aio.rs
+++ b/src/io/aio.rs
@@ -360,13 +360,55 @@ impl AsyncBackend {
                     // will prepend the buffered bytes.
                     read_buffered = state.buffer.len();
                 }
+                IoOp::ReadExact { count } => {
+                    // ReadExact's unit is whatever the port is measured in:
+                    // bytes for Binary, graphemes for Text.  If the buffered
+                    // prefix already contains `count` units, serve from buffer.
+                    let early = match port.encoding() {
+                        Encoding::Binary => {
+                            if state.buffer.len() >= *count {
+                                Some(*count)
+                            } else {
+                                None
+                            }
+                        }
+                        Encoding::Text => crate::io::nth_grapheme_byte_end(&state.buffer, *count),
+                    };
+                    if let Some(take_bytes) = early {
+                        let chunk: Vec<u8> = state.buffer.drain(..take_bytes).collect();
+                        let value = match port.encoding() {
+                            Encoding::Text => {
+                                Value::string(String::from_utf8_lossy(&chunk).as_ref())
+                            }
+                            Encoding::Binary => Value::bytes(chunk),
+                        };
+                        inner.buffer_pool.release(buf_handle);
+                        inner.completions.push_back(Completion {
+                            id,
+                            result: Ok(value),
+                        });
+                        return Ok(id);
+                    }
+                    // Not enough yet — leave buffered bytes in place.  For
+                    // Binary the kernel-read size is reduced by what's
+                    // buffered; for Text we always ask the kernel for
+                    // `count` more bytes (best-case ASCII estimate) and
+                    // resubmit on short reads — see the completion-side
+                    // resubmit gate.
+                    if matches!(port.encoding(), Encoding::Binary) {
+                        read_buffered = state.buffer.len();
+                    }
+                }
                 _ => {}
             }
         }
 
         // Dispatch by operation type
         match &request.op {
-            IoOp::Accept { ref options } => {
+            IoOp::Accept {
+                ref options,
+                encoding,
+            } => {
                 let listener_kind = Some(port.kind());
 
                 let AsyncBackendInner {
@@ -392,6 +434,7 @@ impl AsyncBackend {
                     PendingOp::Port {
                         op: IoOp::Accept {
                             options: options.clone(),
+                            encoding: *encoding,
                         },
                         port_key,
                         port: request.port,
@@ -571,6 +614,28 @@ impl AsyncBackend {
                                 fd,
                                 size: *count - read_buffered,
                             },
+                            IoOp::ReadExact { count } => {
+                                let is_text = matches!(port.encoding(), Encoding::Text);
+                                if is_text {
+                                    // Grapheme-counted: the worker grows its
+                                    // own buffer and loops until `count`
+                                    // graphemes are present.  `read_buffered`
+                                    // bytes already sitting in fd_state are
+                                    // handled by the completion path on the
+                                    // combined buffer.
+                                    PoolOp::ReadExact {
+                                        fd,
+                                        size: *count,
+                                        graphemes: true,
+                                    }
+                                } else {
+                                    PoolOp::ReadExact {
+                                        fd,
+                                        size: *count - read_buffered,
+                                        graphemes: false,
+                                    }
+                                }
+                            }
                             IoOp::Write { data } => {
                                 let bytes = Self::extract_write_bytes(data);
                                 PoolOp::Write { fd, data: bytes }
@@ -588,6 +653,7 @@ impl AsyncBackend {
                         op: match &request.op {
                             IoOp::ReadLine => IoOp::ReadLine,
                             IoOp::Read { count } => IoOp::Read { count: *count },
+                            IoOp::ReadExact { count } => IoOp::ReadExact { count: *count },
                             IoOp::ReadAll => IoOp::ReadAll,
                             IoOp::Write { data } => IoOp::Write { data: *data },
                             IoOp::Flush => IoOp::Flush,
@@ -642,11 +708,14 @@ impl AsyncBackend {
                                 addr: host,
                                 port,
                                 ref options,
+                                ..
                             } => PoolOp::ConnectTcp {
                                 addr: crate::io::sockaddr::format_host_port(host, *port),
                                 options: options.clone(),
                             },
-                            ConnectAddr::Unix { path, ref options } => PoolOp::ConnectUnix {
+                            ConnectAddr::Unix {
+                                path, ref options, ..
+                            } => PoolOp::ConnectUnix {
                                 path: path.clone(),
                                 options: options.clone(),
                             },
@@ -663,11 +732,14 @@ impl AsyncBackend {
                         addr: host,
                         port,
                         ref options,
+                        ..
                     } => PoolOp::ConnectTcp {
                         addr: crate::io::sockaddr::format_host_port(host, *port),
                         options: options.clone(),
                     },
-                    ConnectAddr::Unix { path, ref options } => PoolOp::ConnectUnix {
+                    ConnectAddr::Unix {
+                        path, ref options, ..
+                    } => PoolOp::ConnectUnix {
                         path: path.clone(),
                         options: options.clone(),
                     },
@@ -685,14 +757,21 @@ impl AsyncBackend {
                         addr: host,
                         port,
                         ref options,
+                        encoding,
                     } => ConnectAddr::Tcp {
                         addr: host.clone(),
                         port: *port,
                         options: options.clone(),
+                        encoding: *encoding,
                     },
-                    ConnectAddr::Unix { path, ref options } => ConnectAddr::Unix {
+                    ConnectAddr::Unix {
+                        path,
+                        ref options,
+                        encoding,
+                    } => ConnectAddr::Unix {
                         path: path.clone(),
                         options: options.clone(),
+                        encoding: *encoding,
                     },
                 },
                 buffer_handle: buf_handle,
@@ -1483,7 +1562,8 @@ impl AsyncBackendInner {
             IoOp::ReadLine => StdinOpKind::ReadLine,
             IoOp::Read { count } => StdinOpKind::Read { count: *count },
             IoOp::ReadAll => StdinOpKind::ReadAll,
-            IoOp::Write { .. }
+            IoOp::ReadExact { .. }
+            | IoOp::Write { .. }
             | IoOp::Flush
             | IoOp::Accept { .. }
             | IoOp::Connect { .. }
@@ -1880,6 +1960,7 @@ mod tests {
             .submit(&IoRequest {
                 op: IoOp::Accept {
                     options: Default::default(),
+                    encoding: crate::port::Encoding::Binary,
                 },
                 port: listener_port,
                 timeout: None,
@@ -1973,6 +2054,7 @@ mod tests {
         let accept_req = IoRequest {
             op: IoOp::Accept {
                 options: Default::default(),
+                encoding: crate::port::Encoding::Binary,
             },
             port: listener_port,
             timeout: None,
@@ -2035,6 +2117,7 @@ mod tests {
                     addr: "127.0.0.1".to_string(),
                     port: bound_addr.port(),
                     options: Default::default(),
+                    encoding: crate::port::Encoding::Binary,
                 },
             },
             port: Value::NIL,
@@ -2115,6 +2198,7 @@ mod tests {
             .submit(&IoRequest {
                 op: IoOp::Accept {
                     options: Default::default(),
+                    encoding: crate::port::Encoding::Binary,
                 },
                 port: listener_port,
                 timeout: None,
@@ -2128,6 +2212,7 @@ mod tests {
                         addr: "127.0.0.1".to_string(),
                         port: bound_port,
                         options: Default::default(),
+                        encoding: crate::port::Encoding::Binary,
                     },
                 },
                 port: Value::NIL,

--- a/src/io/completion.rs
+++ b/src/io/completion.rs
@@ -176,12 +176,15 @@ pub(super) fn process_raw_completion(
                 } => crate::io::sockaddr::format_host_port(host, *port),
                 ConnectAddr::Unix { path, .. } => path.clone(),
             };
+            let encoding = addr.encoding();
             let new_port = match addr {
                 ConnectAddr::Tcp { .. } => {
                     set_tcp_nodelay(&fd);
-                    Port::new_tcp_stream(fd, peer_addr)
+                    Port::new_tcp_stream(fd, peer_addr).with_encoding(encoding)
                 }
-                ConnectAddr::Unix { .. } => Port::new_unix_stream(fd, peer_addr),
+                ConnectAddr::Unix { .. } => {
+                    Port::new_unix_stream(fd, peer_addr).with_encoding(encoding)
+                }
             };
             Completion {
                 id,
@@ -316,7 +319,11 @@ pub(super) fn process_raw_completion(
                 };
             }
 
-            if result_code == 0 && matches!(op, IoOp::ReadLine | IoOp::Read { .. } | IoOp::ReadAll)
+            if result_code == 0
+                && matches!(
+                    op,
+                    IoOp::ReadLine | IoOp::Read { .. } | IoOp::ReadExact { .. } | IoOp::ReadAll
+                )
             {
                 // EOF for read operations
                 let state = fd_states
@@ -352,6 +359,19 @@ pub(super) fn process_raw_completion(
                             }),
                         };
                     }
+                }
+
+                // For ReadExact: EOF before the full count is a failed
+                // read — discard whatever partial sat in the buffer and
+                // return nil so the caller can distinguish "got n bytes"
+                // from "stream ended early".  Callers who want the
+                // partial should use Read.
+                if matches!(op, IoOp::ReadExact { .. }) {
+                    state.buffer.clear();
+                    return Completion {
+                        id,
+                        result: Ok(Value::NIL),
+                    };
                 }
 
                 // For ReadAll: return accumulated buffer on EOF
@@ -400,11 +420,12 @@ pub(super) fn process_raw_completion(
                         Value::string(trimmed)
                     }
                 }
-                IoOp::Read { .. } | IoOp::ReadAll => {
+                IoOp::Read { .. } | IoOp::ReadExact { .. } | IoOp::ReadAll => {
                     // Prepend any bytes left in the fd_state buffer from a
                     // previous over-read (e.g. ReadLine read past the line
-                    // boundary). The submit path reduced the kernel read count
-                    // by this amount so the total equals the requested count.
+                    // boundary, or a previous short-read for this op).  The
+                    // submit/resubmit path reduced the kernel read count by
+                    // what was buffered.
                     let state = fd_states
                         .entry(port_key.clone())
                         .or_insert_with(FdState::new);
@@ -415,7 +436,33 @@ pub(super) fn process_raw_completion(
                     } else {
                         data
                     };
-                    if let Some(p) = port.as_external::<Port>() {
+                    // ReadExact on a text port is grapheme-counted: split
+                    // at the Nth grapheme boundary and stash the trailing
+                    // bytes for the next read.  Other paths (binary Read /
+                    // ReadExact / ReadAll, text Read, text ReadAll) return
+                    // the full combined buffer per their existing contract.
+                    let text_exact_count = match op {
+                        IoOp::ReadExact { count } => port
+                            .as_external::<Port>()
+                            .filter(|p| matches!(p.encoding(), Encoding::Text))
+                            .map(|_| *count),
+                        _ => None,
+                    };
+                    if let Some(n) = text_exact_count {
+                        if let Some(end) = crate::io::nth_grapheme_byte_end(&combined, n) {
+                            let leftover = combined[end..].to_vec();
+                            if !leftover.is_empty() {
+                                state.buffer.extend_from_slice(&leftover);
+                            }
+                            Value::string(String::from_utf8_lossy(&combined[..end]).as_ref())
+                        } else {
+                            // The resubmit gate should have caught this and
+                            // looped; reaching here means the gate's grapheme
+                            // probe and ours disagree (impossible given the
+                            // same input).  Treat defensively as nil.
+                            Value::NIL
+                        }
+                    } else if let Some(p) = port.as_external::<Port>() {
                         match p.encoding() {
                             Encoding::Text => {
                                 let s = String::from_utf8_lossy(&combined);
@@ -429,7 +476,10 @@ pub(super) fn process_raw_completion(
                 }
                 IoOp::Write { .. } | IoOp::SendTo { .. } => Value::int(result_code as i64),
                 IoOp::Flush | IoOp::Shutdown { .. } | IoOp::Sleep { .. } => Value::NIL,
-                IoOp::Accept { ref options } => {
+                IoOp::Accept {
+                    ref options,
+                    encoding,
+                } => {
                     // Accept: result_code is the new fd (from both io_uring and thread pool).
                     // Peer address is obtained via getpeername() — works uniformly.
                     let fd = result_code;
@@ -440,9 +490,11 @@ pub(super) fn process_raw_completion(
                     let new_port = match listener_kind {
                         Some(PortKind::TcpListener) => {
                             set_tcp_nodelay(&fd);
-                            Port::new_tcp_stream(fd, peer_addr)
+                            Port::new_tcp_stream(fd, peer_addr).with_encoding(*encoding)
                         }
-                        Some(PortKind::UnixListener) => Port::new_unix_stream(fd, peer_addr),
+                        Some(PortKind::UnixListener) => {
+                            Port::new_unix_stream(fd, peer_addr).with_encoding(*encoding)
+                        }
                         _ => {
                             return Completion {
                                 id,

--- a/src/io/mock.rs
+++ b/src/io/mock.rs
@@ -107,6 +107,7 @@ impl crate::io::IoBackend for MockBackend {
         let op_name = match &request.op {
             IoOp::ReadLine => "read-line",
             IoOp::Read { .. } => "read",
+            IoOp::ReadExact { .. } => "read-exact",
             IoOp::ReadAll => "read-all",
             IoOp::Write { .. } => "write",
             IoOp::Flush => "flush",
@@ -139,7 +140,7 @@ impl crate::io::IoBackend for MockBackend {
             ))
         } else {
             match &request.op {
-                IoOp::ReadLine | IoOp::Read { .. } | IoOp::ReadAll => {
+                IoOp::ReadLine | IoOp::Read { .. } | IoOp::ReadExact { .. } | IoOp::ReadAll => {
                     if inner.read_cursor < inner.read_data.len() {
                         let data = inner.read_data[inner.read_cursor].clone();
                         inner.read_cursor += 1;

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -23,6 +23,61 @@ use crate::value::heap::TableKey;
 use crate::value::Value;
 use std::collections::BTreeMap;
 
+/// Byte offset where the Nth grapheme cluster ends in `buf` (treated
+/// as UTF-8).  Used by text-port `ReadExact` to count progress in
+/// graphemes — the unit Elle strings are measured in — instead of
+/// bytes, so `(port/read-exact text-port 50)` returns a string of
+/// `(length 50)` regardless of how many kernel bytes that needed.
+///
+/// Returns:
+/// - `Some(offset)` when at least `n` graphemes have been assembled;
+///   `offset` is the byte position one past the Nth grapheme so the
+///   caller can split into `buf[..offset]` (the result) and
+///   `buf[offset..]` (leftover to stash for the next read).
+/// - `None` when `buf` doesn't yet contain `n` graphemes.  This also
+///   covers the trailing-partial-codepoint case (final bytes don't
+///   form a complete UTF-8 sequence) — the caller resubmits for more
+///   bytes.  Mid-buffer invalid UTF-8 is conservatively treated the
+///   same way (stop at the last valid prefix); in practice this never
+///   fires for well-formed text.
+pub(crate) fn grapheme_count_in_valid_prefix(buf: &[u8]) -> usize {
+    use unicode_segmentation::UnicodeSegmentation;
+    let valid = match std::str::from_utf8(buf) {
+        Ok(s) => s,
+        Err(e) => {
+            let upto = e.valid_up_to();
+            unsafe { std::str::from_utf8_unchecked(&buf[..upto]) }
+        }
+    };
+    valid.graphemes(true).count()
+}
+
+pub(crate) fn nth_grapheme_byte_end(buf: &[u8], n: usize) -> Option<usize> {
+    use unicode_segmentation::UnicodeSegmentation;
+    if n == 0 {
+        return Some(0);
+    }
+    let valid = match std::str::from_utf8(buf) {
+        Ok(s) => s,
+        Err(e) => {
+            let upto = e.valid_up_to();
+            // SAFETY: valid_up_to() is by definition the length of the
+            // longest valid UTF-8 prefix.
+            unsafe { std::str::from_utf8_unchecked(&buf[..upto]) }
+        }
+    };
+    let mut pos = 0usize;
+    let mut count = 0usize;
+    for g in valid.graphemes(true) {
+        pos += g.len();
+        count += 1;
+        if count == n {
+            return Some(pos);
+        }
+    }
+    None
+}
+
 /// Completion from an async I/O operation.
 pub(crate) struct Completion {
     pub(crate) id: u64,

--- a/src/io/request.rs
+++ b/src/io/request.rs
@@ -165,6 +165,13 @@ pub enum IoOp {
     ReadLine,
     /// Read up to `count` bytes. Returns bytes/string or nil (EOF).
     Read { count: usize },
+    /// Read exactly `count` bytes, looping over short reads.  Returns
+    /// bytes/string of length `count`, or nil if the stream ended
+    /// before `count` bytes arrived.  Unlike `Read`, this resubmits
+    /// short reads on stream sockets too — `Read` follows POSIX "up
+    /// to N" semantics on streams; this is the "no, really, exactly
+    /// N" variant for length-prefixed framing.
+    ReadExact { count: usize },
     /// Read everything remaining. Returns string or bytes.
     ReadAll,
     /// Write data to port. Returns bytes written (int).
@@ -179,7 +186,13 @@ pub enum IoOp {
     Tell,
     /// Accept a connection on a listener. Returns new stream port.
     /// Socket options are applied to the accepted fd after accept(2).
-    Accept { options: SocketOptions },
+    /// `encoding` controls the resulting port's text/binary mode —
+    /// callers default to Binary (POSIX sockets are byte streams);
+    /// pass Text for line-oriented protocols (SMTP, IRC, etc.).
+    Accept {
+        options: SocketOptions,
+        encoding: crate::port::Encoding,
+    },
     /// Connect to a remote address. Returns connected stream port.
     Connect { addr: ConnectAddr },
     /// Send data to a remote address via UDP. Returns bytes sent.
@@ -296,10 +309,12 @@ pub enum ConnectAddr {
         addr: String,
         port: u16,
         options: SocketOptions,
+        encoding: crate::port::Encoding,
     },
     Unix {
         path: String,
         options: SocketOptions,
+        encoding: crate::port::Encoding,
     },
 }
 
@@ -308,6 +323,13 @@ impl ConnectAddr {
         match self {
             ConnectAddr::Tcp { options, .. } => options,
             ConnectAddr::Unix { options, .. } => options,
+        }
+    }
+
+    pub fn encoding(&self) -> crate::port::Encoding {
+        match self {
+            ConnectAddr::Tcp { encoding, .. } => *encoding,
+            ConnectAddr::Unix { encoding, .. } => *encoding,
         }
     }
 }

--- a/src/io/threadpool.rs
+++ b/src/io/threadpool.rs
@@ -1,5 +1,6 @@
 //! Thread-pool backend and stdin thread for async I/O.
 
+use crate::io::grapheme_count_in_valid_prefix;
 use crate::io::request::SocketOptions;
 use std::os::unix::io::{IntoRawFd, RawFd};
 
@@ -8,6 +9,19 @@ pub(super) enum PoolOp {
     Read {
         fd: RawFd,
         size: usize,
+    },
+    /// Read exactly `size` units, looping until full or EOF/error.
+    /// Units are bytes when `graphemes` is false and grapheme clusters
+    /// when true — Elle strings are grapheme-counted, so a text-port
+    /// `port/read-exact 50` must yield a string of `(length 50)`
+    /// regardless of how many kernel bytes that took.  The worker
+    /// keeps calling `read(2)` until the requested count is met,
+    /// the peer closes, or an error fires.  On EOF before `size`,
+    /// the completion path treats the partial result as nil.
+    ReadExact {
+        fd: RawFd,
+        size: usize,
+        graphemes: bool,
     },
     Write {
         fd: RawFd,
@@ -129,6 +143,66 @@ impl ThreadPoolBackend {
                     } else {
                         buf.truncate(ret as usize);
                         (ret as i32, buf)
+                    }
+                }
+                PoolOp::ReadExact {
+                    fd,
+                    size,
+                    graphemes,
+                } => {
+                    // Buffer grows as we go — graphemes mode can't preallocate
+                    // because we don't know the byte count in advance.  In
+                    // bytes mode we still grow into a `size`-capacity Vec so
+                    // the loop's tail-read writes into one buffer.
+                    let mut buf: Vec<u8> = if graphemes {
+                        Vec::with_capacity(size)
+                    } else {
+                        vec![0u8; size]
+                    };
+                    let mut total = 0usize;
+                    // chunk_size is how many bytes we ask the kernel for on
+                    // each iteration.  Bytes mode knows exactly (size - total);
+                    // graphemes mode estimates one byte per missing grapheme
+                    // (ASCII best case) and loops on undershoot.
+                    loop {
+                        let want = if graphemes {
+                            // Re-evaluate progress every iteration.
+                            let g = grapheme_count_in_valid_prefix(&buf[..total]);
+                            if g >= size {
+                                break (total as i32, buf[..total].to_vec());
+                            }
+                            (size - g).max(1)
+                        } else {
+                            if total >= size {
+                                break (total as i32, buf);
+                            }
+                            size - total
+                        };
+                        // Make room for the next read if we're in graphemes
+                        // mode (bytes mode preallocated).
+                        if graphemes && buf.len() < total + want {
+                            buf.resize(total + want, 0);
+                        }
+                        let ret = unsafe {
+                            libc::read(fd, buf[total..].as_mut_ptr() as *mut libc::c_void, want)
+                        };
+                        if ret < 0 {
+                            if total == 0 {
+                                break (
+                                    -(std::io::Error::last_os_error().raw_os_error().unwrap_or(1)),
+                                    Vec::new(),
+                                );
+                            }
+                            // Partial read then error: surface what we got
+                            // so the completion path treats it as short-then-EOF.
+                            break (total as i32, buf[..total].to_vec());
+                        }
+                        if ret == 0 {
+                            // EOF before full count.  Return short; the
+                            // completion handler maps short-on-ReadExact to nil.
+                            break (total as i32, buf[..total].to_vec());
+                        }
+                        total += ret as usize;
                     }
                 }
                 PoolOp::ReadLine { fd } | PoolOp::ReadAll { fd } => {

--- a/src/io/uring.rs
+++ b/src/io/uring.rs
@@ -40,7 +40,7 @@ pub(super) fn submit_uring_stream(
                 .build()
                 .user_data(id)
         }
-        IoOp::Read { count } => {
+        IoOp::Read { count } | IoOp::ReadExact { count } => {
             let buf = buffer_pool.get_mut(buf_handle);
             buf.resize(*count - read_buffered, 0);
             opcode::Read::new(Fd(fd), buf.as_mut_ptr(), buf.len() as u32)
@@ -726,7 +726,9 @@ pub(super) fn drain_cqes(
                         encoded.extend_from_slice(&payload);
                         encoded
                     }
-                    IoOp::ReadLine | IoOp::Read { .. } | IoOp::ReadAll if result_code > 0 => {
+                    IoOp::ReadLine | IoOp::Read { .. } | IoOp::ReadExact { .. } | IoOp::ReadAll
+                        if result_code > 0 =>
+                    {
                         let buf = buffer_pool.get_mut(buf_handle);
                         buf[..result_code as usize].to_vec()
                     }
@@ -773,37 +775,80 @@ pub(super) fn drain_cqes(
             // Read short-read re-submission: regular files may return short
             // reads before EOF (rare but POSIX-legal). Buffer partial data
             // and resubmit for the remainder. Stream sockets (TCP, Unix)
-            // are excluded — port/read returns "up to N bytes" per POSIX
-            // semantics, so a short read is a normal completion.
-            if let PendingOp::Port {
-                op: IoOp::Read { count },
-                ref port_key,
-                ref port,
-                ..
-            } = pending_op
-            {
-                let is_stream = port
-                    .as_external::<Port>()
+            // are excluded for plain `Read` — port/read returns "up to N
+            // bytes" per POSIX semantics, so a short read is a normal
+            // completion.  `ReadExact` is the strict variant: we resubmit
+            // for stream sockets too, so callers get exactly N units (or
+            // nil if the stream ended early).  Units are bytes on binary
+            // ports, graphemes on text ports — strings under Elle are
+            // measured in graphemes, so `(length (port/read-exact text 50))`
+            // must be 50 graphemes regardless of how many kernel bytes
+            // that took.
+            let (read_count, is_exact) = match pending_op {
+                PendingOp::Port {
+                    op: IoOp::Read { count },
+                    ..
+                } => (Some(count), false),
+                PendingOp::Port {
+                    op: IoOp::ReadExact { count },
+                    ..
+                } => (Some(count), true),
+                _ => (None, false),
+            };
+            if let Some(count) = read_count {
+                let (port_key_ref, port_ref) = match &pending_op {
+                    PendingOp::Port {
+                        ref port_key,
+                        ref port,
+                        ..
+                    } => (port_key, port),
+                    _ => unreachable!(),
+                };
+                let port_ext = port_ref.as_external::<Port>();
+                let is_stream = port_ext
                     .map(|p| matches!(p.kind(), PortKind::TcpStream | PortKind::UnixStream))
                     .unwrap_or(false);
-                if !is_stream && result_code > 0 {
+                let is_text = is_exact
+                    && port_ext
+                        .map(|p| matches!(p.encoding(), crate::port::Encoding::Text))
+                        .unwrap_or(false);
+                if (is_exact || !is_stream) && result_code > 0 {
                     let got = result_code as usize;
                     let state = fd_states
-                        .entry(port_key.clone())
+                        .entry(port_key_ref.clone())
                         .or_insert_with(FdState::new);
-                    let total = state.buffer.len() + got;
-                    if total < count {
-                        // Short read — buffer and resubmit for remainder.
+                    let needs_more = if is_text {
+                        // Combined buffer (already-buffered + freshly read) —
+                        // check it has `count` graphemes.  We don't extend
+                        // state.buffer yet; only extend if we need to resubmit.
+                        let mut probe = Vec::with_capacity(state.buffer.len() + data.len());
+                        probe.extend_from_slice(&state.buffer);
+                        probe.extend_from_slice(&data);
+                        crate::io::nth_grapheme_byte_end(&probe, count).is_none()
+                    } else {
+                        state.buffer.len() + got < count
+                    };
+                    if needs_more {
+                        // Short read — buffer and resubmit for more bytes.
                         state.buffer.extend_from_slice(&data);
                         buffer_pool.release(buf_handle);
-                        let fd = match port_key {
+                        let fd = match port_key_ref {
                             PortKey::Fd(raw) => *raw,
                             PortKey::Stdout => 1,
                             PortKey::Stderr => 2,
                             PortKey::Stdin => unreachable!(),
                         };
-                        let remaining = count - total;
-                        read_resubmits.push((id, fd, remaining, pending_op));
+                        // For binary the remaining count is exact bytes.
+                        // For text we estimate one byte per missing
+                        // grapheme (ASCII best case) — if that under-reads,
+                        // we'll loop on the next short.
+                        let request = if is_text {
+                            let g_so_far = crate::io::grapheme_count_in_valid_prefix(&state.buffer);
+                            (count - g_so_far).max(1)
+                        } else {
+                            count - state.buffer.len()
+                        };
+                        read_resubmits.push((id, fd, request, pending_op));
                         continue;
                     }
                 }

--- a/src/port.rs
+++ b/src/port.rs
@@ -234,6 +234,17 @@ impl Port {
         self.direction
     }
 
+    /// Builder: set the port's encoding.  Used by `tcp/connect` /
+    /// `tcp/accept` / `unix/connect` / `unix/accept` to honor an
+    /// explicit `:encoding text|binary` keyword override; the raw
+    /// stream constructors default to `Binary` (the bytes-stream
+    /// interpretation of POSIX sockets) but line-oriented text
+    /// protocols (SMTP, IRC, plain HTTP/1.x) want `Text`.
+    pub fn with_encoding(mut self, enc: Encoding) -> Self {
+        self.encoding = enc;
+        self
+    }
+
     /// The port encoding.
     pub fn encoding(&self) -> Encoding {
         self.encoding

--- a/src/primitives/kwarg.rs
+++ b/src/primitives/kwarg.rs
@@ -4,6 +4,7 @@
 //! keyword arguments from primitive arg slices.
 
 use crate::io::request::SocketOptions;
+use crate::port::Encoding;
 use crate::value::fiber::{SignalBits, SIG_ERROR};
 use crate::value::{error_val, Value};
 use std::time::Duration;
@@ -12,6 +13,11 @@ use std::time::Duration;
 pub(crate) struct ConnectKwargs {
     pub timeout: Option<Duration>,
     pub options: SocketOptions,
+    /// Port encoding for the resulting stream.  `None` => caller's default
+    /// (binary for raw socket primitives).  Explicit `:text` opts into
+    /// grapheme-mode reads / `port/read-exact` graphemes / etc., for
+    /// line-oriented text protocols (SMTP, IRC, plain HTTP/1.x).
+    pub encoding: Option<Encoding>,
 }
 
 /// Scan args starting at `start` for keyword-value pairs.
@@ -112,6 +118,7 @@ pub(crate) fn extract_connect_kwargs(
     let mut result = ConnectKwargs {
         timeout: None,
         options: SocketOptions::default(),
+        encoding: None,
     };
 
     if args.len() <= start {
@@ -176,6 +183,38 @@ pub(crate) fn extract_connect_kwargs(
             }
             Some("keepalive") => {
                 result.options.keepalive = Some(extract_bool(val, "keepalive", prim_name)?);
+            }
+            Some("encoding") => {
+                let enc = match val.as_keyword_name().as_deref() {
+                    Some("text") => Encoding::Text,
+                    Some("binary") => Encoding::Binary,
+                    Some(other) => {
+                        return Err((
+                            SIG_ERROR,
+                            error_val(
+                                "value-error",
+                                format!(
+                                    "{}: :encoding must be :text or :binary, got :{}",
+                                    prim_name, other
+                                ),
+                            ),
+                        ));
+                    }
+                    None => {
+                        return Err((
+                            SIG_ERROR,
+                            error_val(
+                                "type-error",
+                                format!(
+                                    "{}: :encoding value must be keyword (:text or :binary), got {}",
+                                    prim_name,
+                                    val.type_name()
+                                ),
+                            ),
+                        ));
+                    }
+                };
+                result.encoding = Some(enc);
             }
             Some(other) => {
                 return Err((

--- a/src/primitives/net.rs
+++ b/src/primitives/net.rs
@@ -244,7 +244,14 @@ fn prim_tcp_listen(args: &[Value]) -> (SignalBits, Value) {
     }
 }
 
-/// (tcp/accept listener [:sndbuf n] [:rcvbuf n] [:nodelay bool] [:keepalive bool] [:timeout ms]) → stream-port
+/// (tcp/accept listener [:sndbuf n] [:rcvbuf n] [:nodelay bool] [:keepalive bool]
+///                       [:encoding :text|:binary] [:timeout ms]) → stream-port
+///
+/// `:encoding` controls the resulting stream port's mode.  Default is
+/// `:binary` (POSIX-style: a TCP connection is a byte stream).  Pass
+/// `:text` for line-oriented text protocols (SMTP, IRC, plain HTTP/1.x)
+/// — then `port/read` and `port/read-exact` return strings and treat
+/// `n` as graphemes (the unit Elle strings are measured in).
 fn prim_tcp_accept(args: &[Value]) -> (SignalBits, Value) {
     let port_val = match extract_port_of_kind(&args[0], PortKind::TcpListener, "tcp/accept") {
         Ok(v) => v,
@@ -259,6 +266,7 @@ fn prim_tcp_accept(args: &[Value]) -> (SignalBits, Value) {
         IoRequest::with_timeout(
             IoOp::Accept {
                 options: kwargs.options,
+                encoding: kwargs.encoding.unwrap_or(crate::port::Encoding::Binary),
             },
             port_val,
             kwargs.timeout,
@@ -266,7 +274,12 @@ fn prim_tcp_accept(args: &[Value]) -> (SignalBits, Value) {
     )
 }
 
-/// (tcp/connect addr port [:sndbuf n] [:rcvbuf n] [:nodelay bool] [:keepalive bool] [:timeout ms]) → stream-port
+/// (tcp/connect addr port [:sndbuf n] [:rcvbuf n] [:nodelay bool] [:keepalive bool]
+///                         [:encoding :text|:binary] [:timeout ms]) → stream-port
+///
+/// `:encoding` controls the resulting stream port's mode.  Default is
+/// `:binary` (POSIX-style: a TCP connection is a byte stream).  Pass
+/// `:text` for line-oriented text protocols (SMTP, IRC, plain HTTP/1.x).
 fn prim_tcp_connect(args: &[Value]) -> (SignalBits, Value) {
     let addr = match extract_string(&args[0], "addr", "tcp/connect") {
         Ok(s) => s,
@@ -288,6 +301,7 @@ fn prim_tcp_connect(args: &[Value]) -> (SignalBits, Value) {
                     addr,
                     port,
                     options: kwargs.options,
+                    encoding: kwargs.encoding.unwrap_or(crate::port::Encoding::Binary),
                 },
             },
             Value::NIL,

--- a/src/primitives/ports.rs
+++ b/src/primitives/ports.rs
@@ -313,6 +313,30 @@ fn prim_port_path(args: &[Value]) -> (SignalBits, Value) {
     }
 }
 
+/// (port/encoding port) → :text | :binary
+///
+/// Returns the port's encoding mode as a keyword.  `:text` ports return
+/// strings from read operations and treat `port/read-exact`'s count as
+/// graphemes (the unit Elle strings are measured in).  `:binary` ports
+/// return bytes and treat the count as bytes — what byte-framed
+/// protocols (RESP, gRPC, HTTP/2, length-prefixed everything) need.
+///
+/// Use this to guard protocol-implementing code that requires one or
+/// the other.  Example: a RESP reader can assert
+/// `(= :binary (port/encoding port))` up front and fail with a clear
+/// error instead of silently corrupting bulk-string framing.
+fn prim_port_encoding(args: &[Value]) -> (SignalBits, Value) {
+    let port = match extract_port(&args[0], "port/encoding") {
+        Ok(p) => p,
+        Err(e) => return e,
+    };
+    let kw = match port.encoding() {
+        crate::port::Encoding::Text => "text",
+        crate::port::Encoding::Binary => "binary",
+    };
+    (SIG_OK, Value::keyword(kw))
+}
+
 /// (port/seek port offset)
 /// (port/seek port offset :from :start|:current|:end)
 ///
@@ -564,6 +588,19 @@ pub(crate) const PRIMITIVES: &[PrimitiveDef] = &[
         params: &["port"],
         category: "port",
         example: "(port/set-options p :timeout 5000)",
+        aliases: &[],
+    },
+    PrimitiveDef {
+        name: "port/encoding",
+        func: prim_port_encoding,
+        signal: Signal::errors(),
+        arity: Arity::Exact(1),
+        doc: "Return the port's encoding as a keyword: :text or :binary. \
+              :text ports return strings and grapheme-count read-exact; \
+              :binary ports return bytes and byte-count.",
+        params: &["port"],
+        category: "port",
+        example: "(port/encoding (tcp/connect \"127.0.0.1\" 6379)) #=> :binary",
         aliases: &[],
     },
     PrimitiveDef {

--- a/src/primitives/stream.rs
+++ b/src/primitives/stream.rs
@@ -84,6 +84,47 @@ fn prim_stream_read(args: &[Value]) -> (SignalBits, Value) {
     )
 }
 
+/// (port/read-exact port n [:timeout ms]) → bytes | nil
+fn prim_stream_read_exact(args: &[Value]) -> (SignalBits, Value) {
+    let port = match extract_port_value(&args[0], "port/read-exact") {
+        Ok(p) => p,
+        Err(e) => return e,
+    };
+    let count = match args[1].as_int() {
+        Some(n) if n > 0 => n as usize,
+        Some(0) => return (SIG_OK, Value::bytes(vec![])),
+        Some(n) => {
+            return (
+                SIG_ERROR,
+                error_val(
+                    "value-error",
+                    format!("port/read-exact: count must be non-negative, got {}", n),
+                ),
+            )
+        }
+        None => {
+            return (
+                SIG_ERROR,
+                error_val(
+                    "type-error",
+                    format!(
+                        "port/read-exact: expected integer for count, got {}",
+                        args[1].type_name()
+                    ),
+                ),
+            )
+        }
+    };
+    let timeout = match extract_keyword_timeout(args, 2, "port/read-exact") {
+        Ok(t) => t,
+        Err(e) => return e,
+    };
+    (
+        SIG_YIELD | SIG_IO,
+        IoRequest::with_timeout(IoOp::ReadExact { count }, port, timeout),
+    )
+}
+
 /// (port/read-all port [:timeout ms]) → string | bytes
 fn prim_stream_read_all(args: &[Value]) -> (SignalBits, Value) {
     let port = match extract_port_value(&args[0], "port/read-all") {
@@ -169,6 +210,24 @@ pub(crate) const PRIMITIVES: &[PrimitiveDef] = &[
         category: "port",
         example: "(port/read (port/open \"file.txt\" :read) 1024)",
         aliases: &["stream/read"],
+    },
+    PrimitiveDef {
+        name: "port/read-exact",
+        func: prim_stream_read_exact,
+        signal: Signal {
+            bits: SIG_ERROR.union(SIG_YIELD).union(SIG_IO),
+            propagates: 0,
+        },
+        arity: Arity::AtLeast(2),
+        doc: "Read exactly n bytes from port, looping over short reads. \
+              Returns bytes/string of length n, or nil if EOF arrived first. \
+              Unlike port/read (which is 'up to n' per POSIX), this resubmits \
+              short reads on stream sockets too — use it for length-prefixed \
+              binary framing (RESP, gRPC, h2 DATA, etc.).",
+        params: &["port", "n"],
+        category: "port",
+        example: "(port/read-exact tcp-sock 1024)",
+        aliases: &[],
     },
     PrimitiveDef {
         name: "port/read-all",

--- a/src/primitives/unix.rs
+++ b/src/primitives/unix.rs
@@ -104,6 +104,7 @@ pub(crate) fn prim_unix_accept(args: &[Value]) -> (SignalBits, Value) {
         IoRequest::with_timeout(
             IoOp::Accept {
                 options: kwargs.options,
+                encoding: kwargs.encoding.unwrap_or(crate::port::Encoding::Binary),
             },
             port_val,
             kwargs.timeout,
@@ -111,7 +112,12 @@ pub(crate) fn prim_unix_accept(args: &[Value]) -> (SignalBits, Value) {
     )
 }
 
-/// (unix/connect path [:sndbuf n] [:rcvbuf n] [:keepalive bool] [:timeout ms]) → stream-port
+/// (unix/connect path [:sndbuf n] [:rcvbuf n] [:keepalive bool]
+///                    [:encoding :text|:binary] [:timeout ms]) → stream-port
+///
+/// `:encoding` controls the resulting stream port's mode.  Default is
+/// `:binary` (Unix-domain stream sockets are byte streams).  Pass
+/// `:text` for line-oriented text protocols carried over Unix sockets.
 pub(crate) fn prim_unix_connect(args: &[Value]) -> (SignalBits, Value) {
     let path = match extract_string(&args[0], "path", "unix/connect") {
         Ok(s) => s,
@@ -128,6 +134,7 @@ pub(crate) fn prim_unix_connect(args: &[Value]) -> (SignalBits, Value) {
                 addr: ConnectAddr::Unix {
                     path,
                     options: kwargs.options,
+                    encoding: kwargs.encoding.unwrap_or(crate::port::Encoding::Binary),
                 },
             },
             Value::NIL,

--- a/tests/elle/port-encoding.lisp
+++ b/tests/elle/port-encoding.lisp
@@ -1,0 +1,141 @@
+(elle/epoch 10)
+# tests/elle/port-encoding.lisp — `port/encoding` accessor + the
+# `:encoding text|binary` keyword on tcp/connect / tcp/accept /
+# unix/connect / unix/accept.
+#
+# Background: POSIX sockets are byte streams, so the raw-socket
+# constructors default to `:binary` — bytes from port/read, byte-counted
+# port/read-exact, what byte-framed protocols (RESP, gRPC, HTTP/2,
+# length-prefixed everything) need.  Line-oriented text protocols
+# (SMTP, IRC, plain HTTP/1.x) want strings and grapheme-counted
+# reads; they opt in via `:encoding :text` at connect / accept time.
+# `port/encoding` lets protocol code self-check up front so a wrong
+# mode raises a clear error instead of silently corrupting framing.
+
+# ── 1. Default is :binary on raw sockets ─────────────────────────────
+(def listener (tcp/listen "127.0.0.1" 0))
+(def listener-port
+  (let [p (port/path listener)]
+    (parse-int (slice p (+ 1 (string/find p ":"))))))
+
+(def accepted-port-keyword (box nil))
+(def server-fiber
+  (ev/spawn
+    (fn []
+      (let [c (tcp/accept listener)]
+        (rebox accepted-port-keyword (port/encoding c))
+        (protect (port/close c))))))
+
+(let [c (tcp/connect "127.0.0.1" listener-port)]
+  (defer
+    (protect (port/close c))
+    (assert (= :binary (port/encoding c))
+            "1a: tcp/connect defaults to :binary")
+    # let accept finish
+    (ev/sleep 0.05)
+    (assert (= :binary (unbox accepted-port-keyword))
+            "1b: tcp/accept defaults to :binary")))
+(protect (ev/join-protected server-fiber))
+(protect (port/close listener))
+
+# ── 2. Opt-in :text on tcp/connect ───────────────────────────────────
+(def listener2 (tcp/listen "127.0.0.1" 0))
+(def listener2-port
+  (let [p (port/path listener2)]
+    (parse-int (slice p (+ 1 (string/find p ":"))))))
+
+(def server-fiber2
+  (ev/spawn
+    (fn []
+      (let [c (tcp/accept listener2)]
+        # Server side writes a 4-grapheme word that's also 5 bytes — the
+        # multibyte é confirms we're grapheme-counting on the client
+        (port/write c "café!")
+        (port/flush c)
+        (protect (port/close c))))))
+
+(let [c (tcp/connect "127.0.0.1" listener2-port :encoding :text)]
+  (defer
+    (protect (port/close c))
+    (assert (= :text (port/encoding c))
+            "2a: :encoding :text honored")
+    # 4 graphemes = "café", leftover "!" stays in the per-fd buffer
+    (let [d (port/read-exact c 4)]
+      (assert (string? d) "2b: text-port read returns string")
+      (assert (= (length d) 4) "2c: (length) is grapheme count")
+      (assert (= d "café") "2d: byte-precise across multibyte boundary"))
+    (let [d (port/read-exact c 1)]
+      (assert (= d "!") "2e: leftover bang consumed cleanly"))))
+(protect (ev/join-protected server-fiber2))
+(protect (port/close listener2))
+
+# ── 3. Opt-in :text on tcp/accept ────────────────────────────────────
+(def listener3 (tcp/listen "127.0.0.1" 0))
+(def listener3-port
+  (let [p (port/path listener3)]
+    (parse-int (slice p (+ 1 (string/find p ":"))))))
+
+(def accepted-enc (box nil))
+(def accepted-read (box nil))
+(def server-fiber3
+  (ev/spawn
+    (fn []
+      (let [c (tcp/accept listener3 :encoding :text)]
+        (rebox accepted-enc (port/encoding c))
+        (rebox accepted-read (port/read-exact c 3))
+        (protect (port/close c))))))
+
+(let [c (tcp/connect "127.0.0.1" listener3-port)]
+  (defer
+    (protect (port/close c))
+    (port/write c "héy!")
+    (port/flush c)
+    (ev/sleep 0.05)))
+(protect (ev/join-protected server-fiber3))
+(protect (port/close listener3))
+(assert (= :text (unbox accepted-enc))
+        "3a: tcp/accept :encoding :text honored")
+(let [r (unbox accepted-read)]
+  (assert (string? r) "3b: accepted-port read returns string")
+  (assert (= (length r) 3) "3c: 3 graphemes")
+  (assert (= r "héy") "3d: bytes correct"))
+
+# ── 4. Bad :encoding value raises ────────────────────────────────────
+(let [[ok? err] (protect
+                  (tcp/connect "127.0.0.1" 1
+                               :encoding :utf8))]
+  (assert (not ok?) "4a: bogus :encoding raises")
+  (assert (string/contains? err:message ":encoding must be")
+          (concat "4b: error mentions :encoding (" err:message ")")))
+
+# ── 5. Redis guard fires on a text-mode port ─────────────────────────
+# Use a real Redis if available so we exercise the guard on the actual
+# (redis:with) path; otherwise skip — the guard is unit-tested via the
+# explicit (redis:require-binary-port) below.
+(def redis ((import-file "lib/redis.lisp")))
+
+(let [[ok? _] (protect (redis:with "127.0.0.1" 6379 (fn [] (redis:ping))))]
+  (when ok?
+    # Build a text-mode TCP connection and prove redis:require-binary-port
+    # rejects it — this catches "I opened the port the wrong way" before
+    # any wire byte is parsed under grapheme semantics.
+    (let [bogus-listener (tcp/listen "127.0.0.1" 0)
+          bogus-port (let [p (port/path bogus-listener)]
+                      (parse-int (slice p (+ 1 (string/find p ":")))))
+          _accept-f (ev/spawn (fn []
+                                (protect (port/close
+                                          (tcp/accept bogus-listener)))))
+          text-port (tcp/connect "127.0.0.1" bogus-port :encoding :text)]
+      (defer
+        (begin
+          (protect (port/close text-port))
+          (protect (port/close bogus-listener)))
+        (let [[g-ok g-err]
+              (protect (redis:require-binary-port text-port "test"))]
+          (assert (not g-ok) "5a: guard rejects text port")
+          (assert (= :wrong-port-encoding (get g-err :reason))
+                  "5b: reason is :wrong-port-encoding")
+          (assert (string/contains? (get g-err :message) "binary port")
+                  "5c: message mentions binary port"))))))
+
+(println "port-encoding: all tests passed")

--- a/tests/elle/port-read-exact.lisp
+++ b/tests/elle/port-read-exact.lisp
@@ -1,0 +1,158 @@
+(elle/epoch 10)
+# tests/elle/port-read-exact.lisp — `port/read-exact` semantics.
+#
+# `port/read` follows POSIX "up to N" semantics and never resubmits
+# short reads on stream sockets (per the gate in src/io/uring.rs).
+# `port/read-exact` is the strict variant: it loops in the runtime
+# until exactly N bytes have arrived, returning nil only on EOF
+# before N.  This test exercises both the file-port (small enough
+# that one read suffices) and stream-socket (large enough to force
+# the kernel to hand it back in pieces, exposing the resubmission
+# path) cases, plus the EOF-before-N → nil case.
+
+(def small-text "hello world goodbye")
+
+(spit "/tmp/elle-port-read-exact-small" small-text)
+
+# ── 1. Text-mode file port: N is graphemes, result is a string of (length N).
+#      ASCII case — bytes and graphemes coincide, but the contract is
+#      grapheme-counted regardless.
+(let [p (port/open "/tmp/elle-port-read-exact-small" :read)]
+  (defer
+    (port/close p)
+    (let [d (port/read-exact p 5)]
+      (assert (string? d) "1a: text port returns string")
+      (assert (= (length d) 5) "1b: (length d) is grapheme count, = N")
+      (assert (= d "hello") "1c: bytes match"))
+    (let [d (port/read-exact p 6)]
+      (assert (= (length d) 6) "1d: second read continues")
+      (assert (= d " world") "1e: bytes match"))))
+
+# ── 2. EOF before N → nil.  Note: count is graphemes here, and we ask for
+#      more graphemes than the file has, regardless of byte size.
+(let [p (port/open "/tmp/elle-port-read-exact-small" :read)]
+  (defer
+    (port/close p)
+    (let [d (port/read-exact p (+ (length small-text) 100))]
+      (assert (nil? d) "2a: EOF before N -> nil (not partial)"))))
+
+# ── 3. Zero count returns empty (string on text port, no kernel I/O needed).
+(let [p (port/open "/tmp/elle-port-read-exact-small" :read)]
+  (defer
+    (port/close p)
+    (let [d (port/read-exact p 0)]
+      (assert (= (length d) 0) "3a: zero count returns empty"))))
+
+# ── 3b. Multi-byte UTF-8 grapheme: a single 'é' is 2 bytes but 1 grapheme.
+#      port/read-exact 1 must reassemble both bytes and return the string "é"
+#      of length 1.  Plain byte-counted code would split the codepoint.
+(spit "/tmp/elle-port-read-exact-utf8" "café")
+(let [p (port/open "/tmp/elle-port-read-exact-utf8" :read)]
+  (defer
+    (port/close p)
+    (let [d (port/read-exact p 3)]
+      (assert (= (length d) 3) "3b1: 3 graphemes from \"café\"")
+      (assert (= d "caf") "3b2: first three graphemes are 'caf'"))
+    (let [d (port/read-exact p 1)]
+      (assert (= (length d) 1) "3b3: one more grapheme")
+      (assert (= d "é") "3b4: fourth grapheme is the multi-byte 'é'"))))
+
+# ── 3c. Over-read leftover stays for the next call.  After
+#       (port/read-exact p 1) on "café", the second byte of 'é' must NOT
+#       leak into subsequent reads.  Use a deliberately-mismatched read
+#       size so any byte-vs-grapheme confusion would surface.
+(spit "/tmp/elle-port-read-exact-utf8b" "café!")
+(let [p (port/open "/tmp/elle-port-read-exact-utf8b" :read)]
+  (defer
+    (port/close p)
+    (let [a (port/read-exact p 1)
+          b (port/read-exact p 2)
+          c (port/read-exact p 2)]
+      (assert (= a "c") "3c1: c")
+      (assert (= b "af") "3c2: af")
+      (assert (= c "é!") "3c3: é! (multi-byte 'é' assembled, '!' after)"))))
+
+# ── 3d. read-line over-read followed by read-exact.  port/read-line
+#       reads more bytes than the line it returned (everything up to the
+#       first '\n') and stashes the trailing bytes in the per-fd buffer.
+#       The next port/read-exact must consume from that stash first,
+#       split at the Nth grapheme, and stash the remainder back.  This
+#       is the path the completion-side grapheme split exists for —
+#       without it the read-line over-read leaks extra graphemes into
+#       the read-exact result.
+(spit "/tmp/elle-port-read-exact-mixed" "header\nbody-café-trailer\n")
+(let [p (port/open "/tmp/elle-port-read-exact-mixed" :read)]
+  (defer
+    (port/close p)
+    (let [hdr (port/read-line p)]
+      (assert (= hdr "header") "3d1: read-line returns first line"))
+    (let [chunk (port/read-exact p 4)]
+      (assert (= (length chunk) 4)
+              (concat "3d2: 4 graphemes, got " (string (length chunk))
+                      " (" chunk ")"))
+      (assert (= chunk "body") "3d3: chunk = 'body'"))
+    (let [chunk (port/read-exact p 1)]
+      (assert (= chunk "-") "3d4: next read sees the '-' that was buffered"))
+    (let [chunk (port/read-exact p 4)]
+      (assert (= chunk "café") "3d5: multi-byte assembled across stash"))))
+
+# ── 4. TCP loopback, count large enough to span TCP segments ──────────
+# The kernel TCP recv buffer default is ~64 KiB on Linux loopback; a
+# value past that almost always forces a short read on a single
+# port/read call.  port/read-exact must loop to assemble the whole
+# payload, byte-for-byte.
+
+(def value-size 200000)
+(def big-bytes
+  (let [@b @""
+        @i 0]
+    (while (< i value-size)
+      (push b (string (mod i 10)))
+      (assign i (+ i 1)))
+    (freeze b)))
+
+(def listener (tcp/listen "127.0.0.1" 0))
+(def server-port
+  (let [path (port/path listener)]
+    (parse-int (slice path (+ 1 (string/find path ":"))))))
+
+(def server-fiber
+  (ev/spawn (fn []
+    (let [client (tcp/accept listener)]
+      (port/write client big-bytes)
+      (port/flush client)
+      (port/close client)))))
+
+(let [sock (tcp/connect "127.0.0.1" server-port)]
+  (defer
+    (protect (port/close sock))
+    (let [d (port/read-exact sock value-size)]
+      (assert (not (nil? d))
+              "4a: port/read-exact on 200KB returns non-nil")
+      (assert (= (length d) value-size)
+              (concat "4b: got " (string (length d))
+                      " bytes, want " (string value-size)))
+      # Spot-check bytes at the boundaries and around the expected
+      # short-read split points.  d is bytes (TCP is Binary encoding);
+      # walking every index would dominate the test runtime in the
+      # VM-only path, so we sample.  '0'..'9' as bytes is 48+(i mod 10).
+      (let [check-at @[0 1 2 100 1000 65535 65536 65537
+                       131071 131072 131073
+                       (- value-size 1)]
+            @j 0
+            @mismatch nil]
+        (while (and (nil? mismatch) (< j (length check-at)))
+          (let [i (get check-at j)
+                expected (+ 48 (mod i 10))]
+            (when (not (= (get d i) expected))
+              (assign mismatch
+                      (string "byte " i ": got " (get d i)
+                              " want " expected))))
+          (assign j (+ j 1)))
+        (assert (nil? mismatch)
+                (concat "4c: " (or mismatch "")))))))
+
+(protect (port/close listener))
+(protect (ev/join-protected server-fiber))
+
+(println "port-read-exact: all tests passed")

--- a/tests/elle/redis-short-read.lisp
+++ b/tests/elle/redis-short-read.lisp
@@ -1,0 +1,105 @@
+(elle/epoch 10)
+# tests/elle/redis-short-read.lisp — resp-read must reassemble bulk
+# strings that span more than one TCP segment.
+#
+# Background: port/read on a stream socket (TCP, Unix) follows POSIX
+# "up to N bytes" semantics — io_uring deliberately does *not* resubmit
+# short reads on stream sockets (see src/io/uring.rs, the
+# `if !is_stream` gate around the read-short-read resubmission path).
+# So a single (port/read port (+ len 2)) for a bulk reply that the
+# kernel hands back across two recv() calls returns truncated data and
+# leaves the tail of the bulk plus its trailing \r\n on the wire.  The
+# next resp-read then read-lines those leftover bytes as a "reply" and
+# parses a chunk of payload as a RESP prefix — typically a digit or
+# '-' that surfaces as "integer: cannot parse \"...,...,...\" as
+# base-10 integer" or "unexpected RESP prefix: <byte>".
+#
+# This test confirms the property even single-fiber callers depend on:
+# a redis bulk reply round-trips byte-for-byte regardless of size.
+#
+# The threshold for short reads on loopback is roughly the kernel TCP
+# recv buffer (default ~64 KiB on Linux); we use 200 KiB so the kernel
+# almost always splits the reply.  Off-loopback the threshold is much
+# smaller (1 MSS), but a single test value covers both regimes.
+#
+# Pre-fix: at least one round trips a short read; the failing read
+# either truncates the returned string or pollutes the next reply and
+# raises an unexpected-prefix / cannot-parse error.
+# Post-fix: 200 round trips all succeed with byte-exact echo.
+#
+# Requires a live Redis on 127.0.0.1:6379.  Skips silently otherwise.
+
+(def redis ((import-file "lib/redis.lisp")))
+
+(def value-size 200000)
+(def n-rounds 200)
+(def test-key "test:redis-short-read:big")
+
+(let [[ok? _] (protect
+                (redis:with "127.0.0.1" 6379
+                  (fn [] (redis:ping))))]
+  (when (not ok?)
+    (eprintln "SKIP: Redis not available at 127.0.0.1:6379")
+    (exit 0)))
+(println "  redis: available")
+
+(def big-value
+  (let [@buf @""
+        @i 0]
+    (while (< i value-size)
+      (push buf (string (mod i 10)))
+      (assign i (+ i 1)))
+    (freeze buf)))
+
+(redis:with "127.0.0.1" 6379
+  (fn []
+    (redis:set test-key big-value)
+    (println "  seeded " value-size "-byte value")
+
+    (def @ok true)
+    (def @fail-msgs @[])
+    (let [@r 0]
+      (while (< r n-rounds)
+        (let [[gok val] (protect (redis:get test-key))]
+          (cond
+            (not gok)
+              (begin
+                (assign ok false)
+                (push fail-msgs (string "round " r ": get raised "
+                                        val)))
+            (nil? val)
+              (begin
+                (assign ok false)
+                (push fail-msgs (string "round " r ": got nil")))
+            (not (= (string/size-of val) value-size))
+              (begin
+                (assign ok false)
+                (push fail-msgs (string "round " r ": short reply, got "
+                                        (string/size-of val) " want "
+                                        value-size)))
+            (not (= val big-value))
+              (begin
+                (assign ok false)
+                (push fail-msgs (string "round " r
+                                        ": reply does not byte-match")))))
+        (assign r (+ r 1))))
+
+    (redis:del test-key)
+
+    (if ok
+      (println "  " n-rounds " rounds × " value-size
+               "-byte get: all byte-exact")
+      (begin
+        (eprintln "FAIL: redis-short-read detected "
+                  (length fail-msgs) " corruption(s)")
+        (let [@i 0]
+          (while (and (< i (length fail-msgs)) (< i 10))
+            (eprintln "  " (get fail-msgs i))
+            (assign i (+ i 1))))
+        (when (> (length fail-msgs) 10)
+          (eprintln "  ... (" (- (length fail-msgs) 10) " more)"))
+        (assert false
+                "redis-short-read: bulk-string framing corrupted by short read")))))
+
+(println "")
+(println "redis-short-read test passed.")


### PR DESCRIPTION
port/read on a stream socket (TCP, Unix) follows POSIX "up to N" semantics — io_uring deliberately does not resubmit short reads on stream sockets (see the is_stream gate in src/io/uring.rs), and the threadpool backend issues a single read(2).  For length-prefixed wire protocols (RESP bulk strings, h2 DATA frames, gRPC envelopes, fixed-record framing) that's the wrong default: a reply that straddles a TCP segment boundary (anything past ~64 KiB on loopback, smaller off-loopback) leaves its tail on the wire to be misparsed as the next reply's prefix.  Single-fiber callers hit corruption too; the recent redis fiber-mutex made it less frequent under contention but the underlying short-read was untouched.

This commit lifts read-exact into the runtime, adds an explicit text/binary encoding to the socket constructors, and gives Lisp code an accessor so protocol implementations can self-check.

  port/read-exact port n [:timeout ms] -> bytes | string | nil

The unit of N depends on the port's encoding:

  - Binary port: N bytes.  Returns a bytes value of length N, or nil if EOF arrived before N bytes.  The runtime loops short reads on a single pre-allocated buffer — no per-iteration concat, no Lisp-level helper, and stream sockets get the resubmission gate flipped on for ReadExact only (plain Read keeps "up to N").

  - Text port: N graphemes.  Strings under Elle are measured in grapheme clusters, so this is the only N that makes `(length (port/read-exact text-port 50))` equal 50 unconditionally. The runtime reads kernel bytes until the valid-UTF-8 prefix contains N graphemes, splits at the Nth grapheme boundary, returns the string, and stashes the trailing bytes for the next read. Returns nil on EOF before N graphemes.  Two helpers in src/io/mod.rs (nth_grapheme_byte_end, grapheme_count_in_valid_prefix) are shared by the submit early-out, the uring short-read resubmission gate, the threadpool worker loop, and the completion-side split.

  port/encoding port -> :text | :binary

Accessor for the port's encoding.  Lets protocol code self-check before any bytes touch the wire — RESP, gRPC, h2, and friends are byte-framed and must refuse a text-mode port; a line-oriented text protocol (SMTP, IRC, plain HTTP/1.x) can do the inverse.

  tcp/connect / tcp/accept / unix/connect / unix/accept now take
  :encoding :text | :binary

Default is :binary, matching POSIX-socket convention (and what Python, Rust, Go, and Node all default to).  Existing callers see no behavior change.  Opt into :text when the protocol is line-oriented and you want string returns plus grapheme-counted reads.  Threaded through ConnectAddr::{Tcp,Unix} and IoOp::Accept, applied at completion time via a new Port::with_encoding builder so the existing constructor signatures stay stable.

lib/redis.lisp adds require-binary-port (also exported as :require-binary-port for downstream wrappers); redis-cmd and redis-pipeline call it up front and raise
{:reason :wrong-port-encoding :encoding :text :message "...redis requires a binary port..."} instead of silently corrupting framing. resp-read drops its inline byte-loop and calls port/read-exact directly.  The self-test stand-ins switched from port/open to port/open-bytes (TCP is binary; the file stand-ins must match).

Tests:

  tests/elle/redis-short-read.lisp — the redis-level counter-factual.
  Single fiber, 200 rounds of redis:get on a 200 KB value.  Pre-fix
  the test fails after the first round with a short reply, and the
  next read raises "unexpected RESP prefix" on the leaked tail.

  tests/elle/port-read-exact.lisp — primitive-level: file-port small
  reads (ASCII), EOF-before-N → nil, zero-count, multi-byte UTF-8
  ("café" with `é` as a 2-byte cluster, byte-precise across the
  grapheme boundary), TCP loopback 200 KB end-to-end, and the
  read-line-over-read → read-exact path that the completion-side
  grapheme split exists for.

  tests/elle/port-encoding.lisp — encoding defaults to :binary on
  tcp/connect and tcp/accept; :encoding :text honored on both;
  bad-keyword rejected with a clear error; redis:require-binary-port
  rejects a text port with :wrong-port-encoding reason.

Existing redis.lisp, redis-race.lisp, read-after-readline.lisp still pass; full make smoke green.  Counter-factuals verified for both the short-read fix, the text-port grapheme path, and the connect-side encoding honor.