### PR TITLE
ffi: resolve Linux .so specs to host-native .dylib/.dll names

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -254,24 +254,46 @@ jobs:
         run: brew install parallel coreutils
       - name: make elle
         run: make elle
-      - name: Diagnose process-io.lisp hang (ELLE_TRACE=io)
+      - name: Diagnose process-io.lisp hang (timing loop)
         # TEMPORARY (remove with the io_trace instrumentation once test 18 is
-        # fixed): the macOS smoke wedges in tests/elle/process-io.lisp on the
-        # threadpool backend (no io_uring). ELLE_TRACE=io turns on [trace:io]
-        # (raw write(2), survives the timeout's SIGTERM); the last
-        # `tp-submit` / `close … shutdown` with no matching `tp-complete`
-        # names the stuck op and fd. Kept untraced in `make smoke` below so
-        # the two runs give a differential if tracing perturbs the timing.
-        # See src/io/AGENTS.md "Diagnostics".
+        # fixed): the macOS smoke wedges in tests/elle/process-io.lisp (test
+        # 18) on the threadpool backend. It is a TIGHT TIMING RACE — a single
+        # ELLE_TRACE=io run passed, because the per-op write(2) widens the
+        # loser's window enough to close the race. So probe the timing
+        # dependence directly: run untraced N times to measure the hang rate,
+        # then traced N times to try to catch a hung run with its [trace:io]
+        # tail. The last `tp-submit`/`close … shutdown` with no matching
+        # `tp-complete` in a hung trace names the stuck op and fd.
         continue-on-error: true
         run: |
           set +e
-          ELLE_TRACE=io timeout 40s ./target/release/elle \
-            --checked-intrinsics --jit=off --mlir=off \
-            tests/elle/process-io.lisp > pio.out 2>&1
-          echo "process-io.lisp exit=$? (124 = timeout/hang)"
-          echo "==== last 80 lines ([trace:io] to the wedge) ===="
-          tail -80 pio.out
+          BIN=./target/release/elle
+          FLAGS="--checked-intrinsics --jit=off --mlir=off"
+          T=tests/elle/process-io.lisp
+          echo "==== untraced: hang rate ===="
+          uh=0
+          for i in $(seq 1 8); do
+            timeout 30s $BIN $FLAGS $T >/dev/null 2>&1
+            [ $? -eq 124 ] && uh=$((uh+1)) && echo "  untraced run $i: HANG"
+          done
+          echo "untraced hangs: $uh/8"
+          echo "==== traced: try to catch a hung run ===="
+          th=0
+          for i in $(seq 1 8); do
+            ELLE_TRACE=io timeout 30s $BIN $FLAGS $T >run.out 2>&1
+            if [ $? -eq 124 ]; then
+              th=$((th+1)); echo "  traced run $i: HANG (captured)"
+              cp run.out hung-trace.txt
+            fi
+          done
+          echo "traced hangs: $th/8"
+          if [ -f hung-trace.txt ]; then
+            echo "==== last 60 lines of a HUNG traced run ===="
+            tail -60 hung-trace.txt
+          else
+            echo "(no traced run hung: tracing masks the race — next step is a"
+            echo " near-zero-overhead in-memory ring dumped on SIGTERM)"
+          fi
       - name: make doctest
         run: make doctest
       - name: make smoke

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -254,6 +254,24 @@ jobs:
         run: brew install parallel coreutils
       - name: make elle
         run: make elle
+      - name: Diagnose process-io.lisp hang (ELLE_TRACE=io)
+        # TEMPORARY (remove with the io_trace instrumentation once test 18 is
+        # fixed): the macOS smoke wedges in tests/elle/process-io.lisp on the
+        # threadpool backend (no io_uring). ELLE_TRACE=io turns on [trace:io]
+        # (raw write(2), survives the timeout's SIGTERM); the last
+        # `tp-submit` / `close … shutdown` with no matching `tp-complete`
+        # names the stuck op and fd. Kept untraced in `make smoke` below so
+        # the two runs give a differential if tracing perturbs the timing.
+        # See src/io/AGENTS.md "Diagnostics".
+        continue-on-error: true
+        run: |
+          set +e
+          ELLE_TRACE=io timeout 40s ./target/release/elle \
+            --checked-intrinsics --jit=off --mlir=off \
+            tests/elle/process-io.lisp > pio.out 2>&1
+          echo "process-io.lisp exit=$? (124 = timeout/hang)"
+          echo "==== last 80 lines ([trace:io] to the wedge) ===="
+          tail -80 pio.out
       - name: make doctest
         run: make doctest
       - name: make smoke

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -254,46 +254,44 @@ jobs:
         run: brew install parallel coreutils
       - name: make elle
         run: make elle
-      - name: Diagnose process-io.lisp hang (timing loop)
+      - name: Diagnose process-io.lisp hang (traced, under smoke load)
         # TEMPORARY (remove with the io_trace instrumentation once test 18 is
-        # fixed): the macOS smoke wedges in tests/elle/process-io.lisp (test
-        # 18) on the threadpool backend. It is a TIGHT TIMING RACE — a single
-        # ELLE_TRACE=io run passed, because the per-op write(2) widens the
-        # loser's window enough to close the race. So probe the timing
-        # dependence directly: run untraced N times to measure the hang rate,
-        # then traced N times to try to catch a hung run with its [trace:io]
-        # tail. The last `tp-submit`/`close … shutdown` with no matching
-        # `tp-complete` in a hung trace names the stuck op and fd.
+        # fixed): test 18 only wedges under `make smoke`'s PARALLEL LOAD — it
+        # never hung in 8 isolated runs, traced or not. The race needs CPU
+        # contention to open its window. So reproduce the load (run the rest
+        # of the .lisp suite as untraced background jobs saturating the cores)
+        # and run ONLY process-io.lisp with ELLE_TRACE=io in the foreground,
+        # so its [trace:io] stays scoped (no 40-file trace flood). If it
+        # hangs, its tail's last `tp-submit`/`close … shutdown` with no
+        # matching `tp-complete` names the stuck op. `make smoke` below stays
+        # untraced as the real gate.
         continue-on-error: true
         run: |
           set +e
           BIN=./target/release/elle
           FLAGS="--checked-intrinsics --jit=off --mlir=off"
-          T=tests/elle/process-io.lisp
-          echo "==== untraced: hang rate ===="
-          uh=0
-          for i in $(seq 1 8); do
-            timeout 30s $BIN $FLAGS $T >/dev/null 2>&1
-            [ $? -eq 124 ] && uh=$((uh+1)) && echo "  untraced run $i: HANG"
-          done
-          echo "untraced hangs: $uh/8"
-          echo "==== traced: try to catch a hung run ===="
-          th=0
-          for i in $(seq 1 8); do
-            ELLE_TRACE=io timeout 30s $BIN $FLAGS $T >run.out 2>&1
-            if [ $? -eq 124 ]; then
-              th=$((th+1)); echo "  traced run $i: HANG (captured)"
-              cp run.out hung-trace.txt
+          LOAD=$(find stdlib.lisp prelude.lisp lib/ tests/ demos/ -name '*.lisp' | grep -v process-io.lisp)
+          for round in $(seq 1 6); do
+            pids=""
+            for f in $LOAD; do
+              timeout 30s $BIN $FLAGS "$f" >/dev/null 2>&1 &
+              pids="$pids $!"
+            done
+            sleep 1   # let the load ramp up and saturate cores
+            ELLE_TRACE=io timeout 30s $BIN $FLAGS tests/elle/process-io.lisp > pio.out 2>&1
+            rc=$?
+            for p in $pids; do kill "$p" 2>/dev/null; done
+            wait 2>/dev/null
+            if [ $rc -eq 124 ]; then
+              echo "round $round: process-io.lisp HUNG under load (traced)"
+              echo "==== [trace:io] tail (last 70 lines to the wedge) ===="
+              tail -70 pio.out
+              exit 0
             fi
+            echo "round $round: no hang (traced under load)"
           done
-          echo "traced hangs: $th/8"
-          if [ -f hung-trace.txt ]; then
-            echo "==== last 60 lines of a HUNG traced run ===="
-            tail -60 hung-trace.txt
-          else
-            echo "(no traced run hung: tracing masks the race — next step is a"
-            echo " near-zero-overhead in-memory ring dumped on SIGTERM)"
-          fi
+          echo "no traced hang in 6 loaded rounds — if make smoke still hangs,"
+          echo "tracing masks it even under load; next is the SIGTERM-dumped ring"
       - name: make doctest
         run: make doctest
       - name: make smoke

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -254,32 +254,31 @@ jobs:
         run: brew install parallel coreutils
       - name: make elle
         run: make elle
-      - name: Diagnose process-io.lisp hang (traced smoke-vm)
+      - name: Diagnose process-io.lisp hang (ioring smoke-vm)
         # TEMPORARY (remove with the io_trace instrumentation once test 18 is
-        # fixed): test 18 wedges only under `make smoke`'s BOUNDED parallel
-        # contention. A hand-rolled 40-wide background load over-starved it —
-        # it timed out during startup with an empty trace, not at test 18. So
-        # run the exact failing target, `make smoke-vm`, with ELLE_TRACE=io a
-        # few times; `parallel --tag` prefixes every line with the filename,
-        # so grep pulls out process-io.lisp's own [trace:io] tail. The last
-        # `h2-close:`/`server-conn:` marker with no following `done` (or the
-        # last `tp-submit` with no `tp-complete`) names the stuck step.
-        # `make smoke` below stays as the real gate.
+        # fixed): `--trace=io`'s per-op write(2) perturbed the timing-tight
+        # test-18 race away (5 traced smoke-vm rounds stayed green). Use
+        # ELLE_TRACE=ioring instead: events go to an in-memory ring with NO
+        # syscall on the hot path, dumped to stderr only when a `timeout`
+        # SIGTERM kills the hung process. So only the wedged process-io.lisp
+        # dumps (no flood), and the ring adds ~no perturbation. `parallel
+        # --tag` prefixes each line with the file; grep pulls process-io's
+        # ring tail. Last `h2-close:`/`server-conn:` marker with no following
+        # `done` (or last `tp-submit` with no `tp-complete`) = the stuck step.
         continue-on-error: true
         run: |
           set +e
