### PR TITLE
json: declare parse, serialize, and pretty as signalling primitives

### DIFF
--- a/src/primitives/json/AGENTS.md
+++ b/src/primitives/json/AGENTS.md
@@ -33,9 +33,9 @@ JSON parsing and serialization primitives.
 
 | Name | Arity | Signal | Purpose |
 |------|-------|--------|---------|
-| `json/parse` | 1–3 | Silent | Parse JSON string to Elle value; accepts `:keys :keyword` option |
-| `json/serialize` | 1 | Silent | Serialize Elle value to compact JSON |
-| `json/serialize-pretty` | 1 | Silent | Serialize Elle value to pretty JSON |
+| `json/parse` | 1–3 | Errors | Parse JSON string to Elle value; accepts `:keys :keyword` option |
+| `json/serialize` | 1 | Errors | Serialize Elle value to compact JSON |
+| `json/serialize-pretty` | 1 | Errors | Serialize Elle value to pretty JSON |
 
 ### json/parse options
 
@@ -98,6 +98,8 @@ whole module.
 4. **String escaping is bidirectional.** `serialize_value()` escapes special characters; `JsonParser` unescapes them.
 
 5. **No external JSON library.** All parsing and serialization is hand-written to avoid dependencies.
+
+6. **All three primitives declare `Signal::errors()`.** The declaration matches the `SIG_ERROR` each returns, so effect inference propagates `:error` to callers and `try` reaches the failure at any call depth. `tests/elle/prim-json.lisp` pins this.
 
 ## Dependents
 

--- a/src/primitives/json/AGENTS.md
+++ b/src/primitives/json/AGENTS.md
@@ -43,8 +43,18 @@ JSON parsing and serialization primitives.
 
 `(json/parse json-string :keys :keyword)` — parse JSON objects using keyword keys (`:field`) instead of string keys (`"field"`). The option applies recursively to nested objects. Arrays are unaffected.
 
-- 2 args is never valid and returns `arity-error`.
-- 3 args with an unrecognized key name or value returns `argument-error`.
+### Error kinds
+
+| Condition | Kind |
+|-----------|------|
+| Malformed input to `json/parse` | `serde-error` |
+| A value neither serializer can encode, such as a closure | `serde-error` |
+| A non-string first argument to `json/parse` | `type-error` |
+| 2 args to `json/parse` | `arity-error` |
+| 3 args to `json/parse` with an unrecognized key name or value | `argument-error` |
+
+Both directions of the codec report `serde-error`, so one `catch` covers the
+whole module.
 
 ## JSON ↔ Elle value mapping
 

--- a/src/primitives/json/README.md
+++ b/src/primitives/json/README.md
@@ -37,11 +37,14 @@ JSON serialization and deserialization primitives for Elle. Converts between Ell
 
 ## Error Handling
 
-JSON primitives return errors for:
+JSON primitives signal `:serde-error` for:
 
 - **Invalid JSON**: Malformed input to `json/parse`
 - **Unsupported types**: Values that can't be serialized (e.g., closures)
 - **Circular references**: Tables that reference themselves
+
+Catch one with `try` or `protect`. Parsing and serializing report the same
+kind, so one `catch` covers both directions.
 
 ## See Also
 

--- a/src/primitives/json/mod.rs
+++ b/src/primitives/json/mod.rs
@@ -67,7 +67,7 @@ pub(crate) fn prim_json_parse(
     };
     match result {
         Ok(v) => (SIG_OK, v),
-        Err(e) => (SIG_ERROR, ctx.error("parse-error", e)),
+        Err(e) => (SIG_ERROR, ctx.error("serde-error", e)),
     }
 }
 
@@ -78,7 +78,7 @@ pub(crate) fn prim_json_serialize(
 ) -> (SignalBits, Value) {
     let json_str = match serialize_value(&args[0]) {
         Ok(s) => s,
-        Err(e) => return (SIG_ERROR, ctx.error("parse-error", e)),
+        Err(e) => return (SIG_ERROR, ctx.error("serde-error", e)),
     };
     (SIG_OK, ctx.string(json_str))
 }
@@ -90,7 +90,7 @@ pub(crate) fn prim_json_serialize_pretty(
 ) -> (SignalBits, Value) {
     let json_str = match serialize_value_pretty(&args[0], 0) {
         Ok(s) => s,
-        Err(e) => return (SIG_ERROR, ctx.error("parse-error", e)),
+        Err(e) => return (SIG_ERROR, ctx.error("serde-error", e)),
     };
     (SIG_OK, ctx.string(json_str))
 }

