### PR TITLE
ev/run: program-completion teardown for the root scheduler

### DIFF
--- a/stdlib.lisp
+++ b/stdlib.lisp
@@ -1537,10 +1537,34 @@
         (push runnable fiber)
         fiber)
      :step step
-     :pump  # pump-fn: event loop
-      (fn ()
-        (block :loop
-          (forever (when (= (step (- 0 1)) :done) (break :loop nil))))  # Crash on unjoined errored fibers — never swallow errors silently.
+     :pump  # pump-fn: event loop.
+     # Program-completion teardown: when called with the program's
+     # fibers (its thunks), the loop ends as soon as THEY have all
+     # completed.  Each iteration first drains runnable work without
+     # blocking (step 0); once the program's fibers are done it shuts
+     # the scheduler down — aborting every remaining fiber uniformly
+     # (do-shutdown) rather than blocking forever on orphans that can
+     # never complete on their own (a futex never woken, a reader on a
+     # socket the program never closed).  This is NOT a fiber taxonomy:
+     # `entry` is simply the program; everything else is torn down
+     # identically.  Called with no fibers it runs until the scheduler
+     # is globally idle (legacy behaviour, e.g. ev/run-on).
+      (fn (& entry)
+        (let [have-entry (> (length entry) 0)
+              all-done? (fn (fs)
+                          (let [@d true]
+                            (each f in fs
+                              (let [s (fiber/status f)]
+                                (unless (or (= s :dead) (= s :error))
+                                  (assign d false))))
+                            d))]
+          (block :loop
+            (forever  # Drain all currently-runnable work without blocking on I/O.
+              (when (= (step 0) :done) (break :loop nil))  # Program complete?  Tear down instead of waiting on orphans.
+              (when (and have-entry (all-done? entry))
+                (do-shutdown 100)
+                (break :loop nil))  # Live program work remains — block for the next I/O event.
+              (when (= (step (- 0 1)) :done) (break :loop nil)))))  # Crash on unjoined errored fibers — never swallow errors silently.
         # scheduler-killed fibers are excluded: we injected their :shutdown
         # at teardown time, so re-raising would surface our own signal as a
         # user error.
@@ -1588,7 +1612,19 @@
 (defn ev/run (& thunks)
   "Create an async scheduler, run thunks, return the last thunk's result.
    Used internally by the compiler to wrap top-level code in a scheduler.
-   Propagates errors from fibers — unjoined errored fibers crash the process."
+
+   Program-completion teardown: the program is its thunks.  Once they
+   complete, the scheduler is shut down and every remaining fiber is
+   aborted uniformly (do-shutdown) — ev/run does NOT wait for the
+   scheduler to go globally idle.  A background fiber that never
+   completes on its own (e.g. the reader of a connection the program
+   never closed) therefore cannot keep the process alive past the
+   program.  Fibers the program explicitly joins (ev/join, ev/scope)
+   still complete first: the thunk fiber doesn't go :dead until its
+   joins return.  Only genuinely un-awaited fibers are cancelled.
+
+   Propagates errors from fibers — unjoined errored fibers crash the
+   process."
   (let [sched (make-async-scheduler)]
     (parameterize ((*scheduler* sched)
                    (*spawn* (get sched :spawn))
@@ -1597,13 +1633,18 @@
       (let [mark (get sched :mark-joined)
             fibers @[]]
         (each t in thunks
-          (push fibers (ev/spawn t)))
-        ((get sched :pump))  # Mark all entry-point fibers as joined — they're owned by ev/run,
-        # not orphaned.  Propagate the first error we find among them.
+          (push fibers (ev/spawn t)))  # ev/run owns its thunk fibers: mark them joined so :pump's
+        # unjoined-error tail won't re-raise them — we surface the first
+        # error ourselves below.
+        (each f in fibers
+          (mark f))  # Run the program; :pump drains runnable work, and once these
+        # fibers complete it tears the scheduler down, aborting every
+        # remaining (un-awaited) fiber uniformly — see :pump's note.
+        (apply (get sched :pump) fibers)  # Propagate the first error among our thunks; else the last
+        # thunk's value.
         (def @result nil)
         (def @first-error nil)
         (each f in fibers
-          (mark f)
           (let [s (fiber/status f)]
             (when (and (nil? first-error)
                        (or (= s :error) (not (= 0 (bit/and (fiber/bits f) 1)))))

--- a/tests/elle/ev-run-teardown.lisp
+++ b/tests/elle/ev-run-teardown.lisp
@@ -1,0 +1,101 @@
+(elle/epoch 10)
+## tests/elle/ev-run-teardown.lisp
+##
+## Regression test for ev/run "program-completion teardown".
+##
+## The program is its thunks.  Once the top-level program completes,
+## ev/run shuts the scheduler down and aborts EVERY remaining fiber
+## uniformly (do-shutdown) — it does NOT wait for the scheduler to go
+## globally idle.  A background fiber that never completes on its own
+## (a futex-parked fiber that is never woken, or a reader parked on a
+## socket the program never closes — e.g. an unclosed grpc/h2
+## connection) must therefore NOT keep the process alive past the
+## program.
+##
+## Pre-fix, ev/run pumped until `step` reported :done, which requires
+## `pending` (in-flight I/O) and `park-queues` to be empty.  An orphan
+## fiber parked forever kept them non-empty, so pump looped forever and
+## the process hung at teardown (only killable via SIGTERM).
+##
+## How this test asserts: it spawns orphan fibers that can never
+## complete on their own, then the top-level completes.  If ev/run
+## reaps them, the process exits and the harness sees a clean pass.
+## If it regresses, the process hangs and the harness times the test
+## out — a failure.  We also self-bound with ev/timeout so the failure
+## mode is a crisp assertion rather than a wall-clock hang.
+
+## ── 1. A futex-parked orphan must not block program teardown ─────────────
+##
+## Run a sub-program (via ev/run) that spawns a fiber parked forever on
+## a futex key that is never woken, then returns.  ev/run must return.
+
+(let* [start (clock/monotonic)
+       result (ev/timeout 5.0
+                          (fn []
+                            (ev/run (fn []
+                                      (let [b (box 0)]
+                                        (ev/spawn (fn []
+                                          (ev/futex-wait :never-woken b 0)
+                                          (println "  BUG: futex orphan resumed")))
+                                        :program-done)))))
+       elapsed (- (clock/monotonic) start)]
+  (assert (not (nil? result))
+          (concat "1a: ev/run with a forever-futex-parked orphan must "
+                  "return (teardown), not hang; ev/timeout fired after "
+                  (string elapsed) "s"))
+  (assert (= result :program-done)
+          (concat "1b: ev/run must return its thunk's value; got "
+                  (string result)))
+  (assert (< elapsed 4.0)
+          (concat "1c: teardown must be prompt, not ride the timeout; took "
+                  (string elapsed) "s")))
+
+(println "  PASS: futex-parked orphan reaped at program completion")
+
+## ── 2. An I/O-parked orphan must not block program teardown ──────────────
+##
+## The real-world shape: a fiber parked on a socket read/accept that no
+## one will ever satisfy (the connection's reader the program forgot to
+## close).  Park a fiber on accept against a listener nobody connects
+## to, then complete the program.
+
+(let* [start (clock/monotonic)
+       result (ev/timeout 5.0
+                          (fn []
+                            (ev/run (fn []
+                                      (let [listener (tcp/listen "127.0.0.1" 0)]
+                                        (ev/spawn (fn []
+                                          (protect (tcp/accept listener))
+                                          (println "  (accept orphan unparked)")))  ## Give the orphan a tick to actually park on accept.
+                                        (ev/sleep 0.05)
+                                        :program-done)))))
+       elapsed (- (clock/monotonic) start)]
+  (assert (not (nil? result))
+          (concat "2a: ev/run with an I/O-parked (accept) orphan must "
+                  "return (teardown), not hang; ev/timeout fired after "
+                  (string elapsed) "s"))
+  (assert (= result :program-done)
+          (concat "2b: ev/run must return its thunk's value; got "
+                  (string result)))
+  (assert (< elapsed 4.0)
+          (concat "2c: teardown must be prompt; took " (string elapsed) "s")))
+
+(println "  PASS: I/O-parked orphan reaped at program completion")
+
+## ── 3. Explicitly-joined work still completes (no premature kill) ────────
+##
+## Teardown must only reap UN-awaited fibers.  A fiber the program joins
+## must run to completion and deliver its value before the program ends.
+
+(let [result (ev/run (fn []
+                       (let [f (ev/spawn (fn []
+                               (ev/sleep 0.05)
+                               41))]
+                         (+ 1 (ev/join f)))))]
+  (assert (= result 42)
+          (concat "3a: joined fiber must complete and deliver its value "
+                  "(teardown must not kill awaited work); got " (string result))))
+
+(println "  PASS: explicitly-joined work completes before teardown")
+
+(println "ev-run-teardown: all tests passed")


### PR DESCRIPTION
ev/run pumped the scheduler until `step` reported `:done`, which requires `pending` (in-flight I/O) and `park-queues` to be empty. A fiber parked forever — a futex that's never woken, or a reader blocked on a socket the program never closed (e.g. an unclosed grpc/h2 connection) — keeps those non-empty, so the pump looped forever and the process hung at teardown. With the eager TERM/INT trap (#858) installed, SIGTERM was then the only way out: every program that opened a connection and didn't explicitly close it (or call sys/exit) wedged on exit.

Fix: the program is its thunks. `:pump` now takes the program's fibers and, each iteration, drains all runnable work without blocking (step 0); once those fibers have completed it shuts the scheduler down — do-shutdown aborts every remaining fiber uniformly (pending I/O, futex-parked, runnable) — instead of blocking on orphans that can never complete on their own. This is not a fiber taxonomy: `entry` is just the program; everything else is torn down identically. Called with no fibers :pump keeps its old run-until-globally-idle behaviour (ev/run-on et al.).

Fibers the program explicitly awaits still finish first: a thunk doesn't go :dead until its ev/join / ev/scope children return, so only genuinely un-awaited fibers are reaped. Unjoined errored fibers still crash the process (the pump's error tail is unchanged); ev/run marks its own thunk fibers joined and surfaces their first error itself.

Regression test tests/elle/ev-run-teardown.lisp: a futex-parked orphan, an I/O-parked (accept) orphan, and a joined fiber — the first two must be reaped at program completion (no hang), the third must complete and deliver its value (teardown must not kill awaited work). Pre-fix the orphan cases hang; the test self-bounds with ev/timeout so the failure mode is an assertion, not a wall-clock hang.