-          for round in 1 2 3 4 5; do
-            ELLE_TRACE=io timeout 200s make smoke-vm > smoke.out 2>&1
+          for round in 1 2 3 4 5 6; do
+            ELLE_TRACE=ioring timeout 200s make smoke-vm > smoke.out 2>&1
             if grep -F 'process-io.lisp' smoke.out | grep -q 'terminated by SIGTERM'; then
-              echo "round $round: process-io.lisp HUNG in smoke-vm (traced)"
-              echo "==== process-io.lisp [trace:io] tail (last 90 lines) ===="
-              grep -F 'process-io.lisp' smoke.out | tail -90
+              echo "round $round: process-io.lisp HUNG in smoke-vm (ioring)"
+              echo "==== process-io.lisp [trace:io ring] tail (last 100) ===="
+              grep -F 'process-io.lisp' smoke.out | tail -100
               exit 0
             fi
             echo "round $round: process-io.lisp did not hang"
           done
-          echo "no process-io hang in 5 traced smoke-vm rounds — tracing may"
-          echo "mask it even under bounded load; next is a SIGTERM-dumped ring"
+          echo "no process-io hang in 6 ioring smoke-vm rounds"
       - name: make doctest
         run: make doctest
       - name: make smoke

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -254,44 +254,32 @@ jobs:
         run: brew install parallel coreutils
       - name: make elle
         run: make elle
-      - name: Diagnose process-io.lisp hang (traced, under smoke load)
+      - name: Diagnose process-io.lisp hang (traced smoke-vm)
         # TEMPORARY (remove with the io_trace instrumentation once test 18 is
-        # fixed): test 18 only wedges under `make smoke`'s PARALLEL LOAD — it
-        # never hung in 8 isolated runs, traced or not. The race needs CPU
-        # contention to open its window. So reproduce the load (run the rest
-        # of the .lisp suite as untraced background jobs saturating the cores)
-        # and run ONLY process-io.lisp with ELLE_TRACE=io in the foreground,
-        # so its [trace:io] stays scoped (no 40-file trace flood). If it
-        # hangs, its tail's last `tp-submit`/`close … shutdown` with no
-        # matching `tp-complete` names the stuck op. `make smoke` below stays
-        # untraced as the real gate.
+        # fixed): test 18 wedges only under `make smoke`'s BOUNDED parallel
+        # contention. A hand-rolled 40-wide background load over-starved it —
+        # it timed out during startup with an empty trace, not at test 18. So
+        # run the exact failing target, `make smoke-vm`, with ELLE_TRACE=io a
+        # few times; `parallel --tag` prefixes every line with the filename,
+        # so grep pulls out process-io.lisp's own [trace:io] tail. The last
+        # `h2-close:`/`server-conn:` marker with no following `done` (or the
+        # last `tp-submit` with no `tp-complete`) names the stuck step.
+        # `make smoke` below stays as the real gate.
         continue-on-error: true
         run: |
           set +e
-          BIN=./target/release/elle
-          FLAGS="--checked-intrinsics --jit=off --mlir=off"
-          LOAD=$(find stdlib.lisp prelude.lisp lib/ tests/ demos/ -name '*.lisp' | grep -v process-io.lisp)
-          for round in $(seq 1 6); do
-            pids=""
-            for f in $LOAD; do
-              timeout 30s $BIN $FLAGS "$f" >/dev/null 2>&1 &
-              pids="$pids $!"
-            done
-            sleep 1   # let the load ramp up and saturate cores
-            ELLE_TRACE=io timeout 30s $BIN $FLAGS tests/elle/process-io.lisp > pio.out 2>&1
-            rc=$?
-            for p in $pids; do kill "$p" 2>/dev/null; done
-            wait 2>/dev/null
-            if [ $rc -eq 124 ]; then
-              echo "round $round: process-io.lisp HUNG under load (traced)"
-              echo "==== [trace:io] tail (last 70 lines to the wedge) ===="
-              tail -70 pio.out
+          for round in 1 2 3 4 5; do
+            ELLE_TRACE=io timeout 200s make smoke-vm > smoke.out 2>&1
+            if grep -F 'process-io.lisp' smoke.out | grep -q 'terminated by SIGTERM'; then
+              echo "round $round: process-io.lisp HUNG in smoke-vm (traced)"
+              echo "==== process-io.lisp [trace:io] tail (last 90 lines) ===="
+              grep -F 'process-io.lisp' smoke.out | tail -90
               exit 0
             fi
-            echo "round $round: no hang (traced under load)"
+            echo "round $round: process-io.lisp did not hang"
           done
-          echo "no traced hang in 6 loaded rounds — if make smoke still hangs,"
-          echo "tracing masks it even under load; next is the SIGTERM-dumped ring"
+          echo "no process-io hang in 5 traced smoke-vm rounds — tracing may"
+          echo "mask it even under bounded load; next is a SIGTERM-dumped ring"
       - name: make doctest
         run: make doctest
       - name: make smoke

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -254,31 +254,49 @@ jobs:
         run: brew install parallel coreutils
       - name: make elle
         run: make elle
-      - name: Diagnose process-io.lisp hang (ioring smoke-vm)
+      - name: Diagnose process-io.lisp hang (heavy load + ioring)
         # TEMPORARY (remove with the io_trace instrumentation once test 18 is
-        # fixed): `--trace=io`'s per-op write(2) perturbed the timing-tight
-        # test-18 race away (5 traced smoke-vm rounds stayed green). Use
-        # ELLE_TRACE=ioring instead: events go to an in-memory ring with NO
-        # syscall on the hot path, dumped to stderr only when a `timeout`
-        # SIGTERM kills the hung process. So only the wedged process-io.lisp
-        # dumps (no flood), and the ring adds ~no perturbation. `parallel
-        # --tag` prefixes each line with the file; grep pulls process-io's
-        # ring tail. Last `h2-close:`/`server-conn:` marker with no following
-        # `done` (or last `tp-submit` with no `tp-complete`) = the stuck step.
+        # fixed): the race needs HEAVY contention to keep its window open under
+        # tracing — `make smoke-vm`'s bounded -j didn't reproduce it traced,
+        # but a ~40-wide background load did (an earlier ELLE_TRACE=io round
+        # caught the full trace). Reproduce that: launch the rest of the suite
+        # as untraced background jobs saturating the cores, and run only
+        # process-io.lisp with ELLE_TRACE=ioring (in-memory ring, dumped on
+        # SIGTERM — ~no per-op perturbation). That load sometimes starves
+        # process-io at startup (a hang with an EMPTY ring); loop past those
+        # and only report a hang whose ring actually has events. The last
+        # `h2-close:`/`server-conn:` marker with no following `done` (or last
+        # `tp-submit` with no `tp-complete`) names the stuck step.
         continue-on-error: true
         run: |
           set +e
-          for round in 1 2 3 4 5 6; do
-            ELLE_TRACE=ioring timeout 200s make smoke-vm > smoke.out 2>&1
-            if grep -F 'process-io.lisp' smoke.out | grep -q 'terminated by SIGTERM'; then
-              echo "round $round: process-io.lisp HUNG in smoke-vm (ioring)"
-              echo "==== process-io.lisp [trace:io ring] tail (last 100) ===="
-              grep -F 'process-io.lisp' smoke.out | tail -100
-              exit 0
+          BIN=./target/release/elle
+          FLAGS="--checked-intrinsics --jit=off --mlir=off"
+          LOAD=$(find stdlib.lisp prelude.lisp lib/ tests/ demos/ -name '*.lisp' | grep -v process-io.lisp)
+          for round in $(seq 1 15); do
+            pids=""
+            for f in $LOAD; do
+              timeout 30s $BIN $FLAGS "$f" >/dev/null 2>&1 &
+              pids="$pids $!"
+            done
+            sleep 1
+            ELLE_TRACE=ioring timeout 30s $BIN $FLAGS tests/elle/process-io.lisp > pio.out 2>&1
+            rc=$?
+            for p in $pids; do kill "$p" 2>/dev/null; done
+            wait 2>/dev/null
+            if [ $rc -eq 124 ]; then
+              if grep -qE 'h2-close:|tp-complete' pio.out; then
+                echo "round $round: process-io.lisp HUNG with a populated ring (the race)"
+                echo "==== [trace:io ring] tail (last 100) ===="
+                tail -100 pio.out
+                exit 0
+              fi
+              echo "round $round: hung but EMPTY ring (startup starvation) — retrying"
+            else
+              echo "round $round: no hang"
             fi
-            echo "round $round: process-io.lisp did not hang"
           done
-          echo "no process-io hang in 6 ioring smoke-vm rounds"
+          echo "no populated-ring hang in 15 loaded rounds"
       - name: make doctest
         run: make doctest
       - name: make smoke

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -144,7 +144,7 @@ Root AGENTS.md references these docs:
 | `debugging.md` | 220 | Debugging toolkit |
 | `oddities.md` | 280 | Intentional design oddities |
 | `fibers.md` | 312 | Fiber architecture |
-| `ffi.md` | 455 | FFI design |
+| `ffi.md` | ~480 | FFI design |
 | `modules.md` | ~240 | Module system design |
 | `reference/janet.md` | ~200 | Janet language reference |
 | `reference/janet-compiler.md` | ~150 | Janet compiler design |

