### PR TITLE
http2: futex keys from gensym, not module-local counters

### DIFF
--- a/lib/http2/session.lisp
+++ b/lib/http2/session.lisp
@@ -11,8 +11,14 @@
 ##           :notify-all-streams :encode-and-send-headers
 ##           :send-data-with-flow-control :ack-settings-received
 ##           :default-settings :initial-window :max-frame :test}
-
-(def @*session-futex-id* 1000000)
+##
+## The SETTINGS-ACK latch key comes from `(gensym)`, a process-global
+## primitive counter, NOT a module-local counter.  `(import ...)` returns
+## a fresh module instance each call, so a module-local counter would
+## restart in every importer and hand out colliding keys; since the
+## scheduler's park-queue is process-global, acking one session's SETTINGS
+## would then wake another session's settings-waiter (same elle bug class
+## as the lib/sync futex-key collision, #861).
 
 (fn [&named frame stream hpack]
   (def C frame:constants)
@@ -103,8 +109,7 @@
     "Send SETTINGS and start a 30s timeout for the ACK."
     (let [[ftype flags sid payload] (frame:make-settings-frame settings)]
       (send-frame session ftype flags sid payload))
-    (assign *session-futex-id* (inc *session-futex-id*))
-    (let [latch-key *session-futex-id*
+    (let [latch-key (gensym)
           latch-box (box 0)]
       (put session :settings-ack-latch @{:key latch-key :box latch-box})
       (ev/spawn (fn []

--- a/lib/http2/stream.lisp
+++ b/lib/http2/stream.lisp
@@ -7,9 +7,15 @@
 ##
 ## No sync dependency — uses bare ev/futex-wait and ev/futex-wake.
 ##
+## Futex keys come from `(gensym)`, a process-global primitive counter,
+## NOT a module-local counter.  `(import ...)` returns a fresh module
+## instance each call, so a module-local counter would restart at 0 in
+## every importer and hand out colliding keys — and since the scheduler's
+## park-queue is process-global (one key -> one wait list), a wake on one
+## channel/flow-control futex would unpark a waiter on another instance's
+## (same elle bug class as the lib/sync futex-key collision, #861).
+##
 ## Exports: {:make-stream :make-channel :transition :make-flow-control :test}
-
-(def @*chan-id* 0)
 
 (fn [&named frame]
 
@@ -18,8 +24,11 @@
   ## single-threaded cooperative runtime.
 
   (defn make-channel []
-    (assign *chan-id* (inc *chan-id*))
-    (let [key *chan-id* bx (box 0) buf @[] @closed false @waiting false]
+    (let [key (gensym)
+          bx (box 0)
+          buf @[]
+          @closed false
+          @waiting false]
       {:put (fn [val]
               (push buf val)
               (when waiting
@@ -30,8 +39,7 @@
                (while (and (not closed) (= (length buf) 0))
                  (assign waiting true)
                  (let [gen (unbox bx)]
-                   (when (= (length buf) 0)
-                     (ev/futex-wait key bx gen)))
+                   (when (= (length buf) 0) (ev/futex-wait key bx gen)))
                  (assign waiting false))
                (when (> (length buf) 0)
                  (let [val (get buf 0)]
@@ -99,8 +107,8 @@
   ## ── Flow control ───────────────────────────────────────────────────────
 
   (defn make-flow-control [initial-window]
-    (assign *chan-id* (inc *chan-id*))
-    (let [key *chan-id* bx (box 0)]
+    (let [key (gensym)
+          bx (box 0)]
       @{:send-window initial-window
         :recv-window initial-window
         :futex-key key
@@ -151,7 +159,8 @@
       (stream-transition s :recv-headers)
       (assert (= s:state :open) "stream server: idle->open")
       (stream-transition s :recv-end-stream)
-      (assert (= s:state :half-closed-remote) "stream server: open->half-closed-remote")
+      (assert (= s:state :half-closed-remote)
+              "stream server: open->half-closed-remote")
       (stream-transition s :send-end-stream)
       (assert (= s:state :closed) "stream server: half-closed-remote->closed"))
 

--- a/tests/elle/http2-session-futex.lisp
+++ b/tests/elle/http2-session-futex.lisp
@@ -1,0 +1,50 @@
+(elle/epoch 10)
+## tests/elle/http2-session-futex.lisp
+##
+## Regression: the HTTP/2 session SETTINGS-ACK latch must use a
+## process-globally-unique futex key, not a module-local counter.
+##
+## `lib/http2/session.lisp` minted the latch key from a module-local
+## `*session-futex-id*` counter.  `(import ...)` returns a fresh module
+## instance each call, so two independently-imported session modules
+## restarted that counter and handed colliding keys to the scheduler's
+## process-global park-queue.  Acking one session's SETTINGS would then
+## wake the *other* session's settings-waiter (which re-checks its own
+## still-zero latch box and re-parks); the intended waiter is never
+## woken, so its 30s timeout fires and tears the connection down with a
+## spurious SETTINGS_TIMEOUT GOAWAY.  (Same bug class as the lib/sync
+## futex-key collision pinned by tests/elle/sync.lisp §11.)
+##
+## Keys must be unique across module instances.  Tested at the latch
+## layer: two session instances minting two SETTINGS-ACK latches must
+## not share a key.  The main fiber only inspects state (never parks);
+## the 30s timeout-waiter fibers spawned by send-settings stay parked
+## and are aborted at teardown.
+
+(def huffman ((import "std/http2/huffman")))
+(def hpack ((import "std/http2/hpack") :huffman huffman))
+(def frame ((import "std/http2/frame")))
+(def stream ((import "std/http2/stream") :frame frame))
+
+## Two INDEPENDENT imports of the session module, sharing the same
+## frame/stream/hpack deps — exactly the shape that collides under the bug.
+(def sessionA
+  ((import "std/http2/session") :frame frame :stream stream :hpack hpack))
+(def sessionB
+  ((import "std/http2/session") :frame frame :stream stream :hpack hpack))
+
+(def mock-transport {:read nil :write nil :flush nil :close nil})
+(def sA (sessionA:make-session mock-transport "test" false))
+(def sB (sessionB:make-session mock-transport "test" false))
+
+## Each send-settings mints a SETTINGS-ACK latch and stows it on the
+## session as {:key K :box B}.
+(sessionA:send-settings sA sessionA:default-settings)
+(sessionB:send-settings sB sessionB:default-settings)
+
+(assert (not (nil? sA:settings-ack-latch)) "sA minted a settings-ack latch")
+(assert (not (nil? sB:settings-ack-latch)) "sB minted a settings-ack latch")
+(assert (not (= sA:settings-ack-latch:key sB:settings-ack-latch:key))
+        "two independently-imported session instances must mint distinct SETTINGS-ACK latch keys (process-globally unique)")
+
+(println "tests/elle/http2-session-futex.lisp: all tests passed")


### PR DESCRIPTION
Follow-up to #861.  The HTTP/2 stack carried the same futex-key collision: `lib/http2/session.lisp` minted the SETTINGS-ACK latch key from a module-local `*session-futex-id*` counter (offset at 1_000_000 to dodge the old low-numbered sync keys), and `lib/http2/stream.lisp` minted channel and flow-control keys from a module-local `*chan-id*` counter.

`(import ...)` returns a fresh module instance per call, so two independently-imported session (or stream) modules restart their counter and hand out colliding keys.  The scheduler's park-queue is process-global (one key -> one wait list), so a wake on one instance's futex unparks a waiter on another's, which re-checks its unchanged value and re-parks — the intended waiter is never woken.  For the session latch that means acking one connection's SETTINGS silently strands another connection's ack-waiter until its 30s timeout fires a spurious SETTINGS_TIMEOUT GOAWAY; for channels/flow-control it cross-wakes writer/reader and producer fibers.

Fix: key all three off `(gensym)`, a process-global primitive counter, so keys are unique regardless of import count.  The 1_000_000 offset hack is no longer needed and is dropped — gensym symbols are disjoint from any integer key space anyway.

tests/elle/http2-session-futex.lisp pins it: two independently-imported session instances must mint distinct SETTINGS-ACK latch keys.  Before this change both mint key 1000001 (verified); after, distinct gensyms.  Full http2 + grpc + concurrency suites stay green, and a live grace orchestrator backtest (h2 feature RPCs + grace on every tick) runs clean.