### PR TITLE
formatter: keep own-line comments as leading trivia (stop deleting them)

### DIFF
--- a/src/formatter/core.rs
+++ b/src/formatter/core.rs
@@ -645,4 +645,114 @@ nil
         let second = format_code(&formatted, &config).unwrap();
         assert_eq!(formatted, second, "must be idempotent");
     }
+
+    // ── Comment preservation ────────────────────────────────────
+    //
+    // Idempotency (above) does NOT catch comment loss: a formatter that
+    // deletes a comment is still idempotent (deleting twice == deleting
+    // once). These assert the comment text actually survives, and that a
+    // standalone comment stays on its own line rather than being glued to
+    // the previous form as a trailing comment.
+
+    /// Assert every `#`-comment in `input` appears in the formatted output,
+    /// and the result is idempotent.
+    fn assert_preserves_comments(input: &str) -> String {
+        let config = FormatterConfig::default();
+        let out = format_code(input, &config).unwrap();
+        for line in input.lines() {
+            let t = line.trim_start();
+            if let Some(hash) = t.find('#') {
+                // Only whole-line comments (the line is just a comment).
+                if t.starts_with('#') {
+                    let comment = t[hash..].trim_end();
+                    assert!(
+                        out.contains(comment),
+                        "comment lost: {:?}\n--- input ---\n{}\n--- output ---\n{}",
+                        comment,
+                        input,
+                        out
+                    );
+                }
+            }
+        }
+        let second = format_code(&out, &config).unwrap();
+        assert_eq!(out, second, "not idempotent:\n{}", out);
+        out
+    }
+
+    #[test]
+    fn test_comment_preserved_in_let_body() {
+        // Regression: a standalone comment between the let bindings and the
+        // body form was deleted entirely.
+        let out = assert_preserves_comments("(let [x 1]\n  # leading comment\n  (+ x 1))");
+        // It must be on its own line, not glued as a trailing comment onto
+        // the bindings line.
+        assert!(
+            out.contains("]\n  # leading comment"),
+            "comment should stay on its own line, got:\n{}",
+            out
+        );
+    }
+
+    #[test]
+    fn test_comment_preserved_in_fn_body_first() {
+        let out = assert_preserves_comments("(defn f []\n  # first body comment\n  (+ 1 2))");
+        assert!(
+            out.contains("[]\n  # first body comment"),
+            "comment should be a leading comment on its own line, got:\n{}",
+            out
+        );
+    }
+
+    #[test]
+    fn test_comment_preserved_stacked_in_begin() {
+        let out = assert_preserves_comments("(begin\n  # line one\n  # line two\n  (+ 1 2))");
+        assert!(out.contains("# line one"), "lost line one:\n{}", out);
+        assert!(out.contains("# line two"), "lost line two:\n{}", out);
+    }
+
+    #[test]
+    fn test_comment_between_body_forms_own_line() {
+        // A standalone comment between two body forms stays a leading comment
+        // of the following form, on its own line — not glued to the previous.
+        let out = assert_preserves_comments("(begin\n  (a)\n  # between\n  (b))");
+        assert!(
+            out.contains("(a)\n  # between\n  (b)"),
+            "comment should be on its own line between the forms, got:\n{}",
+            out
+        );
+    }
+
+    #[test]
+    fn test_comment_preserved_in_let_binding_and_body() {
+        // Comment on the bindings line (inline) plus a body comment.
+        assert_preserves_comments(
+            "(let [x 1  # inline on binding\n      y 2]\n  # body comment\n  (+ x y))",
+        );
+    }
+
+    #[test]
+    fn test_comment_preserved_nested_forms() {
+        assert_preserves_comments(
+            "(defn outer [a]\n  (let [b 1]\n    # inner leading\n    (when (> b 0)\n      # deep\n      (inner b))))",
+        );
+    }
+
+    #[test]
+    fn test_comment_preserved_inline_after_let_bindings() {
+        // Regression: an inline comment trailing the bindings vector (after
+        // `]`, on the same line) was dropped by format_let.
+        let out =
+            assert_preserves_comments("(let [a 1\n      b 2]  # trailing bindings\n  (+ a b))");
+        assert!(
+            out.contains("]  # trailing bindings"),
+            "inline comment should trail the bindings, got:\n{}",
+            out
+        );
+    }
+
+    #[test]
+    fn test_comment_preserved_inline_after_parameterize_bindings() {
+        assert_preserves_comments("(parameterize ((*x* 1))  # trailing bindings\n  (body))");
+    }
 }