--- a/docs/ffi.md
+++ b/docs/ffi.md
@@ -46,6 +46,38 @@ This document describes the implemented system.
 ```
 
 
+## Loading Libraries
+
+`ffi/native` loads a shared library and returns a handle for `ffi/lookup`.
+Pass `nil` to load the current process (`dlopen(NULL)`), which exposes libc
+and anything statically linked into the binary.
+
+Library names are written **Linux-style** (`libfoo.so`, `libfoo.so.2`) and
+resolved to the host's native form at load time, so a single call is portable:
+
+| Spec written in Elle | Linux           | macOS                | Windows   |
+|----------------------|-----------------|----------------------|-----------|
+| `"libz.so"`          | `libz.so`       | `libz.dylib`         | `z.dll`   |
+| `"libcairo.so.2"`    | `libcairo.so.2` | `libcairo.2.dylib`   | `cairo.dll` |
+
+Note that the soname version moves: Linux appends it after `.so`
+(`libz.so.1`), macOS embeds it before the extension (`libz.1.dylib`). The
+loader tries the host-native name first and falls back through the
+unversioned form to the original spec, so existing `.so` names keep working
+on Linux while the same code loads `.dylib`/`.dll` elsewhere. The name
+rewriting lives in `library_candidates` (`src/ffi/loader.rs`); if you already
+hold a host-native name (a full path to a `.dylib`, say), pass it directly and
+it is used unchanged.
+
+```lisp
+(def self (ffi/native nil))         # current process, all platforms
+
+# "libz.so" resolves to libz.dylib on macOS and z.dll on Windows. Guarded
+# with protect here because libz may not be installed in every environment.
+(protect (ffi/native "libz.so"))
+```
+
+
 ## Type Descriptors
 
 C types are described by keywords at the Elle level. The `TypeDesc` enum in
@@ -467,6 +499,9 @@ that's kept alive alongside the buffer.
 
 5. **Platform-guarded loading.** Library loading requires Unix
    (`#[cfg(unix)]` — Linux, macOS, BSD). Non-Unix platforms get error stubs.
+   Linux-style `.so` specs are rewritten to the host's native form
+   (`.dylib`/`.dll`) by `library_candidates` before loading (see
+   [Loading Libraries](#loading-libraries)), so the same call is portable.
 
 6. **No automatic memory management.** `ffi/malloc` memory must be
    explicitly freed with `ffi/free`. Callbacks must be freed with

--- a/docs/processes.md
+++ b/docs/processes.md
@@ -523,6 +523,29 @@ tracked by the scheduler and participate in I/O completion.
     (assert (= r2 70) "f2 = 70"))))
 ```
 
+## Orphan sub-fibers and teardown
+
+A sub-fiber outlives the code that spawned it only as long as some
+process is alive to observe it. Once **every** process has terminated,
+any sub-fiber still running — a fire-and-forget `ev/spawn` that parked on
+a futex, a background server blocked in `accept`, an un-joined worker
+waiting on I/O — is an *orphan*: no live process can ever wake it or read
+its result. `process:start` tears these orphans down (aborting them so
+their `defer`/`protect` cleanup runs and cancelling their in-flight I/O)
+rather than blocking forever waiting on work that can never complete.
+This mirrors `ev/run`'s program-completion teardown for the root
+scheduler (see [concurrency.md](concurrency.md)).
+
+```text
+(process:start (fn []
+  ## fire-and-forget background server; the body never joins or stops it
+  (ev/spawn (fn [] (protect (http2:serve listener handler))))
+  nil))   ## body returns → server sub-fiber is orphaned and torn down
+```
+
+A sub-fiber the body **joins** (`ev/join`) is not an orphan: the process
+stays alive until the join returns, so the sub-fiber completes first.
+
 
 # Process API reference
 

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -63,7 +63,8 @@ cancel. A wakeup gap (notably: macOS `shutdown()` does **not** wake a
 blocked `accept()` on a listening socket) can wedge the scheduler at
 teardown until the CI `timeout` sends `SIGTERM`.
 
-Run with `--trace=io` to emit the threadpool op lifecycle
+Run with `--trace=io` (or set `ELLE_TRACE=io` when the command line is
+fixed, e.g. a CI job) to emit the threadpool op lifecycle
 (`tp-submit`/`tp-complete`) plus close/cancel reaping to stderr via
 async-signal-safe `write(2)`, so the last line before `SIGTERM` survives
 and names the wedged op and fd. See the *Diagnostics* section of

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -54,6 +54,21 @@ for spawned fibers).
 `ev/sleep` and `ev/timeout` use `io_uring` timeout operations for
 precise timer support without polling.
 
+## Diagnosing threadpool hangs (`--trace=io`)
+
+On the threadpool backend (macOS, or Linux with `--no-uring`), a blocking
+`read`/`accept`/`write` runs on a worker thread that can only be woken by
+data, EOF, or a `shutdown(fd)` from the close path — there is no async
+cancel. A wakeup gap (notably: macOS `shutdown()` does **not** wake a
+blocked `accept()` on a listening socket) can wedge the scheduler at
+teardown until the CI `timeout` sends `SIGTERM`.
+
+Run with `--trace=io` to emit the threadpool op lifecycle
+(`tp-submit`/`tp-complete`) plus close/cancel reaping to stderr via
+async-signal-safe `write(2)`, so the last line before `SIGTERM` survives
+and names the wedged op and fd. See the *Diagnostics* section of
+[`src/io/AGENTS.md`](../src/io/AGENTS.md) for how to read the output.
+
 ---
 
 ## See also

--- a/lib/http2.lisp
+++ b/lib/http2.lisp
@@ -25,12 +25,10 @@
   (def stream ((import "std/http2/stream") :frame frame))
   (def transport ((import "std/http2/transport") :tls tls))
   (def session
-    ((import "std/http2/session") :frame frame :stream stream
-                                  :hpack hpack))
+    ((import "std/http2/session") :frame frame :stream stream :hpack hpack))
   (def server
-    ((import "std/http2/server") :hpack hpack :frame frame
-                                 :stream stream :session session :tls tls
-                                 :transport transport))
+    ((import "std/http2/server") :hpack hpack :frame frame :stream stream
+                                 :session session :tls tls :transport transport))
 
   ## ── Convenience aliases ────────────────────────────────────────────────
 
@@ -311,14 +309,17 @@
         (when-let [s (get sess:streams sid)] (protect (s:data-queue:close))))
       (session:send-goaway sess sess:last-stream-id C:err-no-error)
       (sess:write-queue:put :shutdown)
-      (when sess:writer-fiber (ev/join-protected sess:writer-fiber))
-      # Abort reader before closing transport — the reader may have a pending
+      (io/trace "h2-close: join-writer")
+      (when sess:writer-fiber (ev/join-protected sess:writer-fiber))  # Abort reader before closing transport — the reader may have a pending
       # read on the socket (started by fuel preemption or concurrent sub-fiber).
       # Closing the fd while a read is in-flight causes partial-read errors.
+      (io/trace "h2-close: abort+join-reader")
       (when sess:reader-fiber
         (protect (ev/abort sess:reader-fiber))
         (ev/join-protected sess:reader-fiber))
-      (protect (sess:transport:close)))
+      (io/trace "h2-close: close-transport")
+      (protect (sess:transport:close))
+      (io/trace "h2-close: done"))
     nil)
 
   ## ── Tests ──────────────────────────────────────────────────────────────

--- a/lib/http2/server.lisp
+++ b/lib/http2/server.lisp
@@ -128,7 +128,9 @@
                          :on-goaway (fn [sess payload]
                                       (sess:write-queue:put :shutdown)
                                       true))  # Wait for writer to drain queued frames before returning
-      (when sess:writer-fiber (ev/join-protected sess:writer-fiber))))
+      (io/trace "server-conn: read-loop done; join-writer")
+      (when sess:writer-fiber (ev/join-protected sess:writer-fiber))
+      (io/trace "server-conn: done")))
 
   ## ── h2-serve ───────────────────────────────────────────────────────────
 

--- a/lib/process.lisp
+++ b/lib/process.lisp
@@ -911,6 +911,90 @@
             (> (length join-waiting) 0) (> (length select-sets) 0)
             (> (length futex-parked) 0))))
 
+    (def @any-alive?
+      (fn []
+        (def @found false)
+        (each p in procs
+          (when (= (get p :status) :alive) (assign found true)))
+        found))
+
+    # These bindings hold mutable collections but are themselves immutable
+    # (unlike @ready/@waiting, which are @-mutable), so empty them in place
+    # the way the rest of the scheduler does with del/pop.
+    (def @clear-map (fn [m] (each k in (keys m) (del m k))))
+    (def @clear-vec (fn [v] (while (> (length v) 0) (pop v))))
+
+    # Cancel every forwarded I/O submission (process- and sub-fiber-owned
+    # alike) so the root scheduler's forwarded-pending doesn't leak, then
+    # empty io-pending.
+    (def @cancel-all-io
+      (fn []
+        (each [id _entry] in (pairs io-pending)
+          (emit :wait {:op :io-forward-cancel :id id}))
+        (clear-map io-pending)))
+
+    # Snapshot every sub-fiber the scheduler is still tracking, as
+    # {:fiber :pid} entries. At teardown (no process alive) each is an
+    # orphan to abort. Sources, in order: waiting on forwarded I/O; parked
+    # on a futex (only :is-sub waiters remain — a parked process is :alive,
+    # so none exist once any-alive? is false); queued but not yet run;
+    # awaited join targets and their sub-fiber joiners; select candidates.
+    (def @collect-orphan-subs
+      (fn []
+        (def @vs @[])
+        (each [_id e] in (pairs io-pending)
+          (when (get e :fiber)
+            (push vs @{:fiber (get e :fiber) :pid (get e :pid)})))
+        (each [_key waiters] in (pairs futex-parked)
+          (each w in (->list waiters)
+            (when (get w :fiber) (push vs w))))
+        (each e in (->list sub-runnable)
+          (push vs e))
+        (each [target waiters] in (pairs join-waiting)
+          (push vs @{:fiber target :pid 0})
+          (each w in (->list waiters)
+            (when (and (not (integer? w)) (get w :fiber)) (push vs w))))
+        (each [_pid e] in (pairs select-sets)
+          (each f in (get e :candidates)
+            (push vs @{:fiber f :pid 0})))
+        vs))
+
+    (def @clear-sub-state
+      (fn []
+        (cancel-all-io)
+        (clear-vec sub-runnable)
+        (clear-map futex-parked)
+        (clear-map join-waiting)
+        (clear-map select-sets)))
+
+    # Program-completion teardown, mirroring ev/run's make-async-scheduler.
+    # Once no process is alive, every remaining sub-fiber is an orphan: no
+    # live process can wake a parked futex, deliver its I/O, or observe its
+    # result. Left alone they keep has-work? true forever, so sched-run
+    # spins (futex orphan) or blocks on io/wait (I/O orphan). Abort each so
+    # its defer/protect cleanup runs, cancel its forwarded I/O, and empty
+    # the sub-fiber state so has-work? goes false and sched-run returns.
+    #
+    # Aborting runs defers, which may submit fresh I/O or re-park on a
+    # futex; those land back in the tracked collections and are caught the
+    # next round. Bounded so a defer that stubbornly re-parks can't
+    # reintroduce the very hang we're removing; a final clear-sub-state
+    # drops anything still lingering past the round bound.
+    (def @abort-orphan-subs
+      (fn []
+        (def @rounds 0)
+        (while (and (< rounds 64) (has-work?))
+          (assign rounds (+ rounds 1))
+          (let [victims (collect-orphan-subs)]
+            (clear-sub-state)
+            (each v in victims
+              (let [f (get v :fiber)]
+                (when (= (fiber/status f) :paused)
+                  (protect (fiber/abort f {:error :shutdown}))
+                  (handle-sub-fiber-after-resume f (or (get v :pid) 0)))))
+            (reap-io)))
+        (clear-sub-state)))
+
     (def @sched-run
       (fn [init]
         # Parameterize *spawn* so that ev/spawn inside any process or sub-fiber
@@ -935,6 +1019,15 @@
               (drain-sub-runnable)))
           (wake-futex-ready)
           (wake-waiting)
+
+          # No process left alive: every remaining sub-fiber is an orphan
+          # (nothing can wake its futex, deliver its I/O, or read its
+          # result). Tear them down here — after draining, so a fire-and-
+          # forget sub-fiber still runs once, but before the idle handler
+          # below would otherwise spin on a futex orphan or block on
+          # io/wait for an I/O orphan that never completes.
+          (when (not (any-alive?))
+            (abort-orphan-subs))
 
           (when (empty? ready)
             (cond  # Nothing alive anywhere — done

--- a/src/config.rs
+++ b/src/config.rs
@@ -199,7 +199,7 @@ impl MlirPolicy {
 /// silently (forward compat for :spirv, :mlir, :gpu).
 pub const TRACE_KEYWORDS: &[&str] = &[
     "call", "signal", "compile", "fiber", "hir", "lir", "emit", "jit", "io", "gc", "import",
-    "macro", "wasm", "capture", "arena", "escape", "bytecode", "posix",
+    "macro", "wasm", "capture", "arena", "escape", "bytecode", "posix", "ioring",
     // Future: accepted without error
     "spirv", "mlir", "gpu",
 ];
@@ -278,7 +278,12 @@ pub mod trace_bits {
     /// can fire from any thread (including `sys/spawn`'d OS threads)
     /// which has no `&VM` reference.
     pub const CHAN: u32 = 1 << 18;
-    pub const ALL: u32 = (1 << 19) - 1;
+    /// In-memory I/O event ring, dumped to stderr only on `SIGTERM` (the CI
+    /// timeout signal). Unlike `io` (a `write(2)` per event) this adds no
+    /// syscall on the hot path, so it can pin a hang too timing-tight to
+    /// survive `--trace=io`'s per-op latency. See `io_trace`/`io_ring_dump`.
+    pub const IORING: u32 = 1 << 19;
+    pub const ALL: u32 = (1 << 20) - 1;
 
     /// Convert a keyword name to its bit. Returns 0 for unknown keywords.
     pub fn from_name(name: &str) -> u32 {
@@ -302,6 +307,7 @@ pub mod trace_bits {
             "bytecode" => BYTECODE,
             "posix" => POSIX,
             "chan" => CHAN,
+            "ioring" => IORING,
             // Future keywords — accepted but no bit (traced via HashSet)
             _ => 0,
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -551,6 +551,30 @@ impl Config {
     /// `remaining_args` contains file args and everything after `--`.
     pub fn parse(args: &[String]) -> Result<(Config, Vec<String>), String> {
         let mut config = Config::default();
+
+        // `ELLE_TRACE=io,chan` seeds trace keywords from the environment so a
+        // diagnostic trace can be switched on where the command line is fixed
+        // — e.g. a CI job that invokes `elle <script>` verbatim. CLI
+        // `--trace=` appends to this; both feed the same trace-bit set (and
+        // the process-global mirror) via `from_static_config`. `all` expands
+        // to every keyword; unknown keywords are ignored, exactly as for
+        // `--trace=`.
+        if let Ok(v) = std::env::var("ELLE_TRACE") {
+            let v = v.trim();
+            if v == "all" {
+                for kw in TRACE_KEYWORDS {
+                    config.trace_keywords.push(kw.to_string());
+                }
+            } else {
+                for kw in v.split(',') {
+                    let kw = kw.trim();
+                    if !kw.is_empty() {
+                        config.trace_keywords.push(kw.to_string());
+                    }
+                }
+            }
+        }
+
         let mut remaining = Vec::new();
         let mut i = 0;
         let mut eval_exprs: Vec<String> = Vec::new();

--- a/src/ffi/AGENTS.md
+++ b/src/ffi/AGENTS.md
@@ -35,8 +35,10 @@ Does NOT:
 | `CallbackStore` | `callback.rs` | Storage for active callbacks, keyed by code pointer |
 | `CallbackData` | `callback.rs` | Closure + signature captured by a trampoline |
 | `ActiveCallback` | `callback.rs` | Keeps a libffi closure alive; holds code pointer |
-| `load_library` | `loader.rs` | Load a `.so` file via libloading |
+| `load_library` | `loader.rs` | Load a shared library, trying host-native names |
 | `load_self` | `loader.rs` | Load the current process (dlopen(NULL)) |
+| `library_candidates` | `loader.rs` | Rewrite a Linux `.so` spec to host-native names |
+| `current_dl_os` | `loader.rs` | Host OS family (`DlOs`) for naming |
 | `LibraryHandle` | `loader.rs` | Handle to a loaded shared library |
 
 ## Data flow
@@ -44,7 +46,7 @@ Does NOT:
 ```
 Elle code
   │
