### PR TITLE
json: parse into immutable arrays and structs

### DIFF
--- a/src/primitives/json/AGENTS.md
+++ b/src/primitives/json/AGENTS.md
@@ -35,7 +35,7 @@ JSON parsing and serialization primitives.
 |------|-------|--------|---------|
 | `json/parse` | 1–3 | Silent | Parse JSON string to Elle value; accepts `:keys :keyword` option |
 | `json/serialize` | 1 | Silent | Serialize Elle value to compact JSON |
-| `json/serialize-pretty` | 1 | Silent | Serialize Elle value to pretty JSON |
+| `json/pretty` | 1 | Silent | Serialize Elle value to pretty JSON |
 
 ### json/parse options
 
@@ -46,17 +46,24 @@ JSON parsing and serialization primitives.
 - 2 args is never valid and returns `arity-error`.
 - 3 args with an unrecognized key name or value returns `argument-error`.
 
-## JSON ↔ Elle value mapping
+## JSON → Elle value mapping (`json/parse`)
 
-| JSON | Elle |
-|------|------|
-| `null` | `nil` |
-| `true` / `false` | `true` / `false` |
-| Number (int) | `Value::int()` |
-| Number (float) | `Value::float()` |
-| String | `Value::string()` |
-| Array | `Value::array()` (@array, mutable) |
-| Object | `Value::table()` (@struct, mutable) |
+| JSON | Elle | Constructor |
+|------|------|-------------|
+| `null` | `nil` | `Value::NIL` |
+| `true` / `false` | `true` / `false` | `Value::bool()` |
+| Number (int) | Integer | `Value::int()` |
+| Number (float) | Float | `Value::float()` |
+| String | String | `ctx.string()` |
+| Array | Immutable array (`[...]`) | `ctx.array()` |
+| Object | Immutable struct (`{...}`) | `ctx.struct_from()` |
+
+## Elle → JSON value mapping (`json/serialize`, `json/pretty`)
+
+The serializer accepts more types than the parser produces. Lists,
+`@arrays`, and immutable arrays all write as JSON arrays; sets and
+`@sets` write as JSON arrays; `@structs` and immutable structs both
+write as JSON objects; keywords write as JSON strings.
 
 ## Parser implementation
 
@@ -81,16 +88,23 @@ JSON parsing and serialization primitives.
 
 1. **JSON null maps to Elle nil.** `Value::NIL` serializes to `null` and `null` parses to `Value::NIL`.
 
-2. **JSON arrays map to Elle @arrays.** @arrays are mutable (`Value::array()`), not immutable arrays.
+2. **A parsed value is immutable at every depth.** `JsonParser` builds only
+   immutable arrays and immutable structs, so no part of a parsed document can
+   be changed in place. Callers share one parsed document without copying it,
+   and `put`/`del` on any part of it return a new value.
 
-3. **JSON objects map to Elle @structs.** @structs are mutable (`Value::table()`), not immutable structs.
+3. **JSON arrays map to immutable Elle arrays.** `ctx.array()`, not the
+   mutable `ctx.array_mut()` and not a cons list.
 
-4. **String escaping is bidirectional.** `serialize_value()` escapes special characters; `JsonParser` unescapes them.
+4. **JSON objects map to immutable Elle structs.** `ctx.struct_from()`, not
+   the mutable `ctx.struct_mut_from()`.
 
-5. **No external JSON library.** All parsing and serialization is hand-written to avoid dependencies.
+5. **String escaping is bidirectional.** `serialize_value()` escapes special characters; `JsonParser` unescapes them.
+
+6. **No external JSON library.** All parsing and serialization is hand-written to avoid dependencies.
 
 ## Dependents
 
 - `primitives/registration.rs` — registers JSON primitives
 - `primitives/module_init.rs` — initializes JSON module
-- Elle code — via `json/parse`, `json/serialize`, `json/serialize-pretty`
+- Elle code — via `json/parse`, `json/serialize`, `json/pretty`

--- a/src/primitives/json/README.md
+++ b/src/primitives/json/README.md
@@ -1,50 +1,125 @@
 # JSON Support
 
-JSON serialization and deserialization primitives for Elle. Converts between Elle `Value` and JSON text.
+JSON parsing and serialization for Elle. Converts between an Elle `Value`
+and JSON text. The parser and the serializer are hand-written; the module
+depends on no external JSON library.
 
 ## Primitives
 
 | Primitive | Purpose |
 |-----------|---------|