--- a/src/formatter/format.rs
+++ b/src/formatter/format.rs
@@ -34,10 +34,11 @@ pub fn format_forms(
 ) -> Doc {
     let mut all_docs: Vec<Doc> = Vec::new();
 
-    // Format all forms. Between forms, add a HardBreak only if the
-    // next form has no leading trivia (which provides its own spacing).
+    // Format all forms, separated by a HardBreak. Leading trivia no longer
+    // supplies its own preceding break (see format_annotated), so the
+    // separator is emitted unconditionally between siblings.
     for (i, form) in forms.iter().enumerate() {
-        if i > 0 && form.leading.is_empty() {
+        if i > 0 {
             all_docs.push(Doc::hardbreak());
         }
         all_docs.push(format_annotated(form, source, config));
@@ -77,6 +78,27 @@ pub fn format_forms(
 
 // ── Core recursive walk ────────────────────────────────────────
 
+/// Emit leading trivia (comments + blank lines) into `parts`.
+///
+/// Each comment becomes `text + HardBreak`; blank lines become HardBreaks.
+/// The break that puts the first comment on its own line is the caller's
+/// inter-sibling separator, not emitted here — see `format_annotated`.
+fn emit_leading(leading: &[Trivia], parts: &mut Vec<Doc>) {
+    for t in leading {
+        match t {
+            Trivia::Comment { text, .. } => {
+                parts.push(Doc::text(text));
+                parts.push(Doc::hardbreak());
+            }
+            Trivia::BlankLines { count, .. } => {
+                for _ in 0..(*count).min(2) {
+                    parts.push(Doc::hardbreak());
+                }
+            }
+        }
+    }
+}
+
 /// Format a node with its leading and trailing trivia.
 ///
 /// Every AnnotatedSyntax passes through here to ensure trivia is
@@ -90,30 +112,13 @@ pub(super) fn format_annotated(
 
     // Leading trivia: comments and blank lines before this node.
     //
-    // The inter-form HardBreak from format_forms provides the newline
-    // that ends the previous form's line. Leading trivia adds to that:
-    // - BlankLines(n): emit n HardBreaks (n blank lines in output)
-    // - Comment: emit HardBreak + text (comment on its own line)
-    //
-    // After all trivia, one final HardBreak separates the last trivia
-    // from the form itself.
-    if !node.leading.is_empty() {
-        for t in &node.leading {
-            match t {
-                Trivia::Comment { text, .. } => {
-                    parts.push(Doc::hardbreak());
-                    parts.push(Doc::text(text));
-                }
-                Trivia::BlankLines { count, .. } => {
-                    for _ in 0..(*count).min(2) {
-                        parts.push(Doc::hardbreak());
-                    }
-                }
-            }
-        }
-        // Separate from the form
-        parts.push(Doc::hardbreak());
-    }
+    // The break BEFORE this trivia is supplied by the caller — the
+    // inter-sibling separator in format_forms/format_body, a form's
+    // header→body break, or a collection's element separator. So each
+    // comment emits `text + HardBreak` (ending its own line) and blank
+    // lines emit their own HardBreaks. Emitting a leading HardBreak here
+    // too would double the newline (a blank line) after that separator.
+    emit_leading(&node.leading, &mut parts);
 
     // The node itself
     parts.push(format_syntax(node, source, config));
@@ -178,22 +183,7 @@ pub(super) fn format_without_trailing(
     let mut parts = Vec::new();
 
     // Leading trivia (same as format_annotated)
-    if !node.leading.is_empty() {
-        for t in &node.leading {
-            match t {
-                Trivia::Comment { text, .. } => {
-                    parts.push(Doc::hardbreak());
-                    parts.push(Doc::text(text));
-                }
-                Trivia::BlankLines { count, .. } => {
-                    for _ in 0..(*count).min(2) {
-                        parts.push(Doc::hardbreak());
-                    }
-                }
-            }
-        }
-        parts.push(Doc::hardbreak());
-    }
+    emit_leading(&node.leading, &mut parts);
 
     // The node itself — no trailing trivia
     parts.push(format_syntax(node, source, config));

--- a/src/formatter/forms.rs
+++ b/src/formatter/forms.rs
@@ -297,6 +297,10 @@ pub(super) fn format_let(
 
     let head = format_annotated(&children[0], source, config);
     let bindings_doc = format_bindings(&children[1], source, config);
+    // format_bindings works on the vector's elements, so an inline comment
+    // trailing the bindings vector itself (after `]`) must be emitted here
+    // — otherwise it is dropped.
+    let bindings_trivia = format_trailing_trivia(&children[1]);
 
     // Header: (let [...])
     let header = Doc::concat([head, Doc::text(" "), bindings_doc]);
@@ -306,7 +310,7 @@ pub(super) fn format_let(
 
     Doc::align(Doc::concat([
         Doc::text("("),
-        Doc::concat([header, Doc::HardBreak, body]).nest(1),
+        Doc::concat([header, bindings_trivia, Doc::HardBreak, body]).nest(1),
         Doc::text(")"),
     ]))
 }
@@ -636,11 +640,23 @@ pub(super) fn format_parameterize(
         ])
     };
 
+    // Emit the bindings list's own trailing inline comment (built from its
+    // children above, which skips the node's trailing trivia).
+    let bindings_trivia = format_trailing_trivia(bindings_node);
+
     let body = format_body(&children[2..], source, config);
 
     Doc::align(Doc::concat([
         Doc::text("("),
-        Doc::concat([head, Doc::text(" "), bindings, Doc::HardBreak, body]).nest(1),
+        Doc::concat([
+            head,
+            Doc::text(" "),
+            bindings,
+            bindings_trivia,
+            Doc::HardBreak,
+            body,
+        ])
+        .nest(1),
         Doc::text(")"),
     ]))
 }

--- a/src/formatter/trivia.rs
+++ b/src/formatter/trivia.rs
@@ -183,6 +183,20 @@ pub fn collect_trivia(
 
 // ── Attachment pass ───────────────────────────────────────────
 
+/// Line number (1-based) of a byte offset in `source`.
+fn line_at_offset(source: &str, offset: usize) -> u32 {
+    let mut line: u32 = 1;
+    for (i, ch) in source.char_indices() {
+        if i >= offset {
+            break;
+        }
+        if ch == '\n' {
+            line += 1;
+        }
+    }
+    line
+}
+
 /// Attach trivia to top-level Syntax forms.
 ///
 /// The algorithm:
@@ -202,20 +216,6 @@ fn attach_trivia_to_forms(
         // All trivia is dangling if there are no forms
         return (Vec::new(), trivia.to_vec());
     }
-
-    // Helper to calculate line number from byte offset
-    let line_at_offset = |offset: usize| -> u32 {
-        let mut line: u32 = 1;
-        for (i, ch) in source.chars().enumerate() {
-            if i >= offset {
-                break;
-            }
-            if ch == '\n' {
-                line += 1;
-            }
-        }
-        line
-    };
 
     // Pre-compute span starts for looking ahead to next form
     let form_spans: Vec<(usize, usize)> =
@@ -239,7 +239,7 @@ fn attach_trivia_to_forms(
         }
 
         // Build children (recursively attach trivia within this form)
-        let children = attach_to_children(&form, trivia, &mut trivia_idx);
+        let children = attach_to_children(&form, trivia, &mut trivia_idx, source);
 
         // Collect trailing trivia: comments on the same line as this form's end.
         // Blank lines and comments on later lines are left for the next form.
@@ -247,7 +247,7 @@ fn attach_trivia_to_forms(
         let mut trailing = Vec::new();
         let is_last_form = form_idx + 1 >= form_spans.len();
         if !is_last_form {
-            let form_end_line = line_at_offset(span.end);
+            let form_end_line = line_at_offset(source, span.end);
             let next_start = form_spans
                 .get(form_idx + 1)
                 .map(|(s, _)| *s)
@@ -296,6 +296,7 @@ fn attach_to_children(
     parent: &Syntax,
     trivia: &[Trivia],
     trivia_idx: &mut usize,
+    source: &str,
 ) -> Vec<AnnotatedSyntax> {
     let children: Vec<&Syntax> = match &parent.kind {
         SyntaxKind::List(cs)
@@ -332,7 +333,7 @@ fn attach_to_children(
         }
 
         // Recurse into grandchildren
-        let grandchildren = attach_to_children(child, trivia, trivia_idx);
+        let grandchildren = attach_to_children(child, trivia, trivia_idx, source);
 
         // Skip trivia items that fall inside this child's span but were
         // not consumed by grandchildren (e.g. blank lines inside strings).
@@ -340,19 +341,38 @@ fn attach_to_children(
             *trivia_idx += 1;
         }
 
-        // Trailing trivia: after this child but before next child (or parent end)
+        // Trailing trivia: after this child but before the next child (or
+        // the parent's close). Only comments on the SAME line as the child
+        // ends are inline-trailing; an own-line comment is a *leading*
+        // comment of the following child, so it is left for the next
+        // child's leading collection (matching the top-level pass). The
+        // last child has no following sibling, so everything up to the
+        // parent's close attaches to it — otherwise it would be dropped by
+        // the parent's inside-span skip above.
+        let is_last = i + 1 == children.len();
         let next_start = children
             .get(i + 1)
             .map(|c| c.span.start)
             .unwrap_or(parent.span.end);
+        let child_end_line = line_at_offset(source, span.end);
         let mut trailing = Vec::new();
         while *trivia_idx < trivia.len() {
             let t = &trivia[*trivia_idx];
             if t.byte_offset() >= next_start {
                 break;
             }
-            trailing.push(t.clone());
-            *trivia_idx += 1;
+            if is_last {
+                trailing.push(t.clone());
+                *trivia_idx += 1;
+            } else {
+                match t {
+                    Trivia::Comment { line, .. } if *line == child_end_line => {
+                        trailing.push(t.clone());
+                        *trivia_idx += 1;
+                    }
+                    _ => break,
+                }
+            }
         }
 
         annotated.push(AnnotatedSyntax {


### PR DESCRIPTION
`elle fmt` deleted standalone comments and relocated others, corrupting source (e.g. the pre-commit hook stripped comments out of lib/process.lisp).

Root cause, three parts:

1. attach_to_children collected ALL trivia between two child nodes as *trailing* of the preceding child — unlike the top-level pass, which only takes same-line comments as trailing and leaves own-line comments as *leading* of the next node. A leading comment thus attached to the wrong node.

2. Form handlers that format a header child specially then drop its trailing trivia (format_let via format_bindings, format_parameterize) deleted the mis-attached comment outright — the deletion. format_defn/ format_fn already emit it via format_trailing_trivia.

3. Leading-trivia emission began with its own HardBreak, so once (1) was fixed a leading comment would get a doubled newline after the caller's inter-sibling separator.

Fix: attach own-line comments as leading of the following child (same-line stays inline-trailing; the last child still absorbs everything up to the parent close so nothing is dropped). Emit leading comments as `text + HardBreak`, relying on the caller's separator for the preceding break, and have format_forms always emit that separator. Emit the bindings-vector trailing trivia in format_let and format_parameterize.

Verified comment-preserving and idempotent across all 338 .lisp files in the tree (inline and standalone), with new preservation tests in core.rs.