-  ├─ ffi/native "libm.so.6"  →  loader::load_library()  →  LibraryHandle  →  FFISubsystem
+  ├─ ffi/native "libm.so.6"  →  loader::load_library()  →  library_candidates() (host-native names)  →  LibraryHandle  →  FFISubsystem
   ├─ ffi/lookup lib "sqrt"    →  LibraryHandle::get_symbol()  →  Value::pointer(addr)
   ├─ ffi/signature :double [:double]  →  Signature  →  Value::ffi_signature()
   │                                                      └─ HeapObject::FFISignature(sig, RefCell<Option<Cif>>)
@@ -90,7 +92,7 @@ Elle code
 | `from_c.rs` | 99 | `read_value_from_buffer` — C → Value unmarshalling |
 | `call.rs` | 221 | `prepare_cif`, `ffi_call` — CIF preparation and C function dispatch |
 | `callback.rs` | 556 | `create_callback`, `free_callback`, `CallbackStore`, `ActiveCallback`, `trampoline_callback`, thread-local error flag |
-| `loader.rs` | 192 | `load_library`, `load_self`, `LibraryHandle` — platform-guarded (Linux only) |
+| `loader.rs` | ~290 | `load_library`, `load_self`, `library_candidates`, `LibraryHandle` — Unix dlopen, Linux→host name rewriting |
 | `primitives/mod.rs` | 7 | Re-exports from `primitives/context.rs` |
 | `primitives/context.rs` | 13 | Re-exports from `crate::context`, `register_ffi_primitives` (no-op) |
 
@@ -193,8 +195,11 @@ Top-level FFI state. Holds `libraries: HashMap<u32, LibraryHandle>` and
    Elle arrays map to C structs (positional fields) and C arrays (uniform
    elements). Field count must match exactly.
 
-9. **Platform-guarded loading.** `loader.rs` uses `#[cfg(target_os = "linux")]`
-   guards. Non-Linux platforms get stub implementations that return errors.
+9. **Platform-guarded loading.** `loader.rs` uses `#[cfg(unix)]` guards
+   (Linux, macOS, BSD); non-Unix platforms get stub implementations that
+   return errors. Library specs are written Linux-style and rewritten to the
+   host's native form (`.dylib`/`.dll`) by `library_candidates` before the
+   `dlopen`, so a single `(ffi/native "libfoo.so")` call is portable.
 
 ## Dependents
 

--- a/src/ffi/loader.rs
+++ b/src/ffi/loader.rs
@@ -1,14 +1,104 @@
 //! Dynamic library loading with platform abstraction.
 //!
