### PR TITLE
docs: correct the JSON primitives README

### DIFF
--- a/src/primitives/json/README.md
+++ b/src/primitives/json/README.md
@@ -6,42 +6,75 @@ JSON serialization and deserialization primitives for Elle. Converts between Ell
 
 | Primitive | Purpose |
 |-----------|---------|
-| `json/stringify` | Convert Elle value to JSON string |
+| `json/serialize` | Convert Elle value to JSON string |
 | `json/parse` | Parse JSON string to Elle value |
 | `json/pretty` | Convert Elle value to pretty-printed JSON |
 
 ## Type Mapping
 
+Serializing, Elle to JSON:
+
 | Elle Type | JSON Type |
 |-----------|-----------|
 | `nil` | `null` |
 | `true`/`false` | `true`/`false` |
-| Integer | Number |
-| Float | Number |
+| Integer | Number, written without a decimal point |
+| Float | Number, written with a decimal point |
 | String | String |
 | List/Array | Array |
 | Table/Struct | Object |
 
+Parsing, JSON to Elle:
+
+| JSON Type | Elle Type |
+|-----------|-----------|
+| `null` | `nil` |
+| `true`/`false` | `true`/`false` |
+| Number without a decimal point | Integer |
+| Number with a decimal point | Float |
+| String | String |
+| Array | List |
+| Object | `@struct`, keyed by string |
+
+Two properties of a parsed object catch callers out.
+
+**Keys are strings, not keywords.** `(get parsed "id")` reads a field, and
+`(get parsed :id)` returns `nil` rather than signalling, so the mistake is
+silent. Pass `:keys :keyword` to opt in to keyword keys.
+
+**The result is mutable.** `json/parse` returns an `@struct`, so `put` and `del`
+change it in place instead of returning a new value. Copy with `freeze` first
+when the original has to survive the change.
+
 ## Examples
 
-```janet
-(json/stringify {:name "Alice" :age 30})
-;; => "{\"name\":\"Alice\",\"age\":30}"
+```lisp
+(json/serialize {:name "Alice" :age 30})
+# => "{\"age\":30,\"name\":\"Alice\"}"
 
 (json/parse "{\"x\": 1, \"y\": 2}")
-;; => {:x 1 :y 2}
+# => @{"x" 1 "y" 2}
+
+(json/parse "{\"x\": 1}" :keys :keyword)
+# => @{:x 1}
 
 (json/pretty {:items [1 2 3]})
-;; => "{\n  \"items\": [\n    1,\n    2,\n    3\n  ]\n}"
+# => "{\n  \"items\": [\n    1,\n    2,\n    3\n  ]\n}"
 ```
+
+`json/serialize` writes object keys in sorted order, at every depth and inside
+arrays, so the same value always produces the same bytes. Array element order is
+preserved, as JSON requires.
 
 ## Error Handling
 
-JSON primitives return errors for:
+The JSON primitives signal an error for:
 
 - **Invalid JSON**: Malformed input to `json/parse`
 - **Unsupported types**: Values that can't be serialized (e.g., closures)
 - **Circular references**: Tables that reference themselves
+
+Catch one with `try` or `protect`, as with any other error.
 
 ## See Also
 


### PR DESCRIPTION
## Problem

`src/primitives/json/README.md` holds five errors. Each one sends a reader somewhere the runtime does not follow.

1. `json/stringify` does not exist. The name appears in the primitive table and again in the first example. The primitive is `json/serialize`.
2. The parse example shows `{:x 1 :y 2}`. `json/parse` returns string keys unless the caller passes `:keys :keyword`. This error is expensive, because it fails silently: `(get parsed :x)` returns `nil` and does not signal.
3. The README does not say that the parsed object is a mutable `@struct`. `put` and `del` change it in place. A caller who removes a key to compare a value destroys that value.
4. The serialize example shows keys in source order. `json/serialize` writes sorted keys.
5. The example fence says `janet`. The comments use `;;`, which is the splice operator in Elle and not a comment. The block cannot run as written, even with the correct names.

## Change

Correct all five. Run every replacement example and paste its output.

Split the type table by direction. The mapping is not symmetric: a JSON array parses to a list, and a JSON object parses to an `@struct`.

Record that `json/serialize` sorts keys at every depth. Callers who hash serialized output depend on this property.

## Test

Run every example in the new README against the current build. Each output in the file is the output the runtime produced.
