### PR TITLE
hir: stop an SSA rename escaping a conditional branch that has no phi

### DIFF
--- a/src/hir/functionalize/tests.rs
+++ b/src/hir/functionalize/tests.rs
@@ -160,6 +160,91 @@ fn cond_in_let_tail_is_unchanged() {
     assert_eq!(result, Value::int(1));
 }
 
+// ── A short-circuited and/or operand must not leak a rename either ──────
+//
+// Only the first operand of `and`/`or` always runs. Neither form has a
+// phi-insertion path at all, so a rename forked in a later operand escaped to
+// code that never evaluated it.
+
+#[test]
+fn skipped_or_operand_assign_does_not_apply() {
+    // `or` stops at the first truthy operand, so the begin never runs.
+    let result = eval_bare(
+        r#"(do
+                    (var x 1)
+                    (let [y 5] (or true (begin (assign x 9))))
+                    x)"#,
+    )
+    .unwrap();
+    assert_eq!(result, Value::int(1));
+}
+
+#[test]
+fn skipped_and_operand_assign_does_not_apply() {
+    // `and` stops at the first falsy operand, so the begin never runs.
+    let result = eval_bare(
+        r#"(do
+                    (var x 1)
+                    (let [y 5] (and false (begin (assign x 9))))
+                    x)"#,
+    )
+    .unwrap();
+    assert_eq!(result, Value::int(1));
+}
+
+#[test]
+fn skipped_or_operand_preserves_prior_value() {
+    // The uninitialized-slot form: the forked initializer reads the let
+    // binding, so past that scope it read a dead slot and x came back nil.
+    let result = eval_bare(
+        r#"(do
+                    (var x 1)
+                    (let [y 100] (or true (begin (assign x (%add y 5)))))
+                    x)"#,
+    )
+    .unwrap();
+    assert_eq!(result, Value::int(1));
+}
+
+#[test]
+fn evaluated_or_operand_assign_still_applies() {
+    // The other direction: an operand that IS reached must still assign.
+    let result = eval_bare(
+        r#"(do
+                    (var x 1)
+                    (let [y 5] (or false (begin (assign x 9))))
+                    x)"#,
+    )
+    .unwrap();
+    assert_eq!(result, Value::int(9));
+}
+
+#[test]
+fn evaluated_and_operand_assign_still_applies() {
+    let result = eval_bare(
+        r#"(do
+                    (var x 1)
+                    (let [y 5] (and true (begin (assign x 9))))
+                    x)"#,
+    )
+    .unwrap();
+    assert_eq!(result, Value::int(9));
+}
+
+#[test]
+fn first_and_operand_assign_propagates() {
+    // The first operand always runs, so a rename from an assign inside it must
+    // still reach the code after the form.
+    let result = eval_bare(
+        r#"(do
+                    (var x 1)
+                    (let [y 5] (and (begin (assign x 7) true) true))
+                    x)"#,
+    )
+    .unwrap();
+    assert_eq!(result, Value::int(7));
+}
+
 #[test]
 fn bare_assign_in_let_tail_branch_is_unchanged() {
     // A branch body that is an Assign rather than a Begin never reached

--- a/src/hir/functionalize/tests.rs
+++ b/src/hir/functionalize/tests.rs
@@ -76,3 +76,100 @@ fn if_phi_merge_with_continuation_still_works() {
     .unwrap();
     assert_eq!(result, Value::int(42));
 }
+
+// ── An if in a non-begin context must not leak a branch rename ──────────
+//
+// A `let` tail is a non-begin context, so transform_begin_at emits no phi
+// there. A branch whose body is a `begin` used to fork a fresh SSA version of
+// an outer `var` anyway, and the rename escaped to code the branch does not
+// dominate. `(when c ...)` expands to `(if c (begin ...) nil)`, so every `when`
+// in a let tail hit this.
+
+#[test]
+fn branch_begin_assign_does_not_escape_let_tail() {
+    // The branch does not run, so x must keep its prior value. It read 9:
+    // the assign was lifted out of the branch by the escaping rename.
+    let result = eval_bare(
+        r#"(do
+                    (var x 1)
+                    (let [y 5] (if false (begin (assign x 9)) nil))
+                    x)"#,
+    )
+    .unwrap();
+    assert_eq!(result, Value::int(1));
+}
+
+#[test]
+fn branch_begin_assign_reads_the_taken_branch() {
+    // Both arms assign, so both forked a version and the renames chained:
+    // the outer read resolved to the LAST arm transformed rather than the arm
+    // that ran. With the condition true this read 2 — the else-arm's value.
+    let result = eval_bare(
+        r#"(do
+                    (var x 1)
+                    (let [y 5]
+                        (if true
+                            (begin (assign x 9))
+                            (begin (assign x 2))))
+                    x)"#,
+    )
+    .unwrap();
+    assert_eq!(result, Value::int(9));
+}
+
+#[test]
+fn branch_begin_assign_preserves_prior_value() {
+    // The forked version's initializer reads `y`, a binding of the let the
+    // rename escaped. Hoisted past that scope it read a dead slot, so x came
+    // back nil — destroying the value x held before the if.
+    let result = eval_bare(
+        r#"(do
+                    (var x 1)
+                    (let [y 100] (if false (begin (assign x (%add y 5))) nil))
+                    x)"#,
+    )
+    .unwrap();
+    assert_eq!(result, Value::int(1));
+}
+
+#[test]
+fn branch_begin_assign_still_applies_when_taken() {
+    // The other direction: preserving the assign as a slot mutation must not
+    // lose it. The branch runs, so x must be 9.
+    let result = eval_bare(
+        r#"(do
+                    (var x 1)
+                    (let [y 5] (if true (begin (assign x 9)) nil))
+                    x)"#,
+    )
+    .unwrap();
+    assert_eq!(result, Value::int(9));
+}
+
+#[test]
+fn cond_in_let_tail_is_unchanged() {
+    // The Cond arm already saved and restored. Guard that it still does, since
+    // the If arm now shares the treatment.
+    let result = eval_bare(
+        r#"(do
+                    (var x 1)
+                    (let [y 5] (cond false (begin (assign x 9)) true nil))
+                    x)"#,
+    )
+    .unwrap();
+    assert_eq!(result, Value::int(1));
+}
+
+#[test]
+fn bare_assign_in_let_tail_branch_is_unchanged() {
+    // A branch body that is an Assign rather than a Begin never reached
+    // transform_begin, so it was already a slot mutation and already correct.
+    let result = eval_bare(
+        r#"(do
+                    (var x 1)
+                    (let [y 5] (if false (assign x 9) nil))
+                    x)"#,
+    )
+    .unwrap();
+    assert_eq!(result, Value::int(1));
+}

