### PR TITLE
test: build the test target on platforms other than Linux

### DIFF
--- a/src/io/aio/tests/mod.rs
+++ b/src/io/aio/tests/mod.rs
@@ -8,6 +8,28 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 static COUNTER: AtomicU64 = AtomicU64::new(0);
 
+/// A TCP listener socket for the accept tests.
+///
+/// `SOCK_NONBLOCK` as a `socket(2)` flag is a Linux extension, and `libc` does
+/// not define it anywhere else, so naming it unconditionally stopped the whole
+/// test target from compiling off Linux.
+///
+/// The flag is kept on Linux, where these tests already run, so their behaviour
+/// there is unchanged. Elsewhere the listener is left blocking, because the
+/// thread-pool backend calls `accept(2)` directly: on a non-blocking listener
+/// that returns `EAGAIN` before any peer connects, and the backend reports the
+/// error rather than waiting for a connection.
+///
+/// # Safety
+/// The caller owns the returned descriptor and must close it.
+pub(super) unsafe fn tcp_listener_socket() -> libc::c_int {
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    let ty = libc::SOCK_STREAM | libc::SOCK_NONBLOCK;
+    #[cfg(not(any(target_os = "linux", target_os = "android")))]
+    let ty = libc::SOCK_STREAM;
+    libc::socket(libc::AF_INET, ty, 0)
+}
+
 /// Unique scratch path under the platform temp root (honors TMPDIR — never
 /// hardcoded /tmp). Callers create the file and remove it before returning.
 fn temp_path(tag: &str) -> String {

--- a/src/io/aio/tests/net.rs
+++ b/src/io/aio/tests/net.rs
@@ -15,7 +15,7 @@ fn test_accept_wait_does_not_return_zero_completions_spuriously() {
         use std::sync::{Arc, Barrier};
 
         let listener_fd = unsafe {
-            let fd = libc::socket(libc::AF_INET, libc::SOCK_STREAM | libc::SOCK_NONBLOCK, 0);
+            let fd = tcp_listener_socket();
             assert!(fd >= 0);
             let opt: libc::c_int = 1;
             libc::setsockopt(
@@ -118,7 +118,7 @@ fn test_accept_via_uring() {
 
         // Create a TCP listener via libc
         let listener_fd = unsafe {
-            let fd = libc::socket(libc::AF_INET, libc::SOCK_STREAM | libc::SOCK_NONBLOCK, 0);
+            let fd = tcp_listener_socket();
             assert!(fd >= 0, "socket() failed");
 
             let opt: libc::c_int = 1;
@@ -300,7 +300,7 @@ fn test_accept_and_connect_concurrent() {
 
         // Create a non-blocking TCP listener via libc
         let listener_fd = unsafe {
-            let fd = libc::socket(libc::AF_INET, libc::SOCK_STREAM | libc::SOCK_NONBLOCK, 0);
+            let fd = tcp_listener_socket();
             assert!(fd >= 0);
             let opt: libc::c_int = 1;
             libc::setsockopt(

--- a/src/io/request/tests.rs
+++ b/src/io/request/tests.rs
@@ -44,10 +44,11 @@ fn test_stdio_disposition_derives() {
 
 #[test]
 fn test_process_handle_pid() {
-    // Spawn /bin/true, verify pid() returns a nonzero value.
-    // This test requires /bin/true to exist.
+    // Spawn `true`, verify pid() returns a nonzero value.
+    // Resolved through PATH: the binary is /bin/true on Linux and
+    // /usr/bin/true on macOS.
     use std::process::Command;
-    let child = Command::new("/bin/true").spawn().unwrap();
+    let child = Command::new("true").spawn().unwrap();
     let pid = child.id();
     let handle = ProcessHandle::new(pid, child);
     assert_eq!(handle.pid(), pid);
@@ -58,7 +59,7 @@ fn test_process_handle_pid() {
 fn test_process_handle_drop_does_not_panic() {
     // Drop with a running child should not panic.
     use std::process::Command;
-    let child = Command::new("/bin/true").spawn().unwrap();
+    let child = Command::new("true").spawn().unwrap();
     let pid = child.id();
     let handle = ProcessHandle::new(pid, child);
     drop(handle); // should not panic

--- a/src/io/sigfd/tests.rs
+++ b/src/io/sigfd/tests.rs
@@ -389,6 +389,10 @@ fn sigusr1_absorbed_when_unwatched() {
 /// handler. Counter-factual: without the watcher-override
 /// mechanism (i.e. if the sigaction handler fires regardless), the
 /// child terminates with code 143 before it can read the receiver.
+///
+/// Linux-only: the body reads the receiver's fd as a buffer of
+/// `signalfd_siginfo`, which `libc` defines on Linux alone.
+#[cfg(any(target_os = "linux", target_os = "android"))]
 #[test]
 fn watcher_overrides_builtin_for_sigterm() {
     let status = fork_run(5, || {

--- a/src/io/threadpool/tests/mod.rs
+++ b/src/io/threadpool/tests/mod.rs
@@ -11,3 +11,23 @@ mod openfile;
 mod process;
 mod signals;
 mod stdin;
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static COUNTER: AtomicU64 = AtomicU64::new(0);
+
+/// A unique scratch path under the platform temp root.
+///
+/// The root honors `TMPDIR` and is never a hardcoded `/tmp` or `/dev/shm`;
+/// the latter is a Linux tmpfs that does not exist on macOS or the BSDs. The
+/// pid and the counter keep concurrent test binaries, and two tests within
+/// one binary, off each other's files. Callers create the file and remove it
+/// before returning.
+fn file_path(tag: &str) -> String {
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    std::env::temp_dir()
+        .join(format!("elle-tp-{}-{}-{}", tag, std::process::id(), n))
+        .to_str()
+        .unwrap()
+        .to_string()
+}

--- a/src/io/threadpool/tests/openfile.rs
+++ b/src/io/threadpool/tests/openfile.rs
@@ -2,7 +2,7 @@ use super::super::*;
 
 #[test]
 fn test_threadpool_open_existing_file_returns_valid_fd() {
-    let path = "/dev/shm/elle-test-threadpool-open-success";
+    let path = &*std::env::temp_dir().join("elle-tp-open-success").to_string_lossy().into_owned();
     std::fs::write(path, "test").unwrap();
 
     let mut pool = CompletionHub::new();
@@ -31,7 +31,7 @@ fn test_threadpool_open_existing_file_returns_valid_fd() {
 
 #[test]
 fn test_threadpool_open_nonexistent_path_returns_negative_errno() {
-    let path = "/dev/shm/elle-test-threadpool-open-nonexistent-dir/nofile";
+    let path = &*std::env::temp_dir().join("elle-tp-no-such-dir/nofile").to_string_lossy().into_owned();
 
     let mut pool = CompletionHub::new();
     let c_path = std::ffi::CString::new(path).unwrap();

--- a/src/io/threadpool/tests/openfile.rs
+++ b/src/io/threadpool/tests/openfile.rs
@@ -1,12 +1,13 @@
 use super::super::*;
+use super::file_path;
 
 #[test]
 fn test_threadpool_open_existing_file_returns_valid_fd() {
-    let path = &*std::env::temp_dir().join("elle-tp-open-success").to_string_lossy().into_owned();
-    std::fs::write(path, "test").unwrap();
+    let path = file_path("open-success");
+    std::fs::write(&path, "test").unwrap();
 
     let mut pool = CompletionHub::new();
-    let c_path = std::ffi::CString::new(path).unwrap();
+    let c_path = std::ffi::CString::new(path.as_str()).unwrap();
     pool.submit(
         SubmissionId::from_raw(10),
         PoolOp::Open {
@@ -26,15 +27,16 @@ fn test_threadpool_open_existing_file_returns_valid_fd() {
     // Close the fd to avoid leaking it
     unsafe { libc::close(fd) };
 
-    std::fs::remove_file(path).ok();
+    std::fs::remove_file(&path).ok();
 }
 
 #[test]
 fn test_threadpool_open_nonexistent_path_returns_negative_errno() {
-    let path = &*std::env::temp_dir().join("elle-tp-no-such-dir/nofile").to_string_lossy().into_owned();
+    // A file under a directory that no test creates, so the open must fail.
+    let path = format!("{}/nofile", file_path("no-such-dir"));
 
     let mut pool = CompletionHub::new();
-    let c_path = std::ffi::CString::new(path).unwrap();
+    let c_path = std::ffi::CString::new(path.as_str()).unwrap();
     pool.submit(
         SubmissionId::from_raw(11),
         PoolOp::Open {

--- a/src/io/threadpool/tests/process.rs
+++ b/src/io/threadpool/tests/process.rs
@@ -3,7 +3,7 @@ use super::super::*;
 #[test]
 fn test_threadpool_process_wait_success() {
     let mut pool = CompletionHub::new();
-    let mut child = std::process::Command::new("/bin/true").spawn().unwrap();
+    let mut child = std::process::Command::new("true").spawn().unwrap();
     let pid = child.id();
     pool.submit(SubmissionId::from_raw(1), PoolOp::ProcessWait { pid })
         .unwrap();
@@ -13,7 +13,7 @@ fn test_threadpool_process_wait_success() {
     // ProcessWait encodes the exit code in data (LE i32), not result_code.
     assert_eq!(completions[0].result_code, 0, "waitpid should succeed");
     let exit_code = i32::from_le_bytes(completions[0].data[..4].try_into().unwrap());
-    assert_eq!(exit_code, 0, "expected exit code 0 from /bin/true");
+    assert_eq!(exit_code, 0, "expected exit code 0 from `true`");
     // Reap from std::process::Child to avoid zombie
     let _ = child.wait();
 }
@@ -21,7 +21,7 @@ fn test_threadpool_process_wait_success() {
 #[test]
 fn test_threadpool_process_wait_failure() {
     let mut pool = CompletionHub::new();
-    let mut child = std::process::Command::new("/bin/false").spawn().unwrap();
+    let mut child = std::process::Command::new("false").spawn().unwrap();
     let pid = child.id();
     pool.submit(SubmissionId::from_raw(2), PoolOp::ProcessWait { pid })
         .unwrap();
@@ -32,6 +32,6 @@ fn test_threadpool_process_wait_failure() {
     // result_code=0 means waitpid succeeded; the process exit code is in data.
     assert_eq!(completions[0].result_code, 0, "waitpid should succeed");
     let exit_code = i32::from_le_bytes(completions[0].data[..4].try_into().unwrap());
-    assert_ne!(exit_code, 0, "expected non-zero exit code from /bin/false");
+    assert_ne!(exit_code, 0, "expected non-zero exit code from `false`");
     let _ = child.wait();
 }

--- a/src/io/threadpool/tests/signals.rs
+++ b/src/io/threadpool/tests/signals.rs
@@ -156,7 +156,7 @@ fn sig_read_child_logic() -> i32 {
     );
     #[cfg(target_os = "macos")]
     let submit = pool.submit(
-        1,
+        crate::io::SubmissionId::from_raw(1),
         PoolOp::KqSigRead {
             fd,
             signals: vec![libc::SIGUSR1],
@@ -265,7 +265,7 @@ fn close_drain_child_logic() -> i32 {
     );
     #[cfg(target_os = "macos")]
     let submit = pool.submit(
-        1,
+        crate::io::SubmissionId::from_raw(1),
         PoolOp::KqSigRead {
             fd,
             signals: vec![libc::SIGUSR1],

--- a/src/primitives/unix/tests.rs
+++ b/src/primitives/unix/tests.rs
@@ -15,7 +15,6 @@ fn sock_path(tag: &str) -> String {
         .into_owned()
 }
 
-
 #[test]
 fn test_unix_listen_returns_ok() {
     crate::value::arena::with_test_region(|| {

--- a/src/primitives/unix/tests.rs
+++ b/src/primitives/unix/tests.rs
@@ -3,10 +3,23 @@
 use super::*;
 use crate::value::fiber::{SIG_IO, SIG_YIELD};
 
+/// A short socket path under the platform temp root.
+///
+/// `/dev/shm` is a Linux tmpfs and does not exist on macOS or the BSDs. The
+/// name is kept short on purpose: a `sockaddr_un` path is limited to about
+/// 104 bytes, and the macOS temp root is already long.
+fn sock_path(tag: &str) -> String {
+    std::env::temp_dir()
+        .join(format!("elle-{}-{}.sock", tag, std::process::id()))
+        .to_string_lossy()
+        .into_owned()
+}
+
+
 #[test]
 fn test_unix_listen_returns_ok() {
     crate::value::arena::with_test_region(|| {
-        let path = format!("/dev/shm/elle-test-unix-listen-{}.sock", std::process::id());
+        let path = sock_path("listen");
         // `val` is born in the ctx's region, which is released when
         // `with_test_ctx` returns — so inspect and close it inside the ctx
         // rather than dereferencing a freed slot afterward.
@@ -26,7 +39,7 @@ fn test_unix_listen_returns_ok() {
 #[test]
 fn test_unix_accept_returns_sig_io() {
     crate::value::arena::with_test_region(|| {
-        let path = format!("/dev/shm/elle-test-unix-accept-{}.sock", std::process::id());
+        let path = sock_path("accept");
         // `with_test_ctx` releases its region on return, so a Value born in
         // it must not be used afterward. The listener lives in the ctx's
         // region, so listen + accept + close all happen inside one ctx —
@@ -48,7 +61,7 @@ fn test_unix_accept_returns_sig_io() {
 fn test_unix_connect_returns_sig_io() {
     crate::value::arena::with_test_region(|| {
         let (bits, _) = crate::primitives::ctx::with_test_ctx(|ctx| {
-            let arg = ctx.string("/dev/shm/nonexistent.sock");
+            let arg = ctx.string(&*sock_path("nonexistent"));
             prim_unix_connect(ctx, &[arg])
         });
         assert_eq!(bits, SIG_YIELD | SIG_IO);


### PR DESCRIPTION
## Purpose

The test target `cargo test -p elle --lib` compiles on macOS. It also runs
there. Linux behaviour does not change.

## Changes

- `SOCK_NONBLOCK` is a Linux name. The new helper `tcp_listener_socket()` sets
  this flag on Linux only.
- `signalfd_siginfo` is a Linux name. The test
  `watcher_overrides_builtin_for_sigterm` is gated to Linux.
- The macOS arm in `threadpool/tests/signals.rs` passes
  `SubmissionId::from_raw(1)`. The Linux arm passes the same type.
- The tests spawn `true` and `false`. The system finds each one through `PATH`.
  macOS keeps both in `/usr/bin`.
- The tests write below the platform temp directory. `/dev/shm` is a Linux
  directory.
- The new helper `file_path()` makes a unique path from a tag, the pid, and a
  counter. Two test binaries cannot write the same file.

## Results

Tested on macOS 24.6.0 arm64.

- `cargo test -p elle --lib`: 1958 tests pass, 0 tests fail, 2 tests are
  ignored.
- 24 test binaries run the open test at the same time: 0 binaries fail.
- The same 24 test binaries with one fixed path: 5 binaries fail.
- `cargo fmt --check`: clean.
- `make fmt` formats `.lisp` files. This branch changes no `.lisp` file.