-//! Supports loading .so files on Linux and provides stubs for other platforms.
+//! Elle library specs are written Linux-style (`libfoo.so`, `libfoo.so.2`).
+//! On macOS and Windows the same spec is rewritten to the host's native form
+//! (`libfoo.dylib`, `foo.dll`) by `library_candidates`, so a single
+//! `(ffi/native "libfoo.so")` call is portable across platforms. Loading
+//! itself requires a Unix-family `dlopen` (`#[cfg(unix)]`: Linux, macOS, BSD);
+//! other platforms get error stubs.
+
+/// Host OS family for dynamic-library naming.
+///
+/// Kept distinct from `cfg!(target_os = ...)` so the naming rules in
+/// `library_candidates` can be unit-tested for every platform on any host.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum DlOs {
+    Linux,
+    Macos,
+    Windows,
+}
+
+/// The OS family this binary was compiled for.
+pub(crate) fn current_dl_os() -> DlOs {
+    if cfg!(target_os = "macos") {
+        DlOs::Macos
+    } else if cfg!(target_os = "windows") {
+        DlOs::Windows
+    } else {
+        // Linux, BSD, and other dlopen-capable Unixes use the soname scheme.
+        DlOs::Linux
+    }
+}
+
+/// Expand a Linux-style library spec into the ordered list of filenames to
+/// try when loading on `os`.
+///
+/// Specs are written Linux-style. A bare `.so` or versioned `.so.N` soname is
+/// rewritten to the host's native form so the same call works everywhere; a
+/// directory prefix is preserved and only the basename is rewritten:
+///
+/// | spec               | macOS                            | Windows               |
+/// |--------------------|----------------------------------|-----------------------|
+/// | `libz.so`          | `libz.dylib`                     | `z.dll`, `libz.dll`   |
+/// | `libcairo.so.2`    | `libcairo.2.dylib`, `libcairo.dylib` | `cairo.dll`, `libcairo.dll` |
+///
+/// Note the version moves: Linux appends it after `.so` (`libz.so.1`), macOS
+/// embeds it before `.dylib` (`libz.1.dylib`). A spec that is not a Linux
+/// soname (already `.dylib`/`.dll`, or an unrecognized name) is returned
+/// unchanged — the caller is assumed to know the host form. The original spec
+/// is always appended as a final fallback.
+pub(crate) fn library_candidates(spec: &str, os: DlOs) -> Vec<String> {
+    if os == DlOs::Linux {
+        return vec![spec.to_string()];
+    }
+
+    // Split off a directory prefix; only the basename carries the soname.
+    let (dir, base) = match spec.rfind('/') {
+        Some(i) => (&spec[..=i], &spec[i + 1..]),
+        None => ("", spec),
+    };
+
+    // Parse a Linux soname: "libfoo.so" or "libfoo.so.<version>".
+    const SO_VER: &str = ".so.";
+    let (stem, version) = if let Some(stem) = base.strip_suffix(".so") {
+        (stem, None)
+    } else if let Some(idx) = base.find(SO_VER) {
+        (&base[..idx], Some(&base[idx + SO_VER.len()..]))
+    } else {
+        // Not a Linux soname — assume the caller already gave the host form.
+        return vec![spec.to_string()];
+    };
+
+    let mut out = Vec::new();
+    match os {
+        DlOs::Macos => {
+            // macOS embeds the version before the extension: libfoo.2.dylib.
+            if let Some(v) = version {
+                out.push(format!("{dir}{stem}.{v}.dylib"));
+            }
+            out.push(format!("{dir}{stem}.dylib"));
+        }
+        DlOs::Windows => {
+            // Windows DLLs drop the `lib` prefix and carry no soname version.
+            let win = stem.strip_prefix("lib").unwrap_or(stem);
+            out.push(format!("{dir}{win}.dll"));
+            out.push(format!("{dir}{stem}.dll"));
+        }
+        DlOs::Linux => unreachable!("Linux handled above"),
+    }
+    // Keep the original spec as a final fallback.
+    out.push(spec.to_string());
+    out
+}
 
 /// Handle to a loaded shared library.
 pub(crate) struct LibraryHandle {
     /// Unique ID for this library in the FFI subsystem
     pub id: u32,
-    /// Path to the library file
+    /// Path to the library file actually loaded (a resolved candidate, which
+    /// may differ from the requested spec — e.g. `libz.dylib` for `libz.so`)
     pub path: String,
-    /// The underlying native library (Linux only)
+    /// The underlying native library (Unix only)
     #[cfg(unix)]
     pub native: libloading::Library,
 }
@@ -45,14 +135,18 @@ impl LibraryHandle {
     }
 }
 
-/// Load a dynamic library from a file path.
+/// Load a dynamic library from a Linux-style spec.
 ///
 /// # Arguments
-/// * `path` - Path to the library file (.so on Linux)
+/// * `spec` - Library spec written Linux-style (`libfoo.so`, `libfoo.so.2`,
+///   or an absolute/relative path). Rewritten to the host's native name(s)
+///   via `library_candidates` and tried in order.
 ///
 /// # Returns
-/// * `Ok(library)` - Loaded library handle
-/// * `Err(message)` - If file not found or not a valid library
+/// * `Ok(library)` - Loaded library handle (its `path` is the candidate that
+///   actually loaded)
+/// * `Err(message)` - If no candidate could be loaded (file not found or not
+///   a valid library)
 ///
 /// # Example
 /// ```text
