### PR TITLE
chan: scheduler-aware chan/select via per-channel wake fd

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -272,7 +272,13 @@ pub mod trace_bits {
     /// process-global mirror `GLOBAL_TRACE_BITS` (below) — threadpool
     /// worker threads and other off-VM call sites have no VM reference.
     pub const POSIX: u32 = 1 << 17;
-    pub const ALL: u32 = (1 << 18) - 1;
+    /// Channel wake protocol (`chan/wait-ready` register/deregister,
+    /// `chan/send` wake_all, wake-fd write/close).  Read both from
+    /// per-VM `RuntimeConfig` and from `GLOBAL_TRACE_BITS` — `chan/send`
+    /// can fire from any thread (including `sys/spawn`'d OS threads)
+    /// which has no `&VM` reference.
+    pub const CHAN: u32 = 1 << 18;
+    pub const ALL: u32 = (1 << 19) - 1;
 
     /// Convert a keyword name to its bit. Returns 0 for unknown keywords.
     pub fn from_name(name: &str) -> u32 {
@@ -295,6 +301,7 @@ pub mod trace_bits {
             "escape" => ESCAPE,
             "bytecode" => BYTECODE,
             "posix" => POSIX,
+            "chan" => CHAN,
             // Future keywords — accepted but no bit (traced via HashSet)
             _ => 0,
         }

--- a/src/io/aio.rs
+++ b/src/io/aio.rs
@@ -204,6 +204,18 @@ impl AsyncBackend {
             return self.submit_poll_fd(fd, events, request.timeout);
         }
 
+        // ChanSelectPark: poll a chan/wait-ready eventfd until any
+        // registered sender signals it or the timeout elapses.  The
+        // guard owns the fd(s) and the wake-list registrations and is
+        // transferred into PendingOp::ChanSelectPark so cleanup runs
+        // exactly once on completion / cancellation.
+        if let IoOp::ChanSelectPark(ref guard_cell) = request.op {
+            let guard = guard_cell
+                .take()
+                .ok_or_else(|| "io/submit: ChanSelectPark guard already consumed".to_string())?;
+            return self.submit_chan_select_park(guard, request.timeout);
+        }
+
         let port = request
             .port
             .as_external::<Port>()
@@ -820,6 +832,60 @@ impl AsyncBackend {
         Ok(id)
     }
 
+    /// Submit a ChanSelectPark operation — wait for a `chan/wait-ready`
+    /// wake fd to become readable, or for the timeout to elapse.
+    /// Internally the same shape as `submit_poll_fd` (POLL_ADD on uring,
+    /// `poll(2)` on the thread pool) but the `PendingOp::ChanSelectPark`
+    /// retains the guard so its Drop closes the fd and deregisters from
+    /// every `WakeList` exactly once.
+    fn submit_chan_select_park(
+        &self,
+        guard: crate::primitives::chan::ChanSelectGuard,
+        timeout: Option<Duration>,
+    ) -> Result<u64, String> {
+        let fd = guard.poll_fd();
+        let events = libc::POLLIN as u32;
+
+        let mut inner = self.inner.borrow_mut();
+        let id = inner.next_id;
+        inner.next_id += 1;
+        let buf_handle = inner.buffer_pool.alloc(0);
+
+        let AsyncBackendInner {
+            ref mut platform,
+            ref mut network_pool,
+            ref mut pending,
+            ..
+        } = *inner;
+
+        match platform {
+            #[cfg(target_os = "linux")]
+            PlatformBackend::Uring(ring) => {
+                crate::io::uring::submit_uring_poll_add(ring, id, fd, events, timeout)?;
+            }
+            PlatformBackend::ThreadPool(_) => {
+                let timeout_ms = timeout.map(|d| d.as_millis() as i32).unwrap_or(-1);
+                network_pool.submit(
+                    id,
+                    PoolOp::PollFd {
+                        fd,
+                        events,
+                        timeout_ms,
+                    },
+                )?;
+            }
+        }
+
+        pending.insert(
+            id,
+            PendingOp::ChanSelectPark {
+                buffer_handle: buf_handle,
+                guard,
+            },
+        );
+        Ok(id)
+    }
+
     /// Submit a PollFd operation — wait for a raw fd to become ready.
     fn submit_poll_fd(
         &self,
@@ -842,7 +908,7 @@ impl AsyncBackend {
         match platform {
             #[cfg(target_os = "linux")]
             PlatformBackend::Uring(ring) => {
-                crate::io::uring::submit_uring_poll_add(ring, id, fd, events)?;
+                crate::io::uring::submit_uring_poll_add(ring, id, fd, events, timeout)?;
             }
             PlatformBackend::ThreadPool(_) => {
                 let timeout_ms = timeout.map(|d| d.as_millis() as i32).unwrap_or(-1);
@@ -1653,7 +1719,10 @@ impl AsyncBackendInner {
             | IoOp::WatchNext
             | IoOp::SigNext
             | IoOp::Close
-            | IoOp::PollFd { .. } => return Err("io/submit: unsupported operation on stdin".into()),
+            | IoOp::PollFd { .. }
+            | IoOp::ChanSelectPark(_) => {
+                return Err("io/submit: unsupported operation on stdin".into())
+            }
         };
         stdin_thread.submit(id, op_kind)?;
         // No buffer needed for stdin (thread manages its own)

--- a/src/io/completion.rs
+++ b/src/io/completion.rs
@@ -338,6 +338,20 @@ pub(super) fn process_raw_completion(
                 result: Ok(Value::int(result_code as i64)),
             }
         }
+        PendingOp::ChanSelectPark { .. } => {
+            // The guard inside this PendingOp owns the fd(s) and the
+            // wake-list registrations; its Drop runs when the caller
+            // removes this PendingOp from the pending map after we
+            // return.  We don't care which path fired (POLLIN, timeout,
+            // or cancellation) — the wrapper distinguishes "got a
+            // value" from "timed out" via chan/try-select + its own
+            // deadline tracking.  Returning nil keeps the protocol
+            // stateless.
+            Completion {
+                id,
+                result: Ok(Value::NIL),
+            }
+        }
         PendingOp::Resolve { .. } => {
             if result_code < 0 {
                 let msg = if data.is_empty() {
@@ -609,6 +623,11 @@ pub(super) fn process_raw_completion(
                 }
                 IoOp::PollFd { .. } => {
                     unreachable!("PollFd is portless; cannot reach PendingOp::Port")
+                }
+                IoOp::ChanSelectPark(_) => {
+                    unreachable!(
+                        "ChanSelectPark uses PendingOp::ChanSelectPark, not PendingOp::Port"
+                    )
                 }
                 // Close completion: port already closed in submit. Return nil.
                 IoOp::Close => Value::NIL,

--- a/src/io/mock.rs
+++ b/src/io/mock.rs
@@ -128,6 +128,7 @@ impl crate::io::IoBackend for MockBackend {
             IoOp::SigNext => "sig-next",
             IoOp::Close => "close",
             IoOp::PollFd { .. } => "poll-fd",
+            IoOp::ChanSelectPark(_) => "chan-select-park",
         };
         inner.log.push(op_name.to_string());
 
@@ -209,6 +210,9 @@ impl crate::io::IoBackend for MockBackend {
                 IoOp::WatchNext => Err(error_val("io-error", "mock: watch not supported")),
                 IoOp::SigNext => Err(error_val("io-error", "mock: sig-next not supported")),
                 IoOp::PollFd { .. } => Err(error_val("io-error", "mock: poll-fd not supported")),
+                IoOp::ChanSelectPark(_) => {
+                    Err(error_val("io-error", "mock: chan/wait-ready not supported"))
+                }
                 // Close completes synchronously in submit
                 IoOp::Close => Ok(Value::NIL),
             }

--- a/src/io/pending.rs
+++ b/src/io/pending.rs
@@ -71,6 +71,15 @@ pub(crate) enum PendingOp {
     },
     /// Poll a raw fd for readiness. Portless.
     PollFd { buffer_handle: BufferHandle },
+    /// Park a `chan/wait-ready` selector on its wake fd.  Portless.
+    /// The guard owns the wake fd(s) and the wake-list registrations;
+    /// dropping this PendingOp (completion, cancellation, or backend
+    /// teardown) closes the fd(s) and deregisters automatically.
+    ChanSelectPark {
+        buffer_handle: BufferHandle,
+        #[allow(dead_code)] // kept alive for its Drop side effect
+        guard: crate::primitives::chan::ChanSelectGuard,
+    },
 }
 
 impl PendingOp {
@@ -86,6 +95,7 @@ impl PendingOp {
             PendingOp::WatchNext { buffer_handle, .. } => *buffer_handle,
             PendingOp::SigNext { buffer_handle, .. } => *buffer_handle,
             PendingOp::PollFd { buffer_handle, .. } => *buffer_handle,
+            PendingOp::ChanSelectPark { buffer_handle, .. } => *buffer_handle,
         }
     }
 
@@ -101,6 +111,7 @@ impl PendingOp {
             PendingOp::WatchNext { buffer_handle, .. } => buffer_handle,
             PendingOp::SigNext { buffer_handle, .. } => buffer_handle,
             PendingOp::PollFd { buffer_handle, .. } => buffer_handle,
+            PendingOp::ChanSelectPark { buffer_handle, .. } => buffer_handle,
         }
     }
 }

--- a/src/io/request.rs
+++ b/src/io/request.rs
@@ -251,6 +251,13 @@ pub enum IoOp {
         fd: std::os::unix::io::RawFd,
         events: u32,
     },
+    /// Park a fiber on a `chan/wait-ready` wake fd until any sender
+    /// signals it or `timeout` (carried in `IoRequest.timeout`) elapses.
+    /// Portless.  The guard owns the eventfd / pipe2 fds and the Arc
+    /// clones of each receiver's `WakeList`; its Drop deregisters and
+    /// closes when the op completes, is cancelled, or never makes it
+    /// past submit.
+    ChanSelectPark(crate::primitives::chan::ChanSelectGuardCell),
 }
 
 /// Socket options for connect operations.

--- a/src/io/uring.rs
+++ b/src/io/uring.rs
@@ -483,22 +483,47 @@ pub(super) fn submit_uring_sleep(
 /// Submit IORING_OP_POLL_ADD to wait for a raw fd to become ready.
 ///
 /// The CQE result contains the revents mask (which events are ready).
-/// Used by `ev/poll-fd` for waiting on display connections, eventfds, etc.
+/// Used by `ev/poll-fd` for waiting on display connections, eventfds, etc.,
+/// and by `chan/wait-ready` to park on a chan-select wake fd.
+///
+/// `timeout` plumbs through as a linked LinkTimeout SQE (same pattern
+/// as Accept/Connect): when the timeout fires first, the kernel
+/// cancels the poll and the CQE returns `-ECANCELED` (errno 125),
+/// which downstream completion handlers map to a timeout result.
 pub(super) fn submit_uring_poll_add(
     ring: &mut io_uring::IoUring,
     id: u64,
     fd: std::os::unix::io::RawFd,
     events: u32,
+    timeout: Option<Duration>,
 ) -> Result<(), String> {
     use io_uring::opcode;
 
-    let sqe = opcode::PollAdd::new(io_uring::types::Fd(fd), events)
+    let poll_sqe = opcode::PollAdd::new(io_uring::types::Fd(fd), events)
         .build()
         .user_data(id);
+    let poll_sqe = if timeout.is_some() {
+        poll_sqe.flags(io_uring::squeue::Flags::IO_LINK)
+    } else {
+        poll_sqe
+    };
     unsafe {
         ring.submission()
-            .push(&sqe)
+            .push(&poll_sqe)
             .map_err(|_| "io/submit: io_uring submission queue full".to_string())?;
+    }
+    if let Some(dur) = timeout {
+        let ts = io_uring::types::Timespec::new()
+            .sec(dur.as_secs())
+            .nsec(dur.subsec_nanos());
+        let timeout_sqe = opcode::LinkTimeout::new(&ts)
+            .build()
+            .user_data(id | TIMEOUT_USER_DATA_TAG);
+        unsafe {
+            ring.submission()
+                .push(&timeout_sqe)
+                .map_err(|_| "io/submit: io_uring submission queue full".to_string())?;
+        }
     }
     ring.submit()
         .map_err(|e| format!("io/submit: io_uring submit failed: {}", e))?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,7 +37,8 @@ fn print_help() {
     println!("  --trace=KW[,KW,...]   Trace subsystems. Keywords:");
     println!("                          call, signal, compile, fiber, hir, lir,");
     println!("                          emit, jit, io, gc, import, macro, wasm,");
-    println!("                          capture, arena, escape, bytecode, posix");
+    println!("                          capture, arena, escape, bytecode, posix,");
+    println!("                          chan");
     println!("  --trace=all           Trace everything");
     println!("  --checked-intrinsics  Route %-intrinsics through type-checked NativeFn");
     println!("                          (implies --jit=off --mlir=off)");

--- a/src/primitives/AGENTS.md
+++ b/src/primitives/AGENTS.md
@@ -107,7 +107,7 @@ pub fn register_arithmetic(meta: &mut PrimitiveMeta, symbols: &mut SymbolTable) 
 | `types.rs` | `nil?`, `pair?`, `list?`, `number?`, `integer?`, `float?`, `string?`, `boolean?`, `symbol?`, `keyword?`, `array?`, `struct?`, `bytes?`, `mutable?`, `type-of` |
 | `cell.rs` | `box`, `unbox`, `rebox`, `box?` |
 | `concurrency.rs` | `spawn`, `join`, `current-thread-id` |
-| `chan.rs` | `chan/new`, `chan/send`, `chan/recv`, `chan/clone`, `chan/close`, `chan/close-recv`, `chan/select` |
+| `chan.rs` | `chan/new`, `chan/send`, `chan/recv`, `chan/clone`, `chan/close`, `chan/close-recv`, `chan/try-select`, `chan/wait-ready` (see "Channel select wake protocol" below for the `chan/select` Lisp wrapper) |
 | `fibers.rs` | `fiber/new`, `fiber/resume`, `emit`, `fiber/status`, `fiber/value` |
 | `fiber_introspect.rs` | `fiber/bits`, `fiber/mask`, `fiber/parent`, `fiber/child`, `fiber/propagate`, `fiber/cancel`, `fiber?` |
 | `parameters.rs` | `make-parameter`, `parameter?` |
@@ -469,6 +469,58 @@ converts them to `:error` with kind `"signal-violation"`.
 3. **Line and col are integers.** `:line` is the 1-based line number; `:col` is the 0-based column offset within the line.
 4. **Result is an immutable struct.** The returned value is a `{...}` struct, not a mutable `@{...}`.
 
+## Channel select wake protocol
+
+**Location:** `src/primitives/chan.rs`, with the public wrapper in `stdlib.lisp`.
+
+`chan/select` cannot use crossbeam's blocking `Select::select_timeout`: that
+parks the OS thread the fiber scheduler runs on, starving any `ev/spawn`'d
+producer fiber that would have unblocked the select. Instead the chan
+primitives carry a per-channel waker layer on top of crossbeam:
+
+- Each channel's sender and receiver halves share an `Arc<WakeList>`
+  containing `(Mutex<Vec<RawFd>>, AtomicBool)`. The atomic is a fast-path
+  skip: if no fiber is selecting, `chan/send` does not even acquire the
+  mutex.
+- `chan/wait-ready` allocates a wake fd (`eventfd(2)` on Linux, `pipe2(2)`
+  on other Unix) and registers `poll_fd` in every candidate receiver's
+  `WakeList`. The fd is owned by a `ChanSelectGuard`; its `Drop`
+  deregisters, signals `wake_fd` (so any worker thread parked in
+  `poll(2)` returns before we close the fd), and closes the fd(s).
+- `chan/send` (and `chan/close{,recv}`), after a successful `try_send`,
+  loads the atomic; if non-zero, locks and `write(fd, &1u64)` to every
+  registered wake fd. Cross-thread sends from `sys/spawn` Just Work —
+  the write is thread-safe and the scheduler thread observes POLLIN via
+  the same `IORING_OP_POLL_ADD` (or thread-pool `poll(2)`) it uses for
+  `ev/poll-fd`.
+
+Three primitives back the Lisp `chan/select`:
+
+- `chan/try-select rxs` — non-blocking `Select::try_select`. Returns
+  `[i v]`, `[:empty]`, or `[:disconnected]`. Errors if any receiver was
+  explicitly closed via `chan/close-recv`.
+- `chan/wait-ready rxs &opt timeout-ms` — yielding park. Allocates the
+  wake fd, registers, does a post-register `try_select` to close the
+  cross-thread race between the wrapper's first `chan/try-select` and
+  the register. Returns `[:ready i v]` (post-register fast hit, no
+  yield), `[:disconnected]`, or yields `SIG_YIELD|SIG_IO` carrying an
+  `IoOp::ChanSelectPark(ChanSelectGuardCell)`. The IoRequest's timeout
+  flows through to a linked `LinkTimeout` SQE on uring or to the
+  thread-pool `poll(2)` timeout.
+- `chan/select` (Lisp wrapper in `stdlib.lisp`) — runs `chan/try-select`
+  for the fast path, then loops: compute the remaining deadline,
+  short-circuit if exhausted, call `chan/wait-ready`, match its result
+  (`:ready` → return `[i v]`; `:disconnected` → return `[:disconnected]`;
+  nil → `chan/try-select` and re-park on `:empty`).
+
+Cancellation: if the fiber is aborted while parked, the scheduler
+removes the `PendingOp::ChanSelectPark` entry, which drops the guard,
+which closes the fd and deregisters. No leak.
+
+The same plumbing made `submit_uring_poll_add` accept an
+`Option<Duration>` (linked `LinkTimeout` SQE) — `ev/poll-fd`'s timeout
+was previously dropped on uring; that path now honors it.
+
 ## Stream Primitive Timeout Support
 
 **Location:** `src/primitives/stream.rs`
@@ -497,7 +549,7 @@ Arity changed from `Exact(N)` to `AtLeast(N)` to allow keyword args. Timeout is 
 | `loading.rs` | ~330 | FFI library loading, symbol lookup, signatures, callbacks |
 | `calling.rs` | ~95 | FFI function call dispatch |
 | `memory.rs` | ~530 | FFI memory management, typed access, type construction |
-| `chan.rs` | varies | `chan/new`, `chan/send`, `chan/recv`, `chan/clone`, `chan/close`, `chan/close-recv`, `chan/select` |
+| `chan.rs` | varies | `chan/new`, `chan/send`, `chan/recv`, `chan/clone`, `chan/close`, `chan/close-recv`, `chan/try-select`, `chan/wait-ready` |
 | `format.rs` | ~525 | `string/format` entry point, template parsing, value formatting, mode dispatch |
 | `formatspec.rs` | ~202 | `FormatSpec` type, `Align`, `FormatType`, `parse_format_spec`, `spec_type_char` |
 | `net.rs` | ~683 | TCP and UDP primitives, shared helpers, PRIMITIVES array, tests |

--- a/src/primitives/chan.rs
+++ b/src/primitives/chan.rs
@@ -47,12 +47,29 @@ pub struct WakeList {
     nonempty: AtomicBool,
 }
 
-/// Helper: trace registers/wakes/deregisters to stderr when
-/// `ELLE_CHAN_TRACE` is set in the environment.  Cheap when disabled
-/// (one `getenv` per event; on hot paths the fast-path skip in
-/// `wake_all` runs before any tracing).
+/// Trace channel wake events (register / deregister / wake_all /
+/// write / close) to stderr when `--trace=chan` is set.  Gated on the
+/// process-global trace bits so threadpool worker threads and other
+/// off-VM sites (which have no `&VM` reference) gate cheaply.
+///
+/// Mirrors `posix_trace` in `io::sigfd`: direct `write(2, …)` syscall
+/// to bypass Rust stdio buffering, so trace lines survive even when
+/// the process is about to be killed by an outer timeout.
 fn chan_trace_enabled() -> bool {
-    std::env::var_os("ELLE_CHAN_TRACE").is_some()
+    crate::config::global_trace_bit_enabled(crate::config::trace_bits::CHAN)
+}
+
+#[inline]
+fn chan_trace(args: std::fmt::Arguments<'_>) {
+    if !chan_trace_enabled() {
+        return;
+    }
+    let line = format!("[trace:chan] {}\n", args);
+    // SAFETY: writing to fd 2 (stderr) is always valid; failures are
+    // benign (trace lines are diagnostic, not load-bearing).
+    unsafe {
+        libc::write(2, line.as_ptr() as *const libc::c_void, line.len());
+    }
 }
 
 impl WakeList {
@@ -70,13 +87,11 @@ impl WakeList {
         let mut fds = self.wake_fds.lock().expect("WakeList lock poisoned");
         fds.push(wake_fd);
         self.nonempty.store(true, Ordering::Release);
-        if chan_trace_enabled() {
-            eprintln!(
-                "chan/wake: register fd={} (wake-list len now {})",
-                wake_fd,
-                fds.len()
-            );
-        }
+        chan_trace(format_args!(
+            "register fd={} (wake-list len now {})",
+            wake_fd,
+            fds.len()
+        ));
     }
 
     fn deregister(&self, wake_fd: RawFd) {
@@ -87,14 +102,12 @@ impl WakeList {
         if fds.is_empty() {
             self.nonempty.store(false, Ordering::Release);
         }
-        if chan_trace_enabled() {
-            eprintln!(
-                "chan/wake: deregister fd={} ({}→{} entries)",
-                wake_fd,
-                before,
-                fds.len()
-            );
-        }
+        chan_trace(format_args!(
+            "deregister fd={} ({}→{} entries)",
+            wake_fd,
+            before,
+            fds.len()
+        ));
     }
 
     /// Signal every registered wake fd.  Called after a successful
@@ -106,9 +119,7 @@ impl WakeList {
             return;
         }
         let fds = self.wake_fds.lock().expect("WakeList lock poisoned");
-        if chan_trace_enabled() {
-            eprintln!("chan/wake: wake_all signaling {} fd(s)", fds.len());
-        }
+        chan_trace(format_args!("wake_all signaling {} fd(s)", fds.len()));
         for &fd in fds.iter() {
             wake_fd_signal(fd);
         }
@@ -140,10 +151,10 @@ fn wake_fd_signal(fd: RawFd) {
         } else {
             0
         };
-        eprintln!(
-            "chan/wake: write(eventfd={}, 1) -> {} errno={}",
+        chan_trace(format_args!(
+            "write(eventfd={}, 1) -> {} errno={}",
             fd, ret, err
-        );
+        ));
     }
 }
 
@@ -160,7 +171,10 @@ fn wake_fd_signal(fd: RawFd) {
         } else {
             0
         };
-        eprintln!("chan/wake: write(pipe={}, 1) -> {} errno={}", fd, ret, err);
+        chan_trace(format_args!(
+            "write(pipe={}, 1) -> {} errno={}",
+            fd, ret, err
+        ));
     }
 }
 
@@ -177,9 +191,7 @@ fn make_wake_fd() -> std::io::Result<(RawFd, RawFd)> {
     if fd < 0 {
         return Err(std::io::Error::last_os_error());
     }
-    if chan_trace_enabled() {
-        eprintln!("chan/wake: alloc eventfd={}", fd);
-    }
+    chan_trace(format_args!("alloc eventfd={}", fd));
     Ok((fd, fd))
 }
 
@@ -219,12 +231,10 @@ fn make_wake_fd() -> std::io::Result<(RawFd, RawFd)> {
             }
         }
     }
-    if chan_trace_enabled() {
-        eprintln!(
-            "chan/wake: alloc pipe poll_fd(read)={} wake_fd(write)={}",
-            read_fd, write_fd
-        );
-    }
+    chan_trace(format_args!(
+        "alloc pipe poll_fd(read)={} wake_fd(write)={}",
+        read_fd, write_fd
+    ));
     Ok((read_fd, write_fd))
 }
 
@@ -269,12 +279,10 @@ impl Drop for ChanSelectGuard {
         // the fd — critical on the thread-pool backend where a worker
         // may still be in libc::poll(2).
         wake_fd_signal(self.wake_fd);
-        if chan_trace_enabled() {
-            eprintln!(
-                "chan/wake: close poll_fd={} wake_fd={}",
-                self.poll_fd, self.wake_fd
-            );
-        }
+        chan_trace(format_args!(
+            "close poll_fd={} wake_fd={}",
+            self.poll_fd, self.wake_fd
+        ));
         // SAFETY: we own both fds; closing twice (same value on Linux)
         // is guarded by a wake_fd == poll_fd check.
         unsafe {

--- a/src/primitives/chan.rs
+++ b/src/primitives/chan.rs
@@ -33,44 +33,82 @@ use crate::value::{error_val, Value};
 
 /// Shared wake state between a channel's sender and receiver halves.
 ///
-/// Stores the eventfds of any fibers currently parked in `chan/select` on
-/// this channel.  `chan/send` writes a wake byte to each one after a
-/// successful `try_send`; `nonempty` is an atomic fast-path so the common
-/// case (nobody is selecting) takes no lock.
+/// Stores the **write-side** fds of any fibers currently parked in
+/// `chan/select` on this channel.  On Linux these are eventfds (poll
+/// and wake share one fd); on other Unix these are the write ends of
+/// the per-park pipe2 — confusing the two breaks the wake protocol on
+/// macOS (the producer would `write(2)` to a pipe's read end).
+/// `chan/send` writes a wake byte to each registered fd after a
+/// successful `try_send`; `nonempty` is an atomic fast-path so the
+/// common case (nobody is selecting) takes no lock.
 pub struct WakeList {
-    fds: Mutex<Vec<RawFd>>,
+    /// Write-side fds.  Iterated under `fds` lock from `wake_all`.
+    wake_fds: Mutex<Vec<RawFd>>,
     nonempty: AtomicBool,
+}
+
+/// Helper: trace registers/wakes/deregisters to stderr when
+/// `ELLE_CHAN_TRACE` is set in the environment.  Cheap when disabled
+/// (one `getenv` per event; on hot paths the fast-path skip in
+/// `wake_all` runs before any tracing).
+fn chan_trace_enabled() -> bool {
+    std::env::var_os("ELLE_CHAN_TRACE").is_some()
 }
 
 impl WakeList {
     pub fn new() -> Arc<Self> {
         Arc::new(WakeList {
-            fds: Mutex::new(Vec::new()),
+            wake_fds: Mutex::new(Vec::new()),
             nonempty: AtomicBool::new(false),
         })
     }
 
-    fn register(&self, fd: RawFd) {
-        let mut fds = self.fds.lock().expect("WakeList lock poisoned");
-        fds.push(fd);
+    /// Register a wake fd (the write side of the per-park wake pair —
+    /// same as the poll fd only on Linux).
+    fn register(&self, wake_fd: RawFd) {
+        debug_assert!(wake_fd >= 0, "WakeList::register: invalid fd {}", wake_fd);
+        let mut fds = self.wake_fds.lock().expect("WakeList lock poisoned");
+        fds.push(wake_fd);
         self.nonempty.store(true, Ordering::Release);
-    }
-
-    fn deregister(&self, fd: RawFd) {
-        let mut fds = self.fds.lock().expect("WakeList lock poisoned");
-        fds.retain(|&f| f != fd);
-        if fds.is_empty() {
-            self.nonempty.store(false, Ordering::Release);
+        if chan_trace_enabled() {
+            eprintln!(
+                "chan/wake: register fd={} (wake-list len now {})",
+                wake_fd,
+                fds.len()
+            );
         }
     }
 
-    /// Signal every registered eventfd. Called after a successful send (or
-    /// a sender/receiver close) so parked selectors re-evaluate.
+    fn deregister(&self, wake_fd: RawFd) {
+        debug_assert!(wake_fd >= 0, "WakeList::deregister: invalid fd {}", wake_fd);
+        let mut fds = self.wake_fds.lock().expect("WakeList lock poisoned");
+        let before = fds.len();
+        fds.retain(|&f| f != wake_fd);
+        if fds.is_empty() {
+            self.nonempty.store(false, Ordering::Release);
+        }
+        if chan_trace_enabled() {
+            eprintln!(
+                "chan/wake: deregister fd={} ({}→{} entries)",
+                wake_fd,
+                before,
+                fds.len()
+            );
+        }
+    }
+
+    /// Signal every registered wake fd.  Called after a successful
+    /// send (or a sender/receiver close) so parked selectors
+    /// re-evaluate.  Skipped via the `nonempty` atomic when no one is
+    /// selecting on this channel.
     fn wake_all(&self) {
         if !self.nonempty.load(Ordering::Acquire) {
             return;
         }
-        let fds = self.fds.lock().expect("WakeList lock poisoned");
+        let fds = self.wake_fds.lock().expect("WakeList lock poisoned");
+        if chan_trace_enabled() {
+            eprintln!("chan/wake: wake_all signaling {} fd(s)", fds.len());
+        }
         for &fd in fds.iter() {
             wake_fd_signal(fd);
         }
@@ -79,65 +117,115 @@ impl WakeList {
 
 /// Write a wake byte to a `WakeList` fd.  On Linux the fd is an eventfd
 /// (8-byte counter write); on other Unix the fd is the write end of a
-/// pipe2 (single-byte write).  Either way the matching poll on the
+/// pipe (single-byte write).  Either way the matching poll on the
 /// scheduler thread observes POLLIN and resumes the parked fiber.
 #[cfg(target_os = "linux")]
 fn wake_fd_signal(fd: RawFd) {
+    debug_assert!(fd >= 0, "wake_fd_signal: invalid fd {}", fd);
     let one: u64 = 1;
     // SAFETY: writing 8 bytes to an eventfd is always valid; failures
     // (EAGAIN if counter would overflow, EBADF on already-closed) are
     // benign for the wake protocol — a parked poll either already
     // observed POLLIN or no longer cares.
-    unsafe {
+    let ret = unsafe {
         libc::write(
             fd,
             &one as *const u64 as *const libc::c_void,
             std::mem::size_of::<u64>(),
+        )
+    };
+    if chan_trace_enabled() {
+        let err = if ret < 0 {
+            std::io::Error::last_os_error().raw_os_error().unwrap_or(0)
+        } else {
+            0
+        };
+        eprintln!(
+            "chan/wake: write(eventfd={}, 1) -> {} errno={}",
+            fd, ret, err
         );
     }
 }
 
 #[cfg(not(target_os = "linux"))]
 fn wake_fd_signal(fd: RawFd) {
+    debug_assert!(fd >= 0, "wake_fd_signal: invalid fd {}", fd);
     let one: u8 = 1;
-    // SAFETY: a single-byte write to a pipe2 fd is always valid;
+    // SAFETY: a single-byte write to a pipe fd is always valid;
     // failures are benign — see Linux variant.
-    unsafe {
-        libc::write(fd, &one as *const u8 as *const libc::c_void, 1);
+    let ret = unsafe { libc::write(fd, &one as *const u8 as *const libc::c_void, 1) };
+    if chan_trace_enabled() {
+        let err = if ret < 0 {
+            std::io::Error::last_os_error().raw_os_error().unwrap_or(0)
+        } else {
+            0
+        };
+        eprintln!("chan/wake: write(pipe={}, 1) -> {} errno={}", fd, ret, err);
     }
 }
 
 /// Allocate a wake fd usable for `IoOp::ChanSelectPark`.
 ///
-/// Returns `(poll_fd, wake_fd)`.  On Linux both are the same eventfd; on
-/// other Unix `poll_fd` is the read end and `wake_fd` is the write end of
-/// a pipe2.
+/// Returns `(poll_fd, wake_fd)`.  On Linux both are the same eventfd
+/// (counter semantics); on other Unix `poll_fd` is the read end and
+/// `wake_fd` is the write end of a pipe — they are distinct fds and
+/// senders MUST write to `wake_fd`, not `poll_fd`.  Both ends are set
+/// `O_NONBLOCK | O_CLOEXEC`.
 #[cfg(target_os = "linux")]
 fn make_wake_fd() -> std::io::Result<(RawFd, RawFd)> {
     let fd = unsafe { libc::eventfd(0, libc::EFD_CLOEXEC | libc::EFD_NONBLOCK) };
     if fd < 0 {
-        Err(std::io::Error::last_os_error())
-    } else {
-        Ok((fd, fd))
+        return Err(std::io::Error::last_os_error());
     }
+    if chan_trace_enabled() {
+        eprintln!("chan/wake: alloc eventfd={}", fd);
+    }
+    Ok((fd, fd))
 }
 
 #[cfg(not(target_os = "linux"))]
 fn make_wake_fd() -> std::io::Result<(RawFd, RawFd)> {
-    let mut fds = [0 as RawFd; 2];
+    let mut fds: [libc::c_int; 2] = [-1, -1];
+    // SAFETY: fds is a 2-element c_int array; pipe(2) writes both
+    // entries on success and neither on failure.
     let ret = unsafe { libc::pipe(fds.as_mut_ptr()) };
     if ret < 0 {
         return Err(std::io::Error::last_os_error());
     }
-    for &fd in &fds {
+    let (read_fd, write_fd) = (fds[0] as RawFd, fds[1] as RawFd);
+    assert!(
+        read_fd >= 0 && write_fd >= 0,
+        "make_wake_fd: pipe(2) returned 0 but produced invalid fds {:?}",
+        fds
+    );
+    // Set O_NONBLOCK + FD_CLOEXEC on both ends.  Failure here would
+    // leave us with blocking/inheritable fds, which could deadlock
+    // wake_all if a pipe buffer fills.  Treat as a hard error.
+    for &fd in &[read_fd, write_fd] {
         unsafe {
             let flags = libc::fcntl(fd, libc::F_GETFL);
-            libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK);
+            if flags < 0 || libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK) < 0 {
+                let err = std::io::Error::last_os_error();
+                libc::close(read_fd);
+                libc::close(write_fd);
+                return Err(err);
+            }
             let cflags = libc::fcntl(fd, libc::F_GETFD);
-            libc::fcntl(fd, libc::F_SETFD, cflags | libc::FD_CLOEXEC);
+            if cflags < 0 || libc::fcntl(fd, libc::F_SETFD, cflags | libc::FD_CLOEXEC) < 0 {
+                let err = std::io::Error::last_os_error();
+                libc::close(read_fd);
+                libc::close(write_fd);
+                return Err(err);
+            }
         }
     }
-    Ok((fds[0], fds[1]))
+    if chan_trace_enabled() {
+        eprintln!(
+            "chan/wake: alloc pipe poll_fd(read)={} wake_fd(write)={}",
+            read_fd, write_fd
+        );
+    }
+    Ok((read_fd, write_fd))
 }
 
 /// RAII guard for one parked `chan/select`.
@@ -162,12 +250,30 @@ impl ChanSelectGuard {
 
 impl Drop for ChanSelectGuard {
     fn drop(&mut self) {
-        // Wake any in-flight poll first so it returns before we close
+        debug_assert!(
+            self.poll_fd >= 0 && self.wake_fd >= 0,
+            "ChanSelectGuard::drop: invalid fds poll={} wake={}",
+            self.poll_fd,
+            self.wake_fd
+        );
+        // Deregister our wake fd from every receiver's WakeList first
+        // — once deregistered no new sender will signal this fd.
+        // Senders that loaded a stale fd just before deregister still
+        // race to write to it; the write happens against a fd that
+        // may close at any moment.  Both paths (eventfd / pipe write
+        // to a closed fd) return EBADF which wake_fd_signal swallows.
+        for wl in &self.wake_lists {
+            wl.deregister(self.wake_fd);
+        }
+        // Then wake any in-flight poll so it returns before we close
         // the fd — critical on the thread-pool backend where a worker
         // may still be in libc::poll(2).
         wake_fd_signal(self.wake_fd);
-        for wl in &self.wake_lists {
-            wl.deregister(self.poll_fd);
+        if chan_trace_enabled() {
+            eprintln!(
+                "chan/wake: close poll_fd={} wake_fd={}",
+                self.poll_fd, self.wake_fd
+            );
         }
         // SAFETY: we own both fds; closing twice (same value on Linux)
         // is guarded by a wake_fd == poll_fd check.
@@ -658,14 +764,16 @@ fn prim_chan_wait_ready(args: &[Value]) -> (SignalBits, Value) {
             }
         };
 
-        // Register the poll_fd in every receiver's wake list *before* the
-        // post-register re-check below.  Any send happening from this
-        // moment on writes to our wake fd (which has counter semantics
-        // on Linux's eventfd, byte-buffer semantics on pipe2), so the
-        // upcoming POLL_ADD returns POLLIN immediately even if the kernel
-        // hasn't yet armed the poll when the send fires.
+        // Register the *wake* fd in every receiver's wake list — the
+        // write-side fd (same as poll_fd on Linux's eventfd, distinct
+        // on pipe-based platforms).  Doing this *before* the
+        // post-register re-check below means any send happening from
+        // this moment on writes to our wake fd (counter semantics on
+        // eventfd, byte-buffer semantics on pipe), so the upcoming
+        // POLL_ADD / poll(2) returns POLLIN immediately even if the
+        // kernel hasn't yet armed the poll when the send fires.
         for wl in &wake_lists {
-            wl.register(poll_fd);
+            wl.register(wake_fd);
         }
 
         // Close the cross-thread race window between the wrapper's first

--- a/src/primitives/chan.rs
+++ b/src/primitives/chan.rs
@@ -1,15 +1,211 @@
 //! Channel primitives — crossbeam-channel wrappers for inter-fiber messaging.
+//!
+//! ## Scheduler-aware select
+//!
+//! `chan/select` cannot use crossbeam's blocking `Select::select_timeout`
+//! because that parks the OS thread on which the fiber scheduler runs —
+//! starving any `ev/spawn`'d producer fiber that would have unblocked the
+//! select.  Instead each channel carries a shared `WakeList` of eventfd
+//! file descriptors.  A selecting fiber allocates an eventfd, registers it
+//! in every candidate receiver's `WakeList`, and yields with
+//! `IoOp::ChanSelectPark` — the scheduler waits on the eventfd via
+//! `IORING_OP_POLL_ADD` (or `poll(2)` on the thread-pool backend), exactly
+//! like `ev/poll-fd`.  `chan/send`, after a successful `try_send`, signals
+//! every registered eventfd so any parked selector wakes and re-tries.
+//! Cross-thread `chan/send` (from `sys/spawn`) wakes the scheduler thread
+//! the same way — `write(eventfd, 1)` is thread-safe and the kernel poll
+//! notices it.
 
 use std::cell::RefCell;
+use std::os::unix::io::RawFd;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use crossbeam_channel::{self, TryRecvError, TrySendError};
 
+use crate::io::request::{IoOp, IoRequest};
 use crate::primitives::def::PrimitiveDef;
 use crate::signals::Signal;
-use crate::value::fiber::{SignalBits, SIG_ERROR, SIG_OK};
+use crate::value::fiber::{SignalBits, SIG_ERROR, SIG_IO, SIG_OK, SIG_YIELD};
 use crate::value::types::Arity;
 use crate::value::{error_val, Value};
+
+/// Shared wake state between a channel's sender and receiver halves.
+///
+/// Stores the eventfds of any fibers currently parked in `chan/select` on
+/// this channel.  `chan/send` writes a wake byte to each one after a
+/// successful `try_send`; `nonempty` is an atomic fast-path so the common
+/// case (nobody is selecting) takes no lock.
+pub struct WakeList {
+    fds: Mutex<Vec<RawFd>>,
+    nonempty: AtomicBool,
+}
+
+impl WakeList {
+    pub fn new() -> Arc<Self> {
+        Arc::new(WakeList {
+            fds: Mutex::new(Vec::new()),
+            nonempty: AtomicBool::new(false),
+        })
+    }
+
+    fn register(&self, fd: RawFd) {
+        let mut fds = self.fds.lock().expect("WakeList lock poisoned");
+        fds.push(fd);
+        self.nonempty.store(true, Ordering::Release);
+    }
+
+    fn deregister(&self, fd: RawFd) {
+        let mut fds = self.fds.lock().expect("WakeList lock poisoned");
+        fds.retain(|&f| f != fd);
+        if fds.is_empty() {
+            self.nonempty.store(false, Ordering::Release);
+        }
+    }
+
+    /// Signal every registered eventfd. Called after a successful send (or
+    /// a sender/receiver close) so parked selectors re-evaluate.
+    fn wake_all(&self) {
+        if !self.nonempty.load(Ordering::Acquire) {
+            return;
+        }
+        let fds = self.fds.lock().expect("WakeList lock poisoned");
+        for &fd in fds.iter() {
+            wake_fd_signal(fd);
+        }
+    }
+}
+
+/// Write a wake byte to a `WakeList` fd.  On Linux the fd is an eventfd
+/// (8-byte counter write); on other Unix the fd is the write end of a
+/// pipe2 (single-byte write).  Either way the matching poll on the
+/// scheduler thread observes POLLIN and resumes the parked fiber.
+#[cfg(target_os = "linux")]
+fn wake_fd_signal(fd: RawFd) {
+    let one: u64 = 1;
+    // SAFETY: writing 8 bytes to an eventfd is always valid; failures
+    // (EAGAIN if counter would overflow, EBADF on already-closed) are
+    // benign for the wake protocol — a parked poll either already
+    // observed POLLIN or no longer cares.
+    unsafe {
+        libc::write(
+            fd,
+            &one as *const u64 as *const libc::c_void,
+            std::mem::size_of::<u64>(),
+        );
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+fn wake_fd_signal(fd: RawFd) {
+    let one: u8 = 1;
+    // SAFETY: a single-byte write to a pipe2 fd is always valid;
+    // failures are benign — see Linux variant.
+    unsafe {
+        libc::write(fd, &one as *const u8 as *const libc::c_void, 1);
+    }
+}
+
+/// Allocate a wake fd usable for `IoOp::ChanSelectPark`.
+///
+/// Returns `(poll_fd, wake_fd)`.  On Linux both are the same eventfd; on
+/// other Unix `poll_fd` is the read end and `wake_fd` is the write end of
+/// a pipe2.
+#[cfg(target_os = "linux")]
+fn make_wake_fd() -> std::io::Result<(RawFd, RawFd)> {
+    let fd = unsafe { libc::eventfd(0, libc::EFD_CLOEXEC | libc::EFD_NONBLOCK) };
+    if fd < 0 {
+        Err(std::io::Error::last_os_error())
+    } else {
+        Ok((fd, fd))
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+fn make_wake_fd() -> std::io::Result<(RawFd, RawFd)> {
+    let mut fds = [0 as RawFd; 2];
+    let ret = unsafe { libc::pipe(fds.as_mut_ptr()) };
+    if ret < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    for &fd in &fds {
+        unsafe {
+            let flags = libc::fcntl(fd, libc::F_GETFL);
+            libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK);
+            let cflags = libc::fcntl(fd, libc::F_GETFD);
+            libc::fcntl(fd, libc::F_SETFD, cflags | libc::FD_CLOEXEC);
+        }
+    }
+    Ok((fds[0], fds[1]))
+}
+
+/// RAII guard for one parked `chan/select`.
+///
+/// Owns the wake-fd pair and a clone of each candidate receiver's
+/// `WakeList`.  Constructed in `chan/wait-ready`, transferred into
+/// `PendingOp::ChanSelectPark`, and dropped exactly once — on completion,
+/// cancellation, or aborted submission.  Drop deregisters from every
+/// wake list and closes the fds.
+pub struct ChanSelectGuard {
+    poll_fd: RawFd,
+    wake_fd: RawFd,
+    wake_lists: Vec<Arc<WakeList>>,
+}
+
+impl ChanSelectGuard {
+    /// The fd the scheduler should poll for POLLIN.
+    pub fn poll_fd(&self) -> RawFd {
+        self.poll_fd
+    }
+}
+
+impl Drop for ChanSelectGuard {
+    fn drop(&mut self) {
+        // Wake any in-flight poll first so it returns before we close
+        // the fd — critical on the thread-pool backend where a worker
+        // may still be in libc::poll(2).
+        wake_fd_signal(self.wake_fd);
+        for wl in &self.wake_lists {
+            wl.deregister(self.poll_fd);
+        }
+        // SAFETY: we own both fds; closing twice (same value on Linux)
+        // is guarded by a wake_fd == poll_fd check.
+        unsafe {
+            libc::close(self.poll_fd);
+            if self.wake_fd != self.poll_fd {
+                libc::close(self.wake_fd);
+            }
+        }
+    }
+}
+
+/// Take-once container for the guard inside `IoOp::ChanSelectPark`.
+///
+/// The submit path takes the guard out and transfers it into the
+/// PendingOp; the IoOp's own drop sees `None` and does nothing.  If the
+/// IoOp is dropped without ever being submitted (e.g. fiber aborted
+/// before the scheduler runs `io/submit`), the guard is still inside the
+/// cell and its Drop reclaims the fds and wake-list slots.
+pub struct ChanSelectGuardCell(RefCell<Option<ChanSelectGuard>>);
+
+impl ChanSelectGuardCell {
+    pub fn new(guard: ChanSelectGuard) -> Self {
+        ChanSelectGuardCell(RefCell::new(Some(guard)))
+    }
+
+    /// Move the guard out, leaving the cell empty.  Returns None if
+    /// already taken (which would indicate a backend bug).
+    pub fn take(&self) -> Option<ChanSelectGuard> {
+        self.0.borrow_mut().take()
+    }
+}
+
+impl std::fmt::Debug for ChanSelectGuardCell {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("ChanSelectGuardCell(..)")
+    }
+}
 
 /// Newtype wrapper to satisfy crossbeam's `Send` requirement.
 ///
@@ -24,35 +220,64 @@ pub(crate) struct SendableValue(Value);
 unsafe impl Send for SendableValue {}
 
 /// Sender half of a channel, wrapped for `Value::external`.
-pub(crate) struct ChanSender(pub(crate) RefCell<Option<crossbeam_channel::Sender<SendableValue>>>);
-
-/// Receiver half of a channel, wrapped for `Value::external`.
-pub(crate) struct ChanReceiver(
-    pub(crate) RefCell<Option<crossbeam_channel::Receiver<SendableValue>>>,
+///
+/// Field 0 is the crossbeam sender (Optional so `chan/close` can drop
+/// it without dropping the whole external).  Field 1 is the shared
+/// `WakeList` — the same Arc lives in this channel's receiver half so
+/// `chan/send` can wake any parked `chan/select`.
+pub(crate) struct ChanSender(
+    pub(crate) RefCell<Option<crossbeam_channel::Sender<SendableValue>>>,
+    pub(crate) Arc<WakeList>,
 );
 
-/// Clone the crossbeam sender from a channel sender Value.
-/// Returns None if the value is not a chan/sender or is already closed.
-pub(crate) fn clone_sender(v: &Value) -> Option<crossbeam_channel::Sender<SendableValue>> {
-    v.as_external::<ChanSender>()
-        .and_then(|cs| cs.0.borrow().as_ref().map(|s| s.clone()))
+/// Receiver half of a channel, wrapped for `Value::external`.
+///
+/// Field 1 is the same shared `WakeList` carried by every matching
+/// sender — see `ChanSender`.
+pub(crate) struct ChanReceiver(
+    pub(crate) RefCell<Option<crossbeam_channel::Receiver<SendableValue>>>,
+    pub(crate) Arc<WakeList>,
+);
+
+/// Clone the crossbeam sender and the shared `WakeList` from a sender
+/// Value.  Returns None if the value is not a `chan/sender` or its
+/// crossbeam half is already closed.
+pub(crate) fn clone_sender(
+    v: &Value,
+) -> Option<(crossbeam_channel::Sender<SendableValue>, Arc<WakeList>)> {
+    let cs = v.as_external::<ChanSender>()?;
+    let tx = cs.0.borrow().as_ref().cloned()?;
+    Some((tx, Arc::clone(&cs.1)))
 }
 
-/// Clone the crossbeam receiver from a channel receiver Value.
-/// Returns None if the value is not a chan/receiver or is already closed.
-pub(crate) fn clone_receiver(v: &Value) -> Option<crossbeam_channel::Receiver<SendableValue>> {
-    v.as_external::<ChanReceiver>()
-        .and_then(|cr| cr.0.borrow().as_ref().map(|r| r.clone()))
+/// Clone the crossbeam receiver and the shared `WakeList` from a
+/// receiver Value.  Returns None if the value is not a `chan/receiver`
+/// or its crossbeam half is already closed.
+pub(crate) fn clone_receiver(
+    v: &Value,
+) -> Option<(crossbeam_channel::Receiver<SendableValue>, Arc<WakeList>)> {
+    let cr = v.as_external::<ChanReceiver>()?;
+    let rx = cr.0.borrow().as_ref().cloned()?;
+    Some((rx, Arc::clone(&cr.1)))
 }
 
-/// Create a chan/sender Value from a raw crossbeam sender.
-pub(crate) fn sender_value(tx: crossbeam_channel::Sender<SendableValue>) -> Value {
-    Value::external("chan/sender", ChanSender(RefCell::new(Some(tx))))
+/// Create a chan/sender Value from a raw crossbeam sender and its
+/// shared `WakeList`.  The `WakeList` must be the same Arc that backs
+/// the matching receiver(s).
+pub(crate) fn sender_value(
+    tx: crossbeam_channel::Sender<SendableValue>,
+    wake: Arc<WakeList>,
+) -> Value {
+    Value::external("chan/sender", ChanSender(RefCell::new(Some(tx)), wake))
 }
 
-/// Create a chan/receiver Value from a raw crossbeam receiver.
-pub(crate) fn receiver_value(rx: crossbeam_channel::Receiver<SendableValue>) -> Value {
-    Value::external("chan/receiver", ChanReceiver(RefCell::new(Some(rx))))
+/// Create a chan/receiver Value from a raw crossbeam receiver and its
+/// shared `WakeList`.
+pub(crate) fn receiver_value(
+    rx: crossbeam_channel::Receiver<SendableValue>,
+    wake: Arc<WakeList>,
+) -> Value {
+    Value::external("chan/receiver", ChanReceiver(RefCell::new(Some(rx)), wake))
 }
 
 /// Helper: extract `&ChanSender` from a Value or return a type error.
@@ -95,6 +320,65 @@ fn extract_receiver<'a>(
     })
 }
 
+/// Validate that `arg` is a non-empty array whose every element is a
+/// `chan/receiver` Value, then invoke `f` with a slice of refs to each
+/// underlying `ChanReceiver`.  Errors short-circuit out; otherwise the
+/// closure's result is returned.
+///
+/// Both `chan/try-select` and `chan/wait-ready`'s post-register re-check
+/// need the same validation + receiver-slice prep, but each then
+/// borrows the inner `Option<Receiver>` cells slightly differently
+/// (try-select errors on closed, wait-ready falls through to yield).
+/// Passing a closure keeps the borrow lifetimes self-contained.
+fn with_receivers<R>(
+    arg: &Value,
+    op_name: &str,
+    f: impl FnOnce(&[&ChanReceiver]) -> R,
+) -> Result<R, (SignalBits, Value)> {
+    let cell = arg.as_array_mut().ok_or_else(|| {
+        (
+            SIG_ERROR,
+            error_val(
+                "type-error",
+                format!(
+                    "{}: expected array of receivers, got {}",
+                    op_name,
+                    arg.type_name()
+                ),
+            ),
+        )
+    })?;
+    let vec = cell.borrow();
+    if vec.is_empty() {
+        return Err((
+            SIG_ERROR,
+            error_val(
+                "value-error",
+                format!("{}: receivers array is empty", op_name),
+            ),
+        ));
+    }
+    let mut recvs: Vec<&ChanReceiver> = Vec::with_capacity(vec.len());
+    for (i, val) in vec.iter().enumerate() {
+        let cr = val.as_external::<ChanReceiver>().ok_or_else(|| {
+            (
+                SIG_ERROR,
+                error_val(
+                    "type-error",
+                    format!(
+                        "{}: element {} is not a chan/receiver, got {}",
+                        op_name,
+                        i,
+                        val.external_type_name().unwrap_or(val.type_name())
+                    ),
+                ),
+            )
+        })?;
+        recvs.push(cr);
+    }
+    Ok(f(&recvs))
+}
+
 /// `(chan)` or `(chan capacity)`
 ///
 /// Returns `[sender receiver]` as an array.
@@ -129,8 +413,12 @@ fn prim_chan_new(args: &[Value]) -> (SignalBits, Value) {
         crossbeam_channel::bounded(cap)
     };
 
-    let sender = Value::external("chan/sender", ChanSender(RefCell::new(Some(tx))));
-    let receiver = Value::external("chan/receiver", ChanReceiver(RefCell::new(Some(rx))));
+    let wake = WakeList::new();
+    let sender = Value::external(
+        "chan/sender",
+        ChanSender(RefCell::new(Some(tx)), Arc::clone(&wake)),
+    );
+    let receiver = Value::external("chan/receiver", ChanReceiver(RefCell::new(Some(rx)), wake));
     (SIG_OK, Value::array(vec![sender, receiver]))
 }
 
@@ -149,8 +437,12 @@ fn prim_chan_send(args: &[Value]) -> (SignalBits, Value) {
         None => return (SIG_OK, Value::array(vec![Value::keyword("disconnected")])),
     };
 
-    match tx.try_send(SendableValue(args[1])) {
-        Ok(()) => (SIG_OK, Value::array(vec![Value::keyword("ok")])),
+    let result = tx.try_send(SendableValue(args[1]));
+    match result {
+        Ok(()) => {
+            sender.1.wake_all();
+            (SIG_OK, Value::array(vec![Value::keyword("ok")]))
+        }
         Err(TrySendError::Full(_)) => (SIG_OK, Value::array(vec![Value::keyword("full")])),
         Err(TrySendError::Disconnected(_)) => {
             (SIG_OK, Value::array(vec![Value::keyword("disconnected")]))
@@ -195,7 +487,10 @@ fn prim_chan_clone(args: &[Value]) -> (SignalBits, Value) {
             let cloned = tx.clone();
             (
                 SIG_OK,
-                Value::external("chan/sender", ChanSender(RefCell::new(Some(cloned)))),
+                Value::external(
+                    "chan/sender",
+                    ChanSender(RefCell::new(Some(cloned)), Arc::clone(&sender.1)),
+                ),
             )
         }
         None => (
@@ -208,6 +503,9 @@ fn prim_chan_clone(args: &[Value]) -> (SignalBits, Value) {
 /// `(chan/close sender)` — close the sender half.
 ///
 /// Drops the inner `Sender`, disconnecting the channel from this end.
+/// Wakes any parked `chan/select` so it observes `[:disconnected]` once
+/// every sender clone is gone (crossbeam reports the channel as
+/// disconnected only after the last sender drops).
 fn prim_chan_close(args: &[Value]) -> (SignalBits, Value) {
     let sender = match extract_sender(&args[0], "chan/close") {
         Ok(s) => s,
@@ -215,12 +513,14 @@ fn prim_chan_close(args: &[Value]) -> (SignalBits, Value) {
     };
 
     sender.0.borrow_mut().take();
+    sender.1.wake_all();
     (SIG_OK, Value::NIL)
 }
 
 /// `(chan/close-recv receiver)` — close the receiver half.
 ///
 /// Drops the inner `Receiver`, disconnecting the channel from this end.
+/// Wakes any parked `chan/select` so it observes `[:disconnected]`.
 fn prim_chan_close_recv(args: &[Value]) -> (SignalBits, Value) {
     let receiver = match extract_receiver(&args[0], "chan/close-recv") {
         Ok(r) => r,
@@ -228,91 +528,100 @@ fn prim_chan_close_recv(args: &[Value]) -> (SignalBits, Value) {
     };
 
     receiver.0.borrow_mut().take();
+    receiver.1.wake_all();
     (SIG_OK, Value::NIL)
 }
 
-/// `(chan/select receivers)` or `(chan/select receivers timeout-ms)`
+/// `(chan/try-select receivers)` — non-blocking poll over receivers.
 ///
-/// Blocks until one receiver has a message. Returns `[index msg]`.
-/// With timeout, returns `[:timeout]` if no message arrives in time.
-fn prim_chan_select(args: &[Value]) -> (SignalBits, Value) {
-    // Extract the array of receivers.
-    let receivers_cell = match args[0].as_array_mut() {
-        Some(arr) => arr,
-        None => {
-            return (
-                SIG_ERROR,
-                error_val(
-                    "type-error",
-                    format!(
-                        "chan/select: expected array of receivers, got {}",
-                        args[0].type_name()
-                    ),
-                ),
-            );
-        }
-    };
-
-    let receivers_vec = receivers_cell.borrow();
-    if receivers_vec.is_empty() {
-        return (
-            SIG_ERROR,
-            error_val("value-error", "chan/select: receivers array is empty"),
-        );
-    }
-
-    // Extract the inner crossbeam Receivers.
-    let mut rxs: Vec<&crossbeam_channel::Receiver<SendableValue>> =
-        Vec::with_capacity(receivers_vec.len());
-    // We need to hold the borrows alive while we use the receivers.
-    let mut borrows: Vec<std::cell::Ref<'_, Option<crossbeam_channel::Receiver<SendableValue>>>> =
-        Vec::with_capacity(receivers_vec.len());
-
-    for (i, val) in receivers_vec.iter().enumerate() {
-        let chan_recv = match val.as_external::<ChanReceiver>() {
-            Some(r) => r,
-            None => {
-                return (
-                    SIG_ERROR,
-                    error_val(
-                        "type-error",
-                        format!(
-                            "chan/select: element {} is not a chan/receiver, got {}",
-                            i,
-                            val.external_type_name().unwrap_or(val.type_name())
+/// Returns `[index msg]` if some receiver has a value ready right now,
+/// `[:empty]` if none are ready, or `[:disconnected]` if the ready
+/// receiver was observed disconnected.  Errors if any receiver in the
+/// array is already closed (via `chan/close-recv`).  Never yields and
+/// never blocks — this is the building block the Lisp-level
+/// `chan/select` uses to retry after a `chan/wait-ready` wake.
+fn prim_chan_try_select(args: &[Value]) -> (SignalBits, Value) {
+    match with_receivers(&args[0], "chan/try-select", |recvs| {
+        let borrows: Vec<_> = recvs.iter().map(|r| r.0.borrow()).collect();
+        let mut sel = crossbeam_channel::Select::new();
+        let mut rxs: Vec<&crossbeam_channel::Receiver<SendableValue>> =
+            Vec::with_capacity(borrows.len());
+        for (i, b) in borrows.iter().enumerate() {
+            match b.as_ref() {
+                Some(rx) => {
+                    rxs.push(rx);
+                    sel.recv(rx);
+                }
+                None => {
+                    return (
+                        SIG_ERROR,
+                        error_val(
+                            "state-error",
+                            format!("chan/try-select: receiver at index {} is closed", i),
                         ),
-                    ),
-                );
-            }
-        };
-        borrows.push(chan_recv.0.borrow());
-    }
-
-    for (i, borrow) in borrows.iter().enumerate() {
-        match borrow.as_ref() {
-            Some(rx) => rxs.push(rx),
-            None => {
-                return (
-                    SIG_ERROR,
-                    error_val(
-                        "state-error",
-                        format!("chan/select: receiver at index {} is closed", i),
-                    ),
-                );
+                    );
+                }
             }
         }
+        // Bind so the SelectedOperation temporary is dropped before
+        // `borrows` at the end of the closure scope.
+        let outcome = match sel.try_select() {
+            Ok(oper) => {
+                let index = oper.index();
+                match oper.recv(rxs[index]) {
+                    Ok(SendableValue(v)) => {
+                        (SIG_OK, Value::array(vec![Value::int(index as i64), v]))
+                    }
+                    Err(_) => (SIG_OK, Value::array(vec![Value::keyword("disconnected")])),
+                }
+            }
+            Err(_) => (SIG_OK, Value::array(vec![Value::keyword("empty")])),
+        };
+        outcome
+    }) {
+        Ok(v) => v,
+        Err(e) => e,
     }
+}
 
-    // Optional timeout.
-    let timeout_ms = if args.len() == 2 {
+/// `(chan/wait-ready receivers)` / `(chan/wait-ready receivers timeout-ms)`
+///
+/// Park the current fiber until any receiver in `receivers` is signaled
+/// by a `chan/send` (or sender/receiver close), or until `timeout-ms`
+/// elapses.  Three possible returns:
+///
+/// - `[:ready index msg]` — fast path: after registering the wake fd in
+///   every receiver's `WakeList`, a final `try_select` saw a value
+///   already in the channel.  No yield happened; the caller can use
+///   the returned `index`/`msg` directly without calling
+///   `chan/try-select`.
+/// - `[:disconnected]` — same fast path, but the ready receiver was
+///   disconnected.
+/// - `nil` — the primitive yielded; the fiber was parked on the wake
+///   fd until POLLIN or timeout fired.  Caller must follow up with
+///   `chan/try-select` to actually pick a ready receiver (and re-park
+///   with the remaining timeout if the wake turned out to be spurious;
+///   the Lisp `chan/select` wrapper handles this).
+///
+/// Allocates one wake fd (eventfd on Linux, pipe2 elsewhere) and
+/// registers it in every receiver's `WakeList`.  A successful
+/// `chan/send` on any of those channels writes a wake byte; the
+/// scheduler observes POLLIN via `IORING_OP_POLL_ADD` (or `poll(2)` on
+/// the thread-pool backend) and resumes this fiber.  The
+/// `ChanSelectGuard` carried by the IoRequest deregisters and closes
+/// the fd on completion, cancellation, or aborted submission.
+fn prim_chan_wait_ready(args: &[Value]) -> (SignalBits, Value) {
+    // Parse timeout before any allocation so a bad timeout cleans up
+    // nothing.  nil/missing means wait forever.
+    let timeout = if args.len() == 2 && !args[1].is_nil() {
         match args[1].as_int() {
-            Some(ms) if ms >= 0 => Some(ms as u64),
+            Some(ms) if ms >= 0 => Some(Duration::from_millis(ms as u64)),
             Some(ms) => {
                 return (
                     SIG_ERROR,
                     error_val(
                         "value-error",
-                        format!("chan/select: timeout must be non-negative, got {}", ms),
+                        format!("chan/wait-ready: timeout must be non-negative, got {}", ms),
                     ),
                 );
             }
@@ -322,7 +631,7 @@ fn prim_chan_select(args: &[Value]) -> (SignalBits, Value) {
                     error_val(
                         "type-error",
                         format!(
-                            "chan/select: expected integer for timeout, got {}",
+                            "chan/wait-ready: expected integer for timeout, got {}",
                             args[1].type_name()
                         ),
                     ),
@@ -333,37 +642,103 @@ fn prim_chan_select(args: &[Value]) -> (SignalBits, Value) {
         None
     };
 
-    // Build the Select set.
-    let mut sel = crossbeam_channel::Select::new();
-    for rx in &rxs {
-        sel.recv(rx);
-    }
+    match with_receivers(&args[0], "chan/wait-ready", |recvs| {
+        let wake_lists: Vec<Arc<WakeList>> = recvs.iter().map(|r| Arc::clone(&r.1)).collect();
 
-    // Wait for a message.
-    match timeout_ms {
-        None => {
-            let oper = sel.select();
-            let index = oper.index();
-            match oper.recv(rxs[index]) {
-                Ok(SendableValue(v)) => (SIG_OK, Value::array(vec![Value::int(index as i64), v])),
-                Err(_) => {
-                    // Channel disconnected during select.
-                    (SIG_OK, Value::array(vec![Value::keyword("disconnected")]))
-                }
+        let (poll_fd, wake_fd) = match make_wake_fd() {
+            Ok(pair) => pair,
+            Err(e) => {
+                return (
+                    SIG_ERROR,
+                    error_val(
+                        "io-error",
+                        format!("chan/wait-ready: failed to allocate wake fd: {}", e),
+                    ),
+                );
             }
+        };
+
+        // Register the poll_fd in every receiver's wake list *before* the
+        // post-register re-check below.  Any send happening from this
+        // moment on writes to our wake fd (which has counter semantics
+        // on Linux's eventfd, byte-buffer semantics on pipe2), so the
+        // upcoming POLL_ADD returns POLLIN immediately even if the kernel
+        // hasn't yet armed the poll when the send fires.
+        for wl in &wake_lists {
+            wl.register(poll_fd);
         }
-        Some(ms) => match sel.select_timeout(Duration::from_millis(ms)) {
-            Ok(oper) => {
-                let index = oper.index();
-                match oper.recv(rxs[index]) {
-                    Ok(SendableValue(v)) => {
-                        (SIG_OK, Value::array(vec![Value::int(index as i64), v]))
+
+        // Close the cross-thread race window between the wrapper's first
+        // chan/try-select and this register: a send that snuck in
+        // between (with an empty wake-list and therefore no signal) is
+        // still observed by this re-check.  If we find something
+        // ready, do not yield — extract the value and return [:ready i
+        // v] so the caller can skip its own chan/try-select call.  A
+        // closed receiver here falls through to the yield path; the
+        // wake from chan/close-recv will unblock us promptly and the
+        // wrapper's chan/try-select reports the closure.
+        //
+        // Done inside an inner block so the borrows / Select / rxs all
+        // drop before we either build the guard early (fast return) or
+        // hand it to the yield IoRequest.
+        let recheck: Option<Value> = {
+            let borrows: Vec<_> = recvs.iter().map(|r| r.0.borrow()).collect();
+            let mut sel = crossbeam_channel::Select::new();
+            let mut rxs: Vec<&crossbeam_channel::Receiver<SendableValue>> =
+                Vec::with_capacity(borrows.len());
+            let mut all_open = true;
+            for b in borrows.iter() {
+                match b.as_ref() {
+                    Some(rx) => {
+                        rxs.push(rx);
+                        sel.recv(rx);
                     }
-                    Err(_) => (SIG_OK, Value::array(vec![Value::keyword("disconnected")])),
+                    None => {
+                        all_open = false;
+                        break;
+                    }
                 }
             }
-            Err(_) => (SIG_OK, Value::array(vec![Value::keyword("timeout")])),
-        },
+            if all_open {
+                match sel.try_select() {
+                    Ok(oper) => {
+                        let index = oper.index();
+                        Some(match oper.recv(rxs[index]) {
+                            Ok(SendableValue(v)) => Value::array(vec![
+                                Value::keyword("ready"),
+                                Value::int(index as i64),
+                                v,
+                            ]),
+                            Err(_) => Value::array(vec![Value::keyword("disconnected")]),
+                        })
+                    }
+                    Err(_) => None,
+                }
+            } else {
+                None
+            }
+        };
+
+        if let Some(result) = recheck {
+            let _guard = ChanSelectGuard {
+                poll_fd,
+                wake_fd,
+                wake_lists,
+            };
+            return (SIG_OK, result);
+        }
+
+        let guard = ChanSelectGuard {
+            poll_fd,
+            wake_fd,
+            wake_lists,
+        };
+        let cell = ChanSelectGuardCell::new(guard);
+        let req = IoRequest::with_timeout(IoOp::ChanSelectPark(cell), Value::NIL, timeout);
+        (SIG_YIELD | SIG_IO, req)
+    }) {
+        Ok(v) => v,
+        Err(e) => e,
     }
 }
 
@@ -435,14 +810,28 @@ pub const PRIMITIVES: &[PrimitiveDef] = &[
         aliases: &[],
     },
     PrimitiveDef {
-        name: "chan/select",
-        func: prim_chan_select,
+        name: "chan/try-select",
+        func: prim_chan_try_select,
         signal: Signal::errors(),
+        arity: Arity::Exact(1),
+        doc: "Non-blocking poll over receivers. Returns [index msg], [:empty], or [:disconnected].",
+        params: &["receivers"],
+        category: "chan",
+        example: "(chan/try-select @[r1 r2])",
+        aliases: &[],
+    },
+    PrimitiveDef {
+        name: "chan/wait-ready",
+        func: prim_chan_wait_ready,
+        signal: Signal {
+            bits: SIG_ERROR.union(SIG_YIELD).union(SIG_IO),
+            propagates: 0,
+        },
         arity: Arity::Range(1, 2),
-        doc: "Block until one receiver has a message. Returns [index msg] or [:timeout].",
+        doc: "Park the current fiber until a receiver is ready, a sender closes, or timeout-ms elapses. Returns nil; caller re-checks with chan/try-select.",
         params: &["receivers", "&opt timeout-ms"],
         category: "chan",
-        example: "(chan/select @[r1 r2])",
+        example: "(chan/wait-ready @[r1 r2] 1000)",
         aliases: &[],
     },
 ];

--- a/src/value/send.rs
+++ b/src/value/send.rs
@@ -158,13 +158,21 @@ pub enum SendValue {
     /// Meaningful only within a `SendBundle`; a bare `Ref` without a bundle is invalid.
     Ref(usize),
 
-    /// Cloned crossbeam channel sender (Send + Clone).
+    /// Cloned crossbeam channel sender plus the shared `WakeList` so a
+    /// `chan/send` on the receiving thread can wake any `chan/select`
+    /// parked on the original-thread receiver.
     #[allow(private_interfaces)]
-    ChanSender(crossbeam_channel::Sender<crate::primitives::chan::SendableValue>),
+    ChanSender(
+        crossbeam_channel::Sender<crate::primitives::chan::SendableValue>,
+        std::sync::Arc<crate::primitives::chan::WakeList>,
+    ),
 
-    /// Cloned crossbeam channel receiver (Send + Clone).
+    /// Cloned crossbeam channel receiver plus the shared `WakeList`.
     #[allow(private_interfaces)]
-    ChanReceiver(crossbeam_channel::Receiver<crate::primitives::chan::SendableValue>),
+    ChanReceiver(
+        crossbeam_channel::Receiver<crate::primitives::chan::SendableValue>,
+        std::sync::Arc<crate::primitives::chan::WakeList>,
+    ),
 }
 
 /// Unit of cross-thread value transfer.
@@ -466,10 +474,10 @@ fn from_value_inner(value: Value, ctx: &mut SerContext) -> Result<SendValue, Str
         // External objects: channels are sendable, others are not
         HeapObject::External { obj, .. } => match obj.type_name {
             "chan/sender" => crate::primitives::chan::clone_sender(&value)
-                .map(SendValue::ChanSender)
+                .map(|(tx, wake)| SendValue::ChanSender(tx, wake))
                 .ok_or_else(|| "Cannot send closed channel sender".to_string()),
             "chan/receiver" => crate::primitives::chan::clone_receiver(&value)
-                .map(SendValue::ChanReceiver)
+                .map(|(rx, wake)| SendValue::ChanReceiver(rx, wake))
                 .ok_or_else(|| "Cannot send closed channel receiver".to_string()),
             _ => Err(format!("Cannot send external object: {}", obj.type_name)),
         },
@@ -665,8 +673,8 @@ impl SendValue {
                 })
             }
             SendValue::NativeFn(f) => Value::native_fn(f),
-            SendValue::ChanSender(tx) => crate::primitives::chan::sender_value(tx),
-            SendValue::ChanReceiver(rx) => crate::primitives::chan::receiver_value(rx),
+            SendValue::ChanSender(tx, wake) => crate::primitives::chan::sender_value(tx, wake),
+            SendValue::ChanReceiver(rx, wake) => crate::primitives::chan::receiver_value(rx, wake),
             SendValue::Closure(_box_val) => {
                 panic!("bug: bare SendValue::Closure; use SendBundle::into_value")
             }
@@ -863,8 +871,8 @@ fn into_value_inner(sv: SendValue, ctx: &mut DeserContext) -> Value {
             })
         }
         SendValue::NativeFn(f) => Value::native_fn(f),
-        SendValue::ChanSender(tx) => crate::primitives::chan::sender_value(tx),
-        SendValue::ChanReceiver(rx) => crate::primitives::chan::receiver_value(rx),
+        SendValue::ChanSender(tx, wake) => crate::primitives::chan::sender_value(tx, wake),
+        SendValue::ChanReceiver(rx, wake) => crate::primitives::chan::receiver_value(rx, wake),
 
         // Closure variant: only appears stored directly in SendBundle::closures.
         // At the top-level call it means the bundle was constructed incorrectly.

--- a/stdlib.lisp
+++ b/stdlib.lisp
@@ -1218,7 +1218,7 @@
         scheduler-killed @||  # set of fibers the scheduler aborted during shutdown
         shutdown-req @[nil]  # nil = running, integer = shutdown requested with timeout
         park-queues @{}
-        forwarded-pending @{}]  # id → {:queue @[] :wake-box box} (process scheduler I/O)
+        forwarded-pending @{}]
     (defn cleanup-select [waiter entry]
       "Delete a select-set entry after resolution."
       (del select-sets waiter))
@@ -1432,9 +1432,6 @@
       "Wait for I/O completions and route fibers."
       (let [completions (io/wait backend timeout-ms)
             @has-forwarded false]
-        # Process all completions — push forwarded ones to queue without
-        # waking the process scheduler yet (it would run and miss later
-        # completions in this batch).
         (each c in completions
           (let* [id (get c :id)
                  fiber (get pending id)]
@@ -1454,15 +1451,13 @@
                   (del forwarded-pending id)
                   (push fwd:queue c)
                   (rebox fwd:wake-box (+ (unbox fwd:wake-box) 1))
-                  (assign has-forwarded true))))))
-        # After all completions are queued, wake parked process schedulers
+                  (assign has-forwarded true))))))  # After all completions are queued, wake parked process schedulers
         (when has-forwarded
           (let [q (get park-queues :io-forward-wakeup)]
             (when (and q (> (length q) 0))
               (let [parked (get q 0)]
                 (remove q 0)
-                (when (= (length q) 0)
-                  (del park-queues :io-forward-wakeup))
+                (when (= (length q) 0) (del park-queues :io-forward-wakeup))
                 (fiber/resume parked nil)
                 (handle-fiber-after-resume parked)))))))
 
@@ -1486,7 +1481,8 @@
       # fibers blocked on (chan:take), sync locks, etc. never get cleaned
       # up and `step` never sees park-queues empty.
       (let [snapshot (pairs park-queues)]
-        (each [k _] in snapshot (del park-queues k))
+        (each [k _] in snapshot
+          (del park-queues k))
         (each [_ q] in snapshot
           (each fiber in q
             (add scheduler-killed fiber)
@@ -1549,8 +1545,7 @@
         # at teardown time, so re-raising would surface our own signal as a
         # user error.
         (each [fiber status] in (pairs completed)
-          (when (and (= status :error)
-                     (not (contains? joined fiber))
+          (when (and (= status :error) (not (contains? joined fiber))
                      (not (contains? scheduler-killed fiber)))
             (error (fiber/value fiber)))))
      :shutdown  # shutdown-fn: signal shutdown
@@ -1772,6 +1767,63 @@
               (assign n (+ n 1))))))  # Collect in input order
       (map (fn [i] (get results i)) (range 0 n)))))
 
+## ── Channel select ──────────────────────────────────────────────────
+
+(defn chan/select [rxs &opt timeout-ms]
+  "Wait for one receiver in rxs to have a message ready, or for
+   timeout-ms milliseconds to elapse.  Returns [index msg] when a
+   receiver has a value, [:timeout] on timeout, or [:disconnected] if
+   the first ready receiver was found disconnected.
+
+   Cooperatively yields to the scheduler: the OS thread is not parked,
+   so any fiber producing on rxs (or an OS thread sending via sys/spawn
+   + chan/send) continues to run.  Without timeout-ms, waits forever.
+
+   Builds on chan/try-select (non-blocking poll) and chan/wait-ready
+   (yielding park on a wake fd).  After each wake, re-parks with the
+   remaining timeout so a spurious wake — e.g. another fiber stole the
+   value via chan/recv between the send and our re-poll — does not
+   collapse the deadline.  Skips the eventfd allocation entirely if the
+   deadline is already exhausted on entry to a loop iteration."
+  (let [first (chan/try-select rxs)]
+    (match (get first 0)
+      :empty
+        (let [deadline (when timeout-ms
+                         (+ (clock/monotonic) (/ timeout-ms 1000.0)))]
+          (def @result nil)
+          (forever
+            (let [remaining-ms (when deadline
+                                 (int (* (- deadline (clock/monotonic)) 1000)))]
+              (if (and remaining-ms (<= remaining-ms 0))  ## Deadline exhausted — skip the wake fd allocation.
+                (begin
+                  (assign result [:timeout])
+                  (break))
+                (let [wr (chan/wait-ready rxs remaining-ms)  ## chan/wait-ready returns nil after parking,
+                      ## [:ready i v] if a value was found by the
+                      ## post-register re-check (no yield), or
+                      ## [:disconnected] if the re-check observed a
+                      ## disconnect.
+                      tag (when (array? wr) (get wr 0))]
+                  (match tag
+                    :ready
+                      (begin
+                        (assign result [(get wr 1) (get wr 2)])
+                        (break))
+                    :disconnected
+                      (begin
+                        (assign result [:disconnected])
+                        (break))
+                    _  ## Woken or timed out at the scheduler — pick a
+                    ## ready receiver or loop again.
+                    (let [r (chan/try-select rxs)]
+                      (match (get r 0)
+                        :empty nil  ## spurious wake — re-park
+                        _ (begin
+                            (assign result r)
+                            (break)))))))))
+          result)
+      _ first)))
+
 (defn inc [x]
   "Return x + 1."
   (+ x 1))
@@ -1991,6 +2043,7 @@
    :ev/abort ev/abort
    :ev/as-completed ev/as-completed
    :ev/select ev/select
+   :chan/select chan/select
    :ev/race ev/race
    :ev/timeout ev/timeout
    :ev/scope ev/scope

--- a/tests/elle/chan-select-fiber.lisp
+++ b/tests/elle/chan-select-fiber.lisp
@@ -1,0 +1,207 @@
+(elle/epoch 10)
+# Channel/select × fiber scheduler interaction tests.
+#
+# Regression cover for: chan/select must not park the OS thread, because the
+# fiber scheduler runs on that same thread.  An ev/spawn'd producer fiber
+# cannot fire its chan/send while the parent is parked inside a synchronous
+# crossbeam Select::select_timeout — the bug originally reproduced in
+# ~/git/grace/infra/repro-spawn-chan-select.lisp.
+
+# ============================================================================
+# Test A: ev/spawn'd producer + chan/select with timeout.
+#
+# A trivial fiber sends a value on a channel.  The parent chan/selects with a
+# 1s timeout.  If chan/select is scheduler-aware, the parent yields, the fiber
+# runs, sends, and the parent resumes with the value well under the timeout.
+# If chan/select parks the OS thread, the fiber never runs and the parent
+# hits the timeout.
+# ============================================================================
+
+(let [[tx rx] (chan)
+      _ (ev/spawn (fn [] (chan/send tx :hello-from-fiber)))
+      t0 (clock/monotonic)
+      sel (chan/select @[rx] 1000)
+      elapsed (- (clock/monotonic) t0)]
+  (assert (array? sel) "chan/select should return an array")
+  (assert (= (length sel) 2)
+          "select should resolve to [index msg], not [:timeout]")
+  (assert (= (get sel 0) 0) "select index should be 0 (the only receiver)")
+  (assert (= (get sel 1) :hello-from-fiber)
+          "select should observe the fiber's send")
+  (assert (< elapsed 0.5)
+          "select must resume promptly, not wait out the 1s timeout"))
+
+# ============================================================================
+# Test B: chan/select with no producer must still hit the timeout.
+#
+# Counter-factual to test A — confirms the timeout path still fires when
+# there is genuinely nothing to receive.  Without this we couldn't tell a
+# broken timeout (returns early as :woken/spurious) from a working one.
+# ============================================================================
+
+(let [[tx rx] (chan)
+      t0 (clock/monotonic)
+      sel (chan/select @[rx] 50)
+      elapsed (- (clock/monotonic) t0)]
+  (assert (array? sel) "chan/select should return an array")
+  (assert (= (length sel) 1)
+          "timeout result should be a single-element [:timeout] tuple")
+  (assert (= (get sel 0) :timeout)
+          "select with no producer must return [:timeout]")
+  (assert (>= elapsed 0.04)
+          "select must actually wait the timeout, not return immediately")
+  (assert (< elapsed 0.5) "select must not over-wait the timeout"))
+
+# ============================================================================
+# Test C: ev/spawn'd producer that yields before sending.
+#
+# The producer does an ev/sleep before sending, forcing the parent's
+# chan/select to genuinely park (not just race-win the try-fast-path).
+# Confirms the wake-after-park path actually wakes the parent.
+# ============================================================================
+
+(let [[tx rx] (chan)
+      _ (ev/spawn (fn []
+                    (ev/sleep 0.02)
+                    (chan/send tx :after-sleep)))
+      t0 (clock/monotonic)
+      sel (chan/select @[rx] 1000)
+      elapsed (- (clock/monotonic) t0)]
+  (assert (= (length sel) 2) "parked select must wake when the producer fires")
+  (assert (= (get sel 1) :after-sleep)
+          "parked select must observe the producer's value")
+  (assert (>= elapsed 0.02)
+          "parked select must wait at least the producer's sleep")
+  (assert (< elapsed 0.5)
+          "parked select must resume on the producer's send, not the timeout"))
+
+# ============================================================================
+# Test D: sys/spawn'd OS-thread producer + chan/select.
+#
+# A producer thread sends on the channel from outside the scheduler.  The
+# parent fiber chan/selects.  Confirms the cross-thread wake path works —
+# chan/send from a foreign thread must wake a parked selector on the
+# scheduler thread.
+# ============================================================================
+
+(let [[tx rx] (chan)
+      _ (sys/spawn (fn []  # Small synchronous sleep so the parent definitely
+                     # parks first.  ev/sleep requires a scheduler — we
+                     # don't have one on the spawned OS thread.
+                     (time/sleep 0.02)
+                     (chan/send tx :hello-from-os-thread)))
+      t0 (clock/monotonic)
+      sel (chan/select @[rx] 1000)
+      elapsed (- (clock/monotonic) t0)]
+  (assert (= (length sel) 2)
+          "cross-thread select must wake when producer thread fires")
+  (assert (= (get sel 1) :hello-from-os-thread)
+          "cross-thread select must observe the thread's value")
+  (assert (< elapsed 0.5) "cross-thread select must not wait out the timeout"))
+
+# ============================================================================
+# Test E: cross-thread race stress.
+#
+# Many producer threads, each firing immediately with no sleep, so the parent's
+# initial chan/try-select frequently sees :empty just before the send arrives —
+# exactly the race that the post-register re-check in chan/wait-ready closes.
+# If the race is open, at least one of the chan/selects will park on an
+# eventfd no one will signal, hit the 500ms timeout, and the test will fail.
+# ============================================================================
+
+(let [iterations 200]
+  (each i in (range 0 iterations)
+    (let [[tx rx] (chan)
+          producer (sys/spawn (fn [] (chan/send tx i)))
+          t0 (clock/monotonic)
+          sel (chan/select @[rx] 500)
+          elapsed (- (clock/monotonic) t0)]
+      (sys/join producer)
+      (assert (= (length sel) 2)
+              (string "iteration " i ": cross-thread select hit timeout"))
+      (assert (= (get sel 1) i) (string "iteration " i ": value mismatch"))  # Per-iteration cap — a lost-wake race would push elapsed up to
+      # ~500ms (the timeout) while still returning a value via the
+      # wrapper's post-park chan/try-select.  Anything above 50ms is
+      # extremely suspect on a quiet machine.
+      (assert (< elapsed 0.05)
+              (string "iteration " i ": cross-thread select waited too long: "
+                      elapsed " s — race likely lost the wake")))))
+
+# ============================================================================
+# Test F: multi-receiver select picks the right index.
+#
+# Two channels, only one producer.  chan/select over both must report the
+# correct receiver index — not 0 by default.  Index identifies which channel
+# fired, which is the entire point of select.
+# ============================================================================
+
+(let [[tx0 rx0] (chan)
+      [tx1 rx1] (chan)
+      _ (ev/spawn (fn [] (chan/send tx1 :from-one)))
+      sel (chan/select @[rx0 rx1] 1000)]
+  (assert (= (length sel) 2)
+          "multi-receiver select must resolve to [i v], not :timeout")
+  (assert (= (get sel 0) 1)
+          "multi-receiver select must report the firing receiver's index")
+  (assert (= (get sel 1) :from-one)
+          "multi-receiver select must carry the firing receiver's value"))
+
+# Two producers on different channels: confirm we still get one result
+# (whichever fires first) and that the other value stays in its channel
+# for a subsequent recv.
+
+(let [[tx0 rx0] (chan)
+      [tx1 rx1] (chan)
+      _ (ev/spawn (fn [] (chan/send tx0 :zero)))
+      sel (chan/select @[rx0 rx1] 1000)]
+  (assert (= (get sel 0) 0) "select picks the receiver that has a value")
+  (assert (= (get sel 1) :zero) "select returns the right value")  # The unused channel must still be empty.
+  (let [r1 (chan/recv rx1)]
+    (assert (= (get r1 0) :empty)
+            "untouched receiver in a multi-receiver select stays empty")))
+
+# ============================================================================
+# Test G: receiver closes while parked.
+#
+# Parent parks on a receiver; a fiber closes the sender (last sender → channel
+# becomes disconnected from the receiver's perspective).  The wake from
+# chan/close should unblock the parked select; chan/try-select inside the
+# wrapper then reports the closure via a runtime error (matching the same
+# semantics as a closed receiver passed in upfront).
+# ============================================================================
+
+(let [[tx rx] (chan)
+      _ (ev/spawn (fn []
+                    (ev/sleep 0.02)  # Close every sender so the receiver observes disconnect.
+                    (chan/close tx)))
+      t0 (clock/monotonic)
+      [ok? result] (protect (chan/select @[rx] 1000))
+      elapsed (- (clock/monotonic) t0)]
+  (assert ok? "select must return cleanly when the sender closes mid-park")
+  (assert (= (get result 0) :disconnected)
+          "select must observe :disconnected after the sender closes")
+  (assert (< elapsed 0.5) "select must wake on close, not wait the full timeout"))
+
+# ============================================================================
+# Test H: ev/abort cancels a parked select cleanly.
+#
+# Spawn a fiber that parks forever in chan/select on a never-firing channel,
+# then abort it.  The abort path drops the PendingOp, which drops the
+# ChanSelectGuard, which closes the wake fd and deregisters from the
+# WakeList.  We don't have direct visibility into fd leaks from Lisp, but we
+# can confirm the abort returns promptly and subsequent selects on the same
+# channel still work — a leaked WakeList fd would cause stale wakes.
+# ============================================================================
+
+(let [[tx rx] (chan)
+      victim (ev/spawn (fn [] (chan/select @[rx] 60000)))]
+  (ev/sleep 0.02)
+  (ev/abort victim)  # The aborted fiber should be done now.  A fresh chan/select on the
+  # same channel must work — confirms the WakeList wasn't left with a
+  # dangling fd that would mis-fire or cause errors.
+  (let [_ (ev/spawn (fn [] (chan/send tx :after-abort)))
+        sel (chan/select @[rx] 1000)]
+    (assert (= (length sel) 2)
+            "post-abort select on the same channel must still work")
+    (assert (= (get sel 1) :after-abort)
+            "post-abort select must observe a fresh send")))


### PR DESCRIPTION
chan/select previously used crossbeam_channel::Select::select_timeout, which parks the OS thread.  Since the fiber scheduler runs on that thread, any ev/spawn'd producer fiber that would have unblocked the select was starved — a (chan/select @[rx] timeout) on a channel whose producer was a fiber would unconditionally time out.

Replace the blocking call with an eventfd-based wake protocol carried by the channel itself: sender and receiver halves share an Arc<WakeList> of registered wake fds; chan/send writes a wake byte after a successful try_send; chan/wait-ready allocates an eventfd (Linux) or pipe2 (other Unix), registers it in every candidate receiver's WakeList, and yields via IoOp::ChanSelectPark — which the scheduler waits on via IORING_OP_POLL_ADD (zero threads on uring) or poll(2) on the thread-pool backend.  The Lisp-level chan/select is a defn that loops chan/try-select + chan/wait-ready with the remaining timeout after every wake, so a spurious wake does not collapse the deadline.

Cross-thread sends from sys/spawn Just Work: write(eventfd, 1) is thread-safe and the scheduler thread observes POLLIN exactly like any other fd readiness event.

submit_uring_poll_add now accepts an Option<Duration> and emits a linked LinkTimeout SQE — incidentally fixes a pre-existing bug where ev/poll-fd's timeout was silently dropped on uring.

A ChanSelectGuard RAII owns the wake fd and the wake-list registrations; its Drop wakes any racing poll, deregisters, and closes the fd.  PendingOp::ChanSelectPark holds the guard so the natural drop chain handles completion, cancellation, and aborted submission uniformly.

Tests (tests/elle/chan-select-fiber.lisp):
- A: ev/spawn'd producer + chan/select with timeout — the bug repro
- B: timeout still fires with no producer (counter-factual to A)
- C: parked select wakes after producer's ev/sleep
- D: sys/spawn cross-thread producer
- E: 200-iteration cross-thread stress, per-iteration <50ms cap
- F: multi-receiver select reports the firing receiver's index
- G: receiver closes mid-park → [:disconnected] (catches missing wake_all in chan/close, verified counter-factually)
- H: ev/abort on a parked selector + fresh select still works (guards against leaked WakeList fds)