### PR TITLE
posix: add os/sig-* primitives for sending and receiving POSIX signals

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,6 +1,11 @@
 #!/bin/sh
-# Auto-format staged .lisp files with elle fmt
+# Pre-commit hook:
+#   1. Auto-format staged .lisp files with `elle fmt` and re-stage.
+#   2. If staged .rs files exist, gate on cargo fmt / clippy / rustdoc —
+#      same checks `make test` runs, scoped to Rust-touching commits so
+#      Lisp-only commits don't pay the Cargo cost.
 
+# ── Lisp ────────────────────────────────────────────────────────────
 if [ -n "$ELLE" ]; then
   ELLE="$ELLE"
 elif [ -x ./target/release/elle ]; then
@@ -11,9 +16,27 @@ else
   ELLE=elle
 fi
 
-staged=$(git diff --cached --name-only --diff-filter=ACM -- '*.lisp')
-[ -z "$staged" ] && exit 0
+staged_lisp=$(git diff --cached --name-only --diff-filter=ACM -- '*.lisp')
+if [ -n "$staged_lisp" ]; then
+  for f in $staged_lisp; do
+    "$ELLE" fmt "$f" && git add "$f"
+  done
+fi
 
-for f in $staged; do
-  "$ELLE" fmt "$f" && git add "$f"
-done
+# ── Rust ────────────────────────────────────────────────────────────
+if git diff --cached --name-only | grep -q '\.rs$'; then
+  if ! cargo fmt -- --check; then
+    echo "pre-commit: cargo fmt check failed. Run 'cargo fmt' and re-stage."
+    exit 1
+  fi
+
+  if ! cargo clippy --workspace --all-targets --all-features -- -D warnings; then
+    echo "pre-commit: clippy failed. Fix warnings and re-stage."
+    exit 1
+  fi
+
+  if ! RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps; then
+    echo "pre-commit: rustdoc failed. Fix doc warnings and re-stage."
+    exit 1
+  fi
+fi

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -60,6 +60,7 @@ make smoke                 # run all tests (~30s)
 | [traits](docs/traits.md) | with-traits, trait dispatch |
 | [portrait](docs/analysis/portrait.md) | Semantic analysis and portraits |
 | [io](docs/io.md) | Ports, file I/O, subprocesses |
+| [posix-signals](docs/posix-signals.md) | POSIX signals: `os/sig-send`, `os/sig-watch`, etc. |
 | [ffi](docs/ffi.md) | C interop, libloading, callbacks |
 | [lua](docs/lua.md) | Lua syntax mode |
 | [epochs](docs/epochs.md) | Epoch migration system |

--- a/docs/posix-signals.md
+++ b/docs/posix-signals.md
@@ -105,13 +105,20 @@ automatically. The policy:
    any other Unix program. The first `os/sig-watch` atomically blocks
    the requested signals on the main thread and opens the
    signalfd / kqueue.
-3. **Refcounted block; unblock when refcount hits zero.** A signal
-   stays blocked as long as at least one receiver watches it.
-   `os/sig-close` decrements; when the last watcher for a signal
-   closes, the signal is unblocked. Any instance pending in the
-   kernel queue at the moment of unblock fires its default
-   disposition immediately — this matches plain POSIX semantics and
-   is preferred to silently swallowing the event.
+3. **Refcounted block; drain-then-unblock when refcount hits zero.**
+   A signal stays blocked as long as at least one receiver watches
+   it. `os/sig-close` decrements; when the last watcher for a signal
+   closes, elle drains any instances still pending on the calling
+   thread / process queue (via `sigwait`, which dequeues without
+   invoking a handler) and only then unblocks. This is the only safe
+   order: signals queued during the watch that the user never
+   consumed via `os/sig-next` — and on macOS the kqueue-coalesced
+   leftover from a multi-`kill` burst whose worker delivery only
+   drained one instance — would otherwise fire the signal's default
+   disposition on the unblocking thread, terminating the process
+   mid-close. Signals generated *after* the unblock fire whatever
+   disposition was in effect before the watch started (saved by
+   `os/sig-watch`, restored before unblocking).
 4. **macOS: per-receive worker unblock + no-op handler.** Linux's
    `signalfd` reads pending signals directly from the kernel queue
    even when every thread blocks the signal, so the worker only

--- a/docs/posix-signals.md
+++ b/docs/posix-signals.md
@@ -1,0 +1,233 @@
+# POSIX signals
+
+Elle programs can send POSIX signals to other processes and observe
+signals delivered to themselves. The surface lives under `os/sig-*`.
+
+The word "signal" is overloaded:
+
+- **Elle signals** (`:yield`, `:io`, `:error`, …) — the runtime's
+  unified control-flow mechanism documented in
+  [`signals/`](signals/). They are *compile-time inferred* and flow
+  up the fiber chain.
+- **POSIX signals** (`SIGTERM`, `SIGINT`, `SIGUSR1`, …) — kernel
+  notifications delivered to the process. Documented here. Use the
+  `os/sig-*` primitives; never the bare word "signal".
+
+## Quick start
+
+Watch for `SIGTERM` and `SIGINT`, log each delivery, exit on first:
+
+```text
+(def r (os/sig-watch |:sigterm :sigint|))
+(each ev (os/sig-next r)
+  (println :received (get ev :signal) :from (get ev :sender-pid)))
+(os/sig-close r)
+(sys/exit 0)
+```
+
+Send `SIGUSR1` to another process:
+
+```text
+(os/sig-send 4242 :sigusr1)
+```
+
+Send a signal to yourself:
+
+```text
+(os/sig-raise :sigusr1)
+```
+
+## Surface
+
+| Primitive | Capability | Notes |
+|-----------|-----------|-------|
+| `(os/sig-send pid sig)` | `:os-signal` | `kill(2)`. `sig` is a keyword (`:sigterm`) or a named integer (`15`). |
+| `(os/sig-raise sig)` | `:os-signal` | `raise(3)`. Equivalent to `(os/sig-send (sys/pid) sig)`. |
+| `(os/sig-watch sig-set)` | — | Blocks the signals on the calling thread and returns a `SignalReceiver`. Yields `:io` only on `os/sig-next`. |
+| `(os/sig-next receiver)` | — | Yields `SIG_YIELD\|SIG_IO`. Resumes with an array of delivered-signal structs. |
+| `(os/sig-close receiver)` | — | Closes the receiver. When the last receiver for a signal closes, the signal is unblocked. Idempotent. |
+| `(os/sig-pending)` | — | Returns a set of keywords for signals currently pending delivery on this thread (`sigpending(2)`). |
+| `(os/sig-mask)` | — | Returns a set of keywords for signals currently blocked on this thread (`pthread_sigmask`). |
+| `(os/sig-watching)` | — | Returns a set of keywords for signals currently being watched by at least one live receiver. |
+
+## Recognised signals
+
+`os/sig-*` accepts the standard set:
+
+`:sigterm` `:sigkill` `:sighup` `:sigint` `:sigquit` `:sigpipe`
+`:sigalrm` `:sigusr1` `:sigusr2` `:sigchld` `:sigcont` `:sigstop`
+`:sigtstp` `:sigttin` `:sigttou` `:sigwinch`
+
+Integer signums are accepted only if they round-trip to one of the
+above names. Unknown integers (including realtime signals
+`SIGRTMIN..SIGRTMAX`) are an `:argument-error`. Realtime signals are
+not exposed in v1.
+
+`:sigkill` and `:sigstop` can be *sent*; they cannot be watched (the
+kernel forbids blocking them).
+
+## Delivered-signal struct
+
+`(os/sig-next receiver)` resolves to an *array* of structs (signalfd
+batches deliveries; the array is often one element but may be
+several):
+
+```text
+[{:signal :sigterm
+  :sender-pid 1234
+  :sender-uid 1000
+  :code 0
+  :count 1}]
+```
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| `:signal` | keyword | The delivered signal. |
+| `:sender-pid` | int or nil | The sender's pid. `nil` on macOS. |
+| `:sender-uid` | int or nil | The sender's uid. `nil` on macOS. |
+| `:code` | int | `siginfo.ssi_code` (`SI_USER=0`, `SI_KERNEL=128`, `CLD_EXITED=1`, …). `0` on macOS. |
+| `:count` | int | Always `1` on Linux. On macOS the kevent coalesced count. |
+
+## Mask policy
+
+POSIX signalfd and kqueue both require the target signal to be
+blocked process-wide first — otherwise the default disposition fires
+in some thread before the watcher reads it. Elle handles the mask
+automatically. The policy:
+
+1. **Worker threads block everything.** Every thread Elle spawns
+   internally (the I/O thread pool, the stdin reader, etc.) masks
+   all maskable signals as its first action. Workers are never the
+   kernel's chosen signal delivery target.
+2. **The main thread blocks lazily.** Before the first
+   `os/sig-watch` call, default disposition is in force for every
+   signal — `kill -TERM $pid` terminates an elle program just like
+   any other Unix program. The first `os/sig-watch` atomically blocks
+   the requested signals on the main thread and opens the
+   signalfd / kqueue.
+3. **Refcounted block; unblock when refcount hits zero.** A signal
+   stays blocked as long as at least one receiver watches it.
+   `os/sig-close` decrements; when the last watcher for a signal
+   closes, the signal is unblocked. Any instance pending in the
+   kernel queue at the moment of unblock fires its default
+   disposition immediately — this matches plain POSIX semantics and
+   is preferred to silently swallowing the event.
+
+`(os/sig-mask)` always reflects the actual `pthread_sigmask` on the
+calling thread. `(os/sig-watching)` returns the set of signals
+currently held by at least one receiver.
+
+## Documented limitations
+
+These three are inherent to the chosen mechanism, not bugs.
+
+### macOS does not report sender pid or uid
+
+kqueue's `EVFILT_SIGNAL` reports the signal number and a coalesced
+count, full stop. `:sender-pid` and `:sender-uid` are `nil` on macOS.
+Programs that need sender identity — for example, SIGCHLD-driven
+targeted child reaping — must call `subprocess/wait`-style logic to
+recover it. Linux signalfd populates both fields.
+
+### Library-spawned threads can defeat the worker-mask invariant
+
+Elle masks all signals on every thread it spawns directly. Threads
+spawned by C dependencies (the cranelift JIT codegen threads, libffi
+callbacks, future plugin cdylibs, anything called via FFI) inherit
+whatever the *main thread's* mask was at *their* spawn time. If you
+call `os/sig-watch` after such a thread has spawned, the kernel may
+still select that thread as the delivery target and fire the default
+disposition.
+
+Practical mitigation: call `os/sig-watch` early in your program,
+before triggering JIT compilation, before loading FFI plugins. There
+is no portable way to retroactively change another thread's signal
+mask.
+
+### Standard signals coalesce
+
+Two `SIGUSR1` deliveries from the same sender between consecutive
+`os/sig-next` reads collapse to one event in the kernel queue. This
+is plain POSIX behaviour for non-realtime signals; it is not
+elle-specific. `:count` on each event is a best-effort approximation,
+not a reliable counter. Do not use signals as a counting channel.
+
+## REPL and Ctrl-C
+
+The REPL uses `rustyline`, which installs its own SIGINT handler so
+Ctrl-C cancels the current input. If you call
+`(os/sig-watch |:sigint|)` in the REPL, that handler stops seeing
+Ctrl-C — the watcher takes ownership. Ctrl-\\ (SIGQUIT) is unaffected.
+
+This is the intended behaviour. If you want a quiet REPL again,
+`(os/sig-close r)` releases the lease.
+
+## Cancel semantics
+
+A fiber cancelled while parked in `os/sig-next` follows the same path
+as a fiber cancelled in `watch-next`:
+
+- On the io_uring backend (Linux), the underlying read is cancelled
+  with `IORING_OP_ASYNC_CANCEL`; the receiver survives and can be
+  reused.
+- On the thread-pool backend (macOS, CI, older Linux), there is no
+  `shutdown(2)` equivalent to wake a blocking `read()` on signalfd,
+  so cancel closes the receiver. The next `os/sig-next` on it will
+  fail. Wrap with `(ev/race timer (os/sig-next r))` and you must
+  re-create the receiver on each timeout.
+
+## Patterns
+
+### Graceful shutdown
+
+```text
+(def r (os/sig-watch |:sigterm :sigint|))
+(ev/spawn (fn []
+  (each ev (os/sig-next r)
+    (eprintln "shutting down on " (get ev :signal))
+    (cleanup!)
+    (sys/exit 0))))
+```
+
+### Reload-on-SIGHUP
+
+```text
+(def r (os/sig-watch |:sighup|))
+(forever
+  (each _ (os/sig-next r) (reload-config!)))
+```
+
+### Conditional disposition
+
+```text
+# Block SIGPIPE for the duration of a write loop so a closed peer
+# manifests as a write error instead of process termination.
+(def r (os/sig-watch |:sigpipe|))
+(defer (os/sig-close r)
+  (write-loop!))
+```
+
+## Capabilities
+
+`os/sig-send` and `os/sig-raise` carry the `:os-signal` capability
+bit. A fiber created with `(fiber/new body :deny |:os-signal|)`
+cannot send signals — the call emits a `:capability-denied` signal
+that the parent fiber catches.
+
+`:os-signal` is distinct from `:exec`. Denying `:exec` blocks
+`subprocess/exec` and `subprocess/kill` (since the latter is sending a
+signal to *spawned* children); denying `:os-signal` blocks generic
+signal sends to arbitrary pids. Either may be denied independently.
+
+`os/sig-watch`, `os/sig-next`, `os/sig-close`, `os/sig-pending`,
+`os/sig-mask`, and `os/sig-watching` do not carry a capability bit —
+they observe process state without sending.
+
+## See also
+
+- [`signals/`](signals/) — Elle's runtime signal system (different
+  concept, different word).
+- [`io.md`](io.md) — async scheduler that `os/sig-next` integrates
+  with.
+- [`subprocess`](io.md#subprocesses) — `subprocess/kill` for sending
+  a signal to a child handle.

--- a/docs/posix-signals.md
+++ b/docs/posix-signals.md
@@ -112,10 +112,28 @@ automatically. The policy:
    kernel queue at the moment of unblock fires its default
    disposition immediately — this matches plain POSIX semantics and
    is preferred to silently swallowing the event.
+4. **macOS: per-receive worker unblock + no-op handler.** Linux's
+   `signalfd` reads pending signals directly from the kernel queue
+   even when every thread blocks the signal, so the worker only
+   needs to call `read(2)`. macOS's `EVFILT_SIGNAL` fires from the
+   in-kernel signal-delivery path: when every thread blocks the
+   signal the kernel parks it on the process pending list and the
+   knote never activates. Elle works around this on macOS by
+   installing a process-wide no-op `sigaction` handler for each
+   newly-watched signal (refcounted; restored to the saved
+   disposition when the last watcher closes), and by
+   `pthread_sigmask`-unblocking the watched signals on the
+   threadpool worker thread that calls `kevent()`. The kernel picks
+   that worker as the delivery target, runs the no-op, and the
+   knote activates so `kevent()` returns. None of this is visible to
+   Lisp.
 
 `(os/sig-mask)` always reflects the actual `pthread_sigmask` on the
-calling thread. `(os/sig-watching)` returns the set of signals
-currently held by at least one receiver.
+calling thread — i.e. the main thread (and other elle-spawned
+threads) after `os/sig-watch`. It does not reflect the per-worker
+unblock used to feed `kevent()` on macOS.
+`(os/sig-watching)` returns the set of signals currently held by at
+least one receiver.
 
 ## Documented limitations
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -199,7 +199,7 @@ impl MlirPolicy {
 /// silently (forward compat for :spirv, :mlir, :gpu).
 pub const TRACE_KEYWORDS: &[&str] = &[
     "call", "signal", "compile", "fiber", "hir", "lir", "emit", "jit", "io", "gc", "import",
-    "macro", "wasm", "capture", "arena", "escape", "bytecode",
+    "macro", "wasm", "capture", "arena", "escape", "bytecode", "posix",
     // Future: accepted without error
     "spirv", "mlir", "gpu",
 ];
@@ -266,7 +266,13 @@ pub mod trace_bits {
     pub const ARENA: u32 = 1 << 14;
     pub const ESCAPE: u32 = 1 << 15;
     pub const BYTECODE: u32 = 1 << 16;
-    pub const ALL: u32 = (1 << 17) - 1;
+    /// POSIX-signal subsystem (os/sig-* primitives, signalfd / kqueue
+    /// EVFILT_SIGNAL plumbing, threadpool blocking sig reads). Read both
+    /// from a per-VM `RuntimeConfig` via `has_trace_bit` and from the
+    /// process-global mirror `GLOBAL_TRACE_BITS` (below) — threadpool
+    /// worker threads and other off-VM call sites have no VM reference.
+    pub const POSIX: u32 = 1 << 17;
+    pub const ALL: u32 = (1 << 18) - 1;
 
     /// Convert a keyword name to its bit. Returns 0 for unknown keywords.
     pub fn from_name(name: &str) -> u32 {
@@ -288,10 +294,26 @@ pub mod trace_bits {
             "arena" => ARENA,
             "escape" => ESCAPE,
             "bytecode" => BYTECODE,
+            "posix" => POSIX,
             // Future keywords — accepted but no bit (traced via HashSet)
             _ => 0,
         }
     }
+}
+
+/// Process-global mirror of the active VM's trace bits, kept in sync by
+/// `RuntimeConfig::set_trace` and `from_static_config`. Threadpool
+/// worker threads, signal-handler-adjacent code, and other off-VM call
+/// sites (which can't carry a `&VM` reference) check this directly via
+/// `global_trace_bit_enabled`. In a multi-VM process the most recent
+/// `set_trace` wins — adequate for the diagnostic use case.
+pub static GLOBAL_TRACE_BITS: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
+
+/// Fast check for off-VM trace gates. Single relaxed atomic load when
+/// the bit is off; format args are only evaluated when the bit is on.
+#[inline]
+pub fn global_trace_bit_enabled(bit: u32) -> bool {
+    GLOBAL_TRACE_BITS.load(std::sync::atomic::Ordering::Relaxed) & bit != 0
 }
 
 // ── RuntimeConfig ─────────────────────────────────────────────────
@@ -328,6 +350,9 @@ impl RuntimeConfig {
             trace.insert(kw.clone());
             bits |= trace_bits::from_name(kw);
         }
+        // Mirror to the process-global so off-VM call sites can gate
+        // tracing without a VM reference. See `GLOBAL_TRACE_BITS`.
+        GLOBAL_TRACE_BITS.store(bits, std::sync::atomic::Ordering::Relaxed);
 
         RuntimeConfig {
             trace,
@@ -348,6 +373,8 @@ impl RuntimeConfig {
         }
         self.trace = keywords;
         self.trace_bits = bits;
+        // Keep the off-VM mirror in sync.
+        GLOBAL_TRACE_BITS.store(bits, std::sync::atomic::Ordering::Relaxed);
     }
 
     /// Check if a trace bit is set (fast path — no HashSet lookup).

--- a/src/io/AGENTS.md
+++ b/src/io/AGENTS.md
@@ -17,8 +17,10 @@ to a backend for execution.
 | `aio.rs` | `AsyncBackend` — async I/O with io_uring (Linux) or thread-pool fallback |
 | `request.rs` | `IoRequest` and `IoOp` types — typed I/O request descriptors |
 | `completion.rs` | `process_raw_completion` — converts raw CQE/thread results to `Completion` |
+| `sigfd.rs` | `SignalReceiver` — POSIX signalfd (Linux) or kqueue+EVFILT_SIGNAL (macOS) external for `os/sig-watch`; also the worker-thread mask helper `mask_all_signals_on_this_thread` |
+| `sigmap.rs` | Shared keyword↔signum mapping; `resolve(value, ctx)` parses a `:sigterm`/integer Value to libc signum |
 | `sockaddr.rs` | Sockaddr construction, formatting, parsing — single source of truth |
-| `threadpool.rs` | `ThreadPoolBackend`, `PoolOp`, `PoolCompletion` — typed thread-pool I/O |
+| `threadpool.rs` | `ThreadPoolBackend`, `PoolOp`, `PoolCompletion` — typed thread-pool I/O. Every spawned worker calls `crate::io::sigfd::mask_all_signals_on_this_thread()` first so the kernel never selects it as a POSIX-signal delivery target. |
 | `uring.rs` | io_uring SQE submission and CQE processing (Linux only) |
 
 
@@ -50,6 +52,10 @@ Enum of I/O operations (16 variants):
 **Timer:** `Sleep { duration }`
 
 **Subprocess operations:** `Spawn { program, args, env, cwd, stdin, stdout, stderr }`, `ProcessWait`
+
+**Filesystem watch:** `WatchNext` — portless; the `FsWatcher` external lives in `IoRequest.port`. Read from the inotify (Linux) or kqueue (macOS) fd.
+
+**POSIX signal reception:** `SigNext` — portless; the `SignalReceiver` external lives in `IoRequest.port`. Reads from the signalfd (Linux) / kqueue fd (macOS) opened by `os/sig-watch`. Completion is an array of structs `{:signal :sigterm :sender-pid n :sender-uid n :code n :count n}`. See `docs/posix-signals.md` for the mask policy that backs this op.
 
 **Background task:** `Task(TaskFn)` — run an arbitrary closure on a background thread. `TaskFn` wraps a `FnOnce() -> (i32, Vec<u8>) + Send` in `RefCell<Option<...>>` for take-once semantics. Non-negative result_code = success (data returned as `Value::bytes`), negative = error (data is UTF-8 error message). `IoRequest::task()` is the convenience constructor.
 

--- a/src/io/aio.rs
+++ b/src/io/aio.rs
@@ -967,7 +967,17 @@ impl AsyncBackend {
                 #[cfg(any(target_os = "linux", target_os = "android"))]
                 network_pool.submit(id, PoolOp::SigfdRead { fd })?;
                 #[cfg(target_os = "macos")]
-                network_pool.submit(id, PoolOp::KqSigRead { fd })?;
+                network_pool.submit(
+                    id,
+                    PoolOp::KqSigRead {
+                        fd,
+                        // Worker pthread_sigmask-unblocks these so kqueue's
+                        // EVFILT_SIGNAL has a thread the kernel can pick
+                        // as the delivery target — see kq_sig_read_blocking
+                        // in src/io/threadpool.rs.
+                        signals: receiver.signals(),
+                    },
+                )?;
                 #[cfg(not(any(target_os = "linux", target_os = "android", target_os = "macos")))]
                 {
                     let _ = (id, fd);

--- a/src/io/aio.rs
+++ b/src/io/aio.rs
@@ -177,6 +177,11 @@ impl AsyncBackend {
             return self.submit_watch_next(&request.port);
         }
 
+        // SigNext is portless — the SignalReceiver External is in request.port.
+        if let IoOp::SigNext = request.op {
+            return self.submit_sig_next(&request.port);
+        }
+
         // Open is portless — creates a new port rather than operating on one.
         if let IoOp::Open {
             ref path,
@@ -925,6 +930,54 @@ impl AsyncBackend {
         Ok(id)
     }
 
+    /// Submit a sig-next operation. Reads from the signalfd / kqueue fd.
+    /// Buffer is sized for several batched signalfd_siginfo structs (Linux)
+    /// or several kevent result pairs (macOS).
+    #[allow(unused_variables)]
+    fn submit_sig_next(&self, receiver_val: &Value) -> Result<u64, String> {
+        use crate::io::sigfd::SignalReceiver;
+
+        let receiver = receiver_val
+            .as_external::<SignalReceiver>()
+            .ok_or("sig-next: expected a signal receiver handle")?;
+        let fd = receiver.raw_fd()?;
+
+        let mut inner = self.inner.borrow_mut();
+        let id = inner.next_id;
+        inner.next_id += 1;
+        // signalfd_siginfo is 128 bytes on Linux; round up generously.
+        let buf_handle = inner.buffer_pool.alloc(1024);
+
+        let AsyncBackendInner {
+            ref mut platform,
+            ref mut network_pool,
+            ref mut pending,
+            ref mut buffer_pool,
+            ..
+        } = *inner;
+
+        match platform {
+            #[cfg(target_os = "linux")]
+            PlatformBackend::Uring(ring) => {
+                // signalfd reads behave like a regular fd read; reuse the
+                // watch-next submission path which is also a portless read.
+                crate::io::uring::submit_uring_watch_next(ring, id, fd, buffer_pool, buf_handle)?;
+            }
+            PlatformBackend::ThreadPool(_) => {
+                network_pool.submit(id, PoolOp::SigfdRead { fd })?;
+            }
+        }
+
+        pending.insert(
+            id,
+            PendingOp::SigNext {
+                receiver: *receiver_val,
+                buffer_handle: buf_handle,
+            },
+        );
+        Ok(id)
+    }
+
     /// Submit a file open operation. Open creates a new port, so
     /// request.port is Value::NIL — we handle it before the port guard.
     #[allow(unused_variables)]
@@ -1579,6 +1632,7 @@ impl AsyncBackendInner {
             | IoOp::Task(_)
             | IoOp::Resolve { .. }
             | IoOp::WatchNext
+            | IoOp::SigNext
             | IoOp::Close
             | IoOp::PollFd { .. } => return Err("io/submit: unsupported operation on stdin".into()),
         };

--- a/src/io/aio.rs
+++ b/src/io/aio.rs
@@ -964,7 +964,19 @@ impl AsyncBackend {
                 crate::io::uring::submit_uring_watch_next(ring, id, fd, buffer_pool, buf_handle)?;
             }
             PlatformBackend::ThreadPool(_) => {
+                #[cfg(any(target_os = "linux", target_os = "android"))]
                 network_pool.submit(id, PoolOp::SigfdRead { fd })?;
+                #[cfg(target_os = "macos")]
+                network_pool.submit(id, PoolOp::KqSigRead { fd })?;
+                #[cfg(not(any(
+                    target_os = "linux",
+                    target_os = "android",
+                    target_os = "macos"
+                )))]
+                {
+                    let _ = (id, fd);
+                    return Err("sig-next: not supported on this platform".into());
+                }
             }
         }
 

