### PR TITLE
posix, port: eager signal trap + (port/close *stdin*) cancellation

### DIFF
--- a/docs/io.md
+++ b/docs/io.md
@@ -57,6 +57,25 @@ with `port/close`.
 # (port/writer p)              — writable stream
 ```
 
+### Closing `*stdin*`
+
+`(port/close *stdin*)` is supported and does what you'd expect:
+
+- Any in-flight `(port/read-line *stdin*)` / `(port/read …)` /
+  `(port/read-all *stdin*)` is cancelled. The waiting fiber resumes
+  with an `:io-error` whose message is `stdin closed`.
+- The dedicated stdin worker thread (which sits on `read(2)` against
+  fd 0) is signalled via an internal self-pipe, returns from its
+  syscall, drains any further pending requests as cancelled, and
+  exits cleanly. No leaked OS thread.
+- Subsequent stdin reads error from the `port is closed` check
+  in `AsyncBackend::submit`.
+- The OS file descriptor for stdin is *not* itself closed (the
+  stdio ports never owned it). This matches the existing
+  `*stdout*` / `*stderr*` close semantics.
+
+`port/close` on `*stdin*` is idempotent.
+
 ## Output
 
 ```lisp

--- a/docs/posix-signals.md
+++ b/docs/posix-signals.md
@@ -88,38 +88,70 @@ several):
 | `:code` | int | `siginfo.ssi_code` (`SI_USER=0`, `SI_KERNEL=128`, `CLD_EXITED=1`, …). `0` on macOS. |
 | `:count` | int | Always `1` on Linux. On macOS the kevent coalesced count. |
 
+## Disposition table (eager trap at startup)
+
+`elle::io::init_process_signals` runs from `main()` immediately after
+`elle::config::init` and before `VM::new` (`src/main.rs`). It installs
+process-wide POSIX traps before any worker thread spawns:
+
+| Set | Signals | What we do |
+|-----|---------|------------|
+| Terminate | `TERM`, `INT`, `QUIT`, `HUP` | `sigaction(SA_RESTART)` to a handler that writes a tagged line to stderr (`elle: terminated by SIGTERM\n`, etc.) and calls `_exit(128 + signum)`. The handler is async-signal-safe — no Rust stdio, no allocation, no locks. Conventional shell exit codes: `143`, `130`, `131`, `129`. |
+| Job control | `TSTP`, `TTIN`, `TTOU` | `sigaction` to a handler that calls `raise(SIGSTOP)`. The kernel stops the process; the shell can `bg`/`fg` it. On `SIGCONT` the process resumes mid-handler and returns normally. io_uring + signalfd state survive across SIGSTOP/SIGCONT untouched. |
+| Resume | `CONT` | `sigaction` to an empty handler so the kernel has a delivery target. Nothing to clean up. |
+| Pipe | `PIPE` | `sigaction(SIG_IGN)`. Writes to broken pipes surface as `EPIPE`; nothing entered the kernel queue. |
+| Absorb | `USR1`, `USR2`, `CHLD`, `URG`, `WINCH`, `ALRM` | `pthread_sigmask(SIG_BLOCK)` on the main thread. With every worker also masking on spawn, no thread has these unblocked; the kernel queues them and nobody reads. Silently absorbed unless `os/sig-watch` opens a `signalfd` to drain. Accidental `kill -USR1 $pid` becomes a no-op. |
+| Fault | `SEGV`, `BUS`, `FPE`, `ILL`, `ABRT`, `TRAP`, `SYS` | Untouched. Synchronous fault signals; intercepting them only obscures real bugs. |
+| Uncatchable | `KILL`, `STOP` | Kernel forbids touching these. Pass through. |
+
+## Watcher override
+
+The terminate-set handlers are installed *process-wide* — but only
+fire when the kernel can deliver the signal. With every worker thread
+masking everything and `os/sig-watch :sigterm` adding SIGTERM to the
+main thread's mask, **no thread has SIGTERM unblocked**. The kernel
+parks the signal on the process pending queue, the sigaction handler
+cannot fire, and the watcher's `signalfd` reads the event instead.
+When the last watcher closes, the lazy-unblock on the main thread
+re-enables kernel delivery, and the next SIGTERM runs the handler.
+
+No explicit "watcher overrides built-in" coordination logic in user
+space — the kernel's delivery rules do it for free. Signals in the
+absorb set get a stricter version of the same trick: their close-time
+unblock is suppressed (see "Mask policy" below), because there is no
+sigaction handler to take over, and the kernel default for them is
+Term — we'd be replacing a quietly-blocked queue with an active
+process killer.
+
 ## Mask policy
 
-POSIX signalfd and kqueue both require the target signal to be
-blocked process-wide first — otherwise the default disposition fires
-in some thread before the watcher reads it. Elle handles the mask
-automatically. The policy:
-
 1. **Worker threads block everything.** Every thread Elle spawns
-   internally (the I/O thread pool, the stdin reader, etc.) masks
-   all maskable signals as its first action. Workers are never the
-   kernel's chosen signal delivery target.
-2. **The main thread blocks lazily.** Before the first
-   `os/sig-watch` call, default disposition is in force for every
-   signal — `kill -TERM $pid` terminates an elle program just like
-   any other Unix program. The first `os/sig-watch` atomically blocks
-   the requested signals on the main thread and opens the
-   signalfd / kqueue.
-3. **Refcounted block; drain-then-unblock when refcount hits zero.**
-   A signal stays blocked as long as at least one receiver watches
-   it. `os/sig-close` decrements; when the last watcher for a signal
-   closes, elle drains any instances still pending on the calling
-   thread / process queue (via `sigwait`, which dequeues without
-   invoking a handler) and only then unblocks. This is the only safe
-   order: signals queued during the watch that the user never
-   consumed via `os/sig-next` — and on macOS the kqueue-coalesced
-   leftover from a multi-`kill` burst whose worker delivery only
-   drained one instance — would otherwise fire the signal's default
-   disposition on the unblocking thread, terminating the process
-   mid-close. Signals generated *after* the unblock fire whatever
-   disposition was in effect before the watch started (saved by
-   `os/sig-watch`, restored before unblocking).
-4. **macOS: per-receive worker unblock + no-op handler.** Linux's
+   internally (the I/O thread pool, the stdin reader, the JIT worker,
+   the user `(spawn closure)` worker) masks all maskable signals as
+   its first action. Workers are never the kernel's chosen signal
+   delivery target.
+2. **The main thread blocks the absorb set at startup.** `USR1`,
+   `USR2`, `CHLD`, `URG`, `WINCH`, `ALRM` are masked before `VM::new`
+   runs. The terminate, job-control, resume, and pipe sets are
+   *not* masked at startup — they are dispatched by the sigaction
+   handlers installed alongside.
+3. **`os/sig-watch` lazy-blocks the watched set on the main thread.**
+   The first receiver for a signum bumps the refcount 0→1 and
+   blocks the signal on the main thread (idempotent for absorb-set
+   signums, which are already blocked).
+4. **`os/sig-close` decrements the refcount.** When the last watcher
+   for a signum closes, elle drains any instances still pending on
+   the calling thread / process queue (via `sigwait`, which dequeues
+   without invoking a handler). The unblock is then performed
+   **only for signums outside the absorb set** — absorb-set signums
+   stay masked so a subsequent `kill -USR1 $pid` doesn't escape via
+   the kernel default (which is Term) onto a now-unblocked main
+   thread. The drain still runs so a future watcher doesn't see
+   stale pending state.
+5. **macOS: per-receive worker unblock + no-op handler.**
+   `init_process_signals` is currently Linux-shape on macOS too
+   (sigaction installed, absorb set blocked on the main thread); the
+   per-receiver kqueue path layers on top. Linux's
    `signalfd` reads pending signals directly from the kernel queue
    even when every thread blocks the signal, so the worker only
    needs to call `read(2)`. macOS's `EVFILT_SIGNAL` fires from the
@@ -142,6 +174,21 @@ unblock used to feed `kevent()` on macOS.
 `(os/sig-watching)` returns the set of signals currently held by at
 least one receiver.
 
+## Backend dispatch
+
+Elle's async backend chooses how to wait on a `SignalReceiver`'s
+kernel fd based on platform and CLI flags:
+
+| Platform | Default | `--no-uring` |
+|----------|---------|--------------|
+| Linux | `IORING_OP_READ` on the signalfd, via the dedicated `submit_uring_sig_next` SQE helper. The read is queued on the io_uring instance and the kernel completes a CQE when one or more `signalfd_siginfo` records become available. No worker thread is involved on the elle side. | The threadpool worker calls `poll(POLLIN, -1)` and then `read(2)` on the signalfd. Uses one OS thread per outstanding `os/sig-next`. |
+| macOS | n/a — io_uring is Linux-only | A threadpool worker calls `kevent()` on a per-receiver kqueue registered with `EVFILT_SIGNAL`. The worker temporarily `pthread_sigmask`-unblocks the watched signals on itself so the kernel can pick it as the delivery target (see "macOS: per-receive worker unblock + no-op handler" above). |
+
+The threadpool path on Linux is exercised only when `--no-uring` is
+passed on the CLI or `io_uring_setup(2)` fails on the host kernel
+(extremely old / locked-down kernels). Production Linux always rides
+the dedicated io_uring path.
+
 ## Documented limitations
 
 These three are inherent to the chosen mechanism, not bugs.
@@ -154,20 +201,28 @@ Programs that need sender identity — for example, SIGCHLD-driven
 targeted child reaping — must call `subprocess/wait`-style logic to
 recover it. Linux signalfd populates both fields.
 
-### Library-spawned threads can defeat the worker-mask invariant
+### Library-spawned threads inherit the startup mask, not later watches
 
-Elle masks all signals on every thread it spawns directly. Threads
-spawned by C dependencies (the cranelift JIT codegen threads, libffi
-callbacks, future plugin cdylibs, anything called via FFI) inherit
-whatever the *main thread's* mask was at *their* spawn time. If you
-call `os/sig-watch` after such a thread has spawned, the kernel may
-still select that thread as the delivery target and fire the default
-disposition.
+Elle masks all signals on every thread it spawns directly (threadpool,
+stdin reader, JIT worker, user `(spawn closure)` worker). Threads
+spawned by C dependencies (Cranelift codegen auxiliary threads,
+libffi callbacks, future plugin cdylibs, anything called via FFI)
+inherit whatever the *main thread's* mask was at *their* spawn time.
 
-Practical mitigation: call `os/sig-watch` early in your program,
-before triggering JIT compilation, before loading FFI plugins. There
-is no portable way to retroactively change another thread's signal
-mask.
+Under the eager-trap policy, the main thread's startup mask already
+includes the absorb set (`USR1`, `USR2`, `CHLD`, `URG`, `WINCH`,
+`ALRM`) — so a C-spawned thread post-`init_process_signals` has all
+of those blocked, and an `os/sig-watch` on any of them
+deterministically routes to the watcher's signalfd. The remaining
+hole is the terminate/job-control/resume sets: a C-spawned thread has
+them unblocked, and a `kill -TERM` could pick that thread to run the
+sigaction handler (which still terminates correctly — just on the
+"wrong" thread).
+
+Practical impact is now minimal: the sigaction handler is identical
+regardless of which thread runs it (`_exit(128 + signum)`). The
+historical risk of a C-thread defeating `os/sig-watch` for a
+controlled-disposition signal (USR1, etc.) is closed.
 
 ### Standard signals coalesce
 

