### PR TITLE
docs: correct binding forms that no longer compile, and let doctest see them

### DIFF
--- a/docs/concurrency.md
+++ b/docs/concurrency.md
@@ -7,7 +7,7 @@ For CPU parallelism across cores, see [threads.md](threads.md).
 
 ## Spawn and join
 
-```text
+```lisp
 # Spawn a fiber, wait for its result
 (def f (ev/spawn (fn [] (+ 1 2))))
 (ev/join f)                # => 3
@@ -21,7 +21,7 @@ For CPU parallelism across cores, see [threads.md](threads.md).
 
 The most common pattern:
 
-```text
+```lisp
 (ev/map (fn [x] (* x x)) [1 2 3 4])   # => [1 4 9 16]
 
 # Bounded parallelism (at most n in flight)
@@ -32,14 +32,14 @@ The most common pattern:
 
 `ev/join-protected` returns `[ok? value]` instead of raising errors:
 
-```text
+```lisp
 (let [[ok? val] (ev/join-protected (ev/spawn (fn [] (+ 1 2))))]
   (if ok? val :failed))   # => 3
 ```
 
 ## Select, race, timeout
 
-```text
+```lisp
 # First to complete wins; abort the rest
 (ev/race [(ev/spawn (fn [] :fast))
           (ev/spawn (fn [] (ev/sleep 1) :slow))])  # => :fast
@@ -53,7 +53,7 @@ The most common pattern:
 All children must finish before scope exits. If one child fails, the
 others are aborted.
 
-```text
+```lisp
 (ev/scope (fn [spawn]
   (let [a (spawn (fn [] :users))
         b (spawn (fn [] :settings))]
@@ -62,7 +62,7 @@ others are aborted.
 
 ## Primitives reference
 
-```text
+```lisp
 # (ev/spawn thunk)            — create fiber, returns handle
 # (ev/join fiber-or-seq)      — wait for result(s), propagate errors
 # (ev/join-protected target)  — wait without raising: [ok? value]
@@ -79,7 +79,7 @@ others are aborted.
 
 ## TCP
 
-```text
+```lisp
 # (tcp/listen addr port)      — bind and listen, returns listener
 # (tcp/accept listener)       — yield until connection, returns port
 # (tcp/connect host port)     — yield until connected, returns port
@@ -91,7 +91,7 @@ others are aborted.
 `ev/futex-wait` and `ev/futex-wake`. These cooperate with the async
 scheduler — waiting fibers yield rather than blocking the thread.
 
-```text
+```lisp
 (def sync ((import "std/sync")))
 
 (def lock (sync:make-lock))
@@ -126,7 +126,7 @@ On top of the core process API, the module provides:
 - **Task** — one-shot async work as a monitored process
 - **EventManager** — pub/sub event dispatching
 
-```text
+```lisp
 (def process ((import "std/process")))
 
 (process:start (fn []
@@ -142,7 +142,7 @@ On top of the core process API, the module provides:
 
 ### GenServer example
 
-```text
+```lisp
 (def process ((import "std/process")))
 
 (process:start (fn []
@@ -160,7 +160,7 @@ On top of the core process API, the module provides:
 
 ### Supervisor example
 
-```text
+```lisp
 (def process ((import "std/process")))
 
 (process:start (fn []

--- a/docs/concurrency.md
+++ b/docs/concurrency.md
@@ -131,8 +131,8 @@ On top of the core process API, the module provides:
 
 (process:start (fn []
   # Ping-pong between two processes
-  (let* ([me (process:self)]
-         [peer (process:spawn (fn []
+  (let* [me (process:self)
+         peer (process:spawn (fn []
                  (match (process:recv)
                    [from :ping] (process:send from :pong)
                    _ nil)))]
@@ -164,7 +164,7 @@ On top of the core process API, the module provides:
 (def process ((import "std/process")))
 
 (process:start (fn []
-  (let ([me (process:self)])
+  (let [me (process:self)]
     (process:supervisor-start-link
       [{:id :worker :restart :permanent
         :start (fn []

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -86,7 +86,7 @@ closure that produces a struct:
 The caller imports, calls the closure, and binds the result:
 
 ```lisp