--- a/src/io/aio.rs
+++ b/src/io/aio.rs
@@ -968,11 +968,7 @@ impl AsyncBackend {
                 network_pool.submit(id, PoolOp::SigfdRead { fd })?;
                 #[cfg(target_os = "macos")]
                 network_pool.submit(id, PoolOp::KqSigRead { fd })?;
-                #[cfg(not(any(
-                    target_os = "linux",
-                    target_os = "android",
-                    target_os = "macos"
-                )))]
+                #[cfg(not(any(target_os = "linux", target_os = "android", target_os = "macos")))]
                 {
                     let _ = (id, fd);
                     return Err("sig-next: not supported on this platform".into());

--- a/src/io/aio.rs
+++ b/src/io/aio.rs
@@ -935,12 +935,13 @@ impl AsyncBackend {
     /// or several kevent result pairs (macOS).
     #[allow(unused_variables)]
     fn submit_sig_next(&self, receiver_val: &Value) -> Result<u64, String> {
-        use crate::io::sigfd::SignalReceiver;
+        use crate::io::sigfd::{posix_trace, SignalReceiver};
 
         let receiver = receiver_val
             .as_external::<SignalReceiver>()
             .ok_or("sig-next: expected a signal receiver handle")?;
         let fd = receiver.raw_fd()?;
+        posix_trace(format_args!("submit_sig_next fd={}", fd));
 
         let mut inner = self.inner.borrow_mut();
         let id = inner.next_id;

--- a/src/io/completion.rs
+++ b/src/io/completion.rs
@@ -247,6 +247,66 @@ pub(super) fn process_raw_completion(
                 result: Ok(Value::array(event_values)),
             }
         }
+        PendingOp::SigNext { receiver, .. } => {
+            if result_code <= 0 {
+                let msg = if result_code == 0 {
+                    "signal receiver closed".to_string()
+                } else {
+                    format!(
+                        "sig-next read error: {}",
+                        std::io::Error::from_raw_os_error(-result_code)
+                    )
+                };
+                return Completion {
+                    id,
+                    result: Err(error_val("io-error", msg)),
+                };
+            }
+            let events = if let Some(r) = receiver.as_external::<crate::io::sigfd::SignalReceiver>()
+            {
+                r.parse_events(&data[..result_code as usize])
+            } else {
+                Vec::new()
+            };
+            let event_values: Vec<Value> = events
+                .iter()
+                .map(|ev| {
+                    let name = crate::io::sigmap::signum_to_keyword(ev.signum).unwrap_or("unknown");
+                    let mut fields = std::collections::BTreeMap::new();
+                    fields.insert(
+                        crate::value::heap::TableKey::Keyword("signal".into()),
+                        Value::keyword(name),
+                    );
+                    fields.insert(
+                        crate::value::heap::TableKey::Keyword("sender-pid".into()),
+                        match ev.sender_pid {
+                            Some(p) => Value::int(p as i64),
+                            None => Value::NIL,
+                        },
+                    );
+                    fields.insert(
+                        crate::value::heap::TableKey::Keyword("sender-uid".into()),
+                        match ev.sender_uid {
+                            Some(u) => Value::int(u as i64),
+                            None => Value::NIL,
+                        },
+                    );
+                    fields.insert(
+                        crate::value::heap::TableKey::Keyword("code".into()),
+                        Value::int(ev.code as i64),
+                    );
+                    fields.insert(
+                        crate::value::heap::TableKey::Keyword("count".into()),
+                        Value::int(ev.count as i64),
+                    );
+                    Value::struct_from(fields)
+                })
+                .collect();
+            Completion {
+                id,
+                result: Ok(Value::array(event_values)),
+            }
+        }
         PendingOp::PollFd { .. } => {
             // result_code is the revents mask (positive) or negative errno.
             if result_code < 0 {
@@ -533,6 +593,9 @@ pub(super) fn process_raw_completion(
                 }
                 IoOp::WatchNext => {
                     unreachable!("WatchNext uses PendingOp::WatchNext, not PendingOp::Port")
+                }
+                IoOp::SigNext => {
+                    unreachable!("SigNext uses PendingOp::SigNext, not PendingOp::Port")
                 }
                 IoOp::PollFd { .. } => {
                     unreachable!("PollFd is portless; cannot reach PendingOp::Port")

--- a/src/io/completion.rs
+++ b/src/io/completion.rs
@@ -248,6 +248,12 @@ pub(super) fn process_raw_completion(
             }
         }
         PendingOp::SigNext { receiver, .. } => {
+            crate::io::sigfd::posix_trace(format_args!(
+                "completion: SigNext id={} result_code={} data_len={}",
+                id,
+                result_code,
+                data.len()
+            ));
             if result_code <= 0 {
                 let msg = if result_code == 0 {
                     "signal receiver closed".to_string()
@@ -268,6 +274,10 @@ pub(super) fn process_raw_completion(
             } else {
                 Vec::new()
             };
+            crate::io::sigfd::posix_trace(format_args!(
+                "completion: SigNext parsed {} events",
+                events.len()
+            ));
             let event_values: Vec<Value> = events
                 .iter()
                 .map(|ev| {

--- a/src/io/mock.rs
+++ b/src/io/mock.rs
@@ -125,6 +125,7 @@ impl crate::io::IoBackend for MockBackend {
             IoOp::Task(_) => "task",
             IoOp::Resolve { .. } => "resolve",
             IoOp::WatchNext => "watch-next",
+            IoOp::SigNext => "sig-next",
             IoOp::Close => "close",
             IoOp::PollFd { .. } => "poll-fd",
         };
@@ -206,6 +207,7 @@ impl crate::io::IoBackend for MockBackend {
                 IoOp::Task(_) => Err(error_val("io-error", "mock: task not supported")),
                 IoOp::Resolve { .. } => Err(error_val("io-error", "mock: resolve not supported")),
                 IoOp::WatchNext => Err(error_val("io-error", "mock: watch not supported")),
+                IoOp::SigNext => Err(error_val("io-error", "mock: sig-next not supported")),
                 IoOp::PollFd { .. } => Err(error_val("io-error", "mock: poll-fd not supported")),
                 // Close completes synchronously in submit
                 IoOp::Close => Ok(Value::NIL),

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -11,6 +11,8 @@ pub(crate) mod mock;
 pub(crate) mod pending;
 pub(crate) mod pool;
 pub mod request;
+pub(crate) mod sigfd;
+pub(crate) mod sigmap;
 pub(crate) mod sockaddr;
 pub(crate) mod threadpool;
 pub(crate) mod types;

--- a/src/io/pending.rs
+++ b/src/io/pending.rs
@@ -64,6 +64,11 @@ pub(crate) enum PendingOp {
         watcher: Value,
         buffer_handle: BufferHandle,
     },
+    /// Waiting for POSIX signal deliveries (signalfd/kqueue).
+    SigNext {
+        receiver: Value,
+        buffer_handle: BufferHandle,
+    },
     /// Poll a raw fd for readiness. Portless.
     PollFd { buffer_handle: BufferHandle },
 }
@@ -79,6 +84,7 @@ impl PendingOp {
             PendingOp::Task { buffer_handle, .. } => *buffer_handle,
             PendingOp::Resolve { buffer_handle, .. } => *buffer_handle,
             PendingOp::WatchNext { buffer_handle, .. } => *buffer_handle,
+            PendingOp::SigNext { buffer_handle, .. } => *buffer_handle,
             PendingOp::PollFd { buffer_handle, .. } => *buffer_handle,
         }
     }
@@ -93,6 +99,7 @@ impl PendingOp {
             PendingOp::Task { buffer_handle, .. } => buffer_handle,
             PendingOp::Resolve { buffer_handle, .. } => buffer_handle,
             PendingOp::WatchNext { buffer_handle, .. } => buffer_handle,
+            PendingOp::SigNext { buffer_handle, .. } => buffer_handle,
             PendingOp::PollFd { buffer_handle, .. } => buffer_handle,
         }
     }

--- a/src/io/request.rs
+++ b/src/io/request.rs
@@ -236,6 +236,10 @@ pub enum IoOp {
     /// Wait for filesystem events from an FsWatcher (inotify/kqueue).
     /// Portless — the FsWatcher External is in the IoRequest.port field.
     WatchNext,
+    /// Wait for POSIX signal deliveries from a SignalReceiver
+    /// (signalfd on Linux, kqueue+EVFILT_SIGNAL on macOS).
+    /// Portless — the SignalReceiver External is in IoRequest.port.
+    SigNext,
     /// Close a port: cancel pending I/O ops on its fd, then close the fd.
     /// The scheduler handles the cancel-then-close sequence so that
     /// io_uring operations are properly cancelled before the fd is dropped.

--- a/src/io/sigfd.rs
+++ b/src/io/sigfd.rs
@@ -151,11 +151,74 @@ pub fn currently_watched() -> Vec<libc::c_int> {
     out
 }
 
+/// Drain any of `signals` still pending on the calling thread or the
+/// process-shared queue, using `sigwait`. The signals must still be
+/// blocked on the calling thread for `sigwait` to consume from the
+/// queue without invoking a handler.
+///
+/// Called from each platform's `rollback` immediately before the saved
+/// disposition is restored and the signals are unblocked. Without this
+/// drain, a signal queued during the watch that the watcher never
+/// consumed (e.g. macOS test 5: two kill(SIGUSR1) calls, kqueue
+/// `EVFILT_SIGNAL` reported count=2 but only one delivery actually
+/// drained the process pending queue) would fire its now-restored
+/// default disposition on `pthread_sigmask(SIG_UNBLOCK, …)` and
+/// terminate the process mid-close. On Linux the situation is the same
+/// when a user opens a `SignalReceiver`, the kernel queues a signal
+/// they intentionally chose to watch, and they close without ever
+/// calling `os/sig-next`: the unblock would Term them on the way out.
+///
+/// `sigwait` is POSIX and present on both Linux and macOS. It blocks
+/// until a signal in `set` becomes pending — we gate every call on
+/// `sigpending` so it returns immediately. The dequeued signum is
+/// discarded; this is the close path, no one is left to observe it.
+fn drain_pending_blocked(signals: &[libc::c_int]) {
+    if signals.is_empty() {
+        return;
+    }
+    let mut drain_set: libc::sigset_t = unsafe { std::mem::zeroed() };
+    unsafe { libc::sigemptyset(&mut drain_set) };
+    for &s in signals {
+        unsafe { libc::sigaddset(&mut drain_set, s) };
+    }
+    // Bounded loop — defends against a kernel that somehow keeps
+    // re-queuing the same signal while we drain. We've never observed
+    // more than 2 queued for a non-realtime signal in practice; 64 is
+    // a generous ceiling.
+    for _ in 0..64 {
+        let mut pending: libc::sigset_t = unsafe { std::mem::zeroed() };
+        unsafe { libc::sigemptyset(&mut pending) };
+        unsafe { libc::sigpending(&mut pending) };
+        let any = signals
+            .iter()
+            .any(|&s| unsafe { libc::sigismember(&pending, s) } == 1);
+        if !any {
+            return;
+        }
+        let mut sig_dequeued: libc::c_int = 0;
+        let ret = unsafe { libc::sigwait(&drain_set, &mut sig_dequeued) };
+        posix_trace(format_args!(
+            "rollback: drained pending signum={} via sigwait (ret={})",
+            sig_dequeued, ret
+        ));
+        if ret != 0 {
+            // sigwait shouldn't fail for a blocked, already-pending
+            // signal. If it does, fall through to the unblock rather
+            // than spinning.
+            return;
+        }
+    }
+    posix_trace(format_args!(
+        "rollback: drain loop hit ceiling for signals={:?}; pending instances may remain",
+        signals
+    ));
+}
+
 // ── Linux: signalfd ────────────────────────────────────────────────────
 
 #[cfg(any(target_os = "linux", target_os = "android"))]
 mod platform {
-    use super::{posix_trace, watched_set, SigEvent};
+    use super::{drain_pending_blocked, posix_trace, watched_set, SigEvent};
     use std::cell::RefCell;
     use std::os::unix::io::RawFd;
 
@@ -317,7 +380,7 @@ mod platform {
         // zero so we can pthread_sigmask-unblock them.
         let mut to_unblock: libc::sigset_t = unsafe { std::mem::zeroed() };
         unsafe { libc::sigemptyset(&mut to_unblock) };
-        let mut any = false;
+        let mut newly_freed: Vec<libc::c_int> = Vec::new();
         {
             let mut set = watched_set().lock().unwrap();
             for &s in signals {
@@ -327,12 +390,24 @@ mod platform {
                     }
                     if *c == 0 {
                         unsafe { libc::sigaddset(&mut to_unblock, s) };
-                        any = true;
+                        newly_freed.push(s);
                     }
                 }
             }
         }
-        if any {
+        if !newly_freed.is_empty() {
+            // Drain pending watched signals BEFORE unblocking. If a
+            // watcher closes with signals still queued (signalfd was
+            // never read for them, or the user `kill`d after the
+            // last sig-next), the unblock would otherwise fire each
+            // one's default disposition on this thread — Term for
+            // most. See `drain_pending_blocked` for the failure mode
+            // this defends against.
+            posix_trace(format_args!(
+                "linux: rollback draining + unblocking newly_freed={:?}",
+                newly_freed
+            ));
+            drain_pending_blocked(&newly_freed);
             unsafe {
                 libc::pthread_sigmask(libc::SIG_UNBLOCK, &to_unblock, std::ptr::null_mut());
             }
@@ -344,7 +419,7 @@ mod platform {
 
 #[cfg(target_os = "macos")]
 mod platform {
-    use super::{posix_trace, saved_dispositions, watched_set, SigEvent};
+    use super::{drain_pending_blocked, posix_trace, saved_dispositions, watched_set, SigEvent};
     use std::cell::RefCell;
     use std::os::unix::io::RawFd;
 
@@ -609,25 +684,48 @@ mod platform {
                 }
             }
         }
-        // Restore the saved disposition for every signal we just
-        // released — opposite of the install in `SignalReceiver::new`.
-        // Done before the unblock so any signal already pending in the
-        // process queue when unblock takes effect fires its true
-        // default disposition (matches the documented contract in
-        // docs/posix-signals.md: "pending instances … fire their
-        // default disposition immediately").
-        if !newly_freed.is_empty() {
+        if newly_freed.is_empty() {
+            return;
+        }
+        // Drain pending watched signals via sigwait BEFORE we restore
+        // the saved disposition or unblock. macOS's EVFILT_SIGNAL
+        // only counts kill() generations on the knote — it does NOT
+        // consume from the process pending queue — and the kqueue
+        // worker's brief pthread_sigmask SIG_UNBLOCK + no-op-handler
+        // delivery only drains at most one queued instance. Test 5
+        // (two kill(SIGUSR1) calls in a row, one sig-next read
+        // reporting count=2) leaves a SIGUSR1 in the pending queue
+        // even after the worker reports the event. Restoring the
+        // default disposition (Term for SIGUSR1) and then
+        // unblocking would deliver that orphan to this thread with
+        // its newly-restored default and kill the process mid-close.
+        // sigwait consumes pending instances without invoking the
+        // (still no-op) handler. Done while the signals are still
+        // blocked, so sigwait returns immediately for already-pending
+        // entries.
+        posix_trace(format_args!(
+            "macos: rollback draining + restoring + unblocking newly_freed={:?}",
+            newly_freed
+        ));
+        drain_pending_blocked(&newly_freed);
+        // Restore the saved sigactions, then unblock. Order matters:
+        // any signal generated AFTER the unblock should fire the
+        // user's original disposition (typically the default), not
+        // our no-op.
+        {
             let mut saved = saved_dispositions().lock().unwrap();
             for &s in &newly_freed {
                 if let Some(old) = saved.remove(&s) {
                     unsafe { libc::sigaction(s, &old, std::ptr::null_mut()) };
+                    posix_trace(format_args!(
+                        "macos: rollback restored sigaction for signum={}",
+                        s
+                    ));
                 }
             }
         }
-        if !newly_freed.is_empty() {
-            unsafe {
-                libc::pthread_sigmask(libc::SIG_UNBLOCK, &to_unblock, std::ptr::null_mut());
-            }
+        unsafe {
+            libc::pthread_sigmask(libc::SIG_UNBLOCK, &to_unblock, std::ptr::null_mut());
         }
     }
 }

--- a/src/io/sigfd.rs
+++ b/src/io/sigfd.rs
@@ -1,0 +1,586 @@
+//! POSIX signal reception via signalfd (Linux) and kqueue (macOS).
+//!
+//! `SignalReceiver` is the External object behind `os/sig-watch`. Each
+//! receiver owns a kernel file descriptor (signalfd on Linux, a dedicated
+//! kqueue fd on macOS) that becomes readable when a watched signal is
+//! delivered. The scheduler reads the fd via the same IoOp dispatch
+//! machinery as filesystem watchers.
+//!
+//! ## Mask policy
+//!
+//! The kernel only queues a signal onto signalfd/kqueue if the signal is
+//! blocked from default delivery in every thread that might otherwise
+//! absorb it. A receiver therefore must block its target signals on the
+//! main thread before opening the fd, and worker threads must mask all
+//! signals so the kernel never selects them as the delivery target.
+//!
+//! A module-level [`WatchedSet`] holds the union of currently-blocked
+//! signals and per-signal refcounts. `SignalReceiver::new` increments
+//! refcounts (blocking each new signal as it crosses zero); `Drop`
+//! decrements (unblocking when refcount returns to zero). Pending
+//! instances in the kernel queue at the moment of unblock fire their
+//! default disposition — preferred to silent swallowing. See
+//! `docs/posix-signals.md` for the user-facing contract.
+
+use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
+
+/// A parsed signal delivery.
+#[derive(Debug, Clone)]
+pub(crate) struct SigEvent {
+    pub signum: libc::c_int,
+    /// Sender pid. `None` on macOS (kqueue doesn't populate siginfo).
+    pub sender_pid: Option<u32>,
+    /// Sender uid. `None` on macOS.
+    pub sender_uid: Option<u32>,
+    /// `ssi_code` (e.g. SI_USER=0, SI_KERNEL=128, CLD_EXITED=1). `0` on macOS.
+    pub code: i32,
+    /// Coalesced count. Always `1` on Linux; kevent `data` on macOS.
+    pub count: u32,
+}
+
+/// Process-wide tally of how many `SignalReceiver`s currently want a
+/// given signal blocked. When a refcount transitions 0 → 1 we block;
+/// 1 → 0 we unblock.
+struct WatchedSet {
+    refcount: HashMap<libc::c_int, usize>,
+}
+
+fn watched_set() -> &'static Mutex<WatchedSet> {
+    static SET: OnceLock<Mutex<WatchedSet>> = OnceLock::new();
+    SET.get_or_init(|| {
+        Mutex::new(WatchedSet {
+            refcount: HashMap::new(),
+        })
+    })
+}
+
+/// Mask all maskable signals on the calling thread. Workers call this
+/// as their first action after spawn so the kernel never selects them
+/// as a signal delivery target. Must not be called on the main VM
+/// thread (the lazy-block policy depends on the main thread starting
+/// with an empty mask).
+pub fn mask_all_signals_on_this_thread() {
+    unsafe {
+        let mut full: libc::sigset_t = std::mem::zeroed();
+        libc::sigfillset(&mut full);
+        // SIG_BLOCK is additive; SIG_SETMASK replaces. We want SIG_SETMASK
+        // so a worker thread that gets recycled doesn't accumulate state
+        // from a previous owner.
+        libc::pthread_sigmask(libc::SIG_SETMASK, &full, std::ptr::null_mut());
+    }
+}
+
+/// Return the set of signals currently blocked on the calling thread,
+/// as libc signum integers. Used by `os/sig-mask`.
+pub fn current_thread_blocked() -> Vec<libc::c_int> {
+    let mut current: libc::sigset_t = unsafe { std::mem::zeroed() };
+    unsafe {
+        libc::pthread_sigmask(0, std::ptr::null(), &mut current);
+    }
+    // NSIG isn't exposed by Rust libc; 65 covers SIGRTMAX on Linux and is
+    // larger than every named signal on macOS. sigismember returns -1 for
+    // out-of-range signals, which we filter.
+    (1..65i32)
+        .filter(|&s| unsafe { libc::sigismember(&current, s) == 1 })
+        .collect()
+}
+
+/// Return the set of signals currently pending on the calling thread.
+/// Used by `os/sig-pending`.
+pub fn current_thread_pending() -> Vec<libc::c_int> {
+    let mut pending: libc::sigset_t = unsafe { std::mem::zeroed() };
+    unsafe {
+        libc::sigemptyset(&mut pending);
+        libc::sigpending(&mut pending);
+    }
+    // NSIG isn't exposed by Rust libc; 65 covers SIGRTMAX on Linux and is
+    // larger than every named signal on macOS. sigismember returns -1 for
+    // out-of-range signals, which we filter.
+    (1..65i32)
+        .filter(|&s| unsafe { libc::sigismember(&pending, s) == 1 })
+        .collect()
+}
+
+/// Return the set of signals currently watched by at least one live
+/// receiver (refcount > 0). Used by `os/sig-watching`.
+pub fn currently_watched() -> Vec<libc::c_int> {
+    let set = watched_set().lock().unwrap();
+    let mut out: Vec<libc::c_int> = set
+        .refcount
+        .iter()
+        .filter_map(|(s, c)| if *c > 0 { Some(*s) } else { None })
+        .collect();
+    out.sort_unstable();
+    out
+}
+
+// ── Linux: signalfd ────────────────────────────────────────────────────
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+mod platform {
+    use super::{watched_set, SigEvent};
+    use std::cell::RefCell;
+    use std::os::unix::io::RawFd;
+
+    pub(crate) struct SignalReceiver {
+        inner: RefCell<SignalReceiverInner>,
+    }
+
+    struct SignalReceiverInner {
+        fd: RawFd,
+        signals: Vec<libc::c_int>,
+        closed: bool,
+    }
+
+    impl SignalReceiver {
+        pub fn new(signals: Vec<libc::c_int>) -> Result<Self, String> {
+            // Reject sigkill/sigstop — kernel forbids blocking them.
+            for &s in &signals {
+                if s == libc::SIGKILL || s == libc::SIGSTOP {
+                    return Err(format!(
+                        "os/sig-watch: signal {} cannot be watched (kernel forbids blocking it)",
+                        s
+                    ));
+                }
+            }
+
+            // Bump refcounts and pthread_sigmask-block any signal whose
+            // refcount transitions 0 -> 1. Done under the watched-set
+            // mutex so concurrent watchers can't race.
+            let mut mask: libc::sigset_t = unsafe { std::mem::zeroed() };
+            unsafe { libc::sigemptyset(&mut mask) };
+            {
+                let mut set = watched_set().lock().unwrap();
+                for &s in &signals {
+                    let entry = set.refcount.entry(s).or_insert(0);
+                    if *entry == 0 {
+                        unsafe { libc::sigaddset(&mut mask, s) };
+                    }
+                    *entry += 1;
+                }
+            }
+            // Block the newly-added signals on the current thread.
+            unsafe {
+                libc::pthread_sigmask(libc::SIG_BLOCK, &mask, std::ptr::null_mut());
+            }
+
+            // Build the signalfd mask: all watched signals (including
+            // ones that were already blocked by some other receiver).
+            let mut sfd_mask: libc::sigset_t = unsafe { std::mem::zeroed() };
+            unsafe { libc::sigemptyset(&mut sfd_mask) };
+            for &s in &signals {
+                unsafe { libc::sigaddset(&mut sfd_mask, s) };
+            }
+            let fd =
+                unsafe { libc::signalfd(-1, &sfd_mask, libc::SFD_CLOEXEC | libc::SFD_NONBLOCK) };
+            if fd < 0 {
+                // Roll back refcounts and unblock the signals we just blocked.
+                let err = std::io::Error::last_os_error();
+                rollback(&signals);
+                return Err(format!("os/sig-watch: signalfd: {}", err));
+            }
+
+            Ok(SignalReceiver {
+                inner: RefCell::new(SignalReceiverInner {
+                    fd,
+                    signals,
+                    closed: false,
+                }),
+            })
+        }
+
+        pub fn raw_fd(&self) -> Result<RawFd, String> {
+            let inner = self.inner.borrow();
+            if inner.closed {
+                return Err("os/sig-next: receiver is closed".into());
+            }
+            Ok(inner.fd)
+        }
+
+        #[allow(dead_code)]
+        pub fn signals(&self) -> Vec<libc::c_int> {
+            self.inner.borrow().signals.clone()
+        }
+
+        pub fn close(&self) {
+            let mut inner = self.inner.borrow_mut();
+            if inner.closed {
+                return;
+            }
+            unsafe { libc::close(inner.fd) };
+            inner.closed = true;
+            rollback(&inner.signals);
+            inner.signals.clear();
+        }
+
+        /// Parse a buffer of signalfd_siginfo structs into SigEvents.
+        /// signalfd writes one struct per delivered signal.
+        pub fn parse_events(&self, buf: &[u8]) -> Vec<SigEvent> {
+            let entry_size = std::mem::size_of::<libc::signalfd_siginfo>();
+            let mut events = Vec::new();
+            let mut offset = 0;
+            while offset + entry_size <= buf.len() {
+                let raw = unsafe { &*(buf.as_ptr().add(offset) as *const libc::signalfd_siginfo) };
+                events.push(SigEvent {
+                    signum: raw.ssi_signo as libc::c_int,
+                    sender_pid: Some(raw.ssi_pid),
+                    sender_uid: Some(raw.ssi_uid),
+                    code: raw.ssi_code,
+                    count: 1,
+                });
+                offset += entry_size;
+            }
+            events
+        }
+    }
+
+    impl Drop for SignalReceiver {
+        fn drop(&mut self) {
+            let mut inner = self.inner.borrow_mut();
+            if !inner.closed {
+                unsafe { libc::close(inner.fd) };
+                inner.closed = true;
+                rollback(&inner.signals);
+            }
+        }
+    }
+
+    impl std::fmt::Debug for SignalReceiver {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            let inner = self.inner.borrow();
+            write!(
+                f,
+                "SignalReceiver(fd={}, signals={:?}, closed={})",
+                inner.fd, inner.signals, inner.closed
+            )
+        }
+    }
+
+    fn rollback(signals: &[libc::c_int]) {
+        // Decrement refcounts; collect signals whose refcount fell to
+        // zero so we can pthread_sigmask-unblock them.
+        let mut to_unblock: libc::sigset_t = unsafe { std::mem::zeroed() };
+        unsafe { libc::sigemptyset(&mut to_unblock) };
+        let mut any = false;
+        {
+            let mut set = watched_set().lock().unwrap();
+            for &s in signals {
+                if let Some(c) = set.refcount.get_mut(&s) {
+                    if *c > 0 {
+                        *c -= 1;
+                    }
+                    if *c == 0 {
+                        unsafe { libc::sigaddset(&mut to_unblock, s) };
+                        any = true;
+                    }
+                }
+            }
+        }
+        if any {
+            unsafe {
+                libc::pthread_sigmask(libc::SIG_UNBLOCK, &to_unblock, std::ptr::null_mut());
+            }
+        }
+    }
+}
+
+// ── macOS: kqueue + EVFILT_SIGNAL ──────────────────────────────────────
+
+#[cfg(target_os = "macos")]
+mod platform {
+    use super::{watched_set, SigEvent};
+    use std::cell::RefCell;
+    use std::os::unix::io::RawFd;
+
+    pub(crate) struct SignalReceiver {
+        inner: RefCell<SignalReceiverInner>,
+    }
+
+    struct SignalReceiverInner {
+        kq: RawFd,
+        signals: Vec<libc::c_int>,
+        closed: bool,
+    }
+
+    impl SignalReceiver {
+        pub fn new(signals: Vec<libc::c_int>) -> Result<Self, String> {
+            for &s in &signals {
+                if s == libc::SIGKILL || s == libc::SIGSTOP {
+                    return Err(format!(
+                        "os/sig-watch: signal {} cannot be watched (kernel forbids blocking it)",
+                        s
+                    ));
+                }
+            }
+
+            let mut mask: libc::sigset_t = unsafe { std::mem::zeroed() };
+            unsafe { libc::sigemptyset(&mut mask) };
+            {
+                let mut set = watched_set().lock().unwrap();
+                for &s in &signals {
+                    let entry = set.refcount.entry(s).or_insert(0);
+                    if *entry == 0 {
+                        unsafe { libc::sigaddset(&mut mask, s) };
+                    }
+                    *entry += 1;
+                }
+            }
+            unsafe {
+                libc::pthread_sigmask(libc::SIG_BLOCK, &mask, std::ptr::null_mut());
+            }
+
+            let kq = unsafe { libc::kqueue() };
+            if kq < 0 {
+                let err = std::io::Error::last_os_error();
+                rollback(&signals);
+                return Err(format!("os/sig-watch: kqueue: {}", err));
+            }
+            unsafe { libc::fcntl(kq, libc::F_SETFD, libc::FD_CLOEXEC) };
+
+            // Register one EVFILT_SIGNAL filter per signal.
+            let changelist: Vec<libc::kevent> = signals
+                .iter()
+                .map(|&s| libc::kevent {
+                    ident: s as libc::uintptr_t,
+                    filter: libc::EVFILT_SIGNAL,
+                    flags: libc::EV_ADD | libc::EV_CLEAR,
+                    fflags: 0,
+                    data: 0,
+                    udata: std::ptr::null_mut(),
+                })
+                .collect();
+            let ret = unsafe {
+                libc::kevent(
+                    kq,
+                    changelist.as_ptr(),
+                    changelist.len() as libc::c_int,
+                    std::ptr::null_mut(),
+                    0,
+                    std::ptr::null(),
+                )
+            };
+            if ret < 0 {
+                let err = std::io::Error::last_os_error();
+                unsafe { libc::close(kq) };
+                rollback(&signals);
+                return Err(format!("os/sig-watch: kevent register: {}", err));
+            }
+
+            Ok(SignalReceiver {
+                inner: RefCell::new(SignalReceiverInner {
+                    kq,
+                    signals,
+                    closed: false,
+                }),
+            })
+        }
+
+        pub fn raw_fd(&self) -> Result<RawFd, String> {
+            let inner = self.inner.borrow();
+            if inner.closed {
+                return Err("os/sig-next: receiver is closed".into());
+            }
+            Ok(inner.kq)
+        }
+
+        #[allow(dead_code)]
+        pub fn signals(&self) -> Vec<libc::c_int> {
+            self.inner.borrow().signals.clone()
+        }
+
+        pub fn close(&self) {
+            let mut inner = self.inner.borrow_mut();
+            if inner.closed {
+                return;
+            }
+            unsafe { libc::close(inner.kq) };
+            inner.closed = true;
+            rollback(&inner.signals);
+            inner.signals.clear();
+        }
+
+        /// macOS encodes kevent results as a sequence of (ident:i32, data:u32)
+        /// LE pairs in `buf` (written by the threadpool worker after a
+        /// blocking `kevent()` call).
+        pub fn parse_events(&self, buf: &[u8]) -> Vec<SigEvent> {
+            let entry_size = 4 + 4;
+            let mut events = Vec::new();
+            let mut offset = 0;
+            while offset + entry_size <= buf.len() {
+                let signum = i32::from_le_bytes(buf[offset..offset + 4].try_into().unwrap());
+                let count = u32::from_le_bytes(buf[offset + 4..offset + 8].try_into().unwrap());
+                events.push(SigEvent {
+                    signum,
+                    sender_pid: None,
+                    sender_uid: None,
+                    code: 0,
+                    count,
+                });
+                offset += entry_size;
+            }
+            events
+        }
+    }
+
+    impl Drop for SignalReceiver {
+        fn drop(&mut self) {
+            let mut inner = self.inner.borrow_mut();
+            if !inner.closed {
+                unsafe { libc::close(inner.kq) };
+                inner.closed = true;
+                rollback(&inner.signals);
+            }
+        }
+    }
+
+    impl std::fmt::Debug for SignalReceiver {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            let inner = self.inner.borrow();
+            write!(
+                f,
+                "SignalReceiver(kq={}, signals={:?}, closed={})",
+                inner.kq, inner.signals, inner.closed
+            )
+        }
+    }
+
+    fn rollback(signals: &[libc::c_int]) {
+        let mut to_unblock: libc::sigset_t = unsafe { std::mem::zeroed() };
+        unsafe { libc::sigemptyset(&mut to_unblock) };
+        let mut any = false;
+        {
+            let mut set = watched_set().lock().unwrap();
+            for &s in signals {
+                if let Some(c) = set.refcount.get_mut(&s) {
+                    if *c > 0 {
+                        *c -= 1;
+                    }
+                    if *c == 0 {
+                        unsafe { libc::sigaddset(&mut to_unblock, s) };
+                        any = true;
+                    }
+                }
+            }
+        }
+        if any {
+            unsafe {
+                libc::pthread_sigmask(libc::SIG_UNBLOCK, &to_unblock, std::ptr::null_mut());
+            }
+        }
+    }
+}
+
+#[cfg(any(target_os = "linux", target_os = "android", target_os = "macos"))]
+#[allow(unused_imports)]
+pub(crate) use platform::SignalReceiver;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn current_thread_blocked_starts_empty_or_known() {
+        // We can only assert this on a freshly-spawned thread because the
+        // main thread inherits whatever the test runner set up. Run on a
+        // thread with an explicitly-empty mask.
+        let h = std::thread::spawn(|| {
+            unsafe {
+                let mut empty: libc::sigset_t = std::mem::zeroed();
+                libc::sigemptyset(&mut empty);
+                libc::pthread_sigmask(libc::SIG_SETMASK, &empty, std::ptr::null_mut());
+            }
+            current_thread_blocked()
+        });
+        let blocked = h.join().unwrap();
+        assert!(blocked.is_empty(), "fresh thread starts with empty mask");
+    }
+
+    #[test]
+    fn mask_all_signals_blocks_everything_on_this_thread() {
+        let h = std::thread::spawn(|| {
+            mask_all_signals_on_this_thread();
+            current_thread_blocked()
+        });
+        let blocked = h.join().unwrap();
+        // sigkill and sigstop can't be blocked even via SIG_SETMASK with a
+        // full set — the kernel silently strips them. Everything else
+        // should be present.
+        assert!(blocked.contains(&libc::SIGTERM), "SIGTERM blocked");
+        assert!(blocked.contains(&libc::SIGUSR1), "SIGUSR1 blocked");
+        assert!(blocked.contains(&libc::SIGUSR2), "SIGUSR2 blocked");
+        assert!(blocked.contains(&libc::SIGINT), "SIGINT blocked");
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    #[test]
+    fn parse_events_decodes_synthesized_siginfo() {
+        // Build a fake signalfd_siginfo by hand.
+        let mut buf = vec![0u8; std::mem::size_of::<libc::signalfd_siginfo>() * 2];
+        let entry_size = std::mem::size_of::<libc::signalfd_siginfo>();
+        unsafe {
+            let p0 = buf.as_mut_ptr() as *mut libc::signalfd_siginfo;
+            (*p0).ssi_signo = libc::SIGUSR1 as u32;
+            (*p0).ssi_pid = 4242;
+            (*p0).ssi_uid = 1000;
+            (*p0).ssi_code = 0;
+            let p1 = (buf.as_mut_ptr().add(entry_size)) as *mut libc::signalfd_siginfo;
+            (*p1).ssi_signo = libc::SIGCHLD as u32;
+            (*p1).ssi_pid = 5151;
+            (*p1).ssi_uid = 1000;
+            (*p1).ssi_code = 1; // CLD_EXITED
+        }
+        // Create a SignalReceiver just to call parse_events; the fd it
+        // opens is real but we don't read from it.
+        let r = SignalReceiver::new(vec![libc::SIGWINCH]).expect("receiver");
+        let events = r.parse_events(&buf);
+        r.close();
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].signum, libc::SIGUSR1);
+        assert_eq!(events[0].sender_pid, Some(4242));
+        assert_eq!(events[1].signum, libc::SIGCHLD);
+        assert_eq!(events[1].code, 1);
+    }
+
+    #[test]
+    fn refcount_blocks_and_unblocks() {
+        // SIGURG is rarely touched by the runtime or other tests; safer
+        // than SIGWINCH (which the parse_events test below also opens
+        // a receiver for, racing against the WatchedSet refcount).
+        let h = std::thread::spawn(|| {
+            unsafe {
+                let mut empty: libc::sigset_t = std::mem::zeroed();
+                libc::sigemptyset(&mut empty);
+                libc::pthread_sigmask(libc::SIG_SETMASK, &empty, std::ptr::null_mut());
+            }
+            assert!(!current_thread_blocked().contains(&libc::SIGURG));
+
+            let r1 = SignalReceiver::new(vec![libc::SIGURG]).unwrap();
+            assert!(current_thread_blocked().contains(&libc::SIGURG));
+
+            let r2 = SignalReceiver::new(vec![libc::SIGURG]).unwrap();
+            assert!(current_thread_blocked().contains(&libc::SIGURG));
+
+            r1.close();
+            // Still blocked because r2 holds it.
+            assert!(current_thread_blocked().contains(&libc::SIGURG));
+
+            r2.close();
+            // Both released — unblocked.
+            assert!(!current_thread_blocked().contains(&libc::SIGURG));
+        });
+        h.join().unwrap();
+    }
+
+    #[test]
+    fn cannot_watch_sigkill() {
+        let r = SignalReceiver::new(vec![libc::SIGKILL]);
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn cannot_watch_sigstop() {
+        let r = SignalReceiver::new(vec![libc::SIGSTOP]);
+        assert!(r.is_err());
+    }
+}

--- a/src/io/sigfd.rs
+++ b/src/io/sigfd.rs
@@ -25,27 +25,26 @@
 use std::collections::HashMap;
 use std::sync::{Mutex, OnceLock};
 
-/// Print a diagnostic line to stderr when the `ELLE_POSIX_DEBUG`
-/// environment variable is set. Used to triage the macOS EVFILT_SIGNAL
-/// hang and any future POSIX-signal regressions without rebuilding —
-/// run `ELLE_POSIX_DEBUG=1 elle tests/elle/posix.lisp` and correlate
-/// the Rust trace lines (prefixed `[posix]`) with the eprintln
-/// progress lines emitted by posix.lisp itself.
+/// Emit a `[trace:posix] …` line to stderr when the `posix` trace bit
+/// is active (set via `--trace=posix`, `--trace=all`, or `(vm/config)`
+/// at runtime). Used to triage POSIX-signal regressions — correlate
+/// these with the per-test progress lines emitted by
+/// `tests/elle/posix.lisp` to pinpoint exactly which kernel call
+/// diverges between Linux and macOS.
 ///
-/// Direct `write(2, …)` to fd 2 bypasses the elle scheduler and Rust's
-/// stdio buffering so trace output survives even when the process is
-/// about to be killed by an outer timeout. Cheap when the env var is
-/// unset (single relaxed atomic load).
-fn debug_enabled() -> bool {
-    static CACHED: OnceLock<bool> = OnceLock::new();
-    *CACHED.get_or_init(|| std::env::var_os("ELLE_POSIX_DEBUG").is_some())
-}
-
+/// Gated on the process-global `crate::config::GLOBAL_TRACE_BITS`
+/// mirror so threadpool worker threads and other off-VM callers (which
+/// have no `&VM` and therefore can't use the per-VM `etrace!` macro)
+/// can still gate cheaply.
+///
+/// Output goes via a direct `write(2, …)` syscall, bypassing the elle
+/// scheduler and Rust's stdio buffering, so trace lines survive even
+/// when the process is about to be killed by an outer timeout.
 pub(crate) fn posix_trace(args: std::fmt::Arguments<'_>) {
-    if !debug_enabled() {
+    if !crate::config::global_trace_bit_enabled(crate::config::trace_bits::POSIX) {
         return;
     }
-    let line = format!("[posix] {}\n", args);
+    let line = format!("[trace:posix] {}\n", args);
     unsafe {
         libc::write(2, line.as_ptr() as *const libc::c_void, line.len());
     }

--- a/src/io/sigfd.rs
+++ b/src/io/sigfd.rs
@@ -55,6 +55,17 @@ fn watched_set() -> &'static Mutex<WatchedSet> {
     })
 }
 
+/// Process-wide table of saved sigaction dispositions for signals on
+/// which we installed a no-op handler. macOS only — Linux's signalfd
+/// reads pending signals directly without needing a handler to be
+/// installed. Keyed by signum; populated on refcount 0→1, restored and
+/// removed on 1→0. See `mod platform`'s `new` and `rollback`.
+#[cfg(target_os = "macos")]
+fn saved_dispositions() -> &'static Mutex<HashMap<libc::c_int, libc::sigaction>> {
+    static DISP: OnceLock<Mutex<HashMap<libc::c_int, libc::sigaction>>> = OnceLock::new();
+    DISP.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
 /// Mask all maskable signals on the calling thread. Workers call this
 /// as their first action after spawn so the kernel never selects them
 /// as a signal delivery target. Must not be called on the main VM
@@ -289,7 +300,7 @@ mod platform {
 
 #[cfg(target_os = "macos")]
 mod platform {
-    use super::{watched_set, SigEvent};
+    use super::{saved_dispositions, watched_set, SigEvent};
     use std::cell::RefCell;
     use std::os::unix::io::RawFd;
 
@@ -301,6 +312,26 @@ mod platform {
         kq: RawFd,
         signals: Vec<libc::c_int>,
         closed: bool,
+    }
+
+    /// No-op signal handler installed on the watched signals so kqueue's
+    /// `EVFILT_SIGNAL` can fire without the kernel running the default
+    /// disposition (Term for SIGUSR1, etc.). `kq_sig_read_blocking` in
+    /// `src/io/threadpool.rs` unmasks the watched signals on its own
+    /// thread; the kernel then picks that thread for delivery and runs
+    /// this no-op before `kevent()` returns.
+    extern "C" fn noop_handler(_signum: libc::c_int) {}
+
+    /// Build a `sigaction` that points at `noop_handler` with SA_RESTART
+    /// so the no-op delivery doesn't surface as EINTR on long-running
+    /// syscalls elsewhere in the process. Empty `sa_mask` — we don't
+    /// want to compound the watcher mask while the handler runs.
+    fn noop_sigaction() -> libc::sigaction {
+        let mut sa: libc::sigaction = unsafe { std::mem::zeroed() };
+        sa.sa_sigaction = noop_handler as *const () as libc::sighandler_t;
+        sa.sa_flags = libc::SA_RESTART;
+        unsafe { libc::sigemptyset(&mut sa.sa_mask) };
+        sa
     }
 
     impl SignalReceiver {
@@ -316,18 +347,49 @@ mod platform {
 
             let mut mask: libc::sigset_t = unsafe { std::mem::zeroed() };
             unsafe { libc::sigemptyset(&mut mask) };
+            // Track which signals transitioned 0 → 1 so we install the
+            // no-op handler exactly once per signal, holding the
+            // `WatchedSet` lock for the duration to serialise with
+            // concurrent `SignalReceiver::new` / drop on other receivers.
+            let mut newly_watched: Vec<libc::c_int> = Vec::new();
             {
                 let mut set = watched_set().lock().unwrap();
                 for &s in &signals {
                     let entry = set.refcount.entry(s).or_insert(0);
                     if *entry == 0 {
                         unsafe { libc::sigaddset(&mut mask, s) };
+                        newly_watched.push(s);
                     }
                     *entry += 1;
                 }
             }
             unsafe {
                 libc::pthread_sigmask(libc::SIG_BLOCK, &mask, std::ptr::null_mut());
+            }
+
+            // Install the no-op handler on each newly-watched signal,
+            // saving the old disposition so `rollback` can restore it
+            // when the refcount drops back to zero.
+            //
+            // sigaction is process-wide; both the install here and the
+            // unblock done by `kq_sig_read_blocking` are required for
+            // EVFILT_SIGNAL to fire (delivery requires both: a thread
+            // with the signal unmasked, and a handler that doesn't
+            // terminate the process).
+            if !newly_watched.is_empty() {
+                let new_sa = noop_sigaction();
+                let mut saved = saved_dispositions().lock().unwrap();
+                for &s in &newly_watched {
+                    let mut old: libc::sigaction = unsafe { std::mem::zeroed() };
+                    let ret = unsafe { libc::sigaction(s, &new_sa, &mut old) };
+                    if ret == 0 {
+                        saved.insert(s, old);
+                    }
+                    // sigaction failure on a watchable signal is rare;
+                    // fall back to whatever disposition was already in
+                    // place. EVFILT_SIGNAL will still fire if a user
+                    // handler exists, which is acceptable here.
+                }
             }
 
             let kq = unsafe { libc::kqueue() };
@@ -448,7 +510,11 @@ mod platform {
     fn rollback(signals: &[libc::c_int]) {
         let mut to_unblock: libc::sigset_t = unsafe { std::mem::zeroed() };
         unsafe { libc::sigemptyset(&mut to_unblock) };
-        let mut any = false;
+        // Collect signals whose refcount fell to zero so we can both
+        // restore their saved sigaction and unblock them on the calling
+        // thread. We have to drop the WatchedSet lock before doing the
+        // sigaction restore to avoid holding two global locks in series.
+        let mut newly_freed: Vec<libc::c_int> = Vec::new();
         {
             let mut set = watched_set().lock().unwrap();
             for &s in signals {
@@ -458,12 +524,27 @@ mod platform {
                     }
                     if *c == 0 {
                         unsafe { libc::sigaddset(&mut to_unblock, s) };
-                        any = true;
+                        newly_freed.push(s);
                     }
                 }
             }
         }
-        if any {
+        // Restore the saved disposition for every signal we just
+        // released — opposite of the install in `SignalReceiver::new`.
+        // Done before the unblock so any signal already pending in the
+        // process queue when unblock takes effect fires its true
+        // default disposition (matches the documented contract in
+        // docs/posix-signals.md: "pending instances … fire their
+        // default disposition immediately").
+        if !newly_freed.is_empty() {
+            let mut saved = saved_dispositions().lock().unwrap();
+            for &s in &newly_freed {
+                if let Some(old) = saved.remove(&s) {
+                    unsafe { libc::sigaction(s, &old, std::ptr::null_mut()) };
+                }
+            }
+        }
+        if !newly_freed.is_empty() {
             unsafe {
                 libc::pthread_sigmask(libc::SIG_UNBLOCK, &to_unblock, std::ptr::null_mut());
             }

--- a/src/io/sigfd.rs
+++ b/src/io/sigfd.rs
@@ -25,6 +25,32 @@
 use std::collections::HashMap;
 use std::sync::{Mutex, OnceLock};
 
+/// Print a diagnostic line to stderr when the `ELLE_POSIX_DEBUG`
+/// environment variable is set. Used to triage the macOS EVFILT_SIGNAL
+/// hang and any future POSIX-signal regressions without rebuilding —
+/// run `ELLE_POSIX_DEBUG=1 elle tests/elle/posix.lisp` and correlate
+/// the Rust trace lines (prefixed `[posix]`) with the eprintln
+/// progress lines emitted by posix.lisp itself.
+///
+/// Direct `write(2, …)` to fd 2 bypasses the elle scheduler and Rust's
+/// stdio buffering so trace output survives even when the process is
+/// about to be killed by an outer timeout. Cheap when the env var is
+/// unset (single relaxed atomic load).
+fn debug_enabled() -> bool {
+    static CACHED: OnceLock<bool> = OnceLock::new();
+    *CACHED.get_or_init(|| std::env::var_os("ELLE_POSIX_DEBUG").is_some())
+}
+
+pub(crate) fn posix_trace(args: std::fmt::Arguments<'_>) {
+    if !debug_enabled() {
+        return;
+    }
+    let line = format!("[posix] {}\n", args);
+    unsafe {
+        libc::write(2, line.as_ptr() as *const libc::c_void, line.len());
+    }
+}
+
 /// A parsed signal delivery.
 #[derive(Debug, Clone)]
 pub(crate) struct SigEvent {
@@ -130,7 +156,7 @@ pub fn currently_watched() -> Vec<libc::c_int> {
 
 #[cfg(any(target_os = "linux", target_os = "android"))]
 mod platform {
-    use super::{watched_set, SigEvent};
+    use super::{posix_trace, watched_set, SigEvent};
     use std::cell::RefCell;
     use std::os::unix::io::RawFd;
 
@@ -146,6 +172,10 @@ mod platform {
 
     impl SignalReceiver {
         pub fn new(signals: Vec<libc::c_int>) -> Result<Self, String> {
+            posix_trace(format_args!(
+                "linux: SignalReceiver::new signals={:?}",
+                signals
+            ));
             // Reject sigkill/sigstop — kernel forbids blocking them.
             for &s in &signals {
                 if s == libc::SIGKILL || s == libc::SIGSTOP {
@@ -175,6 +205,9 @@ mod platform {
             unsafe {
                 libc::pthread_sigmask(libc::SIG_BLOCK, &mask, std::ptr::null_mut());
             }
+            posix_trace(format_args!(
+                "linux: blocked newly-watched signals on main thread"
+            ));
 
             // Build the signalfd mask: all watched signals (including
             // ones that were already blocked by some other receiver).
@@ -188,9 +221,14 @@ mod platform {
             if fd < 0 {
                 // Roll back refcounts and unblock the signals we just blocked.
                 let err = std::io::Error::last_os_error();
+                posix_trace(format_args!("linux: signalfd() failed: {}", err));
                 rollback(&signals);
                 return Err(format!("os/sig-watch: signalfd: {}", err));
             }
+            posix_trace(format_args!(
+                "linux: signalfd opened fd={} for {:?}",
+                fd, signals
+            ));
 
             Ok(SignalReceiver {
                 inner: RefCell::new(SignalReceiverInner {
@@ -217,8 +255,15 @@ mod platform {
         pub fn close(&self) {
             let mut inner = self.inner.borrow_mut();
             if inner.closed {
+                posix_trace(format_args!(
+                    "linux: SignalReceiver::close already closed (idempotent)"
+                ));
                 return;
             }
+            posix_trace(format_args!(
+                "linux: SignalReceiver::close fd={} signals={:?}",
+                inner.fd, inner.signals
+            ));
             unsafe { libc::close(inner.fd) };
             inner.closed = true;
             rollback(&inner.signals);
@@ -300,7 +345,7 @@ mod platform {
 
 #[cfg(target_os = "macos")]
 mod platform {
-    use super::{saved_dispositions, watched_set, SigEvent};
+    use super::{posix_trace, saved_dispositions, watched_set, SigEvent};
     use std::cell::RefCell;
     use std::os::unix::io::RawFd;
 
@@ -336,6 +381,10 @@ mod platform {
 
     impl SignalReceiver {
         pub fn new(signals: Vec<libc::c_int>) -> Result<Self, String> {
+            posix_trace(format_args!(
+                "macos: SignalReceiver::new signals={:?}",
+                signals
+            ));
             for &s in &signals {
                 if s == libc::SIGKILL || s == libc::SIGSTOP {
                     return Err(format!(
@@ -366,6 +415,10 @@ mod platform {
             unsafe {
                 libc::pthread_sigmask(libc::SIG_BLOCK, &mask, std::ptr::null_mut());
             }
+            posix_trace(format_args!(
+                "macos: pthread_sigmask blocked newly_watched={:?} on main thread",
+                newly_watched
+            ));
 
             // Install the no-op handler on each newly-watched signal,
             // saving the old disposition so `rollback` can restore it
@@ -384,6 +437,17 @@ mod platform {
                     let ret = unsafe { libc::sigaction(s, &new_sa, &mut old) };
                     if ret == 0 {
                         saved.insert(s, old);
+                        posix_trace(format_args!(
+                            "macos: installed no-op sigaction for signum={}",
+                            s
+                        ));
+                    } else {
+                        let err = std::io::Error::last_os_error();
+                        posix_trace(format_args!(
+                            "macos: sigaction install FAILED for signum={}: {} — kqueue may not fire",
+                            s,
+                            err
+                        ));
                     }
                     // sigaction failure on a watchable signal is rare;
                     // fall back to whatever disposition was already in
@@ -395,10 +459,12 @@ mod platform {
             let kq = unsafe { libc::kqueue() };
             if kq < 0 {
                 let err = std::io::Error::last_os_error();
+                posix_trace(format_args!("macos: kqueue() failed: {}", err));
                 rollback(&signals);
                 return Err(format!("os/sig-watch: kqueue: {}", err));
             }
             unsafe { libc::fcntl(kq, libc::F_SETFD, libc::FD_CLOEXEC) };
+            posix_trace(format_args!("macos: kqueue() opened kq={}", kq));
 
             // Register one EVFILT_SIGNAL filter per signal.
             let changelist: Vec<libc::kevent> = signals
@@ -424,10 +490,18 @@ mod platform {
             };
             if ret < 0 {
                 let err = std::io::Error::last_os_error();
+                posix_trace(format_args!(
+                    "macos: kevent EV_ADD EVFILT_SIGNAL FAILED for {:?}: {}",
+                    signals, err
+                ));
                 unsafe { libc::close(kq) };
                 rollback(&signals);
                 return Err(format!("os/sig-watch: kevent register: {}", err));
             }
+            posix_trace(format_args!(
+                "macos: kevent EV_ADD EVFILT_SIGNAL registered {:?} on kq={}",
+                signals, kq
+            ));
 
             Ok(SignalReceiver {
                 inner: RefCell::new(SignalReceiverInner {
@@ -454,8 +528,15 @@ mod platform {
         pub fn close(&self) {
             let mut inner = self.inner.borrow_mut();
             if inner.closed {
+                posix_trace(format_args!(
+                    "macos: SignalReceiver::close already closed (idempotent)"
+                ));
                 return;
             }
+            posix_trace(format_args!(
+                "macos: SignalReceiver::close kq={} signals={:?}",
+                inner.kq, inner.signals
+            ));
             unsafe { libc::close(inner.kq) };
             inner.closed = true;
             rollback(&inner.signals);

--- a/src/io/sigmap.rs
+++ b/src/io/sigmap.rs
@@ -1,0 +1,164 @@
+//! Shared keyword↔signum mapping for POSIX signals.
+//!
+//! Used by `src/primitives/subprocess.rs` (for `subprocess/kill`) and
+//! `src/primitives/posix.rs` (for `os/sig-send`, `os/sig-raise`, `os/sig-watch`,
+//! and friends). Only the 16 standard signals enumerated below are
+//! recognised — realtime signals (SIGRTMIN..SIGRTMAX) are intentionally
+//! not exposed in v1.
+//!
+//! Integer signums are accepted by the callers only if they round-trip
+//! through `signum_to_keyword`; this rejects arbitrary integers and
+//! tightens a long-standing footgun in `subprocess/kill`.
+
+/// All recognised signals: keyword name (without the leading `:`) and
+/// the libc constant.
+const SIGNALS: &[(&str, libc::c_int)] = &[
+    ("sigterm", libc::SIGTERM),
+    ("sigkill", libc::SIGKILL),
+    ("sighup", libc::SIGHUP),
+    ("sigint", libc::SIGINT),
+    ("sigquit", libc::SIGQUIT),
+    ("sigpipe", libc::SIGPIPE),
+    ("sigalrm", libc::SIGALRM),
+    ("sigusr1", libc::SIGUSR1),
+    ("sigusr2", libc::SIGUSR2),
+    ("sigchld", libc::SIGCHLD),
+    ("sigcont", libc::SIGCONT),
+    ("sigstop", libc::SIGSTOP),
+    ("sigtstp", libc::SIGTSTP),
+    ("sigttin", libc::SIGTTIN),
+    ("sigttou", libc::SIGTTOU),
+    ("sigwinch", libc::SIGWINCH),
+];
+
+/// Map a keyword name (without the colon, e.g. "sigterm") to its libc constant.
+pub fn keyword_to_signum(name: &str) -> Option<libc::c_int> {
+    SIGNALS
+        .iter()
+        .find_map(|(k, v)| if *k == name { Some(*v) } else { None })
+}
+
+/// Inverse: map a libc signum back to its canonical keyword name.
+/// Returns `None` for any unrecognised signum (the basis of the integer
+/// validation contract).
+pub fn signum_to_keyword(signum: libc::c_int) -> Option<&'static str> {
+    SIGNALS
+        .iter()
+        .find_map(|(k, v)| if *v == signum { Some(*k) } else { None })
+}
+
+/// Human-readable list of supported keyword names, comma-separated and
+/// colon-prefixed. Used in error messages.
+pub fn supported_list_str() -> String {
+    SIGNALS
+        .iter()
+        .map(|(k, _)| format!(":{k}"))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+/// Resolve an Elle Value to a libc signum.
+///
+/// Accepts:
+/// - a keyword (e.g. `:sigterm`),
+/// - a named integer (any integer that round-trips through
+///   `signum_to_keyword`).
+///
+/// Unknown keywords and unnamed integers return an error string.
+/// `context` is the primitive name used in error messages.
+pub fn resolve(val: &crate::value::Value, context: &str) -> Result<libc::c_int, ResolveError> {
+    if let Some(n) = val.as_int() {
+        let n_i32 = n as libc::c_int;
+        return match signum_to_keyword(n_i32) {
+            Some(_) => Ok(n_i32),
+            None => Err(ResolveError::UnknownSignum(n)),
+        };
+    }
+    if let Some(name) = val.as_keyword_name() {
+        return match keyword_to_signum(&name) {
+            Some(s) => Ok(s),
+            None => Err(ResolveError::UnknownKeyword(name.to_string())),
+        };
+    }
+    let _ = context;
+    Err(ResolveError::WrongType(val.type_name()))
+}
+
+/// Failure modes from `resolve`. Carries enough information for callers
+/// to construct their own error Value with the right kind tag.
+#[derive(Debug)]
+pub enum ResolveError {
+    /// Integer did not round-trip to a named signal.
+    UnknownSignum(i64),
+    /// Keyword name is not in the recognised set.
+    UnknownKeyword(String),
+    /// Argument is neither integer nor keyword.
+    WrongType(&'static str),
+}
+
+impl ResolveError {
+    /// Return (error-kind, message) for use in `error_val(kind, msg)`.
+    pub fn parts(&self, context: &str) -> (&'static str, String) {
+        match self {
+            ResolveError::UnknownSignum(n) => (
+                "argument-error",
+                format!(
+                    "{}: signum {} is not a named signal; expected one of {} or the equivalent integer",
+                    context,
+                    n,
+                    supported_list_str(),
+                ),
+            ),
+            ResolveError::UnknownKeyword(name) => (
+                "argument-error",
+                format!(
+                    "{}: unknown signal keyword :{}; expected one of {}",
+                    context,
+                    name,
+                    supported_list_str(),
+                ),
+            ),
+            ResolveError::WrongType(t) => (
+                "type-error",
+                format!("{}: signal must be integer or keyword, got {}", context, t),
+            ),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trip_every_keyword() {
+        for (name, signum) in SIGNALS {
+            assert_eq!(keyword_to_signum(name), Some(*signum));
+            assert_eq!(signum_to_keyword(*signum), Some(*name));
+        }
+    }
+
+    #[test]
+    fn unknown_keyword_is_none() {
+        assert_eq!(keyword_to_signum("sigfoo"), None);
+        assert_eq!(keyword_to_signum("SIGTERM"), None); // case-sensitive
+        assert_eq!(keyword_to_signum(""), None);
+    }
+
+    #[test]
+    fn unknown_signum_is_none() {
+        // 99 is not a standard signal on any platform we target.
+        assert_eq!(signum_to_keyword(99), None);
+        assert_eq!(signum_to_keyword(0), None);
+        assert_eq!(signum_to_keyword(-1), None);
+    }
+
+    #[test]
+    fn supported_list_includes_common_signals() {
+        let s = supported_list_str();
+        assert!(s.contains(":sigterm"));
+        assert!(s.contains(":sigkill"));
+        assert!(s.contains(":sigint"));
+        assert!(s.contains(":sigusr1"));
+    }
+}

--- a/src/io/threadpool.rs
+++ b/src/io/threadpool.rs
@@ -88,6 +88,18 @@ pub(super) enum PoolOp {
     WatchRead {
         fd: RawFd,
     },
+    /// Blocking read on a signalfd (Linux) for POSIX signal deliveries.
+    /// On macOS the corresponding op is `KqSigRead`.
+    #[cfg_attr(target_os = "macos", allow(dead_code))]
+    SigfdRead {
+        fd: RawFd,
+    },
+    /// Blocking kevent() on a kqueue fd registered with EVFILT_SIGNAL (macOS).
+    /// On Linux the corresponding op is `SigfdRead`.
+    #[cfg_attr(any(target_os = "linux", target_os = "android"), allow(dead_code))]
+    KqSigRead {
+        fd: RawFd,
+    },
     /// Poll a raw fd for readiness via libc::poll(). Returns revents mask.
     PollFd {
         fd: RawFd,
@@ -130,6 +142,10 @@ impl ThreadPoolBackend {
         let sender = self.sender.clone();
         self.in_flight += 1;
         std::thread::spawn(move || {
+            // Block all signals on this worker so the kernel never selects
+            // it as the delivery target for a watched POSIX signal.
+            // See src/io/sigfd.rs and docs/posix-signals.md.
+            crate::io::sigfd::mask_all_signals_on_this_thread();
             let (result_code, data) = match op {
                 PoolOp::Read { fd, size } => {
                     let mut buf = vec![0u8; size];
@@ -487,6 +503,20 @@ impl ThreadPoolBackend {
                     }
                 }
                 PoolOp::WatchRead { fd } => watch_read_blocking(fd),
+                #[cfg(any(target_os = "linux", target_os = "android"))]
+                PoolOp::SigfdRead { fd } => sigfd_read_blocking(fd),
+                #[cfg(not(any(target_os = "linux", target_os = "android")))]
+                PoolOp::SigfdRead { .. } => (
+                    -libc::ENOTSUP,
+                    b"sig-next: signalfd not supported on this platform".to_vec(),
+                ),
+                #[cfg(target_os = "macos")]
+                PoolOp::KqSigRead { fd } => kq_sig_read_blocking(fd),
+                #[cfg(not(target_os = "macos"))]
+                PoolOp::KqSigRead { .. } => (
+                    -libc::ENOTSUP,
+                    b"sig-next: kqueue signal mode not supported on this platform".to_vec(),
+                ),
                 PoolOp::PollFd {
                     fd,
                     events,
@@ -644,6 +674,7 @@ impl StdinThread {
         let handle = std::thread::Builder::new()
             .name("elle-stdin".into())
             .spawn(move || {
+                crate::io::sigfd::mask_all_signals_on_this_thread();
                 use std::io::{BufRead, Read};
                 while let Ok(req) = request_rx.recv() {
                     let result = match req.op_kind {
@@ -723,6 +754,58 @@ fn watch_read_blocking(fd: RawFd) -> (i32, Vec<u8>) {
         buf.truncate(ret as usize);
         (ret as i32, buf)
     }
+}
+
+/// Blocking read on a signalfd (Linux). Reads up to 8 signalfd_siginfo
+/// structs per call; signalfd has no shutdown(2)-equivalent, so a cancel
+/// triggered by the scheduler closes the signalfd, which makes this
+/// read return 0 (EOF) and the receiver is dead.
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn sigfd_read_blocking(fd: RawFd) -> (i32, Vec<u8>) {
+    let entry_size = std::mem::size_of::<libc::signalfd_siginfo>();
+    let mut buf = vec![0u8; entry_size * 8];
+    let ret = unsafe { libc::read(fd, buf.as_mut_ptr() as *mut libc::c_void, buf.len()) };
+    if ret < 0 {
+        (
+            -(std::io::Error::last_os_error().raw_os_error().unwrap_or(1)),
+            Vec::new(),
+        )
+    } else {
+        buf.truncate(ret as usize);
+        (ret as i32, buf)
+    }
+}
+
+/// Blocking kevent() on a kqueue fd registered with EVFILT_SIGNAL (macOS).
+/// Encodes results as (signum:i32, count:u32) LE pairs for
+/// SignalReceiver::parse_events().
+#[cfg(target_os = "macos")]
+fn kq_sig_read_blocking(kq: RawFd) -> (i32, Vec<u8>) {
+    let mut eventlist: [libc::kevent; 32] = unsafe { std::mem::zeroed() };
+    let n = unsafe {
+        libc::kevent(
+            kq,
+            std::ptr::null(),
+            0,
+            eventlist.as_mut_ptr(),
+            eventlist.len() as i32,
+            std::ptr::null(),
+        )
+    };
+    if n < 0 {
+        return (
+            -(std::io::Error::last_os_error().raw_os_error().unwrap_or(1)),
+            Vec::new(),
+        );
+    }
+    let mut data = Vec::with_capacity(n as usize * 8);
+    for event in &eventlist[..n as usize] {
+        let signum = event.ident as i32;
+        let count = event.data as u32;
+        data.extend_from_slice(&signum.to_le_bytes());
+        data.extend_from_slice(&count.to_le_bytes());
+    }
+    (data.len() as i32, data)
 }
 
 /// Blocking kevent() on a kqueue fd (macOS). Encodes results as

--- a/src/io/threadpool.rs
+++ b/src/io/threadpool.rs
@@ -96,9 +96,20 @@ pub(super) enum PoolOp {
     },
     /// Blocking kevent() on a kqueue fd registered with EVFILT_SIGNAL (macOS).
     /// On Linux the corresponding op is `SigfdRead`.
+    ///
+    /// `signals` is the set the watcher is interested in. The worker
+    /// unblocks them on its own thread before calling kevent() because
+    /// kqueue's `EVFILT_SIGNAL` fires from the in-kernel delivery path
+    /// — when every thread in the process blocks the signal the kernel
+    /// parks it on the process pending list and the knote never
+    /// activates (no thread is selected for delivery, so the kqueue
+    /// hook in psignal_internal is never reached). `SignalReceiver::new`
+    /// installs a process-wide no-op sigaction handler so the signal
+    /// delivered to this thread does no harm.
     #[cfg_attr(any(target_os = "linux", target_os = "android"), allow(dead_code))]
     KqSigRead {
         fd: RawFd,
+        signals: Vec<libc::c_int>,
     },
     /// Poll a raw fd for readiness via libc::poll(). Returns revents mask.
     PollFd {
@@ -511,7 +522,7 @@ impl ThreadPoolBackend {
                     b"sig-next: signalfd not supported on this platform".to_vec(),
                 ),
                 #[cfg(target_os = "macos")]
-                PoolOp::KqSigRead { fd } => kq_sig_read_blocking(fd),
+                PoolOp::KqSigRead { fd, signals } => kq_sig_read_blocking(fd, &signals),
                 #[cfg(not(target_os = "macos"))]
                 PoolOp::KqSigRead { .. } => (
                     -libc::ENOTSUP,
@@ -802,33 +813,70 @@ fn sigfd_read_blocking(fd: RawFd) -> (i32, Vec<u8>) {
 /// Blocking kevent() on a kqueue fd registered with EVFILT_SIGNAL (macOS).
 /// Encodes results as (signum:i32, count:u32) LE pairs for
 /// SignalReceiver::parse_events().
+///
+/// `signals` is the set the receiver registered with kqueue. The worker
+/// `pthread_sigmask`-UNBLOCKs them on itself before kevent() so the
+/// kernel can pick this thread as the delivery target — kqueue's
+/// `EVFILT_SIGNAL` is driven by the in-kernel delivery path, not by
+/// signal generation. With every other thread in the process blocking
+/// the signal (the threadpool worker default + the main thread's
+/// `os/sig-watch` mask), parking SIGUSR1 on the process pending list
+/// without any unblocked thread leaves no delivery path and the knote
+/// never activates — exactly the macOS hang
+/// `tests/elle/posix.lisp` test #1 was timing out on.
+///
+/// `SignalReceiver::new` installs a process-wide no-op sigaction
+/// handler for each watched signal at refcount 0 → 1 (and restores at
+/// 1 → 0) so that the delivery the kernel makes to this worker is a
+/// harmless return-through-the-trampoline rather than the default
+/// disposition (Term for SIGUSR1, etc.).
 #[cfg(target_os = "macos")]
-fn kq_sig_read_blocking(kq: RawFd) -> (i32, Vec<u8>) {
-    let mut eventlist: [libc::kevent; 32] = unsafe { std::mem::zeroed() };
-    let n = unsafe {
-        libc::kevent(
-            kq,
-            std::ptr::null(),
-            0,
-            eventlist.as_mut_ptr(),
-            eventlist.len() as i32,
-            std::ptr::null(),
-        )
-    };
-    if n < 0 {
-        return (
-            -(std::io::Error::last_os_error().raw_os_error().unwrap_or(1)),
-            Vec::new(),
-        );
+fn kq_sig_read_blocking(kq: RawFd, signals: &[libc::c_int]) -> (i32, Vec<u8>) {
+    // Unblock the watched signals on this thread for the lifetime of the
+    // worker. The worker is single-use (each PoolOp spawns a fresh
+    // thread that exits after sending the completion), so we don't
+    // bother restoring on return.
+    let mut to_unblock: libc::sigset_t = unsafe { std::mem::zeroed() };
+    unsafe { libc::sigemptyset(&mut to_unblock) };
+    for &s in signals {
+        unsafe { libc::sigaddset(&mut to_unblock, s) };
     }
-    let mut data = Vec::with_capacity(n as usize * 8);
-    for event in &eventlist[..n as usize] {
-        let signum = event.ident as i32;
-        let count = event.data as u32;
-        data.extend_from_slice(&signum.to_le_bytes());
-        data.extend_from_slice(&count.to_le_bytes());
+    unsafe {
+        libc::pthread_sigmask(libc::SIG_UNBLOCK, &to_unblock, std::ptr::null_mut());
     }
-    (data.len() as i32, data)
+
+    loop {
+        let mut eventlist: [libc::kevent; 32] = unsafe { std::mem::zeroed() };
+        let n = unsafe {
+            libc::kevent(
+                kq,
+                std::ptr::null(),
+                0,
+                eventlist.as_mut_ptr(),
+                eventlist.len() as i32,
+                std::ptr::null(),
+            )
+        };
+        if n < 0 {
+            let errno = std::io::Error::last_os_error().raw_os_error().unwrap_or(1);
+            // If the no-op handler ran without SA_RESTART (or some other
+            // signal interrupted kevent), retry. The knote state is
+            // preserved across EINTR, so a subsequent kevent picks up
+            // the same event.
+            if errno == libc::EINTR {
+                continue;
+            }
+            return (-errno, Vec::new());
+        }
+        let mut data = Vec::with_capacity(n as usize * 8);
+        for event in &eventlist[..n as usize] {
+            let signum = event.ident as i32;
+            let count = event.data as u32;
+            data.extend_from_slice(&signum.to_le_bytes());
+            data.extend_from_slice(&count.to_le_bytes());
+        }
+        return (data.len() as i32, data);
+    }
 }
 
 /// Blocking kevent() on a kqueue fd (macOS). Encodes results as
@@ -952,5 +1000,147 @@ mod tests {
             "expected negative errno for nonexistent path, got {}",
             completions[0].result_code
         );
+    }
+
+    /// Regression test for the macOS `EVFILT_SIGNAL` hang that prevented
+    /// tests/elle/posix.lisp from passing on macOS, and a counter-factual
+    /// guard for the Linux signalfd EAGAIN fix from commit f7aed410.
+    ///
+    /// Forks a child process so we get a clean thread topology that
+    /// mirrors production: only the main thread plus our intentionally-
+    /// spawned threadpool worker, all with the watched signal masked.
+    /// In the cargo test runner this isn't true — peer test threads have
+    /// SIGUSR1 unmasked and would absorb the `kill()` before our
+    /// signalfd/kqueue worker reads it.
+    ///
+    /// Child flow:
+    ///   1. Open a `SignalReceiver` for SIGUSR1 (blocks it on this
+    ///      thread; the threadpool worker spawned in step 2 inherits the
+    ///      mask).
+    ///   2. Submit the platform's blocking signal-read op (`SigfdRead` on
+    ///      Linux, `KqSigRead` on macOS) — the same threadpool primitive
+    ///      `submit_sig_next` uses in production.
+    ///   3. `kill(getpid(), SIGUSR1)` from the main thread.
+    ///   4. Wait up to 5 s for a completion; assert it parses to a
+    ///      single SIGUSR1 event.
+    ///
+    /// Child exits 0 on success, a small positive code on failure.
+    ///
+    /// On macOS this gates the fix: kqueue's `EVFILT_SIGNAL` fires from
+    /// the in-kernel delivery path, so if every thread in the process
+    /// blocks the signal the kernel parks it on the process pending list
+    /// and the knote is never activated. Without the fix the child hangs
+    /// past the parent's wait timeout (waitpid loop bounded at 10 s).
+    #[test]
+    fn sig_read_returns_after_kill_to_self() {
+        use std::time::{Duration, Instant};
+
+        let pid = unsafe { libc::fork() };
+        if pid < 0 {
+            panic!("fork failed: {}", std::io::Error::last_os_error());
+        }
+        if pid == 0 {
+            // CHILD: run the test logic and _exit. Use _exit to skip
+            // atexit/destructors — Rust drop glue across the fork
+            // boundary is unsupported in general.
+            let code = sig_read_child_logic();
+            unsafe { libc::_exit(code) };
+        }
+
+        // PARENT: bounded waitpid so a regression surfaces fast instead
+        // of wedging the test runner.
+        let deadline = Instant::now() + Duration::from_secs(10);
+        let mut status: libc::c_int = 0;
+        loop {
+            let wret = unsafe { libc::waitpid(pid, &mut status, libc::WNOHANG) };
+            if wret == pid {
+                break;
+            }
+            if wret < 0 {
+                let errno = std::io::Error::last_os_error();
+                panic!("waitpid({}): {}", pid, errno);
+            }
+            if Instant::now() >= deadline {
+                // Kill the child so we don't leak the process and panic
+                // with a meaningful message.
+                unsafe { libc::kill(pid, libc::SIGKILL) };
+                let _ = unsafe { libc::waitpid(pid, &mut status, 0) };
+                panic!("sig_read child hung past 10s");
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+
+        if libc::WIFSIGNALED(status) {
+            panic!("sig_read child died from signal {}", libc::WTERMSIG(status));
+        }
+        let code = libc::WEXITSTATUS(status);
+        assert_eq!(
+            code, 0,
+            "sig_read child failed with code {} (see codes in sig_read_child_logic)",
+            code
+        );
+    }
+
+    /// Body of the forked child for `sig_read_returns_after_kill_to_self`.
+    /// Returns a small positive exit code identifying which step failed,
+    /// or 0 on success. Kept narrow on purpose: no allocations between
+    /// fork and the kernel calls beyond what `SignalReceiver` and
+    /// `ThreadPoolBackend` already do.
+    fn sig_read_child_logic() -> i32 {
+        use crate::io::sigfd::SignalReceiver;
+        use std::time::Duration;
+
+        let r = match SignalReceiver::new(vec![libc::SIGUSR1]) {
+            Ok(r) => r,
+            Err(_) => return 11,
+        };
+        let fd = match r.raw_fd() {
+            Ok(f) => f,
+            Err(_) => return 12,
+        };
+
+        let mut pool = ThreadPoolBackend::new();
+        #[cfg(any(target_os = "linux", target_os = "android"))]
+        let submit = pool.submit(1, PoolOp::SigfdRead { fd });
+        #[cfg(target_os = "macos")]
+        let submit = pool.submit(
+            1,
+            PoolOp::KqSigRead {
+                fd,
+                signals: vec![libc::SIGUSR1],
+            },
+        );
+        if submit.is_err() {
+            return 13;
+        }
+
+        // Let the worker enter the blocking syscall first — matches the
+        // (ev/sleep 0.05) preamble in tests/elle/posix.lisp test #1.
+        std::thread::sleep(Duration::from_millis(50));
+
+        if unsafe { libc::kill(libc::getpid(), libc::SIGUSR1) } != 0 {
+            return 14;
+        }
+
+        let completions = match pool.wait(Some(5000)) {
+            Ok(c) => c,
+            Err(_) => return 15,
+        };
+        if completions.is_empty() {
+            return 16;
+        }
+        let pc = &completions[0];
+        if pc.result_code <= 0 {
+            return 17;
+        }
+        let events = r.parse_events(&pc.data[..pc.result_code as usize]);
+        if events.is_empty() {
+            return 18;
+        }
+        if events[0].signum != libc::SIGUSR1 {
+            return 19;
+        }
+        r.close();
+        0
     }
 }

--- a/src/io/threadpool.rs
+++ b/src/io/threadpool.rs
@@ -1189,4 +1189,147 @@ mod tests {
         r.close();
         0
     }
+
+    /// Regression test for the macOS test 5 failure mode: after the
+    /// kqueue worker reports the event for a `kill(getpid(), SIGUSR1)`,
+    /// macOS leaves an instance of the signal in the process pending
+    /// queue (EVFILT_SIGNAL counts kill() generations on the knote but
+    /// does not consume from the pending queue, and the worker's brief
+    /// SIG_UNBLOCK + no-op handler delivery only drains at most one
+    /// instance). Before the `rollback`-time drain
+    /// (src/io/sigfd.rs::drain_pending_blocked) `os/sig-close` would
+    /// restore the SIGUSR1 default disposition (Term) and then
+    /// `pthread_sigmask(SIG_UNBLOCK, …)`, firing the pending Term on
+    /// the closing thread and killing the process mid-close — exactly
+    /// the silent death observed at `test 5: pre-close` in
+    /// tests/elle/posix.lisp on macOS CI.
+    ///
+    /// This test reproduces the shape (two kills, one read, close)
+    /// inside a forked child and asserts the child exits 0 rather
+    /// than dying from signal 10/SIGUSR1.
+    #[test]
+    fn close_drains_pending_after_two_kills() {
+        use std::time::{Duration, Instant};
+
+        let pid = unsafe { libc::fork() };
+        if pid < 0 {
+            panic!("fork failed: {}", std::io::Error::last_os_error());
+        }
+        if pid == 0 {
+            let code = close_drain_child_logic();
+            unsafe { libc::_exit(code) };
+        }
+
+        let deadline = Instant::now() + Duration::from_secs(10);
+        let mut status: libc::c_int = 0;
+        loop {
+            let wret = unsafe { libc::waitpid(pid, &mut status, libc::WNOHANG) };
+            if wret == pid {
+                break;
+            }
+            if wret < 0 {
+                let errno = std::io::Error::last_os_error();
+                panic!("waitpid({}): {}", pid, errno);
+            }
+            if Instant::now() >= deadline {
+                unsafe { libc::kill(pid, libc::SIGKILL) };
+                let _ = unsafe { libc::waitpid(pid, &mut status, 0) };
+                panic!("close_drains_pending child hung past 10s");
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+
+        if libc::WIFSIGNALED(status) {
+            let sig = libc::WTERMSIG(status);
+            panic!(
+                "close_drains_pending child died from signal {} \
+                 (expected clean exit; pending signal at close-time \
+                 unblock was NOT drained)",
+                sig
+            );
+        }
+        let code = libc::WEXITSTATUS(status);
+        assert_eq!(
+            code, 0,
+            "close_drains_pending child failed with code {} (see codes in close_drain_child_logic)",
+            code
+        );
+    }
+
+    /// Body of the forked child for `close_drains_pending_after_two_kills`.
+    /// Reads ONE signal via sig-next (proving the watcher works), then
+    /// raises SIGUSR1 AGAIN with no reader pending so the signal sits in
+    /// the kernel queue at close time. The drain in rollback must
+    /// consume it; otherwise close's post-restore unblock fires the
+    /// default disposition (Term for SIGUSR1) on the calling thread and
+    /// kills us. Reaching `return 0` after `r.close()` IS the test.
+    ///
+    /// This reproduces on both Linux and macOS:
+    ///  - Linux: signalfd dequeues at read time, so the post-read kill
+    ///    is what leaves something stuck in the queue at close.
+    ///  - macOS: the EVFILT_SIGNAL knote never dequeues from the
+    ///    process pending queue, so the original kill ALSO survives —
+    ///    but the post-read kill is the portable trigger.
+    fn close_drain_child_logic() -> i32 {
+        use crate::io::sigfd::SignalReceiver;
+        use std::time::Duration;
+
+        let r = match SignalReceiver::new(vec![libc::SIGUSR1]) {
+            Ok(r) => r,
+            Err(_) => return 21,
+        };
+        let fd = match r.raw_fd() {
+            Ok(f) => f,
+            Err(_) => return 22,
+        };
+
+        // First kill + sig-next round-trip. Proves the watcher works
+        // and consumes one pending instance through the kernel.
+        if unsafe { libc::kill(libc::getpid(), libc::SIGUSR1) } != 0 {
+            return 23;
+        }
+        let mut pool = ThreadPoolBackend::new();
+        #[cfg(any(target_os = "linux", target_os = "android"))]
+        let submit = pool.submit(1, PoolOp::SigfdRead { fd });
+        #[cfg(target_os = "macos")]
+        let submit = pool.submit(
+            1,
+            PoolOp::KqSigRead {
+                fd,
+                signals: vec![libc::SIGUSR1],
+            },
+        );
+        if submit.is_err() {
+            return 24;
+        }
+        let completions = match pool.wait(Some(5000)) {
+            Ok(c) => c,
+            Err(_) => return 25,
+        };
+        if completions.is_empty() {
+            return 26;
+        }
+        if completions[0].result_code <= 0 {
+            return 27;
+        }
+
+        // SECOND kill — no reader pending. The signal sits in the
+        // process pending queue (SIGUSR1 still blocked on this thread
+        // from SignalReceiver::new). On close, without the drain in
+        // rollback the pthread_sigmask SIG_UNBLOCK fires the
+        // about-to-be-restored SIGUSR1 default (Term) and the child
+        // dies from signal 10 — observable as WIFSIGNALED=true,
+        // WTERMSIG=SIGUSR1 in the parent.
+        if unsafe { libc::kill(libc::getpid(), libc::SIGUSR1) } != 0 {
+            return 28;
+        }
+        // Brief sleep so the kill is definitely queued before close.
+        std::thread::sleep(Duration::from_millis(10));
+
+        // The smoking-gun call. With the drain it returns; without it
+        // the process dies here.
+        r.close();
+        std::thread::sleep(Duration::from_millis(10));
+        0
+    }
 }

--- a/src/io/threadpool.rs
+++ b/src/io/threadpool.rs
@@ -762,17 +762,40 @@ fn watch_read_blocking(fd: RawFd) -> (i32, Vec<u8>) {
 /// read return 0 (EOF) and the receiver is dead.
 #[cfg(any(target_os = "linux", target_os = "android"))]
 fn sigfd_read_blocking(fd: RawFd) -> (i32, Vec<u8>) {
+    // The signalfd is created with SFD_NONBLOCK (see src/io/sigfd.rs) so the
+    // io_uring path can rely on the kernel's poll-then-read pipeline. The
+    // threadpool path has no such pipeline: a bare read(2) on a non-blocking
+    // fd before the signal arrives returns -1/EAGAIN. Wait for POLLIN first,
+    // looping on EINTR. POLLHUP on signalfd is unusual (no shutdown(2)
+    // analogue) but we treat it as EOF for parity with WatchRead.
     let entry_size = std::mem::size_of::<libc::signalfd_siginfo>();
-    let mut buf = vec![0u8; entry_size * 8];
-    let ret = unsafe { libc::read(fd, buf.as_mut_ptr() as *mut libc::c_void, buf.len()) };
-    if ret < 0 {
-        (
-            -(std::io::Error::last_os_error().raw_os_error().unwrap_or(1)),
-            Vec::new(),
-        )
-    } else {
+    loop {
+        let mut pfd = libc::pollfd {
+            fd,
+            events: libc::POLLIN,
+            revents: 0,
+        };
+        let pret = unsafe { libc::poll(&mut pfd, 1, -1) };
+        if pret < 0 {
+            let errno = std::io::Error::last_os_error().raw_os_error().unwrap_or(1);
+            if errno == libc::EINTR {
+                continue;
+            }
+            return (-errno, Vec::new());
+        }
+        let mut buf = vec![0u8; entry_size * 8];
+        let ret = unsafe { libc::read(fd, buf.as_mut_ptr() as *mut libc::c_void, buf.len()) };
+        if ret < 0 {
+            let errno = std::io::Error::last_os_error().raw_os_error().unwrap_or(1);
+            // Racy: a different reader may have drained the queue between
+            // poll and read. Loop back to poll.
+            if errno == libc::EAGAIN || errno == libc::EWOULDBLOCK || errno == libc::EINTR {
+                continue;
+            }
+            return (-errno, Vec::new());
+        }
         buf.truncate(ret as usize);
-        (ret as i32, buf)
+        return (ret as i32, buf);
     }
 }
 

--- a/src/io/threadpool.rs
+++ b/src/io/threadpool.rs
@@ -773,12 +773,14 @@ fn watch_read_blocking(fd: RawFd) -> (i32, Vec<u8>) {
 /// read return 0 (EOF) and the receiver is dead.
 #[cfg(any(target_os = "linux", target_os = "android"))]
 fn sigfd_read_blocking(fd: RawFd) -> (i32, Vec<u8>) {
+    use crate::io::sigfd::posix_trace;
     // The signalfd is created with SFD_NONBLOCK (see src/io/sigfd.rs) so the
     // io_uring path can rely on the kernel's poll-then-read pipeline. The
     // threadpool path has no such pipeline: a bare read(2) on a non-blocking
     // fd before the signal arrives returns -1/EAGAIN. Wait for POLLIN first,
     // looping on EINTR. POLLHUP on signalfd is unusual (no shutdown(2)
     // analogue) but we treat it as EOF for parity with WatchRead.
+    posix_trace(format_args!("linux: sigfd_read_blocking entered fd={}", fd));
     let entry_size = std::mem::size_of::<libc::signalfd_siginfo>();
     loop {
         let mut pfd = libc::pollfd {
@@ -786,18 +788,34 @@ fn sigfd_read_blocking(fd: RawFd) -> (i32, Vec<u8>) {
             events: libc::POLLIN,
             revents: 0,
         };
+        posix_trace(format_args!(
+            "linux: sigfd_read_blocking poll(fd={}, POLLIN, -1)",
+            fd
+        ));
         let pret = unsafe { libc::poll(&mut pfd, 1, -1) };
         if pret < 0 {
             let errno = std::io::Error::last_os_error().raw_os_error().unwrap_or(1);
+            posix_trace(format_args!(
+                "linux: sigfd_read_blocking poll errno={}",
+                errno
+            ));
             if errno == libc::EINTR {
                 continue;
             }
             return (-errno, Vec::new());
         }
+        posix_trace(format_args!(
+            "linux: sigfd_read_blocking poll returned, revents=0x{:x}",
+            pfd.revents
+        ));
         let mut buf = vec![0u8; entry_size * 8];
         let ret = unsafe { libc::read(fd, buf.as_mut_ptr() as *mut libc::c_void, buf.len()) };
         if ret < 0 {
             let errno = std::io::Error::last_os_error().raw_os_error().unwrap_or(1);
+            posix_trace(format_args!(
+                "linux: sigfd_read_blocking read errno={}",
+                errno
+            ));
             // Racy: a different reader may have drained the queue between
             // poll and read. Loop back to poll.
             if errno == libc::EAGAIN || errno == libc::EWOULDBLOCK || errno == libc::EINTR {
@@ -806,6 +824,10 @@ fn sigfd_read_blocking(fd: RawFd) -> (i32, Vec<u8>) {
             return (-errno, Vec::new());
         }
         buf.truncate(ret as usize);
+        posix_trace(format_args!(
+            "linux: sigfd_read_blocking returning n={}",
+            ret
+        ));
         return (ret as i32, buf);
     }
 }
@@ -832,6 +854,11 @@ fn sigfd_read_blocking(fd: RawFd) -> (i32, Vec<u8>) {
 /// disposition (Term for SIGUSR1, etc.).
 #[cfg(target_os = "macos")]
 fn kq_sig_read_blocking(kq: RawFd, signals: &[libc::c_int]) -> (i32, Vec<u8>) {
+    use crate::io::sigfd::posix_trace;
+    posix_trace(format_args!(
+        "macos: kq_sig_read_blocking entered kq={} signals={:?}",
+        kq, signals
+    ));
     // Unblock the watched signals on this thread for the lifetime of the
     // worker. The worker is single-use (each PoolOp spawns a fresh
     // thread that exits after sending the completion), so we don't
@@ -841,12 +868,19 @@ fn kq_sig_read_blocking(kq: RawFd, signals: &[libc::c_int]) -> (i32, Vec<u8>) {
     for &s in signals {
         unsafe { libc::sigaddset(&mut to_unblock, s) };
     }
-    unsafe {
-        libc::pthread_sigmask(libc::SIG_UNBLOCK, &to_unblock, std::ptr::null_mut());
-    }
+    let unblock_ret =
+        unsafe { libc::pthread_sigmask(libc::SIG_UNBLOCK, &to_unblock, std::ptr::null_mut()) };
+    posix_trace(format_args!(
+        "macos: kq_sig_read_blocking pthread_sigmask SIG_UNBLOCK ret={}",
+        unblock_ret
+    ));
 
     loop {
         let mut eventlist: [libc::kevent; 32] = unsafe { std::mem::zeroed() };
+        posix_trace(format_args!(
+            "macos: kq_sig_read_blocking calling kevent(kq={})",
+            kq
+        ));
         let n = unsafe {
             libc::kevent(
                 kq,
@@ -859,6 +893,10 @@ fn kq_sig_read_blocking(kq: RawFd, signals: &[libc::c_int]) -> (i32, Vec<u8>) {
         };
         if n < 0 {
             let errno = std::io::Error::last_os_error().raw_os_error().unwrap_or(1);
+            posix_trace(format_args!(
+                "macos: kq_sig_read_blocking kevent returned -1, errno={}",
+                errno
+            ));
             // If the no-op handler ran without SA_RESTART (or some other
             // signal interrupted kevent), retry. The knote state is
             // preserved across EINTR, so a subsequent kevent picks up
@@ -868,10 +906,18 @@ fn kq_sig_read_blocking(kq: RawFd, signals: &[libc::c_int]) -> (i32, Vec<u8>) {
             }
             return (-errno, Vec::new());
         }
+        posix_trace(format_args!(
+            "macos: kq_sig_read_blocking kevent returned n={} events",
+            n
+        ));
         let mut data = Vec::with_capacity(n as usize * 8);
         for event in &eventlist[..n as usize] {
             let signum = event.ident as i32;
             let count = event.data as u32;
+            posix_trace(format_args!(
+                "macos: kq_sig_read_blocking event signum={} count={}",
+                signum, count
+            ));
             data.extend_from_slice(&signum.to_le_bytes());
             data.extend_from_slice(&count.to_le_bytes());
         }

--- a/src/io/uring.rs
+++ b/src/io/uring.rs
@@ -738,6 +738,10 @@ pub(super) fn drain_cqes(
                     let buf = buffer_pool.get_mut(buf_handle);
                     buf[..result_code as usize].to_vec()
                 }
+                PendingOp::SigNext { .. } if result_code > 0 => {
+                    let buf = buffer_pool.get_mut(buf_handle);
+                    buf[..result_code as usize].to_vec()
+                }
                 _ => Vec::new(),
             };
 

--- a/src/jit/worker.rs
+++ b/src/jit/worker.rs
@@ -63,6 +63,7 @@ impl JitWorker {
         let handle = std::thread::Builder::new()
             .name("elle-jit".into())
             .spawn(move || {
+                crate::io::sigfd::mask_all_signals_on_this_thread();
                 // Install a persistent fiber heap on this thread.
                 // translate_const allocates String/Keyword/Symbol Values
                 // in the thread-local heap. Since the heap is never freed,

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,7 +37,7 @@ fn print_help() {
     println!("  --trace=KW[,KW,...]   Trace subsystems. Keywords:");
     println!("                          call, signal, compile, fiber, hir, lir,");
     println!("                          emit, jit, io, gc, import, macro, wasm,");
-    println!("                          capture, arena, escape, bytecode");
+    println!("                          capture, arena, escape, bytecode, posix");
     println!("  --trace=all           Trace everything");
     println!("  --checked-intrinsics  Route %-intrinsics through type-checked NativeFn");
     println!("                          (implies --jit=off --mlir=off)");

--- a/src/primitives/AGENTS.md
+++ b/src/primitives/AGENTS.md
@@ -101,6 +101,7 @@ pub fn register_arithmetic(meta: &mut PrimitiveMeta, symbols: &mut SymbolTable) 
 | `ports.rs` | `port/open`, `port/open-bytes`, `port/close`, `port/stdin`, `port/stdout`, `port/stderr`, `port?`, `port/open?`, `port/set-options`, `port/path`, `port/seek`, `port/tell` |
 | `net.rs` | `tcp/listen`, `tcp/accept`, `tcp/connect`, `tcp/shutdown`, `udp/bind`, `udp/send-to`, `udp/recv-from` |
 | `unix.rs` | `unix/listen`, `unix/accept`, `unix/connect`, `unix/shutdown` |
+| `posix.rs` | `os/sig-send`, `os/sig-raise`, `os/sig-watch`, `os/sig-next`, `os/sig-close`, `os/sig-pending`, `os/sig-mask`, `os/sig-watching` — POSIX signal send/receive. Send/raise gated on `:os-signal` capability (`SIG_OS_SIGNAL`); receive primitives are async (yield `:io`). See `docs/posix-signals.md`. |
 | `kwarg.rs` | `extract_keyword_timeout` helper function |
 | `display.rs` | `print`, `println`, `display`, `newline` |
 | `types.rs` | `nil?`, `pair?`, `list?`, `number?`, `integer?`, `float?`, `string?`, `boolean?`, `symbol?`, `keyword?`, `array?`, `struct?`, `bytes?`, `mutable?`, `type-of` |

--- a/src/primitives/mod.rs
+++ b/src/primitives/mod.rs
@@ -44,6 +44,7 @@ pub mod package;
 pub mod parameters;
 pub mod path;
 pub mod ports;
+pub mod posix;
 pub mod read;
 pub mod registration;
 pub mod seq;

--- a/src/primitives/posix.rs
+++ b/src/primitives/posix.rs
@@ -1,0 +1,403 @@
+//! POSIX signal primitives — send, raise, watch, next, close, plus
+//! introspection (pending / mask / watching).
+//!
+//! See docs/posix-signals.md for the user-facing contract. Naming is
+//! `os/sig-*` to disambiguate from elle's runtime "signal" concept.
+
+use crate::io::request::{IoOp, IoRequest};
+use crate::io::sigfd::SignalReceiver;
+use crate::io::sigmap;
+use crate::primitives::def::PrimitiveDef;
+use crate::signals::{Signal, SIG_OS_SIGNAL};
+use crate::value::fiber::{SignalBits, SIG_ERROR, SIG_IO, SIG_OK, SIG_YIELD};
+use crate::value::types::Arity;
+use crate::value::{error_val, Value};
+use std::collections::BTreeSet;
+
+/// Resolve a Value (single keyword, set/array/list of keywords) to a list
+/// of unique libc signums. Unknown names or non-keywords are an error.
+fn resolve_signal_set(val: &Value, context: &str) -> Result<Vec<libc::c_int>, (SignalBits, Value)> {
+    fn push(out: &mut Vec<libc::c_int>, signum: libc::c_int) {
+        if !out.contains(&signum) {
+            out.push(signum);
+        }
+    }
+
+    let mut out: Vec<libc::c_int> = Vec::new();
+
+    let process_keyword =
+        |name: &str, out: &mut Vec<libc::c_int>| -> Result<(), (SignalBits, Value)> {
+            match sigmap::keyword_to_signum(name) {
+                Some(s) => {
+                    push(out, s);
+                    Ok(())
+                }
+                None => Err((
+                    SIG_ERROR,
+                    error_val(
+                        "argument-error",
+                        format!(
+                            "{}: unknown signal keyword :{}; expected one of {}",
+                            context,
+                            name,
+                            sigmap::supported_list_str()
+                        ),
+                    ),
+                )),
+            }
+        };
+
+    // Single keyword.
+    if let Some(name) = val.as_keyword_name() {
+        process_keyword(&name, &mut out)?;
+        return Ok(out);
+    }
+
+    // Set of keywords.
+    if let Some(set) = val.as_set() {
+        for elem in set.iter() {
+            let name = elem.as_keyword_name().ok_or_else(|| {
+                (
+                    SIG_ERROR,
+                    error_val(
+                        "type-error",
+                        format!(
+                            "{}: set elements must be keywords, got {}",
+                            context,
+                            elem.type_name()
+                        ),
+                    ),
+                )
+            })?;
+            process_keyword(&name, &mut out)?;
+        }
+        return Ok(out);
+    }
+
+    // Array / mutable array of keywords.
+    if let Some(elems) = val.as_array() {
+        for elem in elems.iter() {
+            let name = elem.as_keyword_name().ok_or_else(|| {
+                (
+                    SIG_ERROR,
+                    error_val(
+                        "type-error",
+                        format!(
+                            "{}: array elements must be keywords, got {}",
+                            context,
+                            elem.type_name()
+                        ),
+                    ),
+                )
+            })?;
+            process_keyword(&name, &mut out)?;
+        }
+        return Ok(out);
+    }
+    if let Some(arr) = val.as_array_mut() {
+        for elem in arr.borrow().iter() {
+            let name = elem.as_keyword_name().ok_or_else(|| {
+                (
+                    SIG_ERROR,
+                    error_val(
+                        "type-error",
+                        format!(
+                            "{}: array elements must be keywords, got {}",
+                            context,
+                            elem.type_name()
+                        ),
+                    ),
+                )
+            })?;
+            process_keyword(&name, &mut out)?;
+        }
+        return Ok(out);
+    }
+
+    // List of keywords.
+    if val.as_pair().is_some() {
+        let mut current = *val;
+        while let Some(pair) = current.as_pair() {
+            let name = pair.first.as_keyword_name().ok_or_else(|| {
+                (
+                    SIG_ERROR,
+                    error_val(
+                        "type-error",
+                        format!(
+                            "{}: list elements must be keywords, got {}",
+                            context,
+                            pair.first.type_name()
+                        ),
+                    ),
+                )
+            })?;
+            process_keyword(&name, &mut out)?;
+            current = pair.rest;
+        }
+        return Ok(out);
+    }
+
+    if val.is_empty_list() {
+        return Ok(out);
+    }
+
+    Err((
+        SIG_ERROR,
+        error_val(
+            "type-error",
+            format!(
+                "{}: expected keyword, set, array, or list of keywords, got {}",
+                context,
+                val.type_name()
+            ),
+        ),
+    ))
+}
+
+/// Build a Value-set from a slice of libc signums.
+fn signums_to_keyword_set(signums: &[libc::c_int]) -> Value {
+    let mut set: BTreeSet<Value> = BTreeSet::new();
+    for &s in signums {
+        if let Some(name) = sigmap::signum_to_keyword(s) {
+            set.insert(Value::keyword(name));
+        }
+    }
+    Value::set(set)
+}
+
+// ── os/sig-send ────────────────────────────────────────────────────────
+
+fn prim_sig_send(args: &[Value]) -> (SignalBits, Value) {
+    let pid = match args[0].as_int() {
+        Some(n) => n as i32,
+        None => {
+            return (
+                SIG_ERROR,
+                error_val(
+                    "type-error",
+                    format!(
+                        "os/sig-send: pid must be integer, got {}",
+                        args[0].type_name()
+                    ),
+                ),
+            )
+        }
+    };
+    let signum = match sigmap::resolve(&args[1], "os/sig-send") {
+        Ok(s) => s,
+        Err(e) => {
+            let (kind, msg) = e.parts("os/sig-send");
+            return (SIG_ERROR, error_val(kind, msg));
+        }
+    };
+    let ret = unsafe { libc::kill(pid, signum) };
+    if ret < 0 {
+        let err = std::io::Error::last_os_error();
+        return (
+            SIG_ERROR,
+            error_val("os-signal-error", format!("os/sig-send: {}", err)),
+        );
+    }
+    (SIG_OK, Value::NIL)
+}
+
+// ── os/sig-raise ───────────────────────────────────────────────────────
+
+fn prim_sig_raise(args: &[Value]) -> (SignalBits, Value) {
+    let signum = match sigmap::resolve(&args[0], "os/sig-raise") {
+        Ok(s) => s,
+        Err(e) => {
+            let (kind, msg) = e.parts("os/sig-raise");
+            return (SIG_ERROR, error_val(kind, msg));
+        }
+    };
+    // libc::raise sends to the calling thread; for kqueue/signalfd we want
+    // it delivered to the process, so use kill(getpid()) instead. On
+    // single-threaded targets they're equivalent.
+    let ret = unsafe { libc::kill(libc::getpid(), signum) };
+    if ret < 0 {
+        let err = std::io::Error::last_os_error();
+        return (
+            SIG_ERROR,
+            error_val("os-signal-error", format!("os/sig-raise: {}", err)),
+        );
+    }
+    (SIG_OK, Value::NIL)
+}
+
+// ── os/sig-watch ───────────────────────────────────────────────────────
+
+fn prim_sig_watch(args: &[Value]) -> (SignalBits, Value) {
+    let signums = match resolve_signal_set(&args[0], "os/sig-watch") {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+    if signums.is_empty() {
+        return (
+            SIG_ERROR,
+            error_val(
+                "argument-error",
+                "os/sig-watch: signal set must be non-empty",
+            ),
+        );
+    }
+    match SignalReceiver::new(signums) {
+        Ok(r) => (SIG_OK, Value::external("signal-receiver", r)),
+        Err(msg) => (SIG_ERROR, error_val("os-signal-error", msg)),
+    }
+}
+
+// ── os/sig-next ────────────────────────────────────────────────────────
+
+fn prim_sig_next(args: &[Value]) -> (SignalBits, Value) {
+    if args[0].as_external::<SignalReceiver>().is_none() {
+        return (
+            SIG_ERROR,
+            error_val(
+                "type-error",
+                "os/sig-next: argument must be a signal receiver",
+            ),
+        );
+    }
+    (SIG_YIELD | SIG_IO, IoRequest::new(IoOp::SigNext, args[0]))
+}
+
+// ── os/sig-close ───────────────────────────────────────────────────────
+
+fn prim_sig_close(args: &[Value]) -> (SignalBits, Value) {
+    let receiver = match args[0].as_external::<SignalReceiver>() {
+        Some(r) => r,
+        None => {
+            return (
+                SIG_ERROR,
+                error_val(
+                    "type-error",
+                    "os/sig-close: argument must be a signal receiver",
+                ),
+            )
+        }
+    };
+    receiver.close();
+    (SIG_OK, Value::NIL)
+}
+
+// ── os/sig-pending ─────────────────────────────────────────────────────
+
+fn prim_sig_pending(_args: &[Value]) -> (SignalBits, Value) {
+    let signums = crate::io::sigfd::current_thread_pending();
+    (SIG_OK, signums_to_keyword_set(&signums))
+}
+
+// ── os/sig-mask ────────────────────────────────────────────────────────
+
+fn prim_sig_mask(_args: &[Value]) -> (SignalBits, Value) {
+    let signums = crate::io::sigfd::current_thread_blocked();
+    (SIG_OK, signums_to_keyword_set(&signums))
+}
+
+// ── os/sig-watching ────────────────────────────────────────────────────
+
+fn prim_sig_watching(_args: &[Value]) -> (SignalBits, Value) {
+    let signums = crate::io::sigfd::currently_watched();
+    (SIG_OK, signums_to_keyword_set(&signums))
+}
+
+pub(crate) const PRIMITIVES: &[PrimitiveDef] = &[
+    PrimitiveDef {
+        name: "os/sig-send",
+        func: prim_sig_send,
+        signal: Signal::os_signal_errors(),
+        arity: Arity::Exact(2),
+        doc: "Send a POSIX signal to a pid. signum is a keyword (:sigterm, :sigkill, etc.) or a named integer. Capability: :os-signal.",
+        params: &["pid", "signum"],
+        category: "posix",
+        example: "(os/sig-send 4242 :sigterm)",
+        aliases: &[],
+    },
+    PrimitiveDef {
+        name: "os/sig-raise",
+        func: prim_sig_raise,
+        signal: Signal::os_signal_errors(),
+        arity: Arity::Exact(1),
+        doc: "Send a POSIX signal to the current process. Capability: :os-signal.",
+        params: &["signum"],
+        category: "posix",
+        example: "(os/sig-raise :sigusr1)",
+        aliases: &[],
+    },
+    PrimitiveDef {
+        name: "os/sig-watch",
+        func: prim_sig_watch,
+        signal: Signal::errors(),
+        arity: Arity::Exact(1),
+        doc: "Open a signal receiver that watches a set of POSIX signals. Blocks the signals on the calling thread and queues deliveries onto a kernel fd. Returns a SignalReceiver. See docs/posix-signals.md for mask policy.",
+        params: &["signal-set"],
+        category: "posix",
+        example: "(os/sig-watch |:sigterm :sigint|)",
+        aliases: &[],
+    },
+    PrimitiveDef {
+        name: "os/sig-next",
+        func: prim_sig_next,
+        signal: Signal {
+            bits: SIG_ERROR.union(SIG_YIELD).union(SIG_IO),
+            propagates: 0,
+        },
+        arity: Arity::Exact(1),
+        doc: "Wait for the next batch of signal deliveries on a receiver. Yields to the scheduler. Resumes with an array of [{:signal :sigterm :sender-pid n :sender-uid n :code n :count n} ...].",
+        params: &["receiver"],
+        category: "posix",
+        example: "(os/sig-next r)",
+        aliases: &[],
+    },
+    PrimitiveDef {
+        name: "os/sig-close",
+        func: prim_sig_close,
+        signal: Signal::errors(),
+        arity: Arity::Exact(1),
+        doc: "Close a signal receiver. Decrements the watched-set refcount; the signal is unblocked process-wide when the last watcher releases it. Idempotent.",
+        params: &["receiver"],
+        category: "posix",
+        example: "(os/sig-close r)",
+        aliases: &[],
+    },
+    PrimitiveDef {
+        name: "os/sig-pending",
+        func: prim_sig_pending,
+        signal: Signal::silent(),
+        arity: Arity::Exact(0),
+        doc: "Return a set of keywords for signals currently pending delivery on the calling thread (sigpending(2)).",
+        params: &[],
+        category: "posix",
+        example: "(os/sig-pending)",
+        aliases: &[],
+    },
+    PrimitiveDef {
+        name: "os/sig-mask",
+        func: prim_sig_mask,
+        signal: Signal::silent(),
+        arity: Arity::Exact(0),
+        doc: "Return a set of keywords for signals currently blocked on the calling thread (pthread_sigmask).",
+        params: &[],
+        category: "posix",
+        example: "(os/sig-mask)",
+        aliases: &[],
+    },
+    PrimitiveDef {
+        name: "os/sig-watching",
+        func: prim_sig_watching,
+        signal: Signal::silent(),
+        arity: Arity::Exact(0),
+        doc: "Return a set of keywords for signals currently being watched by at least one live receiver.",
+        params: &[],
+        category: "posix",
+        example: "(os/sig-watching)",
+        aliases: &[],
+    },
+];
+
+// Suppress dead-code warning for the SIG_OS_SIGNAL re-export now that
+// posix.rs is the only caller. Keep `pub use` so the capability bit is
+// visible to anyone who imports it.
+#[allow(dead_code)]
+pub(crate) const _SIG_OS_SIGNAL_USED: SignalBits = SIG_OS_SIGNAL;

--- a/src/primitives/posix.rs
+++ b/src/primitives/posix.rs
@@ -190,9 +190,14 @@ fn prim_sig_send(args: &[Value]) -> (SignalBits, Value) {
             return (SIG_ERROR, error_val(kind, msg));
         }
     };
+    crate::io::sigfd::posix_trace(format_args!(
+        "prim_sig_send kill(pid={}, signum={})",
+        pid, signum
+    ));
     let ret = unsafe { libc::kill(pid, signum) };
     if ret < 0 {
         let err = std::io::Error::last_os_error();
+        crate::io::sigfd::posix_trace(format_args!("prim_sig_send kill FAILED errno={}", err));
         return (
             SIG_ERROR,
             error_val("os-signal-error", format!("os/sig-send: {}", err)),
@@ -214,9 +219,14 @@ fn prim_sig_raise(args: &[Value]) -> (SignalBits, Value) {
     // libc::raise sends to the calling thread; for kqueue/signalfd we want
     // it delivered to the process, so use kill(getpid()) instead. On
     // single-threaded targets they're equivalent.
+    crate::io::sigfd::posix_trace(format_args!(
+        "prim_sig_raise kill(getpid(), signum={})",
+        signum
+    ));
     let ret = unsafe { libc::kill(libc::getpid(), signum) };
     if ret < 0 {
         let err = std::io::Error::last_os_error();
+        crate::io::sigfd::posix_trace(format_args!("prim_sig_raise kill FAILED errno={}", err));
         return (
             SIG_ERROR,
             error_val("os-signal-error", format!("os/sig-raise: {}", err)),

--- a/src/primitives/registration.rs
+++ b/src/primitives/registration.rs
@@ -7,7 +7,7 @@ use super::{
     allocator, arena, arithmetic, array, bitwise, bytes, chan, comparison, compile, concurrency,
     config, convert, debug, disassembly, display, fiber_introspect, fibers, fileio, format,
     intrinsics, introspection, io, json, list, loading, logic, lstruct, math, memory, meta,
-    modules, net, package, parameters, path, ports, r#box, read, sets, sort, stream, string,
+    modules, net, package, parameters, path, ports, posix, r#box, read, sets, sort, stream, string,
     structs, subprocess, time, traits, types, unix, watch,
 };
 
@@ -54,6 +54,7 @@ pub(crate) const ALL_TABLES: &[&[PrimitiveDef]] = &[
     parameters::PRIMITIVES,
     path::PRIMITIVES,
     ports::PRIMITIVES,
+    posix::PRIMITIVES,
     subprocess::PRIMITIVES,
     read::PRIMITIVES,
     sets::PRIMITIVES,

--- a/src/primitives/subprocess.rs
+++ b/src/primitives/subprocess.rs
@@ -54,6 +54,13 @@ pub(crate) fn prim_halt(args: &[Value]) -> (SignalBits, Value) {
     (SIG_HALT, value)
 }
 
+/// Return the current process's pid.
+///
+/// (sys/pid) => int
+pub(crate) fn prim_sys_pid(_args: &[Value]) -> (SignalBits, Value) {
+    (SIG_OK, Value::int(std::process::id() as i64))
+}
+
 /// Return user-provided command-line arguments as a list.
 /// Arguments are those that follow the source file (or `-` for stdin)
 /// in the process argv. Returns an empty list if no args follow.
@@ -482,37 +489,26 @@ fn prim_subprocess_wait(args: &[Value]) -> (SignalBits, Value) {
     (SIG_YIELD | SIG_IO | SIG_EXEC, request)
 }
 
-/// Map a signal name keyword (without the colon) to its libc constant.
-fn keyword_to_signal(name: &str) -> Option<libc::c_int> {
-    match name {
-        "sigterm" => Some(libc::SIGTERM),
-        "sigkill" => Some(libc::SIGKILL),
-        "sighup" => Some(libc::SIGHUP),
-        "sigint" => Some(libc::SIGINT),
-        "sigquit" => Some(libc::SIGQUIT),
-        "sigpipe" => Some(libc::SIGPIPE),
-        "sigalrm" => Some(libc::SIGALRM),
-        "sigusr1" => Some(libc::SIGUSR1),
-        "sigusr2" => Some(libc::SIGUSR2),
-        "sigchld" => Some(libc::SIGCHLD),
-        "sigcont" => Some(libc::SIGCONT),
-        "sigstop" => Some(libc::SIGSTOP),
-        "sigtstp" => Some(libc::SIGTSTP),
-        "sigttin" => Some(libc::SIGTTIN),
-        "sigttou" => Some(libc::SIGTTOU),
-        "sigwinch" => Some(libc::SIGWINCH),
-        _ => None,
-    }
-}
-
 /// Send a signal to a subprocess.
 ///
 /// (subprocess/kill handle-or-struct)           ; sends SIGTERM
-/// (subprocess/kill handle-or-struct 15)        ; integer signal number
+/// (subprocess/kill handle-or-struct 15)        ; integer (must round-trip to a named signal)
 /// (subprocess/kill handle-or-struct :sigterm)  ; keyword signal name
 ///
 /// Synchronous — returns (SIG_OK, nil) on success, (SIG_ERROR, error) on failure.
 fn prim_subprocess_kill(args: &[Value]) -> (SignalBits, Value) {
+    if !(1..=2).contains(&args.len()) {
+        return (
+            SIG_ERROR,
+            error_val(
+                "argument-error",
+                format!(
+                    "subprocess/kill: expected 1 or 2 arguments, got {}",
+                    args.len()
+                ),
+            ),
+        );
+    }
     let handle_val = match extract_process_handle(&args[0], "subprocess/kill") {
         Ok(v) => v,
         Err(e) => return e,
@@ -527,34 +523,12 @@ fn prim_subprocess_kill(args: &[Value]) -> (SignalBits, Value) {
         }
     };
     let signal = if args.len() > 1 {
-        if let Some(n) = args[1].as_int() {
-            n as i32
-        } else if let Some(name) = args[1].as_keyword_name() {
-            match keyword_to_signal(&name) {
-                Some(sig) => sig,
-                None => {
-                    return (
-                        SIG_ERROR,
-                        error_val(
-                            "type-error",
-                            format!(
-                                "subprocess/kill: unknown signal keyword :{name}; expected integer or one of :sigterm, :sigkill, :sighup, :sigint, :sigquit, :sigpipe, :sigalrm, :sigusr1, :sigusr2, :sigchld, :sigcont, :sigstop, :sigtstp, :sigttin, :sigttou, :sigwinch"
-                            ),
-                        ),
-                    )
-                }
+        match crate::io::sigmap::resolve(&args[1], "subprocess/kill") {
+            Ok(s) => s,
+            Err(e) => {
+                let (kind, msg) = e.parts("subprocess/kill");
+                return (SIG_ERROR, error_val(kind, msg));
             }
-        } else {
-            return (
-                SIG_ERROR,
-                error_val(
-                    "type-error",
-                    format!(
-                        "subprocess/kill: signal must be integer or keyword, got {}",
-                        args[1].type_name()
-                    ),
-                ),
-            );
         }
     } else {
         libc::SIGTERM
@@ -642,6 +616,17 @@ pub(crate) const PRIMITIVES: &[PrimitiveDef] = &[
         params: &[],
         category: "sys",
         example: "(sys/argv)",
+        aliases: &[],
+    },
+    PrimitiveDef {
+        name: "sys/pid",
+        func: prim_sys_pid,
+        signal: Signal::silent(),
+        arity: Arity::Exact(0),
+        doc: "Return the current process's pid as an integer.",
+        params: &[],
+        category: "sys",
+        example: "(sys/pid)",
         aliases: &[],
     },
     PrimitiveDef {

--- a/src/signals/mod.rs
+++ b/src/signals/mod.rs
@@ -48,7 +48,8 @@ use std::fmt;
 //   Bit  13:    Switch - fiber switch trampoline
 //   Bit  14:    Wait - structured concurrency wait request
 //   Bit  15:    GPU
-//   Bits 16-31: Runtime-reserved (future runtime signals)
+//   Bit  16:    OsSignal — POSIX signal send/raise capability (access control; NOT a dispatch bit)
+//   Bits 17-31: Runtime-reserved (future runtime signals)
 //   Bits 32-63: User-defined signal types
 
 pub const SIG_OK: SignalBits = SignalBits::new(0); // no bits set = normal return
@@ -68,6 +69,7 @@ pub const SIG_FUEL: SignalBits = SignalBits::new(1 << 12); // instruction budget
 pub const SIG_SWITCH: SignalBits = SignalBits::new(1 << 13); // fiber switch trampoline (VM-internal)
 pub const SIG_WAIT: SignalBits = SignalBits::new(1 << 14); // structured concurrency wait request
 pub const SIG_GPU: SignalBits = SignalBits::new(1 << 15); // GPU hardware dispatch (capability bit)
+pub const SIG_OS_SIGNAL: SignalBits = SignalBits::new(1 << 16); // POSIX signal send/raise (capability bit)
 
 /// VM-internal signal bits: infrastructure signals that user code cannot
 /// produce. These are emitted exclusively by the VM's own dispatch machinery.
@@ -167,6 +169,15 @@ impl Signal {
     pub const fn ffi_errors() -> Self {
         Signal {
             bits: SIG_FFI.union(SIG_ERROR),
+            propagates: 0,
+        }
+    }
+
+    /// Sends a POSIX signal (capability-gated) and may error (SIG_OS_SIGNAL | SIG_ERROR).
+    /// Used by os/sig-send and os/sig-raise.
+    pub const fn os_signal_errors() -> Self {
+        Signal {
+            bits: SIG_OS_SIGNAL.union(SIG_ERROR),
             propagates: 0,
         }
     }

--- a/src/signals/registry.rs
+++ b/src/signals/registry.rs
@@ -1,6 +1,6 @@
 use super::{
-    SIG_DEBUG, SIG_ERROR, SIG_EXEC, SIG_FFI, SIG_FUEL, SIG_GPU, SIG_HALT, SIG_IO, SIG_WAIT,
-    SIG_YIELD,
+    SIG_DEBUG, SIG_ERROR, SIG_EXEC, SIG_FFI, SIG_FUEL, SIG_GPU, SIG_HALT, SIG_IO, SIG_OS_SIGNAL,
+    SIG_WAIT, SIG_YIELD,
 };
 /// Signal registry for mapping signal keywords to bit positions.
 ///
@@ -64,6 +64,7 @@ impl SignalRegistry {
         let _ = registry.register_builtin("fuel", SIG_FUEL.trailing_zeros());
         let _ = registry.register_builtin("wait", SIG_WAIT.trailing_zeros());
         let _ = registry.register_builtin("gpu", SIG_GPU.trailing_zeros());
+        let _ = registry.register_builtin("os-signal", SIG_OS_SIGNAL.trailing_zeros());
         registry
     }
 

--- a/tests/elle/posix.lisp
+++ b/tests/elle/posix.lisp
@@ -5,52 +5,103 @@
 # management, and introspection. See docs/posix-signals.md for the
 # surface contract. Run via:
 #   cargo test elle_scripts::posix
+#
+# INSTRUMENTATION POLICY: every step that talks to the kernel about
+# signals (watch, send, raise, next, close) prints a tag-and-state
+# line to *stderr* via eprintln BEFORE the call. Every sig-next is
+# bounded with (ev/timeout 5 …) so a stuck delivery fails fast with a
+# pinpointed "timed out at <site>" message instead of hanging the
+# whole suite under the outer 30s wall.  When ELLE_POSIX_DEBUG=1 the
+# Rust side (src/io/sigfd.rs, src/io/threadpool.rs) emits matching
+# kernel-level trace lines so a triage on macOS can correlate the two
+# halves without a rebuild.
+
+(eprintln "posix.lisp: starting; pid=" (sys/pid) "; initial mask=" (os/sig-mask)
+          "; initial watching=" (os/sig-watching))
+
+# Helper: bounded sig-next. Returns the array of events, or nil on
+# timeout. The site tag is included in the timeout eprintln so a
+# hang in a specific test is identifiable.
+(defn bounded-next [r site]
+  (let [events (ev/timeout 5 (fn [] (os/sig-next r)))]
+    (when (nil? events)
+      (eprintln "  TIMEOUT at " site ": os/sig-next did not return within 5s"
+                "; mask=" (os/sig-mask) "; pending=" (os/sig-pending)
+                "; watching=" (os/sig-watching)))
+    events))
 
 # ── 1. self-raise watched ────────────────────────────────────────────────
 
-(let [r (os/sig-watch |:sigusr1|)
-      waiter (ev/spawn (fn [] (os/sig-next r)))]
-  (ev/sleep 0.05)
-  (os/sig-raise :sigusr1)
-  (let [events (ev/join waiter)]
-    (assert (>= (length events) 1) "1: at least one event delivered")
-    (assert (= :sigusr1 (get (first events) :signal))
-            "1: first event is :sigusr1"))
+(eprintln "test 1: starting (self-raise SIGUSR1)")
+(let [r (os/sig-watch |:sigusr1|)]
+  (eprintln "test 1: opened receiver; mask=" (os/sig-mask) "; watching="
+            (os/sig-watching))
+  (let [waiter (ev/spawn (fn [] (bounded-next r "test 1")))]
+    (eprintln "test 1: spawned waiter; sleeping 50ms")
+    (ev/sleep 0.05)
+    (eprintln "test 1: raising SIGUSR1")
+    (os/sig-raise :sigusr1)
+    (eprintln "test 1: joining waiter")
+    (let [events (ev/join waiter)]
+      (eprintln "test 1: events=" events)
+      (assert (not (nil? events))
+              "1: os/sig-next must return events, not nil (timeout)")
+      (assert (>= (length events) 1) "1: at least one event delivered")
+      (assert (= :sigusr1 (get (first events) :signal))
+              "1: first event is :sigusr1")))
+  (eprintln "test 1: closing receiver")
   (os/sig-close r))
+(eprintln "test 1: done")
 
 # ── 2. cross-process send ─────────────────────────────────────────────────
 
-(let [r (os/sig-watch |:sigusr2|)
-      waiter (ev/spawn (fn [] (os/sig-next r)))]
-  (ev/sleep 0.05)
-  (os/sig-send (sys/pid) :sigusr2)
-  (let [ev (first (ev/join waiter))]
-    (assert (= :sigusr2 (get ev :signal)) "2: signal is :sigusr2")  # :sender-pid is nil on macOS but a valid int on Linux; tolerate both
-    (let [sp (get ev :sender-pid)]
-      (assert (or (nil? sp) (= sp (sys/pid)))
-              "2: :sender-pid is nil or equal to (sys/pid)")))
+(eprintln "test 2: starting (cross-process kill SIGUSR2 to self)")
+(let [r (os/sig-watch |:sigusr2|)]
+  (eprintln "test 2: opened receiver; mask=" (os/sig-mask))
+  (let [waiter (ev/spawn (fn [] (bounded-next r "test 2")))]
+    (ev/sleep 0.05)
+    (eprintln "test 2: sending SIGUSR2 to pid " (sys/pid))
+    (os/sig-send (sys/pid) :sigusr2)
+    (let [events (ev/join waiter)]
+      (eprintln "test 2: events=" events)
+      (assert (not (nil? events))
+              "2: os/sig-next must return events, not nil (timeout)")
+      (let [ev (first events)]
+        (assert (= :sigusr2 (get ev :signal)) "2: signal is :sigusr2")  # :sender-pid is nil on macOS but a valid int on Linux; tolerate both
+        (let [sp (get ev :sender-pid)]
+          (assert (or (nil? sp) (= sp (sys/pid)))
+                  "2: :sender-pid is nil or equal to (sys/pid)")))))
   (os/sig-close r))
+(eprintln "test 2: done")
 
 # ── 3. invalid pid errors ────────────────────────────────────────────────
 
+(eprintln "test 3: starting (invalid pid)")
 (let [[ok? val] (protect ((fn [] (os/sig-send -99999 :sigterm))))]
   (assert (not ok?) "3: os/sig-send to invalid pid errors")
   (assert (= :os-signal-error (get val :error))
           "3: error kind is :os-signal-error"))
+(eprintln "test 3: done")
 
 # ── 5. batching: multiple sends before a single next ─────────────────────
 
+(eprintln "test 5: starting (batched sends)")
 (let [r (os/sig-watch |:sigusr1|)]
   (os/sig-send (sys/pid) :sigusr1)
   (os/sig-send (sys/pid) :sigusr1)
   (ev/sleep 0.05)  # Kernel may coalesce identical signals from the same sender, so
   # we assert at least one event arrived (could be 1 or 2).
-  (let [evs (ev/join (ev/spawn (fn [] (os/sig-next r))))]
+  (let [evs (ev/join (ev/spawn (fn [] (bounded-next r "test 5"))))]
+    (eprintln "test 5: events=" evs)
+    (assert (not (nil? evs))
+            "5: os/sig-next must return events, not nil (timeout)")
     (assert (>= (length evs) 1) "5: at least one event after two sends"))
   (os/sig-close r))
+(eprintln "test 5: done")
 
 # ── 6. capability denial: :os-signal blocks os/sig-send ──────────────────
 
+(eprintln "test 6: starting (capability denial)")
 (let [f (fiber/new (fn [] (os/sig-send (sys/pid) :sigusr2)) |:error :os-signal|
                    :deny |:os-signal|)]
   (fiber/resume f)
@@ -68,24 +119,30 @@
   (fiber/resume f)
   (assert (= (fiber/status f) :dead)
           "6b: os/sig-send succeeds under :exec denial (distinct cap)"))
+(eprintln "test 6: done")
 
 # ── 7. capability denial covers os/sig-raise ─────────────────────────────
 
+(eprintln "test 7: starting")
 (let [f (fiber/new (fn [] (os/sig-raise :sigusr1)) |:error :os-signal|
                    :deny |:os-signal|)]
   (fiber/resume f)
   (let [val (fiber/value f)]
     (assert (= :capability-denied (get val :error))
             "7: os/sig-raise is denied by :os-signal")))
+(eprintln "test 7: done")
 
 # ── 8. os/sig-close is idempotent ────────────────────────────────────────
 
+(eprintln "test 8: starting")
 (let [r (os/sig-watch |:sigwinch|)]
   (assert (nil? (os/sig-close r)) "8a: first close returns nil")
   (assert (nil? (os/sig-close r)) "8b: second close also returns nil"))
+(eprintln "test 8: done")
 
 # ── 10. integer signums must be named ────────────────────────────────────
 
+(eprintln "test 10: starting (integer signum acceptance)")
 # Watch SIGUSR1 so a successful send doesn't fire default disposition,
 # then verify the integer signum (10 on Linux, 30 on macOS) is accepted.
 # Round-trip via the keyword form below to stay platform-portable.
@@ -95,7 +152,7 @@
                           # is accepted on the same kernel.
                            (os/sig-send (sys/pid) :sigusr1))))]
     (assert ok? "10a: keyword signum accepted"))  # Drain so the queued signal doesn't fire when we close.
-  (let [_ (ev/join (ev/spawn (fn [] (os/sig-next r))))]
+  (let [_ (ev/join (ev/spawn (fn [] (bounded-next r "test 10 drain"))))]
     nil)
   (os/sig-close r))
 
@@ -112,9 +169,11 @@
   (assert (not ok?) "10c: subprocess/kill with unnamed signum rejected")
   (assert (= :argument-error (get val :error))
           "10c: error kind is :argument-error"))
+(eprintln "test 10: done")
 
 # ── 11. refcount-driven unblock ──────────────────────────────────────────
 
+(eprintln "test 11: starting (refcount unblock)")
 (assert (not (contains? (os/sig-mask) :sigusr1))
         "11a: :sigusr1 not masked initially")
 (let [r (os/sig-watch |:sigusr1|)]
@@ -122,9 +181,11 @@
   (os/sig-close r))
 (assert (not (contains? (os/sig-mask) :sigusr1))
         "11c: :sigusr1 unmasked after close")
+(eprintln "test 11: done")
 
 # ── 12. multiple watchers share the block ────────────────────────────────
 
+(eprintln "test 12: starting")
 (let [a (os/sig-watch |:sigusr2|)
       b (os/sig-watch |:sigusr2|)]
   (os/sig-close a)
@@ -133,21 +194,27 @@
   (os/sig-close b)
   (assert (not (contains? (os/sig-mask) :sigusr2))
           "12b: :sigusr2 unmasked after both close"))
+(eprintln "test 12: done")
 
 # ── 13. os/sig-pending reflects queued state ─────────────────────────────
 
+(eprintln "test 13: starting")
 # Inherently racy because we may consume via signalfd before we
 # query sigpending. Accept either outcome.
 (let [r (os/sig-watch |:sigchld|)]
   (os/sig-send (sys/pid) :sigchld)
   (ev/sleep 0.02)
   (let [either (or (contains? (os/sig-pending) :sigchld)
-                   (>= (length (ev/join (ev/spawn (fn [] (os/sig-next r))))) 1))]
+                   (let [evs (ev/join (ev/spawn (fn []
+                                        (bounded-next r "test 13"))))]
+                     (and (not (nil? evs)) (>= (length evs) 1))))]
     (assert either "13: either sigpending reports :sigchld or sig-next gets it"))
   (os/sig-close r))
+(eprintln "test 13: done")
 
 # ── 14. os/sig-watching tracks the active set ────────────────────────────
 
+(eprintln "test 14: starting")
 (assert (not (contains? (os/sig-watching) :sigusr1))
         "14a: nothing watched initially")
 (let [a (os/sig-watch |:sigusr1|)
@@ -160,5 +227,6 @@
         "14d: empty after both close")
 (assert (not (contains? (os/sig-watching) :sigusr2))
         "14e: empty after both close")
+(eprintln "test 14: done")
 
 (println "all posix signal tests passed")

--- a/tests/elle/posix.lisp
+++ b/tests/elle/posix.lisp
@@ -1,0 +1,164 @@
+(elle/epoch 10)
+# POSIX signal tests
+#
+# Covers sending, watching, capability gating, refcount-driven mask
+# management, and introspection. See docs/posix-signals.md for the
+# surface contract. Run via:
+#   cargo test elle_scripts::posix
+
+# ── 1. self-raise watched ────────────────────────────────────────────────
+
+(let [r (os/sig-watch |:sigusr1|)
+      waiter (ev/spawn (fn [] (os/sig-next r)))]
+  (ev/sleep 0.05)
+  (os/sig-raise :sigusr1)
+  (let [events (ev/join waiter)]
+    (assert (>= (length events) 1) "1: at least one event delivered")
+    (assert (= :sigusr1 (get (first events) :signal))
+            "1: first event is :sigusr1"))
+  (os/sig-close r))
+
+# ── 2. cross-process send ─────────────────────────────────────────────────
+
+(let [r (os/sig-watch |:sigusr2|)
+      waiter (ev/spawn (fn [] (os/sig-next r)))]
+  (ev/sleep 0.05)
+  (os/sig-send (sys/pid) :sigusr2)
+  (let [ev (first (ev/join waiter))]
+    (assert (= :sigusr2 (get ev :signal)) "2: signal is :sigusr2")  # :sender-pid is nil on macOS but a valid int on Linux; tolerate both
+    (let [sp (get ev :sender-pid)]
+      (assert (or (nil? sp) (= sp (sys/pid)))
+              "2: :sender-pid is nil or equal to (sys/pid)")))
+  (os/sig-close r))
+
+# ── 3. invalid pid errors ────────────────────────────────────────────────
+
+(let [[ok? val] (protect ((fn [] (os/sig-send -99999 :sigterm))))]
+  (assert (not ok?) "3: os/sig-send to invalid pid errors")
+  (assert (= :os-signal-error (get val :error))
+          "3: error kind is :os-signal-error"))
+
+# ── 5. batching: multiple sends before a single next ─────────────────────
+
+(let [r (os/sig-watch |:sigusr1|)]
+  (os/sig-send (sys/pid) :sigusr1)
+  (os/sig-send (sys/pid) :sigusr1)
+  (ev/sleep 0.05)  # Kernel may coalesce identical signals from the same sender, so
+  # we assert at least one event arrived (could be 1 or 2).
+  (let [evs (ev/join (ev/spawn (fn [] (os/sig-next r))))]
+    (assert (>= (length evs) 1) "5: at least one event after two sends"))
+  (os/sig-close r))
+
+# ── 6. capability denial: :os-signal blocks os/sig-send ──────────────────
+
+(let [f (fiber/new (fn [] (os/sig-send (sys/pid) :sigusr2)) |:error :os-signal|
+                   :deny |:os-signal|)]
+  (fiber/resume f)
+  (assert (= (fiber/status f) :paused) "6: fiber paused after :os-signal denial")
+  (let [val (fiber/value f)]
+    (assert (= :capability-denied (get val :error))
+            "6: payload is :capability-denied")
+    (assert ((get val :denied) :os-signal) "6: :denied set contains :os-signal")))
+
+# Counter-test (proves :os-signal is distinct from :exec): a fiber that
+# denies :exec can STILL call os/sig-send. We send :sigchld (default
+# disposition: ignore) so the test doesn't accidentally terminate.
+(let [f (fiber/new (fn [] (os/sig-send (sys/pid) :sigchld)) |:error :os-signal|
+                   :deny |:exec|)]
+  (fiber/resume f)
+  (assert (= (fiber/status f) :dead)
+          "6b: os/sig-send succeeds under :exec denial (distinct cap)"))
+
+# ── 7. capability denial covers os/sig-raise ─────────────────────────────
+
+(let [f (fiber/new (fn [] (os/sig-raise :sigusr1)) |:error :os-signal|
+                   :deny |:os-signal|)]
+  (fiber/resume f)
+  (let [val (fiber/value f)]
+    (assert (= :capability-denied (get val :error))
+            "7: os/sig-raise is denied by :os-signal")))
+
+# ── 8. os/sig-close is idempotent ────────────────────────────────────────
+
+(let [r (os/sig-watch |:sigwinch|)]
+  (assert (nil? (os/sig-close r)) "8a: first close returns nil")
+  (assert (nil? (os/sig-close r)) "8b: second close also returns nil"))
+
+# ── 10. integer signums must be named ────────────────────────────────────
+
+# Watch SIGUSR1 so a successful send doesn't fire default disposition,
+# then verify the integer signum (10 on Linux, 30 on macOS) is accepted.
+# Round-trip via the keyword form below to stay platform-portable.
+(let [r (os/sig-watch |:sigusr1|)]
+  (let [[ok? _] (protect ((fn []  # Re-query the integer at runtime by sending the
+                          # keyword first, then asserting the integer form
+                          # is accepted on the same kernel.
+                           (os/sig-send (sys/pid) :sigusr1))))]
+    (assert ok? "10a: keyword signum accepted"))  # Drain so the queued signal doesn't fire when we close.
+  (let [_ (ev/join (ev/spawn (fn [] (os/sig-next r))))]
+    nil)
+  (os/sig-close r))
+
+(let [[ok? val] (protect ((fn [] (os/sig-send (sys/pid) 99))))]
+  (assert (not ok?) "10b: unnamed integer signum 99 rejected")
+  (assert (= :argument-error (get val :error))
+          "10b: error kind is :argument-error"))
+
+# Same tightening applies to subprocess/kill.
+(let [[ok? val] (protect ((fn []
+                            (let [proc (subprocess/exec "sleep" ["10"])]
+                              (subprocess/kill proc 99)
+                              (subprocess/wait proc)))))]
+  (assert (not ok?) "10c: subprocess/kill with unnamed signum rejected")
+  (assert (= :argument-error (get val :error))
+          "10c: error kind is :argument-error"))
+
+# ── 11. refcount-driven unblock ──────────────────────────────────────────
+
+(assert (not (contains? (os/sig-mask) :sigusr1))
+        "11a: :sigusr1 not masked initially")
+(let [r (os/sig-watch |:sigusr1|)]
+  (assert (contains? (os/sig-mask) :sigusr1) "11b: :sigusr1 masked after watch")
+  (os/sig-close r))
+(assert (not (contains? (os/sig-mask) :sigusr1))
+        "11c: :sigusr1 unmasked after close")
+
+# ── 12. multiple watchers share the block ────────────────────────────────
+
+(let [a (os/sig-watch |:sigusr2|)
+      b (os/sig-watch |:sigusr2|)]
+  (os/sig-close a)
+  (assert (contains? (os/sig-mask) :sigusr2)
+          "12a: :sigusr2 still masked while b holds it")
+  (os/sig-close b)
+  (assert (not (contains? (os/sig-mask) :sigusr2))
+          "12b: :sigusr2 unmasked after both close"))
+
+# ── 13. os/sig-pending reflects queued state ─────────────────────────────
+
+# Inherently racy because we may consume via signalfd before we
+# query sigpending. Accept either outcome.
+(let [r (os/sig-watch |:sigchld|)]
+  (os/sig-send (sys/pid) :sigchld)
+  (ev/sleep 0.02)
+  (let [either (or (contains? (os/sig-pending) :sigchld)
+                   (>= (length (ev/join (ev/spawn (fn [] (os/sig-next r))))) 1))]
+    (assert either "13: either sigpending reports :sigchld or sig-next gets it"))
+  (os/sig-close r))
+
+# ── 14. os/sig-watching tracks the active set ────────────────────────────
+
+(assert (not (contains? (os/sig-watching) :sigusr1))
+        "14a: nothing watched initially")
+(let [a (os/sig-watch |:sigusr1|)
+      b (os/sig-watch |:sigusr2|)]
+  (assert (contains? (os/sig-watching) :sigusr1) "14b: a is tracked")
+  (assert (contains? (os/sig-watching) :sigusr2) "14c: b is tracked")
+  (os/sig-close a)
+  (os/sig-close b))
+(assert (not (contains? (os/sig-watching) :sigusr1))
+        "14d: empty after both close")
+(assert (not (contains? (os/sig-watching) :sigusr2))
+        "14e: empty after both close")
+
+(println "all posix signal tests passed")

--- a/tests/elle/posix.lisp
+++ b/tests/elle/posix.lisp
@@ -8,13 +8,14 @@
 #
 # INSTRUMENTATION POLICY: every step that talks to the kernel about
 # signals (watch, send, raise, next, close) prints a tag-and-state
-# line to *stderr* via eprintln BEFORE the call. Every sig-next is
+# line to *stderr* via eprintln BEFORE the call.  Every sig-next is
 # bounded with (ev/timeout 5 …) so a stuck delivery fails fast with a
 # pinpointed "timed out at <site>" message instead of hanging the
-# whole suite under the outer 30s wall.  When ELLE_POSIX_DEBUG=1 the
-# Rust side (src/io/sigfd.rs, src/io/threadpool.rs) emits matching
-# kernel-level trace lines so a triage on macOS can correlate the two
-# halves without a rebuild.
+# whole suite under the outer 30s wall.  When run with
+# `--trace=posix` the Rust side (src/io/sigfd.rs, src/io/threadpool.rs,
+# src/primitives/posix.rs, src/io/completion.rs) emits matching
+# `[trace:posix] …` kernel-level lines so triage can correlate the
+# two halves at sub-syscall granularity without a rebuild.
 
 (eprintln "posix.lisp: starting; pid=" (sys/pid) "; initial mask=" (os/sig-mask)
           "; initial watching=" (os/sig-watching))
@@ -71,7 +72,10 @@
         (let [sp (get ev :sender-pid)]
           (assert (or (nil? sp) (= sp (sys/pid)))
                   "2: :sender-pid is nil or equal to (sys/pid)")))))
-  (os/sig-close r))
+  (eprintln "test 2: closing receiver; mask=" (os/sig-mask) "; pending="
+            (os/sig-pending))
+  (os/sig-close r)
+  (eprintln "test 2: closed; mask=" (os/sig-mask) "; pending=" (os/sig-pending)))
 (eprintln "test 2: done")
 
 # ── 3. invalid pid errors ────────────────────────────────────────────────
@@ -96,7 +100,11 @@
     (assert (not (nil? evs))
             "5: os/sig-next must return events, not nil (timeout)")
     (assert (>= (length evs) 1) "5: at least one event after two sends"))
-  (os/sig-close r))
+  (eprintln "test 5: pre-close; mask=" (os/sig-mask) "; pending="
+            (os/sig-pending))
+  (os/sig-close r)
+  (eprintln "test 5: post-close; mask=" (os/sig-mask) "; pending="
+            (os/sig-pending)))
 (eprintln "test 5: done")
 
 # ── 6. capability denial: :os-signal blocks os/sig-send ──────────────────
@@ -136,7 +144,9 @@
 
 (eprintln "test 8: starting")
 (let [r (os/sig-watch |:sigwinch|)]
+  (eprintln "test 8: first close")
   (assert (nil? (os/sig-close r)) "8a: first close returns nil")
+  (eprintln "test 8: second close (idempotency)")
   (assert (nil? (os/sig-close r)) "8b: second close also returns nil"))
 (eprintln "test 8: done")
 
@@ -154,7 +164,11 @@
     (assert ok? "10a: keyword signum accepted"))  # Drain so the queued signal doesn't fire when we close.
   (let [_ (ev/join (ev/spawn (fn [] (bounded-next r "test 10 drain"))))]
     nil)
-  (os/sig-close r))
+  (eprintln "test 10: pre-close; mask=" (os/sig-mask) "; pending="
+            (os/sig-pending))
+  (os/sig-close r)
+  (eprintln "test 10: post-close; mask=" (os/sig-mask) "; pending="
+            (os/sig-pending)))
 
 (let [[ok? val] (protect ((fn [] (os/sig-send (sys/pid) 99))))]
   (assert (not ok?) "10b: unnamed integer signum 99 rejected")

--- a/tests/integration/elle_scripts.rs
+++ b/tests/integration/elle_scripts.rs
@@ -94,3 +94,8 @@ fn table_key_expand() {
 fn parameters() {
     run_elle_script("parameters");
 }
+
+#[test]
+fn posix() {
+    run_elle_script("posix");
+}

--- a/tests/integration/elle_scripts.rs
+++ b/tests/integration/elle_scripts.rs
@@ -17,18 +17,28 @@ fn get_elle_binary() -> &'static str {
 ///
 /// Panics with stdout+stderr output if the script exits non-zero or fails to spawn.
 fn run_elle_script(name: &str) {
+    run_elle_script_with_args(name, &[]);
+}
+
+/// Like `run_elle_script` but passes extra args to the elle binary.
+/// Used to gate scripts under non-default backends (e.g. `--no-uring`
+/// for the threadpool I/O path, which is the only path on macOS and a
+/// distinct codepath from io_uring on Linux).
+fn run_elle_script_with_args(name: &str, extra_args: &[&str]) {
     let elle_bin = get_elle_binary();
     let script = format!("tests/elle/{}.lisp", name);
 
-    let output = Command::new(elle_bin)
-        .arg(&script)
+    let mut cmd = Command::new(elle_bin);
+    cmd.args(extra_args).arg(&script);
+    let output = cmd
         .output()
-        .unwrap_or_else(|e| panic!("Failed to spawn elle for {}: {}", script, e));
+        .unwrap_or_else(|e| panic!("Failed to spawn elle for {} {:?}: {}", script, extra_args, e));
 
     assert!(
         output.status.success(),
-        "Elle script {} failed (exit {:?}):\nstdout: {}\nstderr: {}",
+        "Elle script {} {:?} failed (exit {:?}):\nstdout: {}\nstderr: {}",
         script,
+        extra_args,
         output.status.code(),
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr),
@@ -98,4 +108,16 @@ fn parameters() {
 #[test]
 fn posix() {
     run_elle_script("posix");
+}
+
+/// Same script as `posix`, but forces the threadpool I/O backend on
+/// Linux via `--no-uring`. The threadpool path uses the same
+/// `SignalReceiver` / `kq_sig_read_blocking` / `sigfd_read_blocking`
+/// machinery as macOS does, so this gates the threadpool signal flow
+/// — the f7aed410 signalfd EAGAIN-poll fix on Linux and the EVFILT_SIGNAL
+/// worker-unblock + no-op sigaction fix on macOS. Without this we'd
+/// only exercise the io_uring path on the Linux runner.
+#[test]
+fn posix_threadpool() {
+    run_elle_script_with_args("posix", &["--no-uring"]);
 }


### PR DESCRIPTION
New surface: os/sig-send, os/sig-raise (capability-gated via the new :os-signal bit), os/sig-watch / os/sig-next / os/sig-close (async receive via signalfd on Linux, kqueue+EVFILT_SIGNAL on macOS), plus os/sig-pending / os/sig-mask / os/sig-watching for introspection. sys/pid added so user code can self-identify.

Mask policy: worker threads (threadpool, stdin, JIT) mask all signals on spawn so the kernel never selects them as the delivery target; the main thread blocks lazily on os/sig-watch and unblocks via refcount when the last watcher closes. subprocess/kill now shares the same keyword->signum map and rejects unnamed integer signums (footgun fix).

See docs/posix-signals.md for the full contract, mask discipline, and documented limitations.