--- a/src/hir/functionalize/transform.rs
+++ b/src/hir/functionalize/transform.rs
@@ -111,26 +111,39 @@ impl<'a> FnCtx<'a> {
                 )
             }
 
-            // If: transform branches without save/restore. SSA renames
-            // from assigns in branches propagate outward. When the If
-            // is directly in a begin sequence, transform_begin_at handles
-            // phi-insertion for proper merge semantics. When nested
-            // (e.g. inside let body), assigns in branches are either:
-            // - cell-backed (letrec mutated bindings) → set-cell is correct
-            // - in a begin context that handles phi-insertion
-            // - simple cases where propagation is harmless
+            // If: an SSA rename created inside a branch may escape only when a
+            // phi guarded by the same condition is emitted at the merge, and
+            // transform_begin_at is the only place that emits one. Every If
+            // that reaches this arm is one it will NOT emit a phi for: the
+            // begin path intercepts an If with unpreserved branch assigns and
+            // routes it through transform_if_with_phi, which never dispatches
+            // here. So a rename escaping this arm would reach code the branch
+            // does not dominate. Keep those assigns as runtime slot mutations
+            // instead, exactly as the Cond arm below does for the same reason.
             //
-            // Cond/Match DO save/restore because they have multiple
-            // alternative branches; If has exactly two branches and the
-            // begin-level phi handles the merge.
+            // The cond is transformed BEFORE the save: it always executes, so a
+            // rename from an assign inside it must propagate outward.
             HirKind::If {
                 cond,
                 then_branch,
                 else_branch,
             } => {
                 let new_cond = self.transform(cond);
+                let saved = self.renames.clone();
+                let saved_preserved = self.assign_preserved.clone();
+                for branch in [then_branch, else_branch] {
+                    let mut branch_assigns = BTreeSet::new();
+                    self.collect_assigned_bindings(branch, &mut branch_assigns);
+                    for b in &branch_assigns {
+                        let resolved = self.resolve(*b);
+                        self.assign_preserved.insert(resolved);
+                    }
+                }
                 let new_then = self.transform(then_branch);
+                self.renames = saved.clone();
                 let new_else = self.transform(else_branch);
+                self.renames = saved;
+                self.assign_preserved = saved_preserved;
                 Hir::new(
                     HirKind::If {
                         cond: Box::new(new_cond),

--- a/src/hir/functionalize/transform.rs
+++ b/src/hir/functionalize/transform.rs
@@ -308,12 +308,12 @@ impl<'a> FnCtx<'a> {
             }
 
             HirKind::And(exprs) => {
-                let new: Vec<_> = exprs.iter().map(|e| self.transform(e)).collect();
+                let new = self.transform_short_circuit(exprs);
                 Hir::new(HirKind::And(new), span, signal)
             }
 
             HirKind::Or(exprs) => {
-                let new: Vec<_> = exprs.iter().map(|e| self.transform(e)).collect();
+                let new = self.transform_short_circuit(exprs);
                 Hir::new(HirKind::Or(new), span, signal)
             }
 
@@ -526,5 +526,42 @@ impl<'a> FnCtx<'a> {
             | HirKind::QuoteConst(_)
             | HirKind::Error => hir.clone(),
         }
+    }
+
+    /// Transform the operands of a short-circuiting `and`/`or`.
+    ///
+    /// Only the first operand always executes; each later one is conditional on
+    /// the ones before it. Neither form has a phi-insertion path —
+    /// `transform_begin_at` handles Assign, If, Cond, Match and While, and never
+    /// And or Or — so a fresh SSA version forked inside a later operand would
+    /// escape to code that did not evaluate it. Keep those assigns as runtime
+    /// slot mutations, as the If and Cond arms do.
+    ///
+    /// The first operand is transformed before the save: it always runs, so a
+    /// rename from an assign inside it must propagate outward.
+    fn transform_short_circuit(&mut self, exprs: &[Hir]) -> Vec<Hir> {
+        let mut out: Vec<Hir> = Vec::with_capacity(exprs.len());
+        if exprs.is_empty() {
+            return out;
+        }
+        out.push(self.transform(&exprs[0]));
+
+        let saved = self.renames.clone();
+        let saved_preserved = self.assign_preserved.clone();
+        for e in &exprs[1..] {
+            let mut operand_assigns = BTreeSet::new();
+            self.collect_assigned_bindings(e, &mut operand_assigns);
+            for b in &operand_assigns {
+                let resolved = self.resolve(*b);
+                self.assign_preserved.insert(resolved);
+            }
+        }
+        for e in &exprs[1..] {
+            self.renames = saved.clone();
+            out.push(self.transform(e));
+        }
+        self.renames = saved;
+        self.assign_preserved = saved_preserved;
+        out
     }
 }


### PR DESCRIPTION
## The defect

`functionalize` converts `var` and `assign` into SSA form. A rename that a branch
creates can leave that branch only if a phi guards the merge point.
`transform_begin_at` is the only function that emits such a phi. It emits one when
the `if` is an element of a `begin` sequence.

The `If` arm of `transform` let a branch rename propagate outward in every case. An
`if` in another position has no merge point. The tail of a `let` is the common
example.

`when` expands to `(if test (begin ,;body) nil)`. The `begin` is the trigger. A
branch body that is a bare `assign` was always correct, because it does not reach
`transform_begin`.

```lisp
(defn f []
  (var x 1)
  (let [y 5] (when false (assign x 9)))
  x)                                        ;; => 9
```

## Three results, and each one is silent

1. The assignment applies, but the branch does not run.

```lisp
(let [y 5] (if false (begin (push t 1) (assign x 9)) nil))
;; x = 9. t stays empty. Only the assign left the branch.
```

2. Both arms assign. The read gives the value from the arm that does not run.

```lisp
(let [y 5] (if true (begin (assign x 9)) (begin (assign x 2))))
;; x = 2
```

3. The new value reads a binding of the `let`. The variable becomes nil.

```lisp
(let [y 100] (if false (begin (assign x (+ y 5))) nil))
;; x = nil. The previous value of x is lost.
```

## The functionalized HIR

```
(let [y#770 5] (if false (let [x#771 9] nil) nil))
(return x#771)
```

`x#771` is out of scope at the use. Its definition does not dominate the use.
`x#769` holds the original value, and no path reads it.

## Why this is a defect

The module documentation states the rule: "Non-Begin contexts use assign_preserved
to keep assigns as runtime slot mutations." The `Cond` arm does this. Its comment
gives the same reason.

The comment on the `If` arm argues from the number of branches: "Cond/Match DO
save/restore because they have multiple alternative branches; If has exactly two
branches." The number of branches is not the condition. The condition is the
presence of a phi at the merge point.

## The second commit

The `And` and `Or` arms have the same fault. These two forms never had a phi path.
`transform_begin_at` handles `Assign`, `If`, `Cond`, `Match` and `While`. It does
not handle `And` or `Or`.

Only the first operand of a short-circuit form always runs.

```lisp
(let [y 5] (or true (begin (assign x 9))))            ;; x = 9
(let [y 5] (and false (begin (assign x 9))))          ;; x = 9
(let [y 100] (or true (begin (assign x (+ y 5)))))    ;; x = nil
```

## The fix

Each arm now does three steps:

1. Collect the bindings that the branches assign.
2. Put each binding into `assign_preserved`. The pass then keeps the assign as a
   slot mutation.
3. Restore `renames` and `assign_preserved` after the branches.

The pass transforms the condition before the save. The condition always runs, so a
rename from an assign inside the condition must propagate outward.

Every `If` that reaches this arm has no phi. `transform_begin_at` intercepts an
`If` that holds unpreserved branch assigns. It sends that `If` to
`transform_if_with_phi`. That function does not use this arm. The change therefore
cannot alter the phi path.

For `and` and `or`, the first operand keeps its previous behaviour. Only the later
operands change.

## Tests

The two commits add 12 tests to `src/hir/functionalize/tests.rs`:

- 6 tests for the failures above.
- 6 guards: `cond` in a `let` tail, a bare `assign` branch body, an `if` branch
  that runs, an `or` operand that runs, an `and` operand that runs, and an assign
  in the first operand of an `and`.

The two `nested_while_branch_arm` tests cover the same class of escape for loop
parameters. Both still pass.

`cargo test --lib` reports 1970 pass and 0 fail.

## Not verified

- The effect on JIT eligibility. A preserved assign lowers to a slot mutation, not
  to an SSA let. This can make a function less suitable for the JIT. The change
  accepts that cost for correctness. It does not measure the cost.
- Platforms other than macOS arm64.

I ran the tests on macOS arm64. `cargo test` does not build the test target on
`s14` on macOS, so I applied the two commits from #872 for the test run only. Those
commits are not in this branch.
