### PR TITLE
docs: state that accessor sugar needs a symbol receiver

### DIFF
--- a/docs/structs.md
+++ b/docs/structs.md
@@ -28,6 +28,43 @@ user:name                  # => "Alice"
 user:role                  # => :admin
 ```
 
+### The receiver must be a symbol
+
+`obj:field` is one token. The reader absorbs the `:` while reading a
+symbol, so the sugar never applies to an expression. After a closing
+parenthesis the `:field` lexes as a plain keyword instead, and the form
+becomes callable-struct syntax — with the remaining arguments read as the
+default value.
+
+For a plain lookup the two agree, so nothing looks wrong:
+
+```lisp
+(def user {:name "Alice" :age 30})
+(def outer {:inner user})
+
+user:name                    # => "Alice"
+((get outer :inner):name)    # => "Alice"
+```
+
+They part company when the field holds a function. With a symbol receiver
+the sugar calls it. With an expression receiver there is no call: the
+field comes back, and the arguments are silently discarded.
+
+```lisp
+(def obj {:double (fn [x] (* x 2))})
+(def holder {:obj obj})
+
+(obj:double 21)                  # => 42, called
+((get holder :obj):double 21)    # => <closure>, NOT called
+```
+
+Bind the receiver to a name before using the sugar:
+
+```lisp
+(let [o (get holder :obj)]
+  (o:double 21))                 # => 42
+```
+
 ## Immutable updates
 
 Operations on immutable structs return new structs. The original is unchanged.


### PR DESCRIPTION
## Problem

`obj:field` is one token. `read_symbol` in `src/reader/lexer.rs` absorbs the `:` while it reads a symbol. The sugar therefore cannot apply to an expression.

After a closing parenthesis, `:field` becomes a keyword. The form then becomes callable-struct syntax, `(get obj :field default)`. The remaining arguments become the default value.

For a lookup the two forms agree. This is what makes the difference expensive to find:

```lisp
user:name                    # => "Alice"
((get outer :inner):name)    # => "Alice"
```

The two forms diverge when the field holds a function:

```lisp
(obj:double 21)                  # => 42, called
((get holder :obj):double 21)    # => <closure>, NOT called
```

The second form discards its argument and returns the function. Nothing signals. Both features behave as specified. They collide, and the collision looks like a method call that does nothing.

The symptom appears wherever the missing call was to have an effect. That place can be far from the cause.

## Change

Document the restriction in `docs/structs.md`, beside the accessor syntax it qualifies.

## Why document, and not change the behaviour

1. An expression receiver would need a change to the reader grammar.
2. An error on the two-argument callable-struct form would break the documented default-value lookup.

## Test

Run every example. Paste the output the runtime produced. `docs/structs.md` runs clean under doctest.
