### PR TITLE
sync: futex keys must be process-globally unique (gensym)

### DIFF
--- a/lib/sync.lisp
+++ b/lib/sync.lisp
@@ -11,12 +11,19 @@
 
 ## ── Layer 1: Futex ──────────────────────────────────────────────────
 
-(def @*futex-id* 0)
-
+## Futex identity must be unique across the WHOLE process, not just
+## within this module instance.  `(import ...)` returns a fresh module
+## each call, so a module-local counter restarts at 0 in every importer
+## — two independently-imported sync modules would then hand out
+## colliding keys, and since the scheduler's park-queue is process-global
+## (one key → one wait list), a wake on one futex would unpark a waiter
+## on the other (which re-checks its unchanged value and re-parks),
+## losing the intended wakeup.  `gensym` is a process-global primitive
+## counter, so keys are globally unique regardless of how many times the
+## module is imported.
 (defn make-futex [initial]
   "Low-level futex. Wraps a box with park/notify."
-  (assign *futex-id* (inc *futex-id*))
-  (let [key *futex-id*
+  (let [key (gensym)
         bx (box initial)]
     {:wait (fn [expected]
              (while (= (unbox bx) expected) (ev/futex-wait key bx expected)))

--- a/tests/elle/sync.lisp
+++ b/tests/elle/sync.lisp
@@ -375,4 +375,47 @@
   (assert (not ok?) "10d: monitor with propagates error")
   (assert (= :boom val:error) "10e: error value preserved"))
 
+# ============================================================================
+# 11. Cross-instance futex isolation
+# ============================================================================
+#
+# Two independently-imported sync modules must not collide in the
+# process-global scheduler park-queue.  Each (import-file ...) returns a
+# fresh module instance, so any module-LOCAL futex-id counter restarts at
+# the same values — a futex from instance A and a futex from instance B
+# then share a key.  Waking B's futex must wake B's waiter and ONLY B's
+# waiter; under a colliding key it wakes whichever waiter is first in the
+# shared park slot (instance A's), which re-checks its own unchanged value
+# and re-parks, so B's waiter is never woken.  That lost wakeup deadlocks
+# any program that imports sync (or a sync-using module like lib/fserver)
+# more than once — e.g. an orchestrator whose simulator, trader, and main
+# fiber each import the server module separately.  Futex keys must be
+# process-globally unique.
+#
+# Tested at the futex layer so the main fiber never parks (it only
+# set+wakes); the waiters that stay parked are aborted at teardown.
+
+(let [syncA ((import-file "lib/sync.lisp"))
+      syncB ((import-file "lib/sync.lisp"))
+      fxA (syncA:make-futex :a)
+      fxB (syncB:make-futex :b)
+      log @[]]
+  (ev/spawn (fn []
+              (fxA:wait :a)
+              (push log :A-woke)))
+  (ev/sleep 0.05)  # let waiter A reach its park
+  (ev/spawn (fn []
+              (fxB:wait :b)
+              (push log :B-woke)))
+  (ev/sleep 0.05)  # let waiter B reach its park
+  # Wake ONLY fxB, the proper way (change value, then wake the key).
+  (fxB:set :b2)
+  (fxB:wake 1)
+  (ev/sleep 0.1)  # let the woken waiter run
+  (assert (= [:B-woke] (freeze log))
+          "11a: waking instance-B futex wakes B's waiter, not A's (cross-instance futex keys must be unique)")  # Drain waiter A so it does not orphan into teardown.
+  (fxA:set :a2)
+  (fxA:wake 1)
+  (ev/sleep 0.05))
+
 (println "All sync tests passed.")


### PR DESCRIPTION
`make-futex` keyed each futex off `*futex-id*`, a module-LOCAL counter starting at 0.  But `(import ...)` returns a fresh module instance every call, so each independently-imported `lib/sync` restarted the counter at 0 and handed out colliding keys.  The scheduler's `park-queues` is process-GLOBAL (one key -> one wait list), so futexes from two different sync instances shared a park slot: a wake on one futex would unpark a waiter on the other, which re-checked its unchanged value and re-parked, losing the intended wakeup.

This deadlocked any program that imports sync — or a sync-using module like a server abstraction built on `make-queue` — more than once.  The grace orchestrator imports its fserver module three times (simulator, trader, and main fiber each `(import ...)` it separately), so all three servers' internal not-empty condvars got the same key; the first `server:call` woke the wrong server's parked taker and the intended taker was never woken, hanging before any application code ran.

Fix: key futexes off `(gensym)`, a process-global primitive counter, so keys are globally unique regardless of how many times the module is imported.  (Symbols are also disjoint from the integer keys used by lib/http2/session, so the two key spaces can't collide.)

tests/elle/sync.lisp §11 pins it: two independently-imported sync modules, waking instance-B's futex must wake B's waiter and not A's. Fails before this change (woke=1 but the wrong waiter; log empty), passes after.