-| `json/stringify` | Convert Elle value to JSON string |
-| `json/parse` | Parse JSON string to Elle value |
-| `json/pretty` | Convert Elle value to pretty-printed JSON |
+| `json/parse` | Parse a JSON string into an immutable Elle value |
+| `json/serialize` | Convert an Elle value to a compact JSON string |
+| `json/pretty` | Convert an Elle value to a pretty-printed JSON string |
 
-## Type Mapping
+## Type mapping
 
-| Elle Type | JSON Type |
-|-----------|-----------|
-| `nil` | `null` |
-| `true`/`false` | `true`/`false` |
-| Integer | Number |
-| Float | Number |
+The mapping is not symmetric, so each direction has its own table.
+
+`json/parse` produces these Elle types:
+
+| JSON | Elle |
+|------|------|
+| `null` | `nil` |
+| `true` / `false` | `true` / `false` |
+| Number without `.`, `e`, or `E` | Integer |
+| Number with `.`, `e`, or `E` | Float |
 | String | String |
-| List/Array | Array |
-| Table/Struct | Object |
+| Array | Immutable array (`[...]`) |
+| Object | Immutable struct (`{...}`) |
 
-## Examples
+`json/serialize` and `json/pretty` accept these Elle types:
 
-```janet
-(json/stringify {:name "Alice" :age 30})
-;; => "{\"name\":\"Alice\",\"age\":30}"
+| Elle | JSON |
+|------|------|
+| `nil` | `null` |
+| `true` / `false` | `true` / `false` |
+| Integer | Number |
+| Float (finite) | Number |
+| String | String |
+| Keyword | String |
+| List, array, `@array` | Array |
+| Set, `@set` | Array |
+| Struct, `@struct` | Object |
 
-(json/parse "{\"x\": 1, \"y\": 2}")
-;; => {:x 1 :y 2}
+## Parsed values are immutable
 
-(json/pretty {:items [1 2 3]})
-;; => "{\n  \"items\": [\n    1,\n    2,\n    3\n  ]\n}"
+`json/parse` returns an immutable value at every depth. Arrays, structs,
+and every value nested inside them are immutable. `put` and `del` on the
+result return a new value and leave the parsed value unchanged, so a
+caller can compare a field after removing it, and two callers can share
+one parsed document without copying it.
+
+```lisp
+(def doc (json/parse "{\"a\": [1, 2], \"b\": 3}"))
+
+(immutable? doc)                 # => true
+(immutable? (get doc "a"))       # => true
+
+(put doc "b" 99)                 # => {"a" [1 2] "b" 99}
+doc                              # => {"a" [1 2] "b" 3}
 ```
 
-## Error Handling
+To get a mutable copy, use `thaw`. `thaw` is shallow: it converts the
+value you hand it, not the values nested inside it.
 
-JSON primitives return errors for:
+```lisp
+(def m (thaw (json/parse "{\"a\": 1}")))
 