-# (let ([g ((import "greet.lisp"))])
+# (let [g ((import "greet.lisp"))]
 #   (g:greet "world"))       # => "Hello, world!"
 ```
 
@@ -125,7 +125,7 @@ time:
 ```
 
 ```lisp
-# (let ([fmt ((import "formatter.lisp") :prefix "[" :suffix "]" :separator " | ")])
+# (let [fmt ((import "formatter.lisp") :prefix "[" :suffix "]" :separator " | ")]
 #   (fmt:wrap "hello")          # => "[hello]"
 #   (fmt:join [1 2 3]))         # => "1 | 2 | 3"
 ```
@@ -134,8 +134,8 @@ Each call to the closure captures its own configuration. Two imports with
 different arguments produce independent instances:
 
 ```lisp
-# (let ([parens  ((import "formatter.lisp") :prefix "(" :suffix ")")]
-#       [angles  ((import "formatter.lisp") :prefix "<" :suffix ">")])
+# (let [parens  ((import "formatter.lisp") :prefix "(" :suffix ")")
+#       angles  ((import "formatter.lisp") :prefix "<" :suffix ">")]
 #   (parens:wrap "x")           # => "(x)"
 #   (angles:wrap "x"))          # => "<x>"
 ```
@@ -224,7 +224,7 @@ primitives into the compilation cache (available to all subsequent compilations)
 The return value is also a struct, so the qualified pattern works:
 
 ```lisp
-# (let ([rng (import "plugin/random")])
+# (let [rng (import "plugin/random")]
 #   (rng:int 1 100))
 ```
 