--- a/src/primitives/json/mod.rs
+++ b/src/primitives/json/mod.rs
@@ -95,9 +95,21 @@ pub(crate) fn prim_json_serialize_pretty(
     (SIG_OK, ctx.string(json_str))
 }
 
+// All three JSON primitives signal at runtime: `json/parse` on malformed
+// input, and the two serializers on a value they cannot encode, such as a
+// closure. Declaring them `Signal::silent()` therefore contradicts what they
+// do. Effect inference marks any function whose body holds only silent
+// primitives as silent, so a lambda that merely wraps one of these calls is
+// inferred pure. When the primitive then signals, the runtime raises a
+// `silence violation` panic and aborts the process with SIGABRT. No `try` at
+// the call site can intercept that, because the abort happens inside the
+// callee.
+//
+// `Signal::errors()` states the truth and makes the error catchable at any
+// call site. The success path is unchanged.
 primitive! {
     "json/parse" => prim_json_parse {
-        signal: Signal::silent(),
+        signal: Signal::errors(),
         arity: Arity::Range(1, 3),
         doc: "Parse a JSON string into Elle values. Accepts optional :keys :keyword to use keyword keys in parsed structs instead of string keys.",
         params: &["json-string", ":keys", ":keyword"],
@@ -107,7 +119,7 @@ primitive! {
         effect: RegionEffect::Fresh,
     }
     "json/serialize" => prim_json_serialize {
-        signal: Signal::silent(),
+        signal: Signal::errors(),
         arity: Arity::Exact(1),
         doc: "Serialize an Elle value to compact JSON",
         params: &["value"],
@@ -117,7 +129,7 @@ primitive! {
         effect: RegionEffect::Fresh,
     }
     "json/pretty" => prim_json_serialize_pretty {
-        signal: Signal::silent(),
+        signal: Signal::errors(),
         arity: Arity::Exact(1),
         doc: "Serialize an Elle value to pretty-printed JSON with 2-space indentation",
         params: &["value"],

--- a/src/primitives/json/mod.rs
+++ b/src/primitives/json/mod.rs
@@ -95,18 +95,11 @@ pub(crate) fn prim_json_serialize_pretty(
     (SIG_OK, ctx.string(json_str))
 }
 
-// All three JSON primitives signal at runtime: `json/parse` on malformed
-// input, and the two serializers on a value they cannot encode, such as a
-// closure. Declaring them `Signal::silent()` therefore contradicts what they
-// do. Effect inference marks any function whose body holds only silent
-// primitives as silent, so a lambda that merely wraps one of these calls is
-// inferred pure. When the primitive then signals, the runtime raises a
-// `silence violation` panic and aborts the process with SIGABRT. No `try` at
-// the call site can intercept that, because the abort happens inside the
-// callee.
-//
-// `Signal::errors()` states the truth and makes the error catchable at any
-// call site. The success path is unchanged.
+// All three raise `serde-error` — `json/parse` on malformed input, the two
+// serializers on a value JSON cannot represent — so all three declare
+// `Signal::errors()`. Effect inference copies that declaration into every
+// caller, which is what keeps the error catchable by `try` at any call depth.
+// `tests/elle/prim-json.lisp` pins the declaration.
 primitive! {
     "json/parse" => prim_json_parse {
         signal: Signal::errors(),

--- a/tests/elle/prim-json.lisp
+++ b/tests/elle/prim-json.lisp
@@ -132,4 +132,57 @@
 (let [v (json/parse "[]" :keys :keyword)]
   (assert (= v ()) "parse array keyword keys unaffected"))
 
+## ── signal declaration ─────────────────────────────────────────────
+## Each primitive declares the signals it may raise, and effect inference
+## copies that declaration into every function that calls it. The assertions
+## below pin the declaration of all three JSON primitives to exactly
+## |:error|, and admit no other declaration:
+##
+##   - A silent declaration leaves a wrapper inferred pure, so `silent?` is
+##     true, `fn/errors?` is false, and the inferred bits are empty.
+##   - Any wider declaration adds a bit to the set, so the equality fails.
+
+(assert (not (silent? (fn [s] (json/parse s))))
+        "a function wrapping json/parse is not silent")
+(assert (fn/errors? (fn [s] (json/parse s)))
+        "json/parse propagates :error to its caller")
+
+(assert (not (silent? (fn [v] (json/serialize v))))
+        "a function wrapping json/serialize is not silent")
+(assert (fn/errors? (fn [v] (json/serialize v)))
+        "json/serialize propagates :error to its caller")
+
+(assert (not (silent? (fn [v] (json/pretty v))))
+        "a function wrapping json/pretty is not silent")
+(assert (fn/errors? (fn [v] (json/pretty v)))
+        "json/pretty propagates :error to its caller")
+
+(let [a (compile/analyze "
+  (defn wrap-parse [s] (json/parse s))
+  (defn wrap-serialize [v] (json/serialize v))
+  (defn wrap-pretty [v] (json/pretty v))
+")]
+  (assert (= (get (compile/signal a :wrap-parse) :bits) |:error|)
+          "json/parse contributes exactly :error")
+  (assert (= (get (compile/signal a :wrap-serialize) :bits) |:error|)
+          "json/serialize contributes exactly :error")
+  (assert (= (get (compile/signal a :wrap-pretty) :bits) |:error|)
+          "json/pretty contributes exactly :error"))
+
+## The declaration is what carries the error out to the caller, where `try`
+## reaches it. Both directions report the same kind.
+
+(assert (= (get (try
+                  (json/parse "not json")
+                  (catch e e)) :error) :serde-error)
+        "malformed input signals :serde-error at the call site")
+(assert (= (get (try
+                  (json/serialize (fn [] 1))
+                  (catch e e)) :error) :serde-error)
+        "an unencodable value signals :serde-error from json/serialize")
+(assert (= (get (try
+                  (json/pretty (fn [] 1))
+                  (catch e e)) :error) :serde-error)
+        "an unencodable value signals :serde-error from json/pretty")
+
 (println "prim-json: all tests passed")


### PR DESCRIPTION
## What this establishes

`json/parse`, `json/serialize`, and `json/pretty` declare `Signal::errors()`.
Effect inference copies that declaration into every function that calls them.
A caller that wraps one of the three is therefore inferred as signalling, and
`try` reaches the failure at any call depth.

Both directions of the codec report `:serde-error`: `json/parse` on malformed
input, and the two serializers on a value JSON cannot represent. One `catch`
covers the whole module.

## Invariants

1. Each of the three primitives contributes exactly `|:error|` to its caller.
   No wider, no narrower.
2. Parsing and serializing report the same error kind.

## Evidence

`tests/elle/prim-json.lisp` pins invariant 1 and admits no other declaration:

- `silent?` is false and `fn/errors?` is true for a function that wraps each
  primitive. A silent declaration leaves that wrapper inferred pure, so both
  answers flip.
- `(get (compile/signal a :wrap-parse) :bits)` equals `|:error|`, for each of
  the three. A wider declaration adds a bit to the set, so the equality fails.
- `try` at the call site returns `:serde-error` for all three.

Three wrong declarations were built. Each one fails the test:

| Declaration under test | Failing assertion |
|---|---|
| all three `Signal::silent()` | `a function wrapping json/parse is not silent` |
| `json/pretty` alone `Signal::silent()` | `a function wrapping json/pretty is not silent` |
| `json/parse` as `Signal::io_yields_errors()` | expected `\|:error\|`, actual `\|:error :io :yield\|` |

## Scope of the error kind

`serde-error` is confined to `src/primitives/json/`. `parse-float` and
`parse-int` in `src/primitives/convert/numeric.rs`, the `syn` plugin, and the
`tree-sitter` plugin keep `parse-error`. Those four only parse, and
`tests/elle/errors.lisp` and `tests/elle/plugins/syn.lisp` assert the kind.
Nothing in the tree reads the JSON kind, so the rename touches three call
sites and the module documentation.

## Tests

Run on macOS 24.6.0 arm64, release build:

- `elle test tests/elle/prim-json.lisp` — 2 pass, 0 fail, 0 diverge, across
  the VM and JIT tiers.
- `elle fmt --check --no-epoch` over the 580 files of the corpus — clean.
- `cargo fmt --check` — clean.

The Rust integration test target needs the fix in "build the test target on
platforms other than Linux" (#872) before it compiles on macOS.