--- a/src/io/aio.rs
+++ b/src/io/aio.rs
@@ -214,6 +214,41 @@ impl AsyncBackend {
         // when close is requested.
         if matches!(&request.op, IoOp::Close) {
             let port_key = PortKey::from_port(port);
+            // Stdin close has its own path: the dedicated stdin worker
+            // thread reads via blocking poll(2)+read(2) on fd 0, not
+            // through io_uring. Signal the thread to shut down — the
+            // worker detects the self-pipe wakeup inside its next
+            // `poll(2)`, sends a `stdin closed` error completion for
+            // whatever read was in flight, drains any further
+            // requests as cancelled, and exits.
+            //
+            // We do NOT take/drop `stdin_thread` here: dropping joins
+            // the worker, which would block the scheduler **on this
+            // very thread** before the worker's cancellation
+            // completion can be drained by the main poll loop and
+            // delivered to the fiber waiting on the read. The fiber
+            // would then sit in `ev/join` indefinitely. Leave the
+            // struct in place; the worker reaps itself via channel
+            // disconnect at AsyncBackend drop time.
+            //
+            // See `docs/io.md` "Closing `*stdin*`".
+            if matches!(port_key, PortKey::Stdin) {
+                {
+                    let inner = self.inner.borrow();
+                    if let Some(ref st) = inner.stdin_thread {
+                        st.shutdown();
+                    }
+                }
+                port.close();
+                let mut inner = self.inner.borrow_mut();
+                let id = inner.next_id;
+                inner.next_id += 1;
+                inner.completions.push_back(Completion {
+                    id,
+                    result: Ok(Value::NIL),
+                });
+                return Ok(id);
+            }
             if let PortKey::Fd(fd) = &port_key {
                 let mut inner = self.inner.borrow_mut();
                 // Cancel all pending ops on this fd
@@ -960,9 +995,12 @@ impl AsyncBackend {
         match platform {
             #[cfg(target_os = "linux")]
             PlatformBackend::Uring(ring) => {
-                // signalfd reads behave like a regular fd read; reuse the
-                // watch-next submission path which is also a portless read.
-                crate::io::uring::submit_uring_watch_next(ring, id, fd, buffer_pool, buf_handle)?;
+                // Dedicated io_uring + signalfd path: a single
+                // IORING_OP_READ on the signalfd, completing via the
+                // kernel's poll pipeline with no elle-side worker
+                // thread. Threadpool is reached only when --no-uring
+                // is in effect (see PlatformBackend::ThreadPool arm).
+                crate::io::uring::submit_uring_sig_next(ring, id, fd, buffer_pool, buf_handle)?;
             }
             PlatformBackend::ThreadPool(_) => {
                 #[cfg(any(target_os = "linux", target_os = "android"))]

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -12,6 +12,17 @@ pub(crate) mod pending;
 pub(crate) mod pool;
 pub mod request;
 pub(crate) mod sigfd;
+
+/// Install process-wide POSIX signal traps. Called once from
+/// `main()` before any thread spawns. Installs sigaction handlers
+/// for the terminate (TERM/INT/QUIT/HUP), job-control (TSTP/TTIN/TTOU),
+/// and resume (CONT) sets; `SIG_IGN` for SIGPIPE; and
+/// `pthread_sigmask(SIG_BLOCK)` for the absorb set (USR1/USR2/CHLD/
+/// URG/WINCH/ALRM) on the main thread. See `docs/posix-signals.md`
+/// for the full disposition table.
+pub fn init_process_signals() {
+    sigfd::init_process_signals();
+}
 pub(crate) mod sigmap;
 pub(crate) mod sockaddr;
 pub(crate) mod threadpool;

--- a/src/io/sigfd.rs
+++ b/src/io/sigfd.rs
@@ -848,7 +848,18 @@ mod platform {
         // restore their saved sigaction and unblock them on the calling
         // thread. We have to drop the WatchedSet lock before doing the
         // sigaction restore to avoid holding two global locks in series.
+        //
+        // Signals in `crate::io::sigfd::ABSORB_SET` are kept masked at
+        // process scope by `init_process_signals`; the rollback must
+        // not unblock them on close even when refcount hits zero. On
+        // macOS the leak that would otherwise happen is identical to
+        // Linux: a future `kill -USR1 $pid` would, after the close,
+        // find the kqueue no-op handler restored to default (Term)
+        // *and* the main-thread mask cleared, and terminate the
+        // process. We still drain + sigaction-restore for absorb-set
+        // signums; we just skip the pthread_sigmask unblock.
         let mut newly_freed: Vec<libc::c_int> = Vec::new();
+        let mut newly_freed_unblockable: Vec<libc::c_int> = Vec::new();
         {
             let mut set = watched_set().lock().unwrap();
             for &s in signals {
@@ -857,8 +868,11 @@ mod platform {
                         *c -= 1;
                     }
                     if *c == 0 {
-                        unsafe { libc::sigaddset(&mut to_unblock, s) };
                         newly_freed.push(s);
+                        if !super::ABSORB_SET.contains(&s) {
+                            unsafe { libc::sigaddset(&mut to_unblock, s) };
+                            newly_freed_unblockable.push(s);
+                        }
                     }
                 }
             }
@@ -867,30 +881,31 @@ mod platform {
             return;
         }
         // Drain pending watched signals via sigwait BEFORE we restore
-        // the saved disposition or unblock. macOS's EVFILT_SIGNAL
-        // only counts kill() generations on the knote — it does NOT
-        // consume from the process pending queue — and the kqueue
-        // worker's brief pthread_sigmask SIG_UNBLOCK + no-op-handler
-        // delivery only drains at most one queued instance. Test 5
-        // (two kill(SIGUSR1) calls in a row, one sig-next read
-        // reporting count=2) leaves a SIGUSR1 in the pending queue
-        // even after the worker reports the event. Restoring the
-        // default disposition (Term for SIGUSR1) and then
-        // unblocking would deliver that orphan to this thread with
-        // its newly-restored default and kill the process mid-close.
-        // sigwait consumes pending instances without invoking the
-        // (still no-op) handler. Done while the signals are still
-        // blocked, so sigwait returns immediately for already-pending
-        // entries.
+        // the saved disposition or (selectively) unblock. macOS's
+        // EVFILT_SIGNAL only counts kill() generations on the knote —
+        // it does NOT consume from the process pending queue — and
+        // the kqueue worker's brief pthread_sigmask SIG_UNBLOCK +
+        // no-op-handler delivery only drains at most one queued
+        // instance. Test 5 (two kill(SIGUSR1) calls in a row, one
+        // sig-next read reporting count=2) leaves a SIGUSR1 in the
+        // pending queue even after the worker reports the event.
+        // Restoring the default disposition (Term for SIGUSR1) and
+        // then unblocking would deliver that orphan to this thread
+        // with its newly-restored default and kill the process
+        // mid-close. sigwait consumes pending instances without
+        // invoking the (still no-op) handler. Done while the signals
+        // are still blocked, so sigwait returns immediately for
+        // already-pending entries.
         posix_trace(format_args!(
-            "macos: rollback draining + restoring + unblocking newly_freed={:?}",
-            newly_freed
+            "macos: rollback draining newly_freed={:?}; unblocking subset {:?}",
+            newly_freed, newly_freed_unblockable
         ));
         drain_pending_blocked(&newly_freed);
-        // Restore the saved sigactions, then unblock. Order matters:
-        // any signal generated AFTER the unblock should fire the
-        // user's original disposition (typically the default), not
-        // our no-op.
+        // Restore the saved sigactions, then unblock the subset of
+        // signums that should re-arm their kernel default. Order
+        // matters: any signal generated AFTER the unblock should
+        // fire the user's original disposition (typically the
+        // default), not our no-op.
         {
             let mut saved = saved_dispositions().lock().unwrap();
             for &s in &newly_freed {
@@ -903,8 +918,10 @@ mod platform {
                 }
             }
         }
-        unsafe {
-            libc::pthread_sigmask(libc::SIG_UNBLOCK, &to_unblock, std::ptr::null_mut());
+        if !newly_freed_unblockable.is_empty() {
+            unsafe {
+                libc::pthread_sigmask(libc::SIG_UNBLOCK, &to_unblock, std::ptr::null_mut());
+            }
         }
     }
 }

--- a/src/io/sigfd.rs
+++ b/src/io/sigfd.rs
@@ -91,6 +91,164 @@ fn saved_dispositions() -> &'static Mutex<HashMap<libc::c_int, libc::sigaction>>
     DISP.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
+/// Process-wide signal trap installation, called exactly once from
+/// `main()` before any worker thread spawns. Workers call
+/// `mask_all_signals_on_this_thread` on entry and thereby inherit a
+/// no-signal-delivery posture; the *main* thread is what this function
+/// configures, and the policy below decides which signals get a
+/// sigaction handler (delivered to the main thread by the kernel
+/// because everyone else has them masked) and which are
+/// `pthread_sigmask`-blocked on the main thread (queued by the kernel
+/// for `signalfd`-style consumption).
+///
+/// ## Disposition table
+///
+/// | Set | Signals | What we do |
+/// |-----|---------|------------|
+/// | Terminate | TERM, INT, QUIT, HUP | `sigaction(SA_RESTART)` to a handler that writes a tagged line to stderr via `write(2)` and `_exit(128 + signum)`. The handler is async-signal-safe — no allocation, no Rust stdio, no locks. |
+/// | Job control | TSTP, TTIN, TTOU | `sigaction` to a handler that calls `raise(SIGSTOP)`. The kernel stops the process; the shell can later `bg`/`fg` it. On `SIGCONT` the process resumes mid-handler and returns normally. |
+/// | Resume | CONT | `sigaction` to an empty handler so the delivery is consumed and the kernel doesn't try anything else. (No state to clean up — io_uring + signalfd survive across SIGSTOP/SIGCONT untouched.) |
+/// | Pipe | PIPE | `sigaction(SIG_IGN)`. Writes to broken pipes surface as `EPIPE`. |
+/// | Absorb | USR1, USR2, CHLD, URG, WINCH, ALRM | `pthread_sigmask(SIG_BLOCK)` on the main thread. With every worker also masking on spawn, no thread has these unblocked, the kernel queues them, and nobody reads. They are silently absorbed unless a user `os/sig-watch` opens a `signalfd` to drain. |
+/// | Fault | SEGV, BUS, FPE, ILL, ABRT, TRAP, SYS | Untouched. These are synchronous fault signals; intercepting them only obscures real bugs. The kernel default (core/term) runs. |
+/// | Uncatchable | KILL, STOP | Kernel forbids touching these. Pass through. |
+///
+/// ## Watcher override semantics
+///
+/// A user `os/sig-watch :sigterm` (etc.) lazily `pthread_sigmask`-blocks
+/// the watched signal on the main thread before opening its
+/// per-receiver `signalfd`. With the main thread blocking the signal
+/// and every worker thread already masking everything, the kernel has
+/// no delivery target — the sigaction handler installed here cannot
+/// fire while a watcher is alive. The signalfd reads it instead.
+/// When the last watcher closes, the lazy-block unblocks the signal,
+/// the kernel can again pick the main thread, and the sigaction handler
+/// re-arms. No explicit watcher-vs-builtin coordination logic in user
+/// space — the kernel's delivery rules do it for free.
+///
+/// ## Counter-cases this defends against
+///
+/// 1. **Startup race**: a `SIGTERM` arriving between `config::init` and
+///    the first `os/sig-watch` no longer kills the program — the
+///    handler runs.
+/// 2. **C-spawned thread inheritance**: Cranelift / FFI cdylib threads
+///    inherit the main thread's startup mask. After this function,
+///    that mask blocks the absorb-set, narrowing the window where a
+///    rogue thread could absorb a signal the user intended to watch.
+/// 3. **Accidental `kill -USR1`**: previously killed the process
+///    (kernel default Term). Now absorbed by the startup mask.
+///
+/// Idempotent: safe to call multiple times. (`sigaction` overwrites the
+/// previous handler; `pthread_sigmask(SIG_BLOCK)` is additive but the
+/// set is constant.) Tests fork and call it in each child.
+pub fn init_process_signals() {
+    install_terminate_handlers();
+    install_job_control_handlers();
+    install_cont_handler();
+    install_pipe_ignore();
+    block_absorb_set_on_main_thread();
+}
+
+extern "C" fn terminate_handler(signum: libc::c_int) {
+    // Async-signal-safe. No allocation, no Rust stdio, no locks.
+    // `write(2)` and `_exit(2)` are on the POSIX async-signal-safe list.
+    // Tag the message so a user staring at unfamiliar `^elle:
+    // terminated by SIGTERM` output can correlate with this code.
+    let tag: &[u8] = match signum {
+        s if s == libc::SIGTERM => b"elle: terminated by SIGTERM\n",
+        s if s == libc::SIGINT => b"elle: interrupted by SIGINT\n",
+        s if s == libc::SIGQUIT => b"elle: quit by SIGQUIT\n",
+        s if s == libc::SIGHUP => b"elle: hung up by SIGHUP\n",
+        _ => b"elle: terminated\n",
+    };
+    unsafe {
+        libc::write(2, tag.as_ptr() as *const libc::c_void, tag.len());
+        libc::_exit(128 + signum);
+    }
+}
+
+extern "C" fn job_control_handler(_signum: libc::c_int) {
+    // SIGTSTP / SIGTTIN / SIGTTOU all map to "actually stop the
+    // process". `raise(SIGSTOP)` is async-signal-safe and the kernel
+    // honours it even from inside a signal handler.
+    unsafe {
+        libc::raise(libc::SIGSTOP);
+    }
+}
+
+extern "C" fn cont_handler(_signum: libc::c_int) {
+    // Nothing to do — the kernel already resumed us. The handler
+    // exists so the kernel has a delivery target for SIGCONT instead
+    // of running the (no-op) default disposition; without it, a tool
+    // that expects a SIGCONT round-trip (e.g. `kill -CONT` from a
+    // shell-script supervisor) sees the signal vanish.
+}
+
+/// Build a `sigaction` pointing at `handler` with `SA_RESTART` so the
+/// handler running on a syscall doesn't surface as `EINTR` to the
+/// caller (we use io_uring and a few raw `libc::poll` calls; both can
+/// handle EINTR but auto-restart is friendlier).
+fn build_sigaction(handler: extern "C" fn(libc::c_int)) -> libc::sigaction {
+    let mut sa: libc::sigaction = unsafe { std::mem::zeroed() };
+    sa.sa_sigaction = handler as *const () as libc::sighandler_t;
+    sa.sa_flags = libc::SA_RESTART;
+    unsafe { libc::sigemptyset(&mut sa.sa_mask) };
+    sa
+}
+
+fn install_terminate_handlers() {
+    let sa = build_sigaction(terminate_handler);
+    for s in [libc::SIGTERM, libc::SIGINT, libc::SIGQUIT, libc::SIGHUP] {
+        unsafe { libc::sigaction(s, &sa, std::ptr::null_mut()) };
+    }
+}
+
+fn install_job_control_handlers() {
+    let sa = build_sigaction(job_control_handler);
+    for s in [libc::SIGTSTP, libc::SIGTTIN, libc::SIGTTOU] {
+        unsafe { libc::sigaction(s, &sa, std::ptr::null_mut()) };
+    }
+}
+
+fn install_cont_handler() {
+    let sa = build_sigaction(cont_handler);
+    unsafe { libc::sigaction(libc::SIGCONT, &sa, std::ptr::null_mut()) };
+}
+
+fn install_pipe_ignore() {
+    let mut sa: libc::sigaction = unsafe { std::mem::zeroed() };
+    sa.sa_sigaction = libc::SIG_IGN;
+    sa.sa_flags = 0;
+    unsafe {
+        libc::sigemptyset(&mut sa.sa_mask);
+        libc::sigaction(libc::SIGPIPE, &sa, std::ptr::null_mut());
+    }
+}
+
+/// Signals that should be silently absorbed unless a `SignalReceiver`
+/// is actively watching them. Blocked process-wide on the main thread
+/// at startup; workers already mask everything on spawn, so the kernel
+/// has no delivery target and the signals just queue.
+const ABSORB_SET: &[libc::c_int] = &[
+    libc::SIGUSR1,
+    libc::SIGUSR2,
+    libc::SIGCHLD,
+    libc::SIGURG,
+    libc::SIGWINCH,
+    libc::SIGALRM,
+];
+
+fn block_absorb_set_on_main_thread() {
+    let mut set: libc::sigset_t = unsafe { std::mem::zeroed() };
+    unsafe { libc::sigemptyset(&mut set) };
+    for &s in ABSORB_SET {
+        unsafe { libc::sigaddset(&mut set, s) };
+    }
+    unsafe {
+        libc::pthread_sigmask(libc::SIG_BLOCK, &set, std::ptr::null_mut());
+    }
+}
+
 /// Mask all maskable signals on the calling thread. Workers call this
 /// as their first action after spawn so the kernel never selects them
 /// as a signal delivery target. Must not be called on the main VM
@@ -378,9 +536,22 @@ mod platform {
     fn rollback(signals: &[libc::c_int]) {
         // Decrement refcounts; collect signals whose refcount fell to
         // zero so we can pthread_sigmask-unblock them.
+        //
+        // Signals in the eager-trap absorb set
+        // (`crate::io::sigfd::ABSORB_SET`) are intentionally blocked
+        // process-wide by `init_process_signals`. The rollback must
+        // NOT unblock them — otherwise an external `kill -USR1`
+        // arriving between close and process exit would be delivered
+        // by the kernel to the main thread (the only thread without
+        // the signal masked), find no sigaction handler, and run the
+        // kernel default disposition (Term for USR1/USR2/ALRM). We
+        // still drain any pending instances before returning so the
+        // signalfd close doesn't leave them dangling, but we leave
+        // the mask bit set.
         let mut to_unblock: libc::sigset_t = unsafe { std::mem::zeroed() };
         unsafe { libc::sigemptyset(&mut to_unblock) };
-        let mut newly_freed: Vec<libc::c_int> = Vec::new();
+        let mut newly_freed_drainable: Vec<libc::c_int> = Vec::new();
+        let mut newly_freed_unblockable: Vec<libc::c_int> = Vec::new();
         {
             let mut set = watched_set().lock().unwrap();
             for &s in signals {
@@ -389,27 +560,35 @@ mod platform {
                         *c -= 1;
                     }
                     if *c == 0 {
-                        unsafe { libc::sigaddset(&mut to_unblock, s) };
-                        newly_freed.push(s);
+                        newly_freed_drainable.push(s);
+                        if !super::ABSORB_SET.contains(&s) {
+                            unsafe { libc::sigaddset(&mut to_unblock, s) };
+                            newly_freed_unblockable.push(s);
+                        }
                     }
                 }
             }
         }
-        if !newly_freed.is_empty() {
-            // Drain pending watched signals BEFORE unblocking. If a
-            // watcher closes with signals still queued (signalfd was
-            // never read for them, or the user `kill`d after the
-            // last sig-next), the unblock would otherwise fire each
-            // one's default disposition on this thread — Term for
-            // most. See `drain_pending_blocked` for the failure mode
-            // this defends against.
+        if !newly_freed_drainable.is_empty() {
+            // Drain pending watched signals BEFORE any (selective)
+            // unblock. If a watcher closes with signals still queued
+            // (signalfd was never read for them, or the user `kill`d
+            // after the last sig-next), the unblock — for the
+            // unblockable subset — would otherwise fire each one's
+            // default disposition on this thread.  Absorb-set
+            // signals also benefit from the drain: leaving instances
+            // queued is harmless on its own, but a future user
+            // os/sig-watch on the same signum would observe stale
+            // pending state. See `drain_pending_blocked`.
             posix_trace(format_args!(
-                "linux: rollback draining + unblocking newly_freed={:?}",
-                newly_freed
+                "linux: rollback draining newly_freed={:?}; unblocking subset {:?}",
+                newly_freed_drainable, newly_freed_unblockable
             ));
-            drain_pending_blocked(&newly_freed);
-            unsafe {
-                libc::pthread_sigmask(libc::SIG_UNBLOCK, &to_unblock, std::ptr::null_mut());
+            drain_pending_blocked(&newly_freed_drainable);
+            if !newly_freed_unblockable.is_empty() {
+                unsafe {
+                    libc::pthread_sigmask(libc::SIG_UNBLOCK, &to_unblock, std::ptr::null_mut());
+                }
             }
         }
     }
@@ -801,11 +980,19 @@ mod tests {
         assert_eq!(events[1].code, 1);
     }
 
+    /// Refcount accounting + absorb-set unblock suppression. SIGURG is
+    /// in the eager-trap absorb set (`ABSORB_SET`) so once a watcher
+    /// blocks it, close-time rollback intentionally does NOT unblock —
+    /// otherwise the kernel default (Term) would be reachable on the
+    /// main thread after the last watcher closes. The refcount itself
+    /// transitions correctly (0 → 1 → 2 → 1 → 0) and is observable
+    /// via `currently_watched`; only the mask bit is sticky.
+    ///
+    /// SIGURG is rarely touched by the runtime or other tests; safer
+    /// than SIGWINCH (which the parse_events test below also opens
+    /// a receiver for, racing against the WatchedSet refcount).
     #[test]
-    fn refcount_blocks_and_unblocks() {
-        // SIGURG is rarely touched by the runtime or other tests; safer
-        // than SIGWINCH (which the parse_events test below also opens
-        // a receiver for, racing against the WatchedSet refcount).
+    fn refcount_block_while_watched_absorb_set_stays_blocked_after_close() {
         let h = std::thread::spawn(|| {
             unsafe {
                 let mut empty: libc::sigset_t = std::mem::zeroed();
@@ -816,17 +1003,26 @@ mod tests {
 
             let r1 = SignalReceiver::new(vec![libc::SIGURG]).unwrap();
             assert!(current_thread_blocked().contains(&libc::SIGURG));
+            assert!(currently_watched().contains(&libc::SIGURG));
 
             let r2 = SignalReceiver::new(vec![libc::SIGURG]).unwrap();
             assert!(current_thread_blocked().contains(&libc::SIGURG));
 
             r1.close();
-            // Still blocked because r2 holds it.
+            // Still blocked because r2 holds the refcount > 0.
             assert!(current_thread_blocked().contains(&libc::SIGURG));
+            assert!(currently_watched().contains(&libc::SIGURG));
 
             r2.close();
-            // Both released — unblocked.
-            assert!(!current_thread_blocked().contains(&libc::SIGURG));
+            // Refcount transitioned 1 → 0, but SIGURG is in ABSORB_SET
+            // so rollback skips the unblock — see `rollback` in this
+            // file. The mask bit stays set; `currently_watched` flips
+            // off as the source of truth for "is anyone watching this?".
+            assert!(
+                current_thread_blocked().contains(&libc::SIGURG),
+                "ABSORB_SET signal must stay masked after last close"
+            );
+            assert!(!currently_watched().contains(&libc::SIGURG));
         });
         h.join().unwrap();
     }
@@ -841,5 +1037,306 @@ mod tests {
     fn cannot_watch_sigstop() {
         let r = SignalReceiver::new(vec![libc::SIGSTOP]);
         assert!(r.is_err());
+    }
+
+    // ── Eager-trap (init_process_signals) regression tests ──────────────
+    //
+    // These tests fork because the test runner has many peer threads with
+    // various signal masks and unmasked signals would be absorbed by
+    // them before `init_process_signals` could install the disposition we
+    // want to assert. Inside the forked child there is exactly one thread,
+    // making the kernel's signal-delivery target deterministic.
+    //
+    // All five tests follow the same shape:
+    //
+    //   1. fork().
+    //   2. Child calls `init_process_signals()` to install the eager
+    //      sigaction handlers + the absorb-set mask.
+    //   3. Child triggers the scenario (e.g. raise(SIGTERM)).
+    //   4. Parent observes the child via waitpid and asserts on the
+    //      exit status.
+    //
+    // The exit codes are conventional `128 + signum` for terminate-class
+    // signals — matches what the sigaction handlers will encode in their
+    // `_exit()` call. A `WIFSIGNALED` parent status means the kernel
+    // default fired instead of our handler — that's the regression we're
+    // pinning against.
+
+    /// Run `child_logic` in a forked child with a `deadline_secs` timeout.
+    /// Returns the child's exit status struct so individual tests can
+    /// assert on it without each one reimplementing the fork dance.
+    fn fork_run(deadline_secs: u64, child_logic: fn() -> i32) -> libc::c_int {
+        use std::time::{Duration, Instant};
+        let pid = unsafe { libc::fork() };
+        if pid < 0 {
+            panic!("fork failed: {}", std::io::Error::last_os_error());
+        }
+        if pid == 0 {
+            let code = child_logic();
+            unsafe { libc::_exit(code) };
+        }
+        let deadline = Instant::now() + Duration::from_secs(deadline_secs);
+        let mut status: libc::c_int = 0;
+        loop {
+            let wret = unsafe { libc::waitpid(pid, &mut status, libc::WNOHANG) };
+            if wret == pid {
+                return status;
+            }
+            if wret < 0 {
+                panic!("waitpid({}): {}", pid, std::io::Error::last_os_error());
+            }
+            if Instant::now() >= deadline {
+                unsafe { libc::kill(pid, libc::SIGKILL) };
+                let _ = unsafe { libc::waitpid(pid, &mut status, 0) };
+                panic!("fork_run child hung past {}s", deadline_secs);
+            }
+            std::thread::sleep(Duration::from_millis(20));
+        }
+    }
+
+    /// SIGTERM must run the built-in sigaction handler and produce a
+    /// clean `WIFEXITED == 143` (= `128 + SIGTERM`), not a
+    /// `WIFSIGNALED` death. Counter-factual: comment out the SIGTERM
+    /// branch in `install_terminate_handlers` and this test fails
+    /// because the kernel default (Term) fires instead.
+    #[test]
+    fn sigterm_terminates_via_handler_with_code_143() {
+        let status = fork_run(5, || {
+            init_process_signals();
+            unsafe { libc::raise(libc::SIGTERM) };
+            // The handler should have called _exit before we get here.
+            // If we reach this line the handler is broken — return a
+            // distinguishable code so the parent's assertion message
+            // makes it clear.
+            std::thread::sleep(std::time::Duration::from_millis(200));
+            91
+        });
+        assert!(
+            !libc::WIFSIGNALED(status),
+            "child died from signal {} — sigaction handler did not fire",
+            libc::WTERMSIG(status),
+        );
+        assert!(libc::WIFEXITED(status));
+        assert_eq!(
+            libc::WEXITSTATUS(status),
+            128 + libc::SIGTERM,
+            "SIGTERM handler must _exit(128 + SIGTERM)"
+        );
+    }
+
+    /// Same as SIGTERM but for SIGINT / SIGQUIT / SIGHUP — they all
+    /// share the terminate-class dispatch.
+    #[test]
+    fn sigint_terminates_via_handler_with_code_130() {
+        let status = fork_run(5, || {
+            init_process_signals();
+            unsafe { libc::raise(libc::SIGINT) };
+            std::thread::sleep(std::time::Duration::from_millis(200));
+            91
+        });
+        assert!(!libc::WIFSIGNALED(status));
+        assert_eq!(libc::WEXITSTATUS(status), 128 + libc::SIGINT);
+    }
+
+    #[test]
+    fn sigquit_terminates_via_handler_with_code_131() {
+        let status = fork_run(5, || {
+            init_process_signals();
+            unsafe { libc::raise(libc::SIGQUIT) };
+            std::thread::sleep(std::time::Duration::from_millis(200));
+            91
+        });
+        assert!(!libc::WIFSIGNALED(status));
+        assert_eq!(libc::WEXITSTATUS(status), 128 + libc::SIGQUIT);
+    }
+
+    #[test]
+    fn sighup_terminates_via_handler_with_code_129() {
+        let status = fork_run(5, || {
+            init_process_signals();
+            unsafe { libc::raise(libc::SIGHUP) };
+            std::thread::sleep(std::time::Duration::from_millis(200));
+            91
+        });
+        assert!(!libc::WIFSIGNALED(status));
+        assert_eq!(libc::WEXITSTATUS(status), 128 + libc::SIGHUP);
+    }
+
+    /// SIGTSTP must translate into a `raise(SIGSTOP)` from the handler,
+    /// the kernel stops the process, and after the parent sends
+    /// SIGCONT execution resumes. We verify resumption by having the
+    /// child write a sentinel to a pipe AFTER the SIGTSTP raise: if
+    /// the sigaction handler is missing, the kernel default for
+    /// SIGTSTP (also Stop, but no sigaction means we never write the
+    /// sentinel because Continue-only-on-cont still works); to make
+    /// this a sharp test we instead assert the child exits 0 within
+    /// the timeout AFTER parent sends SIGCONT — without the SIGCONT
+    /// the child would hang in the kernel-imposed stop and the
+    /// timeout would fire.
+    ///
+    /// Counter-factual: with no SIGTSTP handler we'd still get a
+    /// kernel-imposed stop (same observed result). So this test
+    /// uniquely pins SIGTSTP → SIGSTOP-via-handler only when paired
+    /// with the next test (sigtstp_handler_returns_to_caller).
+    #[test]
+    fn sigtstp_pauses_and_sigcont_resumes() {
+        use std::time::{Duration, Instant};
+        let pid = unsafe { libc::fork() };
+        if pid < 0 {
+            panic!("fork: {}", std::io::Error::last_os_error());
+        }
+        if pid == 0 {
+            init_process_signals();
+            unsafe { libc::raise(libc::SIGTSTP) };
+            // After SIGCONT we should reach this line and exit cleanly.
+            unsafe { libc::_exit(0) };
+        }
+
+        // Parent: wait until child is stopped, then SIGCONT it.
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let mut status: libc::c_int = 0;
+        let mut stopped = false;
+        loop {
+            let wret = unsafe { libc::waitpid(pid, &mut status, libc::WUNTRACED | libc::WNOHANG) };
+            if wret == pid {
+                if libc::WIFSTOPPED(status) && !stopped {
+                    // Now resume it.
+                    stopped = true;
+                    unsafe { libc::kill(pid, libc::SIGCONT) };
+                } else if libc::WIFEXITED(status) {
+                    break;
+                }
+            } else if wret < 0 {
+                panic!("waitpid: {}", std::io::Error::last_os_error());
+            }
+            if Instant::now() >= deadline {
+                unsafe { libc::kill(pid, libc::SIGKILL) };
+                let _ = unsafe { libc::waitpid(pid, &mut status, 0) };
+                panic!("child hung in stop state past 5s");
+            }
+            std::thread::sleep(Duration::from_millis(20));
+        }
+        assert!(libc::WIFEXITED(status));
+        assert_eq!(libc::WEXITSTATUS(status), 0);
+        assert!(
+            stopped,
+            "child must have transitioned through stopped state"
+        );
+    }
+
+    /// SIGPIPE must be installed as SIG_IGN at startup. Write on a
+    /// closed pipe should return -1/EPIPE rather than terminating
+    /// the process.
+    ///
+    /// Counter-factual: removing the SIG_IGN install would cause the
+    /// child to die with SIGPIPE (WIFSIGNALED, WTERMSIG=SIGPIPE).
+    #[test]
+    fn sigpipe_is_ignored_at_startup() {
+        let status = fork_run(5, || {
+            init_process_signals();
+            let mut fds: [libc::c_int; 2] = [0; 2];
+            if unsafe { libc::pipe(fds.as_mut_ptr()) } != 0 {
+                return 71;
+            }
+            // Close the read end first.
+            unsafe { libc::close(fds[0]) };
+            let buf = [0u8; 4];
+            let ret =
+                unsafe { libc::write(fds[1], buf.as_ptr() as *const libc::c_void, buf.len()) };
+            let errno = std::io::Error::last_os_error().raw_os_error().unwrap_or(0);
+            unsafe { libc::close(fds[1]) };
+            if ret == -1 && errno == libc::EPIPE {
+                0
+            } else {
+                72
+            }
+        });
+        assert!(
+            !libc::WIFSIGNALED(status),
+            "child died from signal {} — SIGPIPE not ignored",
+            libc::WTERMSIG(status),
+        );
+        assert!(libc::WIFEXITED(status));
+        assert_eq!(libc::WEXITSTATUS(status), 0);
+    }
+
+    /// When nothing watches SIGUSR1, the eager-trap policy is "absorb":
+    /// the signal is blocked at startup, the kernel queues it but no
+    /// thread reads it, and the process keeps running. Counter-factual:
+    /// without the absorb-set block, the kernel default for SIGUSR1
+    /// (Term) fires and the child dies signalled.
+    #[test]
+    fn sigusr1_absorbed_when_unwatched() {
+        let status = fork_run(5, || {
+            init_process_signals();
+            unsafe { libc::raise(libc::SIGUSR1) };
+            // Give the kernel a beat to deliver if it were going to.
+            std::thread::sleep(std::time::Duration::from_millis(100));
+            0
+        });
+        assert!(
+            !libc::WIFSIGNALED(status),
+            "child died from signal {} — SIGUSR1 was not absorbed",
+            libc::WTERMSIG(status),
+        );
+        assert!(libc::WIFEXITED(status));
+        assert_eq!(libc::WEXITSTATUS(status), 0);
+    }
+
+    /// Watcher overrides built-in: a live `SignalReceiver` on SIGTERM
+    /// must keep the process alive even after SIGTERM is raised — the
+    /// signal goes to the receiver's signalfd instead of the sigaction
+    /// handler. Counter-factual: without the watcher-override
+    /// mechanism (i.e. if the sigaction handler fires regardless), the
+    /// child terminates with code 143 before it can read the receiver.
+    #[test]
+    fn watcher_overrides_builtin_for_sigterm() {
+        let status = fork_run(5, || {
+            init_process_signals();
+            let r = match SignalReceiver::new(vec![libc::SIGTERM]) {
+                Ok(r) => r,
+                Err(_) => return 81,
+            };
+            unsafe { libc::raise(libc::SIGTERM) };
+            // Poll signalfd directly for the event — we don't need the
+            // full async-backend pipeline here.
+            let fd = match r.raw_fd() {
+                Ok(f) => f,
+                Err(_) => return 82,
+            };
+            let mut pfd = libc::pollfd {
+                fd,
+                events: libc::POLLIN,
+                revents: 0,
+            };
+            let pret = unsafe { libc::poll(&mut pfd, 1, 1000) };
+            if pret <= 0 {
+                return 83;
+            }
+            let mut buf = vec![0u8; std::mem::size_of::<libc::signalfd_siginfo>() * 4];
+            let n = unsafe { libc::read(fd, buf.as_mut_ptr() as *mut libc::c_void, buf.len()) };
+            if n <= 0 {
+                return 84;
+            }
+            buf.truncate(n as usize);
+            let events = r.parse_events(&buf);
+            if events.is_empty() || events[0].signum != libc::SIGTERM {
+                return 85;
+            }
+            r.close();
+            0
+        });
+        assert!(
+            !libc::WIFSIGNALED(status),
+            "child died from signal {} — watcher did not override built-in handler",
+            libc::WTERMSIG(status),
+        );
+        assert!(libc::WIFEXITED(status));
+        assert_eq!(
+            libc::WEXITSTATUS(status),
+            0,
+            "child exited with {} (see codes 81-85 in test)",
+            libc::WEXITSTATUS(status)
+        );
     }
 }

--- a/src/io/threadpool.rs
+++ b/src/io/threadpool.rs
@@ -655,10 +655,16 @@ impl ThreadPoolBackend {
 pub(super) struct StdinThread {
     request_tx: crossbeam_channel::Sender<StdinRequest>,
     completion_rx: crossbeam_channel::Receiver<StdinCompletion>,
-    /// Thread handle kept for Drop semantics: when dropped, the thread detaches.
-    /// Not directly read, but essential for proper cleanup.
-    #[allow(dead_code)]
-    handle: std::thread::JoinHandle<()>,
+    /// Write end of the cancellation self-pipe. Writing any byte here
+    /// wakes the stdin thread out of `libc::poll` so it can either
+    /// (a) acknowledge a shutdown and exit, or (b) treat an in-flight
+    /// read as cancelled. Owned by us; closed in `Drop`.
+    shutdown_write_fd: RawFd,
+    /// Thread handle kept for join in tests and for `is_finished`
+    /// observation. In production, the runtime calls `shutdown()` and
+    /// then drops the thread; the thread exits within a few syscall
+    /// hops of the shutdown write.
+    handle: Option<std::thread::JoinHandle<()>>,
 }
 
 pub(super) struct StdinRequest {
@@ -677,57 +683,51 @@ pub(super) struct StdinCompletion {
     pub(super) result: Result<Vec<u8>, String>,
 }
 
+/// Sentinel string used in the cancelled completion's error message.
+/// `(port/close *stdin*)` translates this into an `:io-error` whose
+/// `:message` field is exactly `"stdin closed"`, matching the contract
+/// documented in `docs/io.md`. Searched for by the threadpool tests.
+const STDIN_CLOSED_MSG: &str = "stdin closed";
+
 impl StdinThread {
     pub(super) fn new() -> Self {
         let (request_tx, request_rx) = crossbeam_channel::unbounded::<StdinRequest>();
         let (completion_tx, completion_rx) = crossbeam_channel::unbounded::<StdinCompletion>();
 
+        // Self-pipe for cancellation. The thread polls the read end
+        // alongside fd 0; writing any byte here wakes the poll(2).
+        // We set the read end to O_NONBLOCK so the thread's drain
+        // (after a shutdown wakeup) never blocks.
+        let mut pipe_fds: [libc::c_int; 2] = [0; 2];
+        let pipe_ret = unsafe { libc::pipe(pipe_fds.as_mut_ptr()) };
+        if pipe_ret != 0 {
+            panic!(
+                "StdinThread: pipe(2) failed: {}",
+                std::io::Error::last_os_error()
+            );
+        }
+        let shutdown_read_fd = pipe_fds[0];
+        let shutdown_write_fd = pipe_fds[1];
+        unsafe {
+            libc::fcntl(shutdown_read_fd, libc::F_SETFL, libc::O_NONBLOCK);
+            libc::fcntl(shutdown_read_fd, libc::F_SETFD, libc::FD_CLOEXEC);
+            libc::fcntl(shutdown_write_fd, libc::F_SETFD, libc::FD_CLOEXEC);
+        }
+
         let handle = std::thread::Builder::new()
             .name("elle-stdin".into())
             .spawn(move || {
                 crate::io::sigfd::mask_all_signals_on_this_thread();
-                use std::io::{BufRead, Read};
-                while let Ok(req) = request_rx.recv() {
-                    let result = match req.op_kind {
-                        StdinOpKind::ReadLine => {
-                            let mut line = String::new();
-                            match std::io::stdin().lock().read_line(&mut line) {
-                                Ok(0) => Ok(Vec::new()), // EOF
-                                Ok(_) => {
-                                    let trimmed =
-                                        line.trim_end_matches('\n').trim_end_matches('\r');
-                                    Ok(trimmed.as_bytes().to_vec())
-                                }
-                                Err(e) => Err(e.to_string()),
-                            }
-                        }
-                        StdinOpKind::Read { count } => {
-                            let mut buf = vec![0u8; count];
-                            match std::io::stdin().lock().read(&mut buf) {
-                                Ok(n) => {
-                                    buf.truncate(n);
-                                    Ok(buf)
-                                }
-                                Err(e) => Err(e.to_string()),
-                            }
-                        }
-                        StdinOpKind::ReadAll => {
-                            let mut buf = Vec::new();
-                            match std::io::stdin().lock().read_to_end(&mut buf) {
-                                Ok(_) => Ok(buf),
-                                Err(e) => Err(e.to_string()),
-                            }
-                        }
-                    };
-                    let _ = completion_tx.send(StdinCompletion { id: req.id, result });
-                }
+                stdin_thread_loop(request_rx, completion_tx, shutdown_read_fd);
+                unsafe { libc::close(shutdown_read_fd) };
             })
             .expect("failed to spawn stdin thread");
 
         StdinThread {
             request_tx,
             completion_rx,
-            handle,
+            shutdown_write_fd,
+            handle: Some(handle),
         }
     }
 
@@ -735,6 +735,37 @@ impl StdinThread {
         self.request_tx
             .send(StdinRequest { id, op_kind })
             .map_err(|_| "stdin thread channel disconnected".to_string())
+    }
+
+    /// Signal the stdin thread to shut down. The thread either:
+    ///   - if currently inside `poll(2)` waiting for input on fd 0,
+    ///     observes the shutdown pipe revents and sends a `stdin
+    ///     closed` error completion for the in-flight request before
+    ///     exiting;
+    ///   - if currently waiting in `request_rx.recv_timeout`, picks
+    ///     the shutdown up on its next 100 ms tick and exits.
+    ///
+    /// Idempotent: subsequent calls write extra bytes into the pipe
+    /// which the thread either drains on exit or never reads (already
+    /// gone). The write is bounded to 1 byte so it cannot ever
+    /// block on a full kernel pipe buffer.
+    pub(super) fn shutdown(&self) {
+        let byte: u8 = 1;
+        unsafe {
+            libc::write(
+                self.shutdown_write_fd,
+                &byte as *const u8 as *const libc::c_void,
+                1,
+            );
+        }
+    }
+
+    /// True once the worker thread has exited. Used by tests to assert
+    /// `shutdown()` actually wound the thread down; callers in the
+    /// runtime don't need this (the drop path waits for them).
+    #[allow(dead_code)]
+    pub(super) fn is_finished(&self) -> bool {
+        self.handle.as_ref().is_none_or(|h| h.is_finished())
     }
 
     /// Expose the receiver for cross-source select in async wait.
@@ -748,6 +779,235 @@ impl StdinThread {
             results.push(c);
         }
         results
+    }
+}
+
+impl Drop for StdinThread {
+    fn drop(&mut self) {
+        // Signal shutdown so the worker exits promptly. Closing the
+        // write end signals EOF on the pipe — the thread's poll picks
+        // it up too — but `shutdown()` writes a byte first to wake
+        // any current poll. Either is sufficient; both is robust.
+        self.shutdown();
+        unsafe { libc::close(self.shutdown_write_fd) };
+        if let Some(h) = self.handle.take() {
+            // Best-effort join. The thread is bounded by the next poll
+            // tick (~100 ms) plus the time to send any pending
+            // cancellation completion. In practice this returns
+            // quickly; we tolerate a brief blip on Drop rather than
+            // detaching and leaking a thread.
+            let _ = h.join();
+        }
+    }
+}
+
+/// Main worker loop. Multiplexes:
+///   - `request_rx`: incoming `(id, op_kind)` requests.
+///   - `shutdown_read_fd`: byte arrival means caller asked us to die.
+///   - fd 0: actual stdin input for the in-flight request.
+///
+/// We don't have a portable way to `select` simultaneously on a
+/// crossbeam channel and a raw fd, so the loop alternates: idle ticks
+/// poll the shutdown fd alongside a short `recv_timeout` on the
+/// channel; the active state (mid-read) uses `poll(2)` on fd 0 plus
+/// the shutdown fd.
+fn stdin_thread_loop(
+    request_rx: crossbeam_channel::Receiver<StdinRequest>,
+    completion_tx: crossbeam_channel::Sender<StdinCompletion>,
+    shutdown_read_fd: RawFd,
+) {
+    use std::time::Duration;
+    let mut leftover: Vec<u8> = Vec::new();
+    loop {
+        if shutdown_signalled(shutdown_read_fd) {
+            return;
+        }
+        let req = match request_rx.recv_timeout(Duration::from_millis(100)) {
+            Ok(r) => r,
+            Err(crossbeam_channel::RecvTimeoutError::Timeout) => continue,
+            Err(crossbeam_channel::RecvTimeoutError::Disconnected) => return,
+        };
+        let result = match req.op_kind {
+            StdinOpKind::ReadLine => read_line_with_cancel(shutdown_read_fd, &mut leftover),
+            StdinOpKind::Read { count } => {
+                read_n_with_cancel(shutdown_read_fd, count, &mut leftover)
+            }
+            StdinOpKind::ReadAll => read_all_with_cancel(shutdown_read_fd, &mut leftover),
+        };
+        let was_cancelled = matches!(&result, Err(s) if s == STDIN_CLOSED_MSG);
+        let _ = completion_tx.send(StdinCompletion { id: req.id, result });
+        if was_cancelled {
+            // Drain any further queued requests as cancelled so their
+            // submitters see a completion rather than hanging.
+            while let Ok(r) = request_rx.try_recv() {
+                let _ = completion_tx.send(StdinCompletion {
+                    id: r.id,
+                    result: Err(STDIN_CLOSED_MSG.to_string()),
+                });
+            }
+            return;
+        }
+    }
+}
+
+/// Non-blocking peek at the shutdown pipe. Returns true if any byte
+/// is present (we don't bother to drain — `read_*_with_cancel` will
+/// see the revents in its next poll).
+fn shutdown_signalled(shutdown_read_fd: RawFd) -> bool {
+    let mut pfd = libc::pollfd {
+        fd: shutdown_read_fd,
+        events: libc::POLLIN,
+        revents: 0,
+    };
+    let ret = unsafe { libc::poll(&mut pfd, 1, 0) };
+    ret > 0 && pfd.revents != 0
+}
+
+/// Poll fd 0 and `shutdown_read_fd` simultaneously. Returns `Ok(true)`
+/// when stdin has input available, `Ok(false)` when shutdown was
+/// signalled, `Err` on real syscall errors. The shutdown branch wins
+/// any race so close-then-arrive-input doesn't leak data into a
+/// completion the caller will never read.
+fn poll_stdin_or_shutdown(shutdown_read_fd: RawFd) -> Result<bool, String> {
+    loop {
+        let mut pfds = [
+            libc::pollfd {
+                fd: 0,
+                events: libc::POLLIN,
+                revents: 0,
+            },
+            libc::pollfd {
+                fd: shutdown_read_fd,
+                events: libc::POLLIN,
+                revents: 0,
+            },
+        ];
+        let ret = unsafe { libc::poll(pfds.as_mut_ptr(), 2, -1) };
+        if ret < 0 {
+            let err = std::io::Error::last_os_error();
+            if err.raw_os_error() == Some(libc::EINTR) {
+                continue;
+            }
+            return Err(format!("poll: {}", err));
+        }
+        // Shutdown wins races against pending stdin input.
+        if pfds[1].revents != 0 {
+            return Ok(false);
+        }
+        if pfds[0].revents != 0 {
+            return Ok(true);
+        }
+        // No revents but poll > 0 should not happen; loop defensively.
+    }
+}
+
+/// One iteration of "wait + read" against fd 0 with shutdown
+/// observation. Returns:
+///   - `Ok(Some(bytes))` — fresh bytes read.
+///   - `Ok(None)` — EOF.
+///   - `Err(STDIN_CLOSED_MSG)` — shutdown was signalled.
+///   - `Err(other)` — real I/O error.
+fn read_chunk_with_cancel(shutdown_read_fd: RawFd, max: usize) -> Result<Option<Vec<u8>>, String> {
+    if !poll_stdin_or_shutdown(shutdown_read_fd)? {
+        return Err(STDIN_CLOSED_MSG.to_string());
+    }
+    let mut buf = vec![0u8; max];
+    loop {
+        let ret = unsafe { libc::read(0, buf.as_mut_ptr() as *mut libc::c_void, buf.len()) };
+        if ret < 0 {
+            let err = std::io::Error::last_os_error();
+            match err.raw_os_error() {
+                Some(libc::EINTR) | Some(libc::EAGAIN) => {
+                    // Re-poll: input may have been consumed by another
+                    // reader, or the signal was harmless.
+                    if !poll_stdin_or_shutdown(shutdown_read_fd)? {
+                        return Err(STDIN_CLOSED_MSG.to_string());
+                    }
+                    continue;
+                }
+                _ => return Err(format!("read: {}", err)),
+            }
+        }
+        if ret == 0 {
+            return Ok(None);
+        }
+        buf.truncate(ret as usize);
+        return Ok(Some(buf));
+    }
+}
+
+fn read_line_with_cancel(
+    shutdown_read_fd: RawFd,
+    leftover: &mut Vec<u8>,
+) -> Result<Vec<u8>, String> {
+    // If a previous read consumed past a newline, the bytes after the
+    // newline went into `leftover`. Serve from there first.
+    if let Some(nl) = leftover.iter().position(|&b| b == b'\n') {
+        let mut line: Vec<u8> = leftover.drain(..=nl).collect();
+        line.pop(); // drop \n
+        if line.last() == Some(&b'\r') {
+            line.pop();
+        }
+        return Ok(line);
+    }
+    // Read chunks until newline or EOF.
+    let mut accum = std::mem::take(leftover);
+    loop {
+        match read_chunk_with_cancel(shutdown_read_fd, 4096)? {
+            Some(bytes) => {
+                accum.extend_from_slice(&bytes);
+                if let Some(nl) = accum.iter().position(|&b| b == b'\n') {
+                    let mut line: Vec<u8> = accum.drain(..=nl).collect();
+                    line.pop(); // drop \n
+                    if line.last() == Some(&b'\r') {
+                        line.pop();
+                    }
+                    *leftover = accum;
+                    return Ok(line);
+                }
+            }
+            None => {
+                // EOF: return whatever we have. `Ok(Vec::new())`
+                // signals EOF to the completion handler.
+                return Ok(accum);
+            }
+        }
+    }
+}
+
+fn read_n_with_cancel(
+    shutdown_read_fd: RawFd,
+    count: usize,
+    leftover: &mut Vec<u8>,
+) -> Result<Vec<u8>, String> {
+    // Drain leftover bytes first. `port/read` returns "up to N bytes"
+    // per POSIX semantics, so if leftover has anything we return that
+    // immediately (matching how std::io::stdin().lock().read worked:
+    // a single read syscall).
+    if !leftover.is_empty() {
+        let take = leftover.len().min(count);
+        let chunk: Vec<u8> = leftover.drain(..take).collect();
+        return Ok(chunk);
+    }
+    if count == 0 {
+        return Ok(Vec::new());
+    }
+    match read_chunk_with_cancel(shutdown_read_fd, count)? {
+        Some(bytes) => Ok(bytes),
+        None => Ok(Vec::new()), // EOF
+    }
+}
+
+fn read_all_with_cancel(
+    shutdown_read_fd: RawFd,
+    leftover: &mut Vec<u8>,
+) -> Result<Vec<u8>, String> {
+    let mut accum = std::mem::take(leftover);
+    loop {
+        match read_chunk_with_cancel(shutdown_read_fd, 4096)? {
+            Some(bytes) => accum.extend_from_slice(&bytes),
+            None => return Ok(accum),
+        }
     }
 }
 
@@ -1254,6 +1514,129 @@ mod tests {
             "close_drains_pending child failed with code {} (see codes in close_drain_child_logic)",
             code
         );
+    }
+
+    /// Shutdown signal must wake the stdin thread when it is sitting in
+    /// `request_rx.recv()` waiting for the next request (no read in
+    /// flight). The thread should exit cleanly within a short
+    /// timeout. Counter-factual: without the self-pipe + shutdown
+    /// wiring, the thread sits in `recv()` until the channel sender
+    /// drops, which doesn't happen until process exit — the test
+    /// helper's `recv_timeout` below would fire.
+    ///
+    /// This test does NOT need to touch fd 0. The thread is idle
+    /// (never submits a request) so the read syscall is never reached.
+    #[test]
+    fn stdin_thread_shutdown_while_idle_joins() {
+        use std::time::{Duration, Instant};
+        let st = StdinThread::new();
+        st.shutdown();
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while !st.is_finished() {
+            if Instant::now() >= deadline {
+                panic!("stdin thread did not exit within 2s of shutdown");
+            }
+            std::thread::sleep(Duration::from_millis(20));
+        }
+    }
+
+    /// Shutdown signal must wake the stdin thread when it is parked
+    /// inside `libc::read(0, …)` waiting for input. We fork so we can
+    /// `dup2` a pipe onto fd 0 in the child without disturbing the
+    /// cargo test runner (peer tests share fd 0). The child holds the
+    /// write end open so the read truly blocks (no EOF). After a 100 ms
+    /// settle, the child calls `shutdown()` and expects an error
+    /// completion within 2 s.
+    ///
+    /// Counter-factual: the legacy
+    /// `std::io::stdin().lock().read_line(…)` auto-retries on EINTR
+    /// and has no shutdown path; a signal or pipe-write cannot wake
+    /// it. The forked child would hang past the 5 s parent timeout
+    /// and panic.
+    #[test]
+    fn stdin_thread_shutdown_cancels_inflight_read() {
+        use std::time::{Duration, Instant};
+        let pid = unsafe { libc::fork() };
+        if pid < 0 {
+            panic!("fork: {}", std::io::Error::last_os_error());
+        }
+        if pid == 0 {
+            unsafe { libc::_exit(stdin_close_child_logic()) };
+        }
+
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let mut status: libc::c_int = 0;
+        loop {
+            let wret = unsafe { libc::waitpid(pid, &mut status, libc::WNOHANG) };
+            if wret == pid {
+                break;
+            }
+            if wret < 0 {
+                panic!("waitpid: {}", std::io::Error::last_os_error());
+            }
+            if Instant::now() >= deadline {
+                unsafe { libc::kill(pid, libc::SIGKILL) };
+                let _ = unsafe { libc::waitpid(pid, &mut status, 0) };
+                panic!("stdin close child hung past 5s");
+            }
+            std::thread::sleep(Duration::from_millis(20));
+        }
+        assert!(
+            !libc::WIFSIGNALED(status),
+            "child died from signal {}",
+            libc::WTERMSIG(status),
+        );
+        assert!(libc::WIFEXITED(status));
+        assert_eq!(
+            libc::WEXITSTATUS(status),
+            0,
+            "child exited with {} (see codes 51-58 in stdin_close_child_logic)",
+            libc::WEXITSTATUS(status)
+        );
+    }
+
+    fn stdin_close_child_logic() -> i32 {
+        use std::time::Duration;
+        // Replace fd 0 with the read end of a pipe and hold the write
+        // end so the read never sees EOF. The stdin thread will block
+        // inside libc::read(0, …) until our shutdown signal wakes it.
+        let mut pipe_fds: [libc::c_int; 2] = [0; 2];
+        if unsafe { libc::pipe(pipe_fds.as_mut_ptr()) } != 0 {
+            return 51;
+        }
+        if unsafe { libc::dup2(pipe_fds[0], 0) } < 0 {
+            return 52;
+        }
+        unsafe { libc::close(pipe_fds[0]) };
+        let _write_end = pipe_fds[1]; // kept open until process exit
+
+        let st = StdinThread::new();
+        if st.submit(1, StdinOpKind::ReadLine).is_err() {
+            return 53;
+        }
+        // Settle: give the thread time to enter the read.
+        std::thread::sleep(Duration::from_millis(100));
+
+        st.shutdown();
+
+        match st.receiver().recv_timeout(Duration::from_secs(2)) {
+            Ok(c) => {
+                if c.id != 1 {
+                    return 54;
+                }
+                match c.result {
+                    Ok(_) => 55, // expected an error, got Ok
+                    Err(msg) => {
+                        if msg.contains("stdin closed") {
+                            0
+                        } else {
+                            56
+                        }
+                    }
+                }
+            }
+            Err(_) => 57,
+        }
     }
 
     /// Body of the forked child for `close_drains_pending_after_two_kills`.

--- a/src/io/uring.rs
+++ b/src/io/uring.rs
@@ -990,6 +990,55 @@ pub(super) fn wait_uring(
     Ok(())
 }
 
+/// Submit a read on a signalfd to wait for the next POSIX signal
+/// delivery. Linux-only — io_uring is not available on macOS.
+///
+/// signalfd is a regular pollable kernel fd: io_uring's
+/// `IORING_OP_READ` is internally driven by the kernel's poll
+/// pipeline, so a CQE fires as soon as the kernel queues a
+/// `signalfd_siginfo` record without ever parking an elle-side
+/// thread. This is the production path used by `submit_sig_next`
+/// (`src/io/aio.rs`) on the `PlatformBackend::Uring` arm.
+///
+/// `signalfd(2)` writes one fixed-size `signalfd_siginfo` (128 bytes
+/// on every Linux ABI we target) per queued signal. We size the read
+/// for eight entries — enough to batch a `kill -USR1` burst without
+/// re-submitting, while keeping per-watcher buffer cost bounded. The
+/// CQE returns the byte count, which `SignalReceiver::parse_events`
+/// (`src/io/sigfd.rs`) carves back into `SigEvent`s.
+///
+/// `buf_handle` is the buffer pool slot already allocated by the
+/// caller (so the buffer survives until the CQE arrives even if the
+/// fiber is suspended). We resize it to the entry-aligned size here
+/// rather than leaving sizing to the caller — the size is a property
+/// of signalfd, not of submit_sig_next.
+pub(super) fn submit_uring_sig_next(
+    ring: &mut io_uring::IoUring,
+    id: u64,
+    fd: RawFd,
+    buffer_pool: &mut BufferPool,
+    buf_handle: BufferHandle,
+) -> Result<(), String> {
+    use io_uring::opcode;
+    use io_uring::types::Fd;
+
+    let entry_size = std::mem::size_of::<libc::signalfd_siginfo>();
+    let buf = buffer_pool.get_mut(buf_handle);
+    buf.resize(entry_size * 8, 0);
+    let sqe = opcode::Read::new(Fd(fd), buf.as_mut_ptr(), buf.len() as u32)
+        .build()
+        .user_data(id);
+
+    unsafe {
+        ring.submission()
+            .push(&sqe)
+            .map_err(|_| "io/submit: io_uring submission queue full".to_string())?;
+    }
+    ring.submit()
+        .map_err(|e| format!("io/submit: io_uring submit failed: {}", e))?;
+    Ok(())
+}
+
 /// Submit a read on an inotify fd to wait for filesystem events.
 pub(super) fn submit_uring_watch_next(
     ring: &mut io_uring::IoUring,
@@ -1020,7 +1069,151 @@ pub(super) fn submit_uring_watch_next(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::io::pool::BufferPool;
     use crate::io::request::SocketOptions;
+    use crate::io::sigfd::SignalReceiver;
+
+    /// End-to-end regression: a SIGUSR1 delivered to the process must
+    /// surface as a CQE on the io_uring instance via the dedicated
+    /// `submit_uring_sig_next` helper, with no threadpool worker
+    /// involved on the elle side.
+    ///
+    /// This is the production Linux path: `submit_sig_next` (in
+    /// `src/io/aio.rs`) on the `PlatformBackend::Uring` arm calls
+    /// `submit_uring_sig_next`, the kernel completes the signalfd read
+    /// asynchronously, and the resulting CQE flows through
+    /// `drain_cqes` → `PendingOp::SigNext` → `parse_events`. The diff
+    /// for #856 used `submit_uring_watch_next` (the fs-watcher helper)
+    /// here, which was structurally correct but hid the io_uring +
+    /// signalfd path inside an unrelated abstraction. This test pins
+    /// the dedicated path so a future refactor can't quietly drop us
+    /// back onto the threadpool fallback without the build breaking.
+    ///
+    /// Forks so the child has a clean thread topology: post-fork there
+    /// is one thread, SIGUSR1 is blocked on it (via
+    /// `SignalReceiver::new`), and the kernel parks the kill() on the
+    /// process pending queue where signalfd can read it. In the cargo
+    /// test runner without the fork, peer threads with SIGUSR1
+    /// unmasked would absorb the kill before our io_uring read sees
+    /// it. Child exits 0 on success, small positive code on failure.
+    #[test]
+    fn sig_next_via_uring_returns_after_kill_to_self() {
+        use std::time::{Duration, Instant};
+
+        let pid = unsafe { libc::fork() };
+        if pid < 0 {
+            panic!("fork failed: {}", std::io::Error::last_os_error());
+        }
+        if pid == 0 {
+            let code = sig_next_uring_child_logic();
+            unsafe { libc::_exit(code) };
+        }
+
+        // PARENT: bounded waitpid so an io_uring regression (CQE never
+        // arrives, ring fd closed early, helper rewires onto something
+        // that doesn't actually submit, etc.) surfaces as a hung child
+        // panic rather than wedging the whole `cargo test` run.
+        let deadline = Instant::now() + Duration::from_secs(10);
+        let mut status: libc::c_int = 0;
+        loop {
+            let wret = unsafe { libc::waitpid(pid, &mut status, libc::WNOHANG) };
+            if wret == pid {
+                break;
+            }
+            if wret < 0 {
+                let errno = std::io::Error::last_os_error();
+                panic!("waitpid({}): {}", pid, errno);
+            }
+            if Instant::now() >= deadline {
+                unsafe { libc::kill(pid, libc::SIGKILL) };
+                let _ = unsafe { libc::waitpid(pid, &mut status, 0) };
+                panic!("sig_next via uring child hung past 10s");
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+
+        if libc::WIFSIGNALED(status) {
+            panic!(
+                "sig_next via uring child died from signal {}",
+                libc::WTERMSIG(status)
+            );
+        }
+        let code = libc::WEXITSTATUS(status);
+        assert_eq!(
+            code, 0,
+            "sig_next via uring child failed with code {} (see codes in sig_next_uring_child_logic)",
+            code
+        );
+    }
+
+    /// Body of the forked child for the io_uring sig-next test.
+    /// Returns small positive codes identifying the failing step so
+    /// the parent's panic message points at the broken kernel call.
+    fn sig_next_uring_child_logic() -> i32 {
+        let r = match SignalReceiver::new(vec![libc::SIGUSR1]) {
+            Ok(r) => r,
+            Err(_) => return 31,
+        };
+        let fd = match r.raw_fd() {
+            Ok(f) => f,
+            Err(_) => return 32,
+        };
+
+        let mut ring = match io_uring::IoUring::new(8) {
+            Ok(ring) => ring,
+            // If io_uring_setup fails on this host kernel we have
+            // nothing to test — skip with success rather than
+            // pretending we covered the path.
+            Err(_) => return 0,
+        };
+        let mut pool = BufferPool::new();
+        // 1024 bytes ≈ 8 signalfd_siginfo entries; matches the size
+        // submit_sig_next in aio.rs allocates.
+        let buf_handle = pool.alloc(1024);
+
+        if super::submit_uring_sig_next(&mut ring, 1, fd, &mut pool, buf_handle).is_err() {
+            return 33;
+        }
+
+        if unsafe { libc::kill(libc::getpid(), libc::SIGUSR1) } != 0 {
+            return 34;
+        }
+
+        // Bounded wait via io_uring's own timespec — if no CQE
+        // arrives within 5 s the helper is broken (or io_uring on
+        // this host doesn't poll signalfd correctly, which would be a
+        // real bug to surface).
+        let ts = io_uring::types::Timespec::new().sec(5).nsec(0);
+        let args = io_uring::types::SubmitArgs::new().timespec(&ts);
+        match ring.submitter().submit_with_args(1, &args) {
+            Ok(_) => {}
+            Err(e) if e.raw_os_error() == Some(libc::ETIME) => return 35,
+            Err(_) => return 36,
+        }
+
+        let cqe = match ring.completion().next() {
+            Some(c) => c,
+            None => return 37,
+        };
+        let n = cqe.result();
+        if cqe.user_data() != 1 {
+            return 38;
+        }
+        if n <= 0 {
+            return 39;
+        }
+
+        let buf = pool.get_mut(buf_handle);
+        let events = r.parse_events(&buf[..n as usize]);
+        if events.is_empty() {
+            return 40;
+        }
+        if events[0].signum != libc::SIGUSR1 {
+            return 41;
+        }
+        r.close();
+        0
+    }
 
     /// Verify apply_socket_options actually sets SO_SNDBUF on a socket fd.
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -609,6 +609,20 @@ fn main() {
     });
     elle::config::init(config);
 
+    // Trap POSIX signals at startup, before any thread spawn. This
+    // installs sigaction handlers for TERM/INT/QUIT/HUP (clean exit),
+    // TSTP/TTIN/TTOU (raise SIGSTOP), CONT (consume), SIGPIPE (ignore),
+    // and pthread_sigmask-blocks the absorb-set (USR1/USR2/CHLD/URG/
+    // WINCH/ALRM) on the main thread. See `init_process_signals` in
+    // src/io/sigfd.rs and docs/posix-signals.md for the full table.
+    //
+    // Must run before VM::new() because VM construction may spawn
+    // worker threads (currently it doesn't, but the JIT worker spawned
+    // later inherits whatever mask the main thread holds at its spawn
+    // time). Workers' own `mask_all_signals_on_this_thread()` calls
+    // are belt-and-suspenders but are not the primary defence.
+    elle::io::init_process_signals();
+
     let mut vm = VM::new();
     let mut symbols = SymbolTable::new();
 

--- a/src/primitives/concurrency.rs
+++ b/src/primitives/concurrency.rs
@@ -23,6 +23,18 @@ fn spawn_closure_impl(closure: &crate::value::Closure) -> LResult<Value> {
     let result_clone = result_holder.clone();
 
     let _handle = std::thread::spawn(move || {
+        // Mask all POSIX signals on this worker so the kernel never
+        // selects it as a delivery target. Without this, a user
+        // `(spawn closure)` thread inherits the main thread's signal
+        // mask at spawn time (typically just the absorb-set from
+        // `init_process_signals`) — TERM/INT/QUIT/HUP are unblocked
+        // on it, and the kernel may pick it to run the terminate
+        // sigaction handler. The handler still calls `_exit`, which
+        // is correct end-state, but masking here keeps delivery on
+        // the main thread where the rest of the runtime expects it
+        // (REPL ^C, watcher-override semantics). Matches the
+        // threadpool/JIT/stdin worker discipline.
+        crate::io::sigfd::mask_all_signals_on_this_thread();
         let mut vm = VM::new();
         let mut symbols = SymbolTable::new();
         // Register primitives so docs are available in the spawned thread.

--- a/src/primitives/ports.rs
+++ b/src/primitives/ports.rs
@@ -158,13 +158,22 @@ fn prim_port_close(args: &[Value]) -> (SignalBits, Value) {
     if port.is_closed() {
         return (SIG_OK, Value::NIL);
     }
-    // Stdio ports don't own their fd — close synchronously.
-    if !port.has_fd() {
+    // Stdout/stderr don't own their fd and have no async resource to
+    // tear down — close synchronously. Stdin DOES have an async
+    // resource: a dedicated worker thread parked in `libc::read(0, …)`.
+    // Even though the port doesn't own fd 0, the close must reach the
+    // AsyncBackend so the worker is signalled out of its blocking read
+    // and the fiber waiting on the in-flight read is resumed with a
+    // `stdin closed` error. See `docs/io.md` and the close branch in
+    // `AsyncBackend::submit` for the full path.
+    if !port.has_fd() && !matches!(port.kind(), crate::port::PortKind::Stdin) {
         port.close();
         return (SIG_OK, Value::NIL);
     }
-    // Ports with an fd: yield to the I/O scheduler so it can cancel
-    // pending operations before the fd is dropped.
+    // Stdin and ports with an owned fd: yield to the I/O scheduler so
+    // it can cancel pending operations / shut down the stdin worker
+    // before the fd is dropped (or, for stdin, the port is marked
+    // closed and any in-flight read is woken).
     (SIG_YIELD | SIG_IO, IoRequest::new(IoOp::Close, args[0]))
 }
 

--- a/tests/elle/posix.lisp
+++ b/tests/elle/posix.lisp
@@ -185,29 +185,48 @@
           "10c: error kind is :argument-error"))
 (eprintln "test 10: done")
 
-# ── 11. refcount-driven unblock ──────────────────────────────────────────
+# ── 11. refcount tracking for absorb-set signals (post eager-trap) ───────
+#
+# Under eager trapping (see docs/posix-signals.md "Disposition table"),
+# absorb-set signals (SIGUSR1, SIGUSR2, SIGCHLD, SIGURG, SIGWINCH,
+# SIGALRM) are pthread_sigmask-blocked process-wide at startup so an
+# unwatched delivery is silently absorbed. The mask bit therefore
+# stays set across the entire watcher lifecycle — open(0→1) finds it
+# already blocked, close(1→0) intentionally does NOT unblock it
+# because doing so would let a subsequent `kill -USR1 $pid` run the
+# kernel default (Term) on the main thread. Refcount accounting is
+# instead observable via `os/sig-watching` (see test 14).
 
-(eprintln "test 11: starting (refcount unblock)")
-(assert (not (contains? (os/sig-mask) :sigusr1))
-        "11a: :sigusr1 not masked initially")
+(eprintln "test 11: starting (refcount tracking for absorb-set)")
+(assert (contains? (os/sig-mask) :sigusr1)
+        "11a: :sigusr1 always masked (absorb-set, blocked at startup)")
+(assert (not (contains? (os/sig-watching) :sigusr1))
+        "11b: nothing watches :sigusr1 initially")
 (let [r (os/sig-watch |:sigusr1|)]
-  (assert (contains? (os/sig-mask) :sigusr1) "11b: :sigusr1 masked after watch")
+  (assert (contains? (os/sig-mask) :sigusr1) "11c: :sigusr1 still masked")
+  (assert (contains? (os/sig-watching) :sigusr1) "11d: refcount > 0 -> watched")
   (os/sig-close r))
-(assert (not (contains? (os/sig-mask) :sigusr1))
-        "11c: :sigusr1 unmasked after close")
+(assert (contains? (os/sig-mask) :sigusr1)
+        "11e: :sigusr1 stays masked after close (eager-trap absorb)")
+(assert (not (contains? (os/sig-watching) :sigusr1))
+        "11f: refcount back to 0 -> unwatched")
 (eprintln "test 11: done")
 
-# ── 12. multiple watchers share the block ────────────────────────────────
+# ── 12. multiple watchers track via refcount (absorb-set stays masked) ───
 
 (eprintln "test 12: starting")
 (let [a (os/sig-watch |:sigusr2|)
       b (os/sig-watch |:sigusr2|)]
   (os/sig-close a)
   (assert (contains? (os/sig-mask) :sigusr2)
-          "12a: :sigusr2 still masked while b holds it")
+          "12a: :sigusr2 always masked (absorb-set)")
+  (assert (contains? (os/sig-watching) :sigusr2)
+          "12b: refcount > 0 while b holds it")
   (os/sig-close b)
-  (assert (not (contains? (os/sig-mask) :sigusr2))
-          "12b: :sigusr2 unmasked after both close"))
+  (assert (contains? (os/sig-mask) :sigusr2)
+          "12c: still masked after both close (eager-trap absorb)")
+  (assert (not (contains? (os/sig-watching) :sigusr2))
+          "12d: refcount back to 0 after both close"))
 (eprintln "test 12: done")
 
 # ── 13. os/sig-pending reflects queued state ─────────────────────────────

--- a/tests/elle/stdin-close.lisp
+++ b/tests/elle/stdin-close.lisp
@@ -1,0 +1,56 @@
+(elle/epoch 10)
+## tests/elle/stdin-close.lisp — verify (port/close *stdin*) cancels
+## an in-flight read and the child program exits cleanly.
+##
+## We spawn an elle child with `:stdin :pipe` and never write to that
+## pipe. Inside the child, a fiber blocks on `(port/read-line (*stdin*))`.
+## After a brief sleep the child calls `(port/close (*stdin*))`. The fix
+## (`src/io/threadpool.rs::StdinThread::shutdown`) wakes the worker
+## thread out of its blocking `libc::read(0, …)`, surfaces a
+## `stdin closed` error to the fiber, and lets the child reach
+## `(sys/exit 0)`.
+##
+## Failure mode without the fix: the worker thread sits in
+## `std::io::stdin().lock().read_line(…)` (auto-retries EINTR, no
+## shutdown path), the fiber never resumes, the child hangs at
+## `ev/join`, the parent's `subprocess/wait` hangs in turn, and the
+## outer 30 s smoke-test timeout `SIGTERM`s us. With the fix wired up,
+## the child exits within ~200 ms.
+
+(def elle
+  (or (get (sys/env) "ELLE")
+      (if (file-exists? "./target/release/elle")
+        "./target/release/elle"
+        "./target/debug/elle")))
+
+(def child-file (string "/tmp/elle-stdin-close-child-" (sys/pid) ".lisp"))
+
+(def child-code
+  "## Spawn a fiber that blocks on stdin, close *stdin* from the main
+   ## fiber, observe the spawned fiber resume (with an error from the
+   ## cancelled read), and exit cleanly. If close-stdin doesn't wake
+   ## the worker thread, this child hangs forever and the parent
+   ## test's subprocess/system never returns.
+   (def f (ev/spawn (fn [] (port/read-line (*stdin*)))))
+   (ev/sleep 0.2)
+   (eprintln \"child: closing stdin\")
+   (port/close (*stdin*))
+   (eprintln \"child: joining fiber\")
+   (let [[ok? val] (protect ((fn [] (ev/join f))))]
+     (eprintln \"child: result ok?=\" ok? \" val=\" val))
+   (eprintln \"child: exiting\")
+   (sys/exit 0)")
+
+(file/write child-file child-code)
+
+(defer
+  (file/delete child-file)
+  (def r (subprocess/system elle [child-file] {:stdin :pipe}))
+  (eprintln "parent: child exit=" (get r :exit))
+  (eprintln "parent: child stderr=" (get r :stderr))
+  (assert (= 0 (get r :exit))
+          (string "child must exit 0 after close-stdin; got exit=" (get r :exit)))
+  (assert (string/contains? (or (get r :stderr) "") "child: exiting")
+          (string "child must reach the 'exiting' line; stderr=" (get r :stderr))))
+
+(println "stdin-close: all tests passed")


### PR DESCRIPTION
POSIX signal traps now install at process startup instead of lazily on the first os/sig-watch. TERM/INT/QUIT/HUP run a sigaction handler that writes a tagged line via write(2) and _exit(128 + signum); TSTP/TTIN/TTOU raise(SIGSTOP); CONT consumes via empty handler; SIGPIPE is SIG_IGN'd; USR1/USR2/CHLD/URG/WINCH/ALRM are pthread_sigmask-blocked on the main thread so they're absorbed unless a user watcher drains them. SIGUSR1/2 default to ignore rather than the kernel's Term. Fault signals (SEGV/BUS/FPE/ILL/ ABRT/TRAP/SYS) are intentionally untouched. Watcher-override is free: a live os/sig-watch lazy-blocks the signal on the main thread, so the sigaction handler can't fire while a receiver is alive and the signalfd reads it instead.

The io_uring + signalfd path got a dedicated submit_uring_sig_next helper. Previously sig-next reused submit_uring_watch_next (named for fs watchers), which was structurally correct but hid the io_uring + signalfd path inside an unrelated abstraction.

(port/close *stdin*) now cancels an in-flight read. StdinThread switched from std::io::stdin().lock() (auto-retries EINTR, no shutdown path) to raw libc::read on fd 0 multiplexed with poll(2) against a self-pipe. shutdown() writes a byte; the worker detects the revents at the next poll, sends a "stdin closed" io-error for whatever read was in flight, drains queued requests as cancelled, and exits. prim_port_close previously short-circuited any port without an owned fd (silently including *stdin*); stdin is now routed through the async path so the worker can be signalled before the port is marked closed.

User-spawned (spawn closure) threads now mask all signals on entry, matching threadpool/JIT/stdin discipline.

New tests:
- src/io/sigfd.rs: forked tests for SIGTERM/INT/QUIT/HUP exit codes, SIGTSTP+SIGCONT pause/resume, SIGPIPE ignore, SIGUSR1 absorb, watcher-overrides-builtin.
- src/io/uring.rs: forked io_uring sig-next round-trip via submit_uring_sig_next.
- src/io/threadpool.rs: forked stdin-close in-flight cancel test, in-process idle shutdown test.
- tests/elle/posix.lisp test 11/12 rewritten for the new mask-monotonic-for-absorb-set semantics.
- tests/elle/stdin-close.lisp: end-to-end (port/close *stdin*) via subprocess/system.

See docs/posix-signals.md (Disposition table, Watcher override, Mask policy) and docs/io.md (Closing *stdin*).