-- **Invalid JSON**: Malformed input to `json/parse`
-- **Unsupported types**: Values that can't be serialized (e.g., closures)
-- **Circular references**: Tables that reference themselves
+(mutable? m)                     # => true
+(put m "b" 2)                    # => @{"a" 1 "b" 2}
+```
 
-## See Also
+## Object keys
 
-- [AGENTS.md](AGENTS.md) - technical reference for LLM agents
-- [`src/primitives/`](../) - other built-in functions
-- [`src/value/`](../../value/) - runtime value representation
+`json/parse` uses string keys by default. Pass `:keys :keyword` to get
+keyword keys instead. The option applies to nested objects too.
+
+```lisp
+(get (json/parse "{\"x\": 1}") "x")               # => 1
+(get (json/parse "{\"x\": 1}") :x)                # => nil
+(get (json/parse "{\"x\": 1}" :keys :keyword) :x) # => 1
+```
+
+The default is the expensive case to get wrong, because it fails
+silently: `get` with the wrong key kind returns `nil` and signals
+nothing.
+
+## Sorted output
+
+`json/serialize` and `json/pretty` write object keys in sorted order at
+every depth, whatever order the source struct was built in. Callers who
+hash serialized output depend on this property.
+
+```lisp
+(json/serialize {:name "Alice" :age 30})
+# => "{\"age\":30,\"name\":\"Alice\"}"
+
+(println (json/pretty {:items [1 2 3]}))
+# {
+#   "items": [
+#     1,
+#     2,
+#     3
+#   ]
+# }
+```
+
+## Errors
+
+The JSON primitives signal an error for:
+
+- **Malformed JSON** — bad tokens, unterminated strings, trailing
+  content, trailing commas, leading zeros, and lone surrogates.
+- **Unserializable values** — closures, symbols, fibers, ports, and the
+  other types with no JSON counterpart.
+- **Non-finite floats** — `json/serialize` rejects NaN and infinity,
+  which JSON cannot represent.
+
+## See also
+
+- [AGENTS.md](AGENTS.md) — technical reference for LLM agents
+- [`tests/elle/prim-json.lisp`](../../../tests/elle/prim-json.lisp) — the
+  behavior tests for these primitives
+- [`src/primitives/`](../) — other built-in functions
+- [`src/value/`](../../value/) — runtime value representation

--- a/src/primitives/json/mod.rs
+++ b/src/primitives/json/mod.rs
@@ -15,7 +15,8 @@ use crate::value::fiber::{SignalBits, SIG_ERROR, SIG_OK};
 use crate::value::types::Arity;
 use crate::value::Value;
 
-/// Parse a JSON string into Elle values
+/// Parse a JSON string into an immutable Elle value: a JSON array becomes an
+/// immutable array, a JSON object an immutable struct.
 pub(crate) fn prim_json_parse(
     ctx: &mut crate::primitives::ctx::NativeCtx<'_>,
     args: &[Value],
@@ -99,7 +100,7 @@ primitive! {
     "json/parse" => prim_json_parse {
         signal: Signal::silent(),
         arity: Arity::Range(1, 3),
-        doc: "Parse a JSON string into Elle values. Accepts optional :keys :keyword to use keyword keys in parsed structs instead of string keys.",
+        doc: "Parse a JSON string into an immutable Elle value: a JSON array becomes an immutable array and a JSON object an immutable struct. Accepts optional :keys :keyword to use keyword keys in parsed structs instead of string keys.",
         params: &["json-string", ":keys", ":keyword"],
         category: "json",
         example: r#"(json/parse "{\"name\": \"Alice\", \"age\": 30}" :keys :keyword)"#,

--- a/src/primitives/json/parser.rs
+++ b/src/primitives/json/parser.rs
@@ -4,6 +4,11 @@ use std::collections::BTreeMap;
 
 /// JSON parser using recursive descent. Holds the `NativeCtx` capability so
 /// every freshly-parsed heap value is born in the call's region (Rule 3).
+///
+/// The value it builds is immutable at every depth: a JSON array becomes an
+/// immutable Elle array and a JSON object an immutable struct. Callers can
+/// therefore share one parsed document without copying it, and `put`/`del`
+/// on any part of it yield a new value instead of editing the document.
 pub struct JsonParser<'a, 'h> {
     input: Vec<char>,
     pos: usize,
@@ -317,7 +322,7 @@ impl<'a, 'h> JsonParser<'a, 'h> {
 
         if self.pos < self.input.len() && self.input[self.pos] == ']' {
             self.pos += 1;
-            return Ok(self.ctx.list(elements));
+            return Ok(self.ctx.array(elements));
         }
 
         loop {
@@ -335,7 +340,7 @@ impl<'a, 'h> JsonParser<'a, 'h> {
                 }
                 ']' => {
                     self.pos += 1;
-                    return Ok(self.ctx.list(elements));
+                    return Ok(self.ctx.array(elements));
                 }
                 c => {
                     return Err(format!(
@@ -362,7 +367,7 @@ impl<'a, 'h> JsonParser<'a, 'h> {
 
         if self.pos < self.input.len() && self.input[self.pos] == '}' {
             self.pos += 1;
-            return Ok(self.ctx.struct_mut_from(map));
+            return Ok(self.ctx.struct_from(map));
         }
 
         loop {
@@ -417,7 +422,7 @@ impl<'a, 'h> JsonParser<'a, 'h> {
                 }
                 '}' => {
                     self.pos += 1;
-                    return Ok(self.ctx.struct_mut_from(map));
+                    return Ok(self.ctx.struct_from(map));
                 }
                 c => {
                     return Err(format!(

--- a/tests/elle/prim-json.lisp
+++ b/tests/elle/prim-json.lisp
@@ -24,12 +24,20 @@
 
 ## ── json/parse collections ─────────────────────────────────────────
 
-(assert (= (json/parse "[]") ()) "parse empty array")
+## A JSON array parses to an immutable Elle array, not a list: `()` and
+## `[]` are different values and do not compare equal.
+(assert (array? (json/parse "[]")) "parse empty array is array")
+(assert (= (json/parse "[]") []) "parse empty array")
+(assert (not (= (json/parse "[]") ())) "parse empty array is not a list")
+(assert (array? (json/parse "[1,2,3]")) "parse array is array")
+(assert (= (json/parse "[1,2,3]") [1 2 3]) "parse array elements")
 (let [v (json/parse "[1,2,3]")]
   (assert (= (length v) 3) "parse array length")
-  (assert (= (first v) 1) "parse array first"))
+  (assert (= (first v) 1) "parse array first")
+  (assert (= (get v 1) 2) "parse array index"))
 (let [v (json/parse "[1,\"two\",true,null]")]
-  (assert (= (length v) 4) "parse mixed array length"))
+  (assert (= (length v) 4) "parse mixed array length")
+  (assert (= v [1 "two" true nil]) "parse mixed array elements"))
 
 ## ── json/parse objects ─────────────────────────────────────────────
 
@@ -39,6 +47,53 @@
 (let [v (json/parse "{\"name\":\"Alice\",\"age\":30}")]
   (assert (= (get v "name") "Alice") "parse object string key")
   (assert (= (get v "age") 30) "parse object int value"))
+
+## ── json/parse returns an immutable value ──────────────────────────
+
+(assert (immutable? (json/parse "[]")) "parsed empty array is immutable")
+(assert (immutable? (json/parse "[1,2,3]")) "parsed array is immutable")
+(assert (not (mutable? (json/parse "[1,2,3]"))) "parsed array is not mutable")
+(assert (immutable? (json/parse "{}")) "parsed empty object is immutable")
+(assert (immutable? (json/parse "{\"a\":1}")) "parsed object is immutable")
+(assert (not (mutable? (json/parse "{\"a\":1}"))) "parsed object is not mutable")
+
+## Immutability reaches every depth, through arrays and objects alike.
+(let [v (json/parse "{\"a\": [1, {\"b\": [2]}]}")]
+  (assert (immutable? v) "parsed root is immutable")
+  (assert (immutable? (get v "a")) "parsed nested array is immutable")
+  (assert (immutable? (get (get v "a") 1)) "parsed nested object is immutable")
+  (assert (immutable? (get (get (get v "a") 1) "b"))
+          "parsed deep nested array is immutable"))
+
+(let [v (json/parse "{\"a\": {\"b\": [1]}}" :keys :keyword)]
+  (assert (immutable? v) "keyword-key root is immutable")
+  (assert (immutable? (get v :a)) "keyword-key nested object is immutable")
+  (assert (immutable? (get (get v :a) :b))
+          "keyword-key nested array is immutable"))
+
+## `put` and `del` build a new value and leave the parsed value intact, so
+## a caller can remove a key and still read the value it removed.
+(let [v (json/parse "{\"a\":1}")]
+  (assert (= (get (put v "b" 2) "b") 2)
+          "put on parsed object returns a new value")
+  (assert (nil? (get v "b")) "put leaves the parsed object unchanged"))
+
+(let [v (json/parse "{\"a\":1,\"b\":2}")]
+  (assert (nil? (get (del v "a") "a"))
+          "del on parsed object returns a new value")
+  (assert (= (get v "a") 1) "del leaves the parsed object unchanged"))
+
+(let [v (json/parse "[1,2,3]")]
+  (assert (= (put v 0 99) [99 2 3]) "put on parsed array returns a new value")
+  (assert (= v [1 2 3]) "put leaves the parsed array unchanged"))
+
+## `thaw` is the way to a mutable copy.
+(let [v (json/parse "{\"a\":1}")
+      m (thaw v)]
+  (put m "b" 2)
+  (assert (mutable? m) "thawed copy is mutable")
+  (assert (= (get m "b") 2) "thawed copy takes the put")
+  (assert (nil? (get v "b")) "thaw leaves the parsed object unchanged"))
 
 ## ── json/parse errors ──────────────────────────────────────────────
 
@@ -92,6 +147,10 @@
 ## ── json/serialize collections ─────────────────────────────────────
 
 (assert (= (json/serialize (list 1 2 3)) "[1,2,3]") "serialize list")
+(assert (= (json/serialize [1 2 3]) "[1,2,3]") "serialize immutable array")
+(assert (= (json/serialize @[1 2 3]) "[1,2,3]") "serialize mutable array")
+(assert (= (json/serialize (json/parse "[1,[2],{\"a\":3}]")) "[1,[2],{\"a\":3}]")
+        "serialize a parsed value")
 
 ## ── json/serialize NaN/Infinity ────────────────────────────────────
 
@@ -106,8 +165,20 @@
 
 ## ── json roundtrip ─────────────────────────────────────────────────
 
+## A list serializes to a JSON array, and that array parses back to an
+## immutable Elle array — so the roundtrip lands on `[...]`, not on the
+## list it started from.
 (let [original (list 1 "test" true nil)]
-  (assert (= (json/parse (json/serialize original)) original) "json roundtrip"))
+  (assert (= (json/parse (json/serialize original)) [1 "test" true nil])
+          "json list roundtrip lands on an array"))
+
+(let [original [1 "test" true nil]]
+  (assert (= (json/parse (json/serialize original)) original)
+          "json array roundtrip"))
+
+(let [original {"a" 1 "b" [2 3] "c" {"d" true}}]
+  (assert (= (json/parse (json/serialize original)) original)
+          "json object roundtrip"))
 
 ## ── json/parse :keys :keyword ──────────────────────────────────────
 
@@ -130,6 +201,6 @@
   (assert (not ok?) "parse 2 args arity error"))
 
 (let [v (json/parse "[]" :keys :keyword)]
-  (assert (= v ()) "parse array keyword keys unaffected"))
+  (assert (= v []) "parse array keyword keys unaffected"))
 
 (println "prim-json: all tests passed")

--- a/tests/unittests/primitives/json.rs
+++ b/tests/unittests/primitives/json.rs
@@ -101,24 +101,73 @@ fn test_json_parse_arrays() {
     let h = elle::primitives::ctx::TestHeap::new();
 
     let result = call_primitive(&json_parse, &[h.ctx().string("[]")]);
-    assert_eq!(result.unwrap(), Value::EMPTY_LIST);
+    assert_eq!(result.unwrap(), h.ctx().array(vec![]));
 
     let result = call_primitive(&json_parse, &[h.ctx().string("[1,2,3]")]);
-    let list = result.unwrap();
-    let vec = list.list_to_vec().unwrap();
-    assert_eq!(vec.len(), 3);
-    assert_eq!(vec[0], Value::int(1));
-    assert_eq!(vec[1], Value::int(2));
-    assert_eq!(vec[2], Value::int(3));
+    let array = result.unwrap();
+    assert!(
+        array.as_array_mut().is_none(),
+        "a parsed JSON array is immutable"
+    );
+    let elements = array.as_array().expect("JSON array parses to an array");
+    assert_eq!(elements.len(), 3);
+    assert_eq!(elements[0], Value::int(1));
+    assert_eq!(elements[1], Value::int(2));
+    assert_eq!(elements[2], Value::int(3));
 
     let result = call_primitive(&json_parse, &[h.ctx().string("[1,\"two\",true,null]")]);
-    let list = result.unwrap();
-    let vec = list.list_to_vec().unwrap();
-    assert_eq!(vec.len(), 4);
-    assert_eq!(vec[0], Value::int(1));
-    assert_eq!(vec[1], h.ctx().string("two"));
-    assert_eq!(vec[2], Value::bool(true));
-    assert_eq!(vec[3], Value::NIL);
+    let array = result.unwrap();
+    let elements = array.as_array().expect("JSON array parses to an array");
+    assert_eq!(elements.len(), 4);
+    assert_eq!(elements[0], Value::int(1));
+    assert_eq!(elements[1], h.ctx().string("two"));
+    assert_eq!(elements[2], Value::bool(true));
+    assert_eq!(elements[3], Value::NIL);
+}
+
+/// Read one string-keyed field out of an immutable struct.
+fn json_field(owner: Value, name: &str) -> Value {
+    use elle::value::TableKey;
+    owner
+        .as_struct()
+        .unwrap_or_else(|| panic!("expected an immutable struct, looking for {:?}", name))
+        .iter()
+        .find(|(k, _)| matches!(k, TableKey::String(s) if s == name))
+        .map(|(_, v)| *v)
+        .unwrap_or_else(|| panic!("no field {:?}", name))
+}
+
+/// Every collection inside a parsed document is immutable too, not just the
+/// value the parser returns at the top.
+#[test]
+fn test_json_parse_is_immutable_at_every_depth() {
+    let (_vm, mut symbols, meta) = setup();
+    let json_parse = get_primitive(&meta, &mut symbols, "json-parse");
+    let h = elle::primitives::ctx::TestHeap::new();
+
+    let result = call_primitive(&json_parse, &[h.ctx().string("{\"a\": [1, {\"b\": [2]}]}")]);
+    let root = result.unwrap();
+    assert!(root.as_struct_mut().is_none(), "root object is immutable");
+
+    let outer = json_field(root, "a");
+    assert!(outer.as_array_mut().is_none(), "nested array is immutable");
+    let outer = outer.as_array().expect("nested array parses to an array");
+
+    let inner = outer[1];
+    assert!(
+        inner.as_struct_mut().is_none(),
+        "nested object is immutable"
+    );
+
+    let deepest = json_field(inner, "b");
+    assert!(
+        deepest.as_array_mut().is_none(),
+        "deepest array is immutable"
+    );
+    assert_eq!(
+        deepest.as_array().expect("deepest value is an array"),
+        &[Value::int(2)]
+    );
 }
 
 #[test]
@@ -128,26 +177,32 @@ fn test_json_parse_objects() {
     let h = elle::primitives::ctx::TestHeap::new();
 
     let result = call_primitive(&json_parse, &[h.ctx().string("{}")]);
-    match result.unwrap() {
-        v if v.as_struct_mut().is_some() => {
-            let t = v.as_struct_mut().unwrap();
-            assert_eq!(t.borrow().len(), 0);
-        }
-        _ => panic!("Expected table"),
-    }
+    let empty = result.unwrap();
+    assert!(
+        empty.as_struct_mut().is_none(),
+        "a parsed JSON object is immutable"
+    );
+    assert_eq!(
+        empty
+            .as_struct()
+            .expect("JSON object parses to a struct")
+            .len(),
+        0
+    );
 
     let result = call_primitive(
         &json_parse,
         &[h.ctx().string("{\"name\":\"Alice\",\"age\":30}")],
     );
-    match result.unwrap() {
-        v if v.as_struct_mut().is_some() => {
-            let t = v.as_struct_mut().unwrap();
-            let table = t.borrow();
-            assert_eq!(table.len(), 2);
-        }
-        _ => panic!("Expected table"),
-    }
+    let parsed = result.unwrap();
+    assert!(
+        parsed.as_struct_mut().is_none(),
+        "a parsed JSON object is immutable"
+    );
+    let fields = parsed.as_struct().expect("JSON object parses to a struct");
+    assert_eq!(fields.len(), 2);
+    assert_eq!(json_field(parsed, "name"), h.ctx().string("Alice"));
+    assert_eq!(json_field(parsed, "age"), Value::int(30));
 }
 
 #[test]
@@ -160,9 +215,11 @@ fn test_json_parse_whitespace() {
     assert_eq!(result.unwrap(), Value::int(42));
 
     let result = call_primitive(&json_parse, &[h.ctx().string("[ 1 , 2 , 3 ]")]);
-    let list = result.unwrap();
-    let vec = list.list_to_vec().unwrap();
-    assert_eq!(vec.len(), 3);
+    assert_eq!(
+        result.unwrap(),
+        h.ctx()
+            .array(vec![Value::int(1), Value::int(2), Value::int(3)])
+    );
 }
 
 #[test]
@@ -271,7 +328,10 @@ fn test_json_serialize_roundtrip() {
     let json_serialize = get_primitive(&meta, &mut symbols, "json-serialize");
     let h = elle::primitives::ctx::TestHeap::new();
 
-    let original = h.ctx().list(vec![
+    // An immutable array is the fixed point of the roundtrip: it serializes to
+    // a JSON array, and a JSON array parses back to an immutable array. A list
+    // serializes the same way but does not survive the return trip unchanged.
+    let original = h.ctx().array(vec![
         Value::int(1),
         h.ctx().string("test"),
         Value::bool(true),
@@ -287,6 +347,24 @@ fn test_json_serialize_roundtrip() {
 
     let deserialized = call_primitive(&json_parse, &[h.ctx().string(json_str)]).unwrap();
     assert_eq!(original, deserialized);
+}
+
+/// A JSON document with nested objects and arrays survives a serialize/parse
+/// roundtrip with its shape intact.
+#[test]
+fn test_json_nested_roundtrip() {
+    let (_vm, mut symbols, meta) = setup();
+    let json_parse = get_primitive(&meta, &mut symbols, "json-parse");
+    let json_serialize = get_primitive(&meta, &mut symbols, "json-serialize");
+    let h = elle::primitives::ctx::TestHeap::new();
+
+    let source = "{\"a\":[1,[2,3]],\"b\":{\"c\":null}}";
+    let parsed = call_primitive(&json_parse, &[h.ctx().string(source)]).unwrap();
+    let serialized = call_primitive(&json_serialize, std::slice::from_ref(&parsed)).unwrap();
+    assert_eq!(serialized, h.ctx().string(source));
+
+    let reparsed = call_primitive(&json_parse, &[serialized]).unwrap();
+    assert_eq!(parsed, reparsed);
 }
 
 #[test]


### PR DESCRIPTION
## Problem

`json/parse` returns a value the caller can change in place, and it
returns the wrong kind of sequence.

Every JSON object became a mutable `@struct` and every JSON array became
a cons list. Both cost the caller something.

1. **The mutable result is shared, not owned.** Two callers holding one
   parsed document see each other's `put` and `del`. A caller who removes
   a key to compare a value destroys that value. Nothing in the API says
   the document is live.

2. **A JSON array became a list, not an array.** `[]` and `()` are
   different values in Elle and do not compare equal, so a caller who
   wrote `(= parsed [1 2 3])` got `false` with no explanation. The
   module's own `AGENTS.md` claimed arrays parsed to `@array`, which was
   wrong in a third direction.

## Change

`json/parse` builds immutable values at every depth: a JSON array becomes
an immutable Elle array (`ctx.array`), a JSON object an immutable struct
(`ctx.struct_from`). `put` and `del` on any part of a parsed document
return a new value and leave the document unchanged, so callers share one
parsed document without copying it. `thaw` is the way to a mutable copy.

The serializer needed no change — it already accepted immutable arrays
and structs. An immutable array is now the fixed point of the roundtrip:
it serializes to a JSON array, and a JSON array parses back to an
immutable array. A list still serializes to a JSON array but comes back
as `[...]`.

Corrected the module docs, which described the old mapping and named two
primitives that do not exist (`json/stringify`, `json/serialize-pretty`).
The README now splits the type table by direction, because the mapping is
not symmetric, and records that `json/serialize` sorts object keys at
every depth.

## Compatibility

This is a breaking change for a caller that mutates a parsed document or
compares one against a list. No such caller exists in the tree: every
consumer here reads only (`lib/aws.lisp`, `tools/aws/aws-codegen.lisp`,
`lib/telemetry.lisp`, `demos/docgen/generate.lisp`, and the JSON-RPC
integration fixture).

## Test

Tests were written against the spec before the parser changed, and all
five new-behavior Rust tests plus the Elle suite failed on the old
implementation first.

`tests/elle/prim-json.lisp` pins: a parsed array is an array and not a
list; parsed arrays and structs report `immutable?`; immutability holds
at every depth through both string keys and `:keys :keyword`; `put` and
`del` leave the parsed value intact; `thaw` yields a mutable copy without
touching it; and the array and object roundtrips.

`tests/unittests/primitives/json.rs` adds a depth walk asserting
`as_array_mut`/`as_struct_mut` are `None` at every level, and a nested
serialize/parse roundtrip.

Gates run locally, all green:

- `make smoke-elle ELLE=./target/release/elle` — 833 pass, 0 fail, 0
  diverge across the VM and JIT tiers
- `make doctest ELLE=./target/release/elle` — pass
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- `make fmt-check` — clean
- `cargo test --test lib -- --skip property` — 875 pass. The one failure,
  `net_wait_timeout_threadpool`, comes from unrelated uncommitted io work
  in the same working tree; neither that test nor its script is in this
  branch.