--- a/docs/processes.md
+++ b/docs/processes.md
@@ -40,7 +40,7 @@ until one arrives.
 (def process ((import "std/process")))
 
 (process:start (fn []
-  (let ([me (process:self)])
+  (let [me (process:self)]
     (process:send me :hello)
     (assert (= (process:recv) :hello) "got :hello"))))
 ```
@@ -55,11 +55,11 @@ parent (crash propagation). `spawn-monitor` monitors without linking
 (def process ((import "std/process")))
 
 (process:start (fn []
-  (let* ([me (process:self)]
-         [peer (process:spawn (fn []
+  (let* [me (process:self)
+         peer (process:spawn (fn []
                  (match (process:recv)
                    [from :ping] (process:send from :pong)
-                   _ nil)))])
+                   _ nil)))]
     (process:send peer [me :ping])
     (assert (= (process:recv) :pong) "ping-pong works"))))
 ```
@@ -73,7 +73,7 @@ matches, leaving non-matching messages in the mailbox in order.
 (def process ((import "std/process")))
 
 (process:start (fn []
-  (let ([me (process:self)])
+  (let [me (process:self)]
     (process:send me :a)
     (process:send me :b)
     (process:send me :c)
@@ -104,8 +104,8 @@ crashes too — unless the parent is trapping exits.
 
 (process:start (fn []
   (process:trap-exit true)
-  (let ([child (process:spawn-link (fn []
-                 (error {:error :boom :message "crash"})))])
+  (let [child (process:spawn-link (fn []
+                 (error {:error :boom :message "crash"})))]
     (match (process:recv)
       [:EXIT pid reason]
         (begin
@@ -125,7 +125,7 @@ process dies, without affecting the monitoring process.
 (def process ((import "std/process")))
 
 (process:start (fn []
-  (let ([[child-pid ref] (process:spawn-monitor (fn [] :done))])
+  (let [[child-pid ref] (process:spawn-monitor (fn [] :done))]
     (match (process:recv)
       [:DOWN got-ref got-pid reason]
         (begin
@@ -145,10 +145,10 @@ by name; `send-named` sends to a registered name.
 (def process ((import "std/process")))
 
 (process:start (fn []
-  (let ([me (process:self)])
+  (let [me (process:self)]
     (process:spawn (fn []
       (process:register :greeter)
-      (let ([msg (process:recv)])
+      (let [msg (process:recv)]
         (match msg
           [from name] (process:send from (string "hello, " name))
           _ nil))))
@@ -185,10 +185,10 @@ processes to run.
 (def process ((import "std/process")))
 
 (process:start (fn []
-  (let ([me (process:self)])
+  (let [me (process:self)]
     # Busy-looper gets preempted
-    (let ([busy (process:spawn (fn []
-            (letrec ([loop (fn [n] (loop (+ n 1)))]) (loop 0))))])
+    (let [busy (process:spawn (fn []
+            (letrec [loop (fn [n] (loop (+ n 1)))] (loop 0))))]
       (process:spawn (fn [] (process:send me :done)))
       (assert (= (process:recv) :done) "worker runs despite busy-looper")
       (process:exit busy :kill))))
@@ -222,7 +222,7 @@ down after replying.
 (def process ((import "std/process")))
 
 (process:start (fn []
-  (let ([pid (process:gen-server-start-link
+  (let [pid (process:gen-server-start-link
                {:init        (fn [_] @{})
                 :handle-call (fn [request _from state]
                   (match request
@@ -230,7 +230,7 @@ down after replying.
                     [:put key val] (begin (put state key val)
                                     [:reply :ok state])
                     _              [:reply :unknown state]))}
-               nil :name :kv)])
+               nil :name :kv)]
     (process:gen-server-call :kv [:put :lang "elle"])
     (assert (= "elle" (process:gen-server-call :kv [:get :lang]))
             "kv store works"))))
@@ -245,7 +245,7 @@ callback runs before it exits.
 (def process ((import "std/process")))
 
 (process:start (fn []
-  (let ([me (process:self)])
+  (let [me (process:self)]
     (process:gen-server-start-link
       {:init        (fn [_] :running)
        :handle-call (fn [req _from state] [:reply state state])
@@ -301,10 +301,10 @@ result. Like `ev/spawn` but the work has a PID and can be monitored.
 (def process ((import "std/process")))
 
 (process:start (fn []
-  (let* ([t1 (process:task-async (fn [] (* 6 7)))]
-         [t2 (process:task-async (fn [] (+ 10 20)))]
-         [r1 (process:task-await t1)]
-         [r2 (process:task-await t2)])
+  (let* [t1 (process:task-async (fn [] (* 6 7)))
+         t2 (process:task-async (fn [] (+ 10 20)))
+         r1 (process:task-await t1)
+         r2 (process:task-await t2)]
     (assert (= r1 42) "task 1")
     (assert (= r2 30) "task 2"))))
 ```
@@ -343,7 +343,7 @@ Each child is a struct with:
 (def process ((import "std/process")))
 
 (process:start (fn []
-  (let ([me (process:self)])
+  (let [me (process:self)]
     (process:supervisor-start-link
       [{:id :worker :restart :permanent
         :start (fn []
@@ -469,9 +469,9 @@ This replaces the manual bridge pattern:
 # Before: every user writes this glue
 {:id :my-daemon :restart :permanent
  :start (fn []
-   (let ([proc (subprocess/exec "/usr/bin/my-daemon" [])])
-     (let ([code (subprocess/wait proc)])
-       (error {:error :subprocess-exit :code code})))}
+   (let [proc (subprocess/exec "/usr/bin/my-daemon" [])]
+     (let [code (subprocess/wait proc)]
+       (error {:error :subprocess-exit :code code}))))}
 
 # After: one-liner
 (process:make-subprocess-child :my-daemon "/usr/bin/my-daemon" [])
@@ -515,10 +515,10 @@ tracked by the scheduler and participate in I/O completion.
 (def process ((import "std/process")))
 
 (process:start (fn []
-  (let* ([f1 (ev/spawn (fn [] (+ 10 20)))]
-         [f2 (ev/spawn (fn [] (+ 30 40)))]
-         [r1 (ev/join f1)]
-         [r2 (ev/join f2)])
+  (let* [f1 (ev/spawn (fn [] (+ 10 20)))
+         f2 (ev/spawn (fn [] (+ 30 40)))
+         r1 (ev/join f1)
+         r2 (ev/join f2)]
     (assert (= r1 30) "f1 = 30")
     (assert (= r2 70) "f2 = 70"))))
 ```

--- a/docs/processes.md
+++ b/docs/processes.md
@@ -8,7 +8,7 @@ wrapper), Supervisor (automatic restart), and Task (one-shot async work).
 
 ## Loading
 
-```text
+```lisp
 (def process ((import "std/process")))
 ```
 
@@ -17,7 +17,7 @@ wrapper), Supervisor (automatic restart), and Task (one-shot async work).
 `process:start` creates a scheduler and runs a closure as the first
 process. It blocks until all processes complete and returns the scheduler.
 
-```text
+```lisp
 (def process ((import "std/process")))
 
 (process:start (fn []
@@ -36,7 +36,7 @@ Use `process:run` when you need a pre-configured or shared scheduler:
 Every process has a mailbox. `send` delivers a message; `recv` blocks
 until one arrives.
 
-```text
+```lisp
 (def process ((import "std/process")))
 
 (process:start (fn []
@@ -51,7 +51,7 @@ until one arrives.
 parent (crash propagation). `spawn-monitor` monitors without linking
 (death notification without crashing the parent).
 
-```text
+```lisp
 (def process ((import "std/process")))
 
 (process:start (fn []
@@ -69,7 +69,7 @@ parent (crash propagation). `spawn-monitor` monitors without linking
 `recv-match` takes a predicate and returns the first message that
 matches, leaving non-matching messages in the mailbox in order.
 
-```text
+```lisp
 (def process ((import "std/process")))
 
 (process:start (fn []
@@ -87,7 +87,7 @@ matches, leaving non-matching messages in the mailbox in order.
 `recv-timeout` returns `:timeout` if no message arrives within the
 given number of scheduler ticks.
 
-```text
+```lisp
 (def process ((import "std/process")))
 
 (process:start (fn []
@@ -99,7 +99,7 @@ given number of scheduler ticks.
 Linked processes crash together. When a linked child crashes, the parent
 crashes too — unless the parent is trapping exits.
 
-```text
+```lisp
 (def process ((import "std/process")))
 
 (process:start (fn []
@@ -121,7 +121,7 @@ crashes too — unless the parent is trapping exits.
 Monitors deliver a `[:DOWN ref pid reason]` message when the monitored
 process dies, without affecting the monitoring process.
 
-```text
+```lisp
 (def process ((import "std/process")))
 
 (process:start (fn []
@@ -141,7 +141,7 @@ process dies, without affecting the monitoring process.
 Processes can register under a keyword name. `whereis` looks up PIDs
 by name; `send-named` sends to a registered name.
 
-```text
+```lisp
 (def process ((import "std/process")))
 
 (process:start (fn []
@@ -164,7 +164,7 @@ by name; `send-named` sends to a registered name.
 Each process has a private key-value store. Useful for per-process
 configuration that doesn't belong in the main state.
 
-```text
+```lisp
 (def process ((import "std/process")))
 
 (process:start (fn []
@@ -181,7 +181,7 @@ Processes are cooperatively scheduled with fuel budgets. A CPU-bound
 process gets preempted after exhausting its fuel, allowing other
 processes to run.
 
-```text
+```lisp
 (def process ((import "std/process")))
 
 (process:start (fn []
@@ -218,7 +218,7 @@ down after replying.
 
 ## Key-value store example
 
-```text
+```lisp
 (def process ((import "std/process")))
 
 (process:start (fn []
@@ -241,7 +241,7 @@ down after replying.
 `gen-server-stop` requests graceful shutdown. The server's `:terminate`
 callback runs before it exits.
 
-```text
+```lisp
 (def process ((import "std/process")))
 
 (process:start (fn []
@@ -279,7 +279,7 @@ from `handle-call` and use `gen-server-reply` later:
 Actor wraps GenServer with a simpler API: just an init function and
 get/update operations on state.
 
-```text
+```lisp
 (def process ((import "std/process")))
 
 (process:start (fn []
@@ -297,7 +297,7 @@ get/update operations on state.
 Task runs a one-shot function as a supervised process and returns the
 result. Like `ev/spawn` but the work has a PID and can be monitored.
 
-```text
+```lisp
 (def process ((import "std/process")))
 
 (process:start (fn []
@@ -339,7 +339,7 @@ Each child is a struct with:
 
 ## Basic supervisor
 
-```text
+```lisp
 (def process ((import "std/process")))
 
 (process:start (fn []
@@ -511,7 +511,7 @@ with `:init`, `:handle-event`, and optional `:terminate` callbacks.
 `ev/spawn` and `ev/join` work inside processes. Sub-fibers are
 tracked by the scheduler and participate in I/O completion.
 
-```text
+```lisp
 (def process ((import "std/process")))
 
 (process:start (fn []

--- a/docs/signals/capabilities.md
+++ b/docs/signals/capabilities.md
@@ -78,7 +78,7 @@ capability space that is NOT withheld:
 (fiber/caps)
 # => |:error :yield :debug :ffi :halt :io :exec|
 
-(let ([f (fiber/new (fn [] 42) |:error| :deny |:io :ffi|)])
+(let [f (fiber/new (fn [] 42) |:error| :deny |:io :ffi|)]
   (fiber/caps f))
 # => |:error :yield :debug :halt :exec|
 ```
@@ -89,14 +89,14 @@ Withheld capabilities propagate from parent to child at resume time.
 A child inherits its parent's restrictions plus any `:deny` of its own:
 
 ```text
-(let ([outer (fiber/new
+(let [outer (fiber/new
                (fn []
                  # inner denies :ffi, inherits :io denial from outer
-                 (let ([inner (fiber/new (fn [] (fiber/caps))
-                                        |:error| :deny |:ffi|)])
+                 (let [inner (fiber/new (fn [] (fiber/caps))
+                                        |:error| :deny |:ffi|)]
                    (fiber/resume inner)))
                |:error|
-               :deny |:io|)])
+               :deny |:io|)]
   (fiber/resume outer))
 # => |:error :yield :debug :halt :exec|
 # (missing :io from parent, missing :ffi from own deny)
@@ -112,14 +112,14 @@ The parent can catch a denial, perform the operation on the child's
 behalf, and resume the child with the result:
 
 ```text
-(let ([f (fiber/new
+(let [f (fiber/new
            (fn [] (length "hello"))
            |:error|
-           :deny |:error|)])
-  (let ([denial (fiber/resume f)])
+           :deny |:error|)]
+  (let [denial (fiber/resume f)]
     # denial is {:error :capability-denied :primitive "length" ...}
-    (let ([val (fiber/value f)])
-      (let ([result (apply length (val :args))])
+    (let [val (fiber/value f)]
+      (let [result (apply length (val :args))]
         (fiber/resume f result)))))
 ```
 
@@ -134,25 +134,25 @@ blocks `length` but not `+`.
 
 ```text
 # Pure computation sandbox — no IO, no FFI, no subprocess
-(let ([f (fiber/new compute |:io :ffi :exec :error|
-                    :deny |:io :ffi :exec|)])
+(let [f (fiber/new compute |:io :ffi :exec :error|
+                    :deny |:io :ffi :exec|)]
   (fiber/resume f))
 
 # Capability-check a plugin before running it
-(let ([f (fiber/new plugin-init |:error| :deny |:exec :ffi|)])
-  (let ([result (fiber/resume f)])
+(let [f (fiber/new plugin-init |:error| :deny |:exec :ffi|)]
+  (let [result (fiber/resume f)]
     (if (= (fiber/status f) :dead)
       result
       (do (println "plugin tried:" ((fiber/value f) :primitive))
           (fiber/cancel f)))))
 
 # Nested sandbox: outer denies IO, inner denies errors
-(let ([outer (fiber/new
+(let [outer (fiber/new
                (fn []
-                 (let ([inner (fiber/new worker |:error| :deny |:error|)])
+                 (let [inner (fiber/new worker |:error| :deny |:error|)]
                    (fiber/resume inner)))
                |:io :error|
-               :deny |:io|)])
+               :deny |:io|)]
   (fiber/resume outer))
 # inner has neither IO (from outer) nor error (from own deny)
 ```

--- a/docs/signals/capabilities.md
+++ b/docs/signals/capabilities.md
@@ -74,7 +74,7 @@ The parent catches this signal through the normal mask routing.
 Returns a keyword set of active capabilities — everything in the
 capability space that is NOT withheld:
 
-```text
+```lisp
 (fiber/caps)
 # => |:error :yield :debug :ffi :halt :io :exec|
 
@@ -88,7 +88,7 @@ capability space that is NOT withheld:
 Withheld capabilities propagate from parent to child at resume time.
 A child inherits its parent's restrictions plus any `:deny` of its own:
 
-```text
+```lisp
 (let [outer (fiber/new
                (fn []
                  # inner denies :ffi, inherits :io denial from outer
@@ -111,7 +111,7 @@ absorbed).
 The parent can catch a denial, perform the operation on the child's
 behalf, and resume the child with the result:
 
-```text
+```lisp
 (let [f (fiber/new
            (fn [] (length "hello"))
            |:error|

--- a/docs/signals/emit.md
+++ b/docs/signals/emit.md
@@ -46,10 +46,10 @@ When a fiber emits a signal, the parent catches it if the signal bits
 overlap the fiber's mask:
 
 ```text
-(let ([f (fiber/new (fn [] (emit :yield 42)) |:yield|)])
+(let [f (fiber/new (fn [] (emit :yield 42)) |:yield|)]
   (fiber/resume f))   # => 42
 
-(let ([f (fiber/new (fn [] (emit :yield 42)) 0)])
+(let [f (fiber/new (fn [] (emit :yield 42)) 0)]
   (fiber/resume f))   # signal propagates (mask doesn't catch :yield)
 ```
 
@@ -68,7 +68,7 @@ overlap the fiber's mask:
 
 ```text
 # Suspension: emit :yield, get resume value back
-(let ([x (emit :yield :waiting)])
+(let [x (emit :yield :waiting)]
   # x is whatever the parent passes to fiber/resume
   (+ x 1))
 


### PR DESCRIPTION
## Problem

Many examples in `docs/` use `(let ([x 1] [y 2]) body)`. This is the binding syntax from before epoch 10. Epoch 10 takes flat pairs, `(let [x 1 y 2] body)`. The old form is a compile error:

```
destructuring pattern element must be a symbol, list, tuple, array, struct, or table
```

The syntax appears at 37 sites in 5 files:

| File | Sites |
|---|---|
| `docs/processes.md` | 16 |
| `docs/signals/capabilities.md` | 12 |
| `docs/modules.md` | 4 |
| `docs/signals/emit.md` | 3 |
| `docs/concurrency.md` | 2 |

Two more defects sit in the same examples:

1. One `letrec` uses the same old shape.
2. Two examples are unbalanced. The ping-pong example in `docs/concurrency.md` never closes its binding list. The subprocess-child example in `docs/processes.md` never closes its `fn`.

## Why this went unnoticed

`make doctest` runs only ```` ```lisp ```` fences. Every site above sits in a ```` ```text ```` fence, or is commented out with `#` inside a ```` ```lisp ```` fence. The doc test cannot see these examples. The examples it cannot see are the ones that rotted.

## Change

The first commit corrects the syntax. The second commit converts 31 fences whose examples run standalone and unchanged:

| File | Fences converted |
|---|---|
| `docs/processes.md` | 17 |
| `docs/concurrency.md` | 11 |
| `docs/signals/capabilities.md` | 3 |

## Test

1. Compile every fenced block that holds a binding form, with `elle lint`.
2. Before the change: 26 of 28 blocks fail.
3. After the change: 0 blocks fail.

Three diagnostics remain. Each names an undefined variable in a fragment that was never a complete program: `compute`, `plugin-init`, and `process`. These are unrelated to the binding syntax.

Run each converted example before conversion. Run the whole set three times. Several examples are supervisor and preemption examples. A flaky doc test is worse than no doc test.

Added cost to the doctest run:

| File | Time |
|---|---|
| `docs/processes.md` | 2.1 s |
| `docs/concurrency.md` | 0.5 s |
| `docs/signals/capabilities.md` | 0.1 s |

## What stays a text fence, and why

1. 25 blocks are fragments, not programs. They name things the block never defines, because they show a shape.
2. Every block in `docs/signals/emit.md`. They call `fiber/resume` on fibers the snippet does not own. They signal a state error when they run alone, although the syntax is correct.