@@ -60,33 +154,44 @@ impl LibraryHandle {
 /// let lib = load_library("/lib/x86_64-linux-gnu/libc.so.6")?;
 /// let strlen_ptr = lib.get_symbol("strlen")?;
 /// ```
-pub(crate) fn load_library(path: &str) -> Result<LibraryHandle, String> {
+pub(crate) fn load_library(spec: &str) -> Result<LibraryHandle, String> {
     #[cfg(unix)]
     {
-        // Only check existence for absolute/relative paths.
-        // Bare names like "libm.so.6" are resolved by the dynamic linker
-        // via LD_LIBRARY_PATH / /etc/ld.so.cache — don't reject them.
-        if path.contains('/') && !crate::path::exists(path) {
-            return Err(format!("Library file not found: {}", path));
-        }
-
-        unsafe {
-            match libloading::Library::new(path) {
-                Ok(native) => Ok(LibraryHandle {
-                    id: 0, // Will be assigned by FFISubsystem
-                    path: path.to_string(),
-                    native,
-                }),
-                Err(e) => Err(format!("Failed to load library '{}': {}", path, e)),
+        // Try the host-native name(s) for this spec in order, returning the
+        // first that loads. This is what lets a Linux-style ".so" spec resolve
+        // to ".dylib" on macOS without rewriting every call site.
+        let candidates = library_candidates(spec, current_dl_os());
+        let mut last_err = None;
+        for cand in &candidates {
+            // Only check existence for absolute/relative paths. Bare names
+            // like "libm.so.6" are resolved by the dynamic linker via
+            // LD_LIBRARY_PATH / /etc/ld.so.cache — don't reject them.
+            if cand.contains('/') && !crate::path::exists(cand) {
+                last_err = Some(format!("Library file not found: {}", cand));
+                continue;
+            }
+            unsafe {
+                match libloading::Library::new(cand) {
+                    Ok(native) => {
+                        return Ok(LibraryHandle {
+                            id: 0, // Will be assigned by FFISubsystem
+                            path: cand.clone(),
+                            native,
+                        });
+                    }
+                    Err(e) => last_err = Some(format!("Failed to load library '{}': {}", cand, e)),
+                }
             }
         }
+        Err(last_err.unwrap_or_else(|| format!("Failed to load library '{}'", spec)))
     }
 
     #[cfg(not(unix))]
     {
+        let _ = current_dl_os(); // keep the helper exercised on all targets
         Err(format!(
-            "Dynamic library loading only supported on Linux (attempted to load {})",
-            path
+            "Dynamic library loading only supported on Unix (attempted to load {})",
+            spec
         ))
     }
 }
@@ -127,6 +232,86 @@ pub(crate) fn load_self() -> Result<LibraryHandle, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Build a `Vec<String>` from string literals for terse expected values.
+    fn svec(xs: &[&str]) -> Vec<String> {
+        xs.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn candidates_linux_passthrough() {
+        // Linux is the canonical form: specs are used verbatim.
+        assert_eq!(
+            library_candidates("libz.so", DlOs::Linux),
+            svec(&["libz.so"])
+        );
+        assert_eq!(
+            library_candidates("libz.so.1", DlOs::Linux),
+            svec(&["libz.so.1"])
+        );
+        assert_eq!(
+            library_candidates("/usr/lib/libz.so.1", DlOs::Linux),
+            svec(&["/usr/lib/libz.so.1"])
+        );
+    }
+
+    #[test]
+    fn candidates_macos_unversioned() {
+        // libz.so → libz.dylib, with the original kept as a fallback.
+        assert_eq!(
+            library_candidates("libz.so", DlOs::Macos),
+            svec(&["libz.dylib", "libz.so"])
+        );
+    }
+
+    #[test]
+    fn candidates_macos_versioned() {
+        // Linux appends the version after .so; macOS embeds it before .dylib.
+        assert_eq!(
+            library_candidates("libcairo.so.2", DlOs::Macos),
+            svec(&["libcairo.2.dylib", "libcairo.dylib", "libcairo.so.2"])
+        );
+    }
+
+    #[test]
+    fn candidates_macos_preserves_directory() {
+        // Only the basename is rewritten; the directory prefix is preserved.
+        assert_eq!(
+            library_candidates("/usr/lib/libz.so.1", DlOs::Macos),
+            svec(&[
+                "/usr/lib/libz.1.dylib",
+                "/usr/lib/libz.dylib",
+                "/usr/lib/libz.so.1"
+            ])
+        );
+    }
+
+    #[test]
+    fn candidates_non_soname_passthrough() {
+        // Already host-native or unrecognized → returned unchanged.
+        assert_eq!(
+            library_candidates("libz.dylib", DlOs::Macos),
+            svec(&["libz.dylib"])
+        );
+        assert_eq!(library_candidates("z.dll", DlOs::Windows), svec(&["z.dll"]));
+        assert_eq!(
+            library_candidates("/opt/foo/bar", DlOs::Macos),
+            svec(&["/opt/foo/bar"])
+        );
+    }
+
+    #[test]
+    fn candidates_windows_strips_lib_prefix() {
+        // Windows DLLs conventionally drop the `lib` prefix and the version.
+        assert_eq!(
+            library_candidates("libzmq.so", DlOs::Windows),
+            svec(&["zmq.dll", "libzmq.dll", "libzmq.so"])
+        );
+        assert_eq!(
+            library_candidates("libcairo.so.2", DlOs::Windows),
+            svec(&["cairo.dll", "libcairo.dll", "libcairo.so.2"])
+        );
+    }
 
     #[test]
     #[cfg(unix)]

--- a/src/io/AGENTS.md
+++ b/src/io/AGENTS.md
@@ -94,7 +94,7 @@ Enum tracking in-flight async operations (5 variants):
 
 Typed thread-pool submission and completion:
 
-- `PoolOp` — enum with 11 variants matching the operations. Each variant carries exactly the data that operation needs (fd, buffers, addresses, or closures). Replaces the old `(fd, op_kind: u8, data: Vec<u8>, size: usize)` untyped submission.
+- `PoolOp` — enum with 21 variants matching the operations. Each variant carries exactly the data that operation needs (fd, buffers, addresses, or closures). Replaces the old `(fd, op_kind: u8, data: Vec<u8>, size: usize)` untyped submission.
 - `PoolCompletion { id, result_code, data }` — typed completion struct. Replaces the old `(u64, i32, Vec<u8>)` tuple.
 
 ### ConnectAddr
@@ -149,6 +149,32 @@ All formatting uses `std::net::Ipv4Addr`/`Ipv6Addr` for canonical output (proper
 `io/cancel` submits `IORING_OP_ASYNC_CANCEL` on io_uring, or removes the pending entry on thread pool. The cancel SQE's CQE uses the high-bit tag (same as timeout CQEs) and is skipped by `drain_cqes`. The cancelled operation generates a CQE with `result = -ECANCELED`.
 
 Used by `do-shutdown` in stdlib to cancel pending I/O before aborting/cancelling fibers.
+
+## Diagnostics: `--trace=io`
+
+`io_trace` (in `mod.rs`) emits `[trace:io]` lines to fd 2 via a raw
+`write(2)` — async-signal-safe and callable from threadpool worker threads
+(no `&VM`; reads the process-global trace mirror). Gated on the `io` trace
+bit, so it is a single atomic load when `--trace=io` is absent.
+
+It logs the threadpool op lifecycle and the close/cancel reaping:
+
+| Line | Meaning |
+|------|---------|
+| `tp-submit id=N op=KIND fd=F in_flight=K` | worker started for submission `N` |
+| `tp-complete id=N op=KIND fd=F rc=R` | that worker's syscall returned `R` |
+| `close fd=F: reaping K pending op(s)` | `port/close` found `K` in-flight ops on `F` |
+| `close fd=F: shutdown(SHUT_RDWR) … id=N` | threadpool close woke pending `N` via `shutdown` |
+| `cancel id=N` | `io/cancel` on submission `N` |
+
+This exists to pin threadpool hangs that only manifest on macOS (no
+io_uring). Because normal teardown *abandons* the reads of force-unwound
+fibers (the process exits and kills their blocked workers), a lone
+`tp-submit` without `tp-complete` is expected and not itself a bug. The
+hang fingerprint is the **last lines before the `SIGTERM` timeout**: an op
+whose worker never returns after a `close … shutdown` — e.g. a
+`op=accept` on a listening socket, which macOS/BSD `shutdown()` does not
+wake (returns `ENOTCONN`) whereas Linux does (returns `EINVAL`).
 
 ## Buffer Drain Invariant
 

--- a/src/io/AGENTS.md
+++ b/src/io/AGENTS.md
@@ -155,7 +155,12 @@ Used by `do-shutdown` in stdlib to cancel pending I/O before aborting/cancelling
 `io_trace` (in `mod.rs`) emits `[trace:io]` lines to fd 2 via a raw
 `write(2)` — async-signal-safe and callable from threadpool worker threads
 (no `&VM`; reads the process-global trace mirror). Gated on the `io` trace
-bit, so it is a single atomic load when `--trace=io` is absent.
+bit, so it is a single atomic load when the bit is unset.
+
+Enable it with `--trace=io`, or — where the command line is fixed (a CI job
+that runs `elle <script>` verbatim) — with the `ELLE_TRACE=io` environment
+variable (see `Config::parse`). Both feed the same trace-bit set and the
+global mirror.
 
 It logs the threadpool op lifecycle and the close/cancel reaping:
 

--- a/src/io/aio.rs
+++ b/src/io/aio.rs
@@ -273,6 +273,11 @@ impl AsyncBackend {
                     })
                     .collect();
 
+                crate::io::io_trace(format_args!(
+                    "close fd={fd}: reaping {} pending op(s)",
+                    ids_to_cancel.len()
+                ));
+
                 for _op_id in ids_to_cancel {
                     match inner.platform {
                         #[cfg(target_os = "linux")]
@@ -284,6 +289,17 @@ impl AsyncBackend {
                             // stuck in accept/read/recv. Do NOT remove the pending
                             // entry — let the thread's error completion flow back
                             // so the fiber resumes and can exit cleanly.
+                            //
+                            // Caveat (traced here for the macOS hang hunt):
+                            // shutdown() wakes a blocked read on a *connected*
+                            // socket everywhere, but on macOS/BSD it returns
+                            // ENOTCONN on a *listening* socket and does NOT wake
+                            // a blocked accept() — so a `tp-submit … op=accept`
+                            // with no matching `tp-complete` after this line is
+                            // the fingerprint of that gap.
+                            crate::io::io_trace(format_args!(
+                                "close fd={fd}: shutdown(SHUT_RDWR) to unblock pending id={_op_id}"
+                            ));
                             unsafe { libc::shutdown(*fd, libc::SHUT_RDWR) };
                         }
                     }
@@ -1310,6 +1326,7 @@ impl AsyncBackend {
     /// mid-flight; the scheduler removes the pending entry and the completion
     /// is discarded when it arrives).
     pub(crate) fn cancel(&self, id: u64) -> Result<(), String> {
+        crate::io::io_trace(format_args!("cancel id={id}"));
         let mut inner = self.inner.borrow_mut();
         match inner.platform {
             #[cfg(target_os = "linux")]

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -36,25 +36,83 @@ use crate::value::heap::TableKey;
 use crate::value::Value;
 use std::collections::BTreeMap;
 
-/// Emit an `[trace:io]` diagnostic line to stderr when the `io` trace bit
-/// (`--trace=io`) is set; otherwise a single relaxed atomic load and return.
+/// Bounded in-memory ring of recent `[trace:io]` lines for `--trace=ioring`.
+/// Raw bytes so `io_ring_dump` can hand the whole tail to one `write(2)` from
+/// the `SIGTERM` handler without touching the allocator. A plain `Mutex`
+/// (not a lock-free ring) keeps it simple: the recorder takes it only to
+/// `extend`/`drain`, and the dump uses `try_lock`, so a signal landing on a
+/// recorder mid-append degrades to a skipped dump rather than a deadlock.
+static IO_RING: std::sync::Mutex<Vec<u8>> = std::sync::Mutex::new(Vec::new());
+
+/// Trim the ring from the front once it exceeds `CAP`, back down to `KEEP`
+/// (~the last few thousand events) — enough tail to name a wedge.
+const IO_RING_CAP: usize = 512 * 1024;
+const IO_RING_KEEP: usize = 384 * 1024;
+
+/// Emit an `[trace:io]` diagnostic line when the `io` or `ioring` trace bit
+/// is set; otherwise two relaxed atomic loads and return.
 ///
-/// Uses a raw `write(2)` rather than `eprintln!` deliberately. It must be
-/// callable from threadpool worker threads, which hold no `&VM` and so read
-/// the process-global trace mirror (`GLOBAL_TRACE_BITS`); and it must be
-/// async-signal-safe, so the *last* line emitted before a `SIGTERM`-at-
-/// timeout survives — which is exactly the line that names a stuck I/O op
-/// when the threadpool scheduler wedges (e.g. a macOS `accept()` a
-/// listening-socket `shutdown()` failed to wake). See `docs/scheduler.md`.
+/// Uses a raw `write(2)` rather than `eprintln!` deliberately: it must be
+/// callable from threadpool worker threads (no `&VM`; they read the
+/// process-global trace mirror `GLOBAL_TRACE_BITS`), and async-signal-safe
+/// so the last line before a `SIGTERM`-at-timeout survives.
+///
+/// Two modes, independent:
+/// - `io` (`--trace=io` / `ELLE_TRACE=io`): write each line to fd 2
+///   immediately. One syscall per event — visible live, but the per-op
+///   latency can perturb a timing-tight hang away.
+/// - `ioring` (`--trace=ioring`): append to an in-memory ring instead, with
+///   no syscall on the hot path; `io_ring_dump` flushes it once on `SIGTERM`.
+///   For hangs too tight to survive `io`'s per-op writes.
 pub(crate) fn io_trace(args: std::fmt::Arguments<'_>) {
-    if !crate::config::global_trace_bit_enabled(crate::config::trace_bits::IO) {
+    let write = crate::config::global_trace_bit_enabled(crate::config::trace_bits::IO);
+    let ring = crate::config::global_trace_bit_enabled(crate::config::trace_bits::IORING);
+    if !write && !ring {
         return;
     }
     let line = format!("[trace:io] {}\n", args);
-    // SAFETY: writing a byte buffer to fd 2 is always sound; a short or
-    // failed write is ignored — tracing is best-effort diagnostics.
+    if ring {
+        if let Ok(mut buf) = IO_RING.lock() {
+            buf.extend_from_slice(line.as_bytes());
+            if buf.len() > IO_RING_CAP {
+                let cut = buf.len() - IO_RING_KEEP;
+                buf.drain(..cut);
+            }
+        }
+    }
+    if write {
+        // SAFETY: writing a byte buffer to fd 2 is always sound; a short or
+        // failed write is ignored — tracing is best-effort diagnostics.
+        unsafe {
+            libc::write(2, line.as_ptr() as *const libc::c_void, line.len());
+        }
+    }
+}
+
+/// Flush the `--trace=ioring` buffer to fd 2. Called from the `SIGTERM`
+/// terminate handler (async-signal context): `try_lock` avoids a deadlock if
+/// the signal landed on a thread mid-append, and the tail is emitted with a
+/// single `write(2)` of already-allocated bytes (no formatting, no alloc).
+/// No-op unless the `ioring` bit is set.
+pub(crate) fn io_ring_dump() {
+    if !crate::config::global_trace_bit_enabled(crate::config::trace_bits::IORING) {
+        return;
+    }
+    let hdr = b"---- [trace:io ring] tail (events before SIGTERM) ----\n";
+    // SAFETY: bare write(2) of a static byte buffer — async-signal-safe.
     unsafe {
-        libc::write(2, line.as_ptr() as *const libc::c_void, line.len());
+        libc::write(2, hdr.as_ptr() as *const libc::c_void, hdr.len());
+    }
+    match IO_RING.try_lock() {
+        Ok(buf) => unsafe {
+            libc::write(2, buf.as_ptr() as *const libc::c_void, buf.len());
+        },
+        Err(_) => {
+            let m = b"---- [trace:io ring] (locked mid-append; skipped) ----\n";
+            unsafe {
+                libc::write(2, m.as_ptr() as *const libc::c_void, m.len());
+            }
+        }
     }
 }
 

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -36,6 +36,28 @@ use crate::value::heap::TableKey;
 use crate::value::Value;
 use std::collections::BTreeMap;
 
+/// Emit an `[trace:io]` diagnostic line to stderr when the `io` trace bit
+/// (`--trace=io`) is set; otherwise a single relaxed atomic load and return.
+///
+/// Uses a raw `write(2)` rather than `eprintln!` deliberately. It must be
+/// callable from threadpool worker threads, which hold no `&VM` and so read
+/// the process-global trace mirror (`GLOBAL_TRACE_BITS`); and it must be
+/// async-signal-safe, so the *last* line emitted before a `SIGTERM`-at-
+/// timeout survives — which is exactly the line that names a stuck I/O op
+/// when the threadpool scheduler wedges (e.g. a macOS `accept()` a
+/// listening-socket `shutdown()` failed to wake). See `docs/scheduler.md`.
+pub(crate) fn io_trace(args: std::fmt::Arguments<'_>) {
+    if !crate::config::global_trace_bit_enabled(crate::config::trace_bits::IO) {
+        return;
+    }
+    let line = format!("[trace:io] {}\n", args);
+    // SAFETY: writing a byte buffer to fd 2 is always sound; a short or
+    // failed write is ignored — tracing is best-effort diagnostics.
+    unsafe {
+        libc::write(2, line.as_ptr() as *const libc::c_void, line.len());
+    }
+}
+
 /// Byte offset where the Nth grapheme cluster ends in `buf` (treated
 /// as UTF-8).  Used by text-port `ReadExact` to count progress in
 /// graphemes — the unit Elle strings are measured in — instead of

--- a/src/io/pending.rs
+++ b/src/io/pending.rs
@@ -99,6 +99,10 @@ impl PendingOp {
         }
     }
 
+    /// Only the io_uring backend rebinds a pending op's buffer (buffer
+    /// reinsertion on short reads, `uring.rs`), so this is unused where
+    /// io_uring isn't compiled — the thread-pool backend never moves buffers.
+    #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
     pub(super) fn buffer_handle_mut(&mut self) -> &mut BufferHandle {
         match self {
             PendingOp::Port { buffer_handle, .. } => buffer_handle,

--- a/src/io/sigfd.rs
+++ b/src/io/sigfd.rs
@@ -161,6 +161,11 @@ extern "C" fn terminate_handler(signum: libc::c_int) {
         s if s == libc::SIGHUP => b"elle: hung up by SIGHUP\n",
         _ => b"elle: terminated\n",
     };
+    // Diagnostic: flush the `--trace=ioring` buffer before we die, so a hang
+    // killed by a `timeout`/CI `SIGTERM` leaves its recent I/O-event tail.
+    // No-op unless the `ioring` bit is set; async-signal-safe (try_lock +
+    // bare write(2)) — see `crate::io::io_ring_dump`.
+    crate::io::io_ring_dump();
     unsafe {
         libc::write(2, tag.as_ptr() as *const libc::c_void, tag.len());
         libc::_exit(128 + signum);

--- a/src/io/threadpool.rs
+++ b/src/io/threadpool.rs
@@ -135,6 +135,39 @@ pub(crate) struct ThreadPoolBackend {
 /// Maximum concurrent thread-pool operations.
 pub(super) const MAX_THREAD_POOL_OPS: usize = 64;
 
+/// A short `(kind, fd)` description of a `PoolOp` for `io_trace`. `fd` is
+/// `-1` for ops that carry no fd (connect-by-name, sleep, resolve, …).
+/// Diagnostics only: a `tp-submit` line with no matching `tp-complete`
+/// names the exact syscall a worker is wedged in — the signal that pins a
+/// macOS threadpool hang (e.g. an `accept()` that a listening-socket
+/// `shutdown()` failed to wake). Exhaustive on purpose so a new `PoolOp`
+/// variant forces a decision here.
+fn pool_op_desc(op: &PoolOp) -> (&'static str, RawFd) {
+    match op {
+        PoolOp::Read { fd, .. } => ("read", *fd),
+        PoolOp::ReadExact { fd, .. } => ("read-exact", *fd),
+        PoolOp::Write { fd, .. } => ("write", *fd),
+        PoolOp::Flush { fd } => ("flush", *fd),
+        PoolOp::Accept { fd } => ("accept", *fd),
+        PoolOp::ConnectTcp { .. } => ("connect-tcp", -1),
+        PoolOp::ConnectUnix { .. } => ("connect-unix", -1),
+        PoolOp::SendTo { fd, .. } => ("sendto", *fd),
+        PoolOp::RecvFrom { fd, .. } => ("recvfrom", *fd),
+        PoolOp::Shutdown { fd, .. } => ("shutdown", *fd),
+        PoolOp::Sleep { .. } => ("sleep", -1),
+        PoolOp::ProcessWait { .. } => ("process-wait", -1),
+        PoolOp::Open { .. } => ("open", -1),
+        PoolOp::Task(_) => ("task", -1),
+        PoolOp::Resolve { .. } => ("resolve", -1),
+        PoolOp::ReadLine { fd } => ("read-line", *fd),
+        PoolOp::ReadAll { fd } => ("read-all", *fd),
+        PoolOp::WatchRead { fd } => ("watch-read", *fd),
+        PoolOp::SigfdRead { fd } => ("sigfd-read", *fd),
+        PoolOp::KqSigRead { fd, .. } => ("kq-sig-read", *fd),
+        PoolOp::PollFd { fd, .. } => ("poll-fd", *fd),
+    }
+}
+
 impl ThreadPoolBackend {
     pub(super) fn new() -> Self {
         let (sender, receiver) = crossbeam_channel::unbounded();
@@ -150,8 +183,13 @@ impl ThreadPoolBackend {
         if self.in_flight >= MAX_THREAD_POOL_OPS {
             return Err("async I/O: too many concurrent operations (max 64)".into());
         }
+        let (op_kind, op_fd) = pool_op_desc(&op);
         let sender = self.sender.clone();
         self.in_flight += 1;
+        crate::io::io_trace(format_args!(
+            "tp-submit   id={id} op={op_kind} fd={op_fd} in_flight={}",
+            self.in_flight
+        ));
         std::thread::spawn(move || {
             // Block all signals on this worker so the kernel never selects
             // it as the delivery target for a watched POSIX signal.
@@ -547,6 +585,9 @@ impl ThreadPoolBackend {
                     }
                 }
             };
+            crate::io::io_trace(format_args!(
+                "tp-complete id={id} op={op_kind} fd={op_fd} rc={result_code}"
+            ));
             let _ = sender.send(PoolCompletion {
                 id,
                 result_code,

--- a/src/io/watch.rs
+++ b/src/io/watch.rs
@@ -16,6 +16,10 @@ pub(crate) struct WatchEvent {
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum WatchEventKind {
+    /// inotify `IN_CREATE` (Linux/Android). kqueue's `EVFILT_VNODE` has no
+    /// create notification for a watched file, so this is never constructed
+    /// on macOS/BSD — but it stays in `as_keyword` for a uniform mapping.
+    #[cfg_attr(not(any(target_os = "linux", target_os = "android")), allow(dead_code))]
     Create,
     Modify,
     Remove,

--- a/src/primitives/io.rs
+++ b/src/primitives/io.rs
@@ -187,6 +187,17 @@ fn prim_io_cancel(args: &[Value]) -> (SignalBits, Value) {
     }
 }
 
+/// (io/trace msg) → nil. Emit `[trace:io] <msg>` to stderr when the `io`
+/// trace bit is set (`--trace=io` or `ELLE_TRACE=io`); otherwise a single
+/// relaxed atomic load and no-op. Lets Elle-level scheduler/library markers
+/// (e.g. h2-close steps) interleave with the threadpool op trace when
+/// pinning a hang, via the same async-signal-safe `write(2)` path so the
+/// last marker survives a `SIGTERM` at timeout. `msg` is shown as-is.
+fn prim_io_trace(args: &[Value]) -> (SignalBits, Value) {
+    crate::io::io_trace(format_args!("{}", args[0]));
+    (SIG_OK, Value::NIL)
+}
+
 // ── Scheduler-yielding I/O primitives ────────────────────────────────
 
 /// Async sleep — yields to the scheduler with a timer IoRequest.
@@ -386,6 +397,19 @@ pub(crate) const PRIMITIVES: &[PrimitiveDef] = &[
         params: &["backend", "id"],
         category: "io",
         example: "(io/cancel backend id)",
+        aliases: &[],
+    },
+    PrimitiveDef {
+        name: "io/trace",
+        func: prim_io_trace,
+        signal: Signal::silent(),
+        arity: Arity::Exact(1),
+        doc: "Emit a diagnostic line to stderr when the `io` trace bit is set \
+              (--trace=io or ELLE_TRACE=io); otherwise a no-op. Interleaves \
+              Elle-level markers with the threadpool op trace.",
+        params: &["msg"],
+        category: "io",
+        example: "(io/trace \"h2-close: join-writer\")",
         aliases: &[],
     },
     PrimitiveDef {

--- a/src/primitives/loading.rs
+++ b/src/primitives/loading.rs
@@ -399,7 +399,7 @@ pub(crate) const PRIMITIVES: &[PrimitiveDef] = &[
         func: prim_ffi_native,
         signal: Signal::ffi_errors(),
         arity: Arity::Exact(1),
-        doc: "Load a shared library. Pass nil for the current process.",
+        doc: "Load a shared library by Linux-style name (resolved to the host's .dylib/.dll). Pass nil for the current process.",
         params: &["path"],
         category: "ffi",
         example: "(ffi/native \"libm.so.6\")",

--- a/stdlib.lisp
+++ b/stdlib.lisp
@@ -1468,7 +1468,7 @@
        'we injected :shutdown' — defer-time errors during shutdown are
        dropped here rather than misattributed to user code."
 
-      # Phase 1a: abort pending-I/O fibers (inject error, let defer run).
+      (io/trace "do-shutdown: enter")  # Phase 1a: abort pending-I/O fibers (inject error, let defer run).
       (each [id fiber] in (pairs pending)
         (del pending id)
         (del fiber-io fiber)
@@ -1515,7 +1515,8 @@
       (while (> (length runnable) 0)
         (let [fiber (pop runnable)]
           (add scheduler-killed fiber)
-          (protect (fiber/cancel fiber {:error :shutdown})))))
+          (protect (fiber/cancel fiber {:error :shutdown}))))
+      (io/trace "do-shutdown: exit"))
 
     (defn step [timeout-ms]
       "Execute one tick of the event loop. Returns :done or :pending."
@@ -1564,6 +1565,11 @@
               (when (and have-entry (all-done? entry))
                 (do-shutdown 100)
                 (break :loop nil))  # Live program work remains — block for the next I/O event.
+              (when (and (= (length pending) 0) (> (length park-queues) 0))
+                (io/trace (concat "pump: block pending=0 park="
+                                  (string (length park-queues)) " run="
+                                  (string (length runnable)) " done="
+                                  (string (all-done? entry)))))
               (when (= (step (- 0 1)) :done) (break :loop nil)))))  # Crash on unjoined errored fibers — never swallow errors silently.
         # scheduler-killed fibers are excluded: we injected their :shutdown
         # at teardown time, so re-raising would surface our own signal as a

--- a/tests/elle/http.lisp
+++ b/tests/elle/http.lisp
@@ -242,8 +242,9 @@
   (assert (= (get gzip-call 1) "hi") "compress-log recorded the data"))
 
 # :compress true ⇒ module imports std/compress itself. Only meaningful
-# when libz/libzstd are available — on macOS the FFI loader expects
-# libz.dylib, which lib/compress.lisp doesn't currently probe for.
+# when libz/libzstd are actually installed. The FFI loader rewrites the
+# Linux-style "libz.so" spec to the host's native name (libz.dylib on
+# macOS), so this guard probes for the real library rather than a name.
 # Mirror the skip guard from tests/elle/compress.lisp.
 (let [[libz-ok? _] (protect ((fn [] (ffi/native "libz.so"))))
       [zstd-ok? _] (protect ((fn [] (ffi/native "libzstd.so"))))]

--- a/tests/elle/process-teardown.lisp
+++ b/tests/elle/process-teardown.lisp
@@ -1,0 +1,163 @@
+(elle/epoch 10)
+## tests/elle/process-teardown.lisp — process:start orphan sub-fiber teardown
+##
+## When a process:start body completes but leaves a fire-and-forget
+## sub-fiber parked — on a futex, on blocked I/O, in a background accept
+## loop — no live process can ever wake it or read its result. The
+## process scheduler must tear such orphans down (aborting them so their
+## defer/protect cleanup runs, and cancelling their in-flight I/O) and
+## return, rather than spinning/blocking forever on work that can never
+## complete. This mirrors ev/run's program-completion teardown for the
+## root scheduler (stdlib.lisp make-async-scheduler).
+##
+## Every "orphan" test below HANGS on a scheduler without this teardown
+## (the CI timeout wrapper kills the run). Reaching each println means the
+## orphan was torn down inside the process:start call.
+##
+## Run: elle tests/elle/process-teardown.lisp
+
+(def process ((import "std/process")))
+(def sync ((import "std/sync")))
+(def http2 ((import "std/http2")))
+
+(defn listen-ephemeral []
+  "Bind an ephemeral TCP port, return [listener port]."
+  (let* [listener (tcp/listen "127.0.0.1" 0)
+         lpath (port/path listener)
+         lport (parse-int (slice lpath (+ 1 (string/find lpath ":"))))]
+    [listener lport]))
+
+(defn h2-handler [req]
+  {:status 200 :headers {:content-type "text/plain"} :body (bytes 79 75)})
+
+(println "tests/elle/process-teardown.lisp:")
+
+## ── 1. Orphan parked on a futex (never notified) ──────────────────
+## The sub-fiber blocks on an empty queue forever. Nothing will ever
+## put to it, and the body exits without joining it.
+
+(process:start (fn []
+                 (ev/spawn (fn []
+                             (let [q (sync:make-queue 1)]
+                               (q:take))))
+                 nil))
+(println "  1. futex orphan torn down: ok")
+
+## ── 2. Orphan blocked on forwarded I/O (accept) ───────────────────
+## The sub-fiber blocks in accept with no client ever connecting; the
+## listener is deliberately left open so the accept cannot fail.
+
+(process:start (fn []
+                 (let* [[listener lport] (listen-ephemeral)]
+                   (ev/spawn (fn [] (tcp/accept listener)))
+                   nil)))
+(println "  2. i/o orphan torn down: ok")
+
+## ── 3. Orphan background h2 server (never stopped) ────────────────
+## The forever-accept serve loop is the http2:serve shape from
+## process-io.lisp; the body never closes the listener or the server.
+
+(process:start (fn []
+                 (let* [[listener lport] (listen-ephemeral)]
+                   (ev/spawn (fn [] (protect (http2:serve listener h2-handler))))
+                   nil)))
+(println "  3. background h2 server orphan torn down: ok")
+
+## ── 4. Nested orphan (sub-fiber spawns a parked sub-sub-fiber) ─────
+
+(process:start (fn []
+                 (ev/spawn (fn []
+                             (ev/spawn (fn []
+                                         (let [q (sync:make-queue 1)]
+                                           (q:take))))
+                             nil))
+                 nil))
+(println "  4. nested orphan torn down: ok")
+
+## ── 5. Orphan cleanup runs (graceful abort, not a hard kill) ──────
+## The orphan runs (via drain) and parks inside its defer after the body
+## exits, then teardown aborts it through its unwind path — so the defer
+## must fire. Asserts the observable side effect, not just that the
+## process returned.
+
+(def @cleanup-ran false)
+(process:start (fn []
+                 (ev/spawn (fn []
+                             (defer
+                               (assign cleanup-ran true)
+                               (let [q (sync:make-queue 1)]
+                                 (q:take)))))
+                 nil))
+(assert cleanup-ran "orphan defer ran during teardown")
+(println "  5. orphan defer runs during teardown: ok")
+
+## ── 6. Real work, then an orphaned server (process-io.lisp shape) ──
+## The body does a full h2 round-trip and closes the session, but leaves
+## the background server running (never closes the listener).
+
+(process:start (fn []
+                 (let* [[listener lport] (listen-ephemeral)
+                        url (concat "http://127.0.0.1:" (string lport))]
+                   (ev/spawn (fn [] (protect (http2:serve listener h2-handler))))
+                   (let [session (http2:connect url)]
+                     (let [resp (http2:send session "GET" "/health")]
+                       (assert (= resp:status 200) "real work: got 200"))
+                     (protect (http2:close session))))))
+## listener left open → orphan
+(println "  6. real work + server orphan torn down: ok")
+
+## ── Regression guards: teardown must NOT fire while a process lives ──
+
+## 7. A joined sub-fiber is not an orphan — the process stays alive until
+##    the join returns.
+
+(def @joined-val nil)
+(process:start (fn []
+                 (let [f (ev/spawn (fn [] (+ 20 22)))]
+                   (assign joined-val (ev/join f)))))
+(assert (= joined-val 42) "joined sub-fiber completed")
+(println "  7. joined sub-fiber completes (no premature teardown): ok")
+
+## 8. A child process outlives PID 0 and completes joined sub-fiber work.
+##    The scheduler must keep running while the child is alive (even while
+##    the child is parked waiting on its own sub-fiber), and must not tear
+##    the child's work down just because PID 0 exited first.
+
+(def @child-result nil)
+(process:start (fn []
+                 (process:spawn (fn []
+                                  (assign
+                                    child-result
+                                    (ev/join (ev/spawn (fn [] (* 6 7)))))))
+                 nil))
+## PID 0 exits first; the child still has work to do
+(assert (= child-result 42) "child completed joined sub-fiber after PID 0 exit")
+(println "  8. child outlives PID 0, completes sub-fiber work: ok")
+
+## 9. Teardown must not leak forwarded I/O into the root scheduler.
+##    Several orphan-leaving process:start calls in a row, then a normal
+##    top-level TCP round-trip: if teardown left a cancelled-but-tracked
+##    submission behind, the root pump would wedge on the final read.
+
+(each i in (range 3)
+  (process:start (fn []
+                   (let* [[listener lport] (listen-ephemeral)]
+                     (ev/spawn (fn [] (tcp/accept listener)))  ## I/O orphan
+                     (ev/spawn (fn []
+                                 (let [q (sync:make-queue 1)]
+                                   (q:take))))  ## futex orphan
+                     nil))))
+(let* [[listener lport] (listen-ephemeral)]
+  (ev/spawn (fn []
+              (let [c (tcp/accept listener)]
+                (port/write c (bytes 88))
+                (port/close c))))
+  (let [c (tcp/connect "127.0.0.1" lport)
+        d (port/read c 1)]
+    (assert (= d (bytes 88)) "top-level I/O works after orphan teardowns")
+    (port/close c)
+    (port/close listener)))
+(println "  9. sequential orphans, root scheduler still healthy: ok")
+
+(println "")
+(println "tests/elle/process-teardown.lisp: all tests passed")

--- a/tests/integration/elle_scripts.rs
+++ b/tests/integration/elle_scripts.rs
@@ -121,3 +121,17 @@ fn posix() {
 fn posix_threadpool() {
     run_elle_script_with_args("posix", &["--no-uring"]);
 }
+
+#[test]
+fn process_teardown() {
+    run_elle_script("process-teardown");
+}
+
+/// Same script on the threadpool I/O backend (`--no-uring`) — the backend
+/// macOS uses, where the `process:start` orphan-sub-fiber teardown
+/// deadlock was found. Without this the Linux runner would only exercise
+/// the io_uring path, missing the threadpool teardown the fix targets.
+#[test]
+fn process_teardown_threadpool() {
+    run_elle_script_with_args("process-teardown", &["--no-uring"]);
+}


### PR DESCRIPTION
Every (ffi/native "libfoo.so") call site hardcodes the Linux soname, so nothing loaded on macOS (.dylib) or Windows (.dll). The plugin resolver already used DLL_EXTENSION, but the FFI loader passed the spec straight to dlopen.

Make the loader platform-aware instead of rewriting every call site: library_candidates(spec, os) expands a Linux soname to ordered host-native candidates (libz.so -> libz.dylib; libcairo.so.2 -> libcairo.2.dylib, libcairo.dylib), and load_library tries each in turn. The OS is a parameter, not cfg!, so every platform name scheme is unit testable on any host.

Also fixes a teardown issue